### PR TITLE
IntelliTest Wizard fix.

### DIFF
--- a/WizardExtensions/MSTestv2IntelliTestExtension/MSTestv2TestFrameworkMetadata.cs
+++ b/WizardExtensions/MSTestv2IntelliTestExtension/MSTestv2TestFrameworkMetadata.cs
@@ -11,14 +11,37 @@ namespace MSTestv2IntelliTestExtension
     /// </summary>
     internal static class MSTestv2TestFrameworkMetadata
     {
-        public static readonly TypeName AssertType = MSTestv2TestFrameworkMetadata.TypeName("Assert");
-        public static readonly TypeDefinitionName AssertTypeDefinition = AssertType.Definition;
-        public static readonly TypeName CollectionAssertType = MSTestv2TestFrameworkMetadata.TypeName("CollectionAssert");
-        public static readonly TypeDefinitionName CollectionAssertTypeDefinition = CollectionAssertType.Definition;
-
         internal static readonly ShortAssemblyName AssemblyName = ShortAssemblyName.FromName("Microsoft.VisualStudio.TestPlatform.TestFramework");
-
         internal static readonly string RootNamespace = "Microsoft.VisualStudio.TestTools.UnitTesting";
+
+        private static TypeName assertType;
+        private static TypeName collectionAssertType;
+
+        public static TypeDefinitionName AssertTypeDefinition
+        {
+            get
+            {
+                if (assertType == null)
+                {
+                    assertType = MSTestv2TestFrameworkMetadata.TypeName("Assert");
+                }
+
+                return assertType.Definition;
+            }
+        }
+
+        public static TypeDefinitionName CollectionAssertTypeDefinition
+        {
+            get
+            {
+                if (collectionAssertType == null)
+                {
+                    collectionAssertType = MSTestv2TestFrameworkMetadata.TypeName("CollectionAssert");
+                }
+
+                return collectionAssertType.Definition;
+            }
+        }
 
         public static TypeName AttributeName(string name)
         {

--- a/WizardExtensions/MSTestv2IntelliTestExtensionPackage/MSTestv2IntelliTestExtensionPackage.csproj
+++ b/WizardExtensions/MSTestv2IntelliTestExtensionPackage/MSTestv2IntelliTestExtensionPackage.csproj
@@ -66,6 +66,7 @@
     <ProjectReference Include="..\MSTestv2IntelliTestExtension\MSTestv2IntelliTestExtension.csproj">
       <Project>{aab9f3cf-72d5-419b-b31e-209388bf3e7c}</Project>
       <Name>MSTestv2IntelliTestExtension</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(TestFxRoot)scripts\build\TestFx.targets" />

--- a/WizardExtensions/MSTestv2UnitTestExtensionPackage/MSTestv2UnitTestExtensionPackage.csproj
+++ b/WizardExtensions/MSTestv2UnitTestExtensionPackage/MSTestv2UnitTestExtensionPackage.csproj
@@ -66,6 +66,7 @@
     <ProjectReference Include="..\MSTestv2UnitTestExtension\MSTestv2UnitTestExtension.csproj">
       <Project>{25bface8-5009-498e-9b18-3e417c312f26}</Project>
       <Name>MSTestv2UnitTestExtension</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup</IncludeOutputGroupsInVSIX>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(TestFxRoot)scripts\build\TestFx.targets" />


### PR DESCRIPTION
CLR starts initializing static variables in the order in which they appear on file. Once we moved all public methods to the top to satisfy stylecop AssemblyName and RootNamespace which needed to be initialized before AssertType and CollectionAssertType used them were initialized later. Moving to an on-demand model instead.

Also just including direct dependecies in the vsix. We do not want to carry around assemblies dropped by VS.