### PR TITLE
TestInitialize failure and ExpectedException.

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -192,6 +192,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             var classInstance = this.CreateTestClassInstance(result);
             var testContextSetup = false;
             bool isExceptionThrown = false;
+            bool hasTestInitializePassed = false;
             Exception testRunnerException = null;
 
             try
@@ -205,6 +206,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                         if (this.RunTestInitializeMethod(classInstance, result))
                         {
+                            hasTestInitializePassed = true;
                             PlatformServiceProvider.Instance.ThreadOperations.ExecuteWithAbortSafety(
                                 () => this.TestMethod.InvokeAsSynchronousTask(classInstance, arguments));
                             result.Outcome = TestTools.UnitTesting.UnitTestOutcome.Passed;
@@ -246,7 +248,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 // if we get here, the test method did not throw the exception
                 // if the user specified that the test was going to throw an exception, and
                 // it did not, we should fail the test
-                if (!isExceptionThrown && this.ExpectedException != null)
+                // We only perform this check if the test initialize passes and the test method is actually run.
+                if (hasTestInitializePassed && !isExceptionThrown && this.ExpectedException != null)
                 {
                     result.TestFailureException = new TestFailedException(
                         UnitTestOutcome.Failed,

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
@@ -430,6 +430,23 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 "   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestMethodInfoTests.<>c.<TestMethodInfoInvokeShouldSetStackTraceInformationIfTestInitializeThrowsUnitTestAssertException>b__");
         }
 
+        [TestMethodV1]
+        public void TestMethodInfoInvokeShouldSetTestInitializeExceptionEvenIfMethodHasExpectedExceptionAttriute()
+        {
+            // Arrange.
+            DummyTestClass.TestInitializeMethodBody = classInstance => { UTF.Assert.Fail("dummyFailMessage"); };
+            this.testClassInfo.TestInitializeMethod = typeof(DummyTestClass).GetMethod("DummyTestInitializeMethod");
+            const string ErrorMessage = "Assert.Fail failed. dummyFailMessage";
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+
+            // Act.
+            var exception = testMethodInfo.Invoke(null).TestFailureException as TestFailedException;
+
+            // Assert.
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(ErrorMessage, exception?.Message);
+        }
+
         #endregion
 
         #region TestCleanup method setup


### PR DESCRIPTION
Fix for #136 . We were not checking if Test Initialize was complete. Doing so now.