### PR TITLE
Logger.LogMessage fix

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/LogMessageListener.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/LogMessageListener.cs
@@ -42,10 +42,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             // Cache the original output/error streams and replace it with the own stream.
             this.redirectLoggerOut = new ThreadSafeStringWriter(CultureInfo.InvariantCulture);
-            Logger.OnLogMessage += this.redirectLoggerOut.WriteLine;
-
             this.redirectStdErr = new ThreadSafeStringWriter(CultureInfo.InvariantCulture);
-            Logger.OnLogMessage += this.redirectStdErr.WriteLine;
+
+            Logger.OnLogMessage += this.redirectLoggerOut.WriteLine;
 
             // Cache the previous redirector if any and replace the trace listener.
             this.previousRedirector = activeRedirector;

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -39,16 +39,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         }
 
         /// <summary>
-        /// Gets testMethod referred by this object
-        /// </summary>
-        public MethodInfo TestMethod { get; private set; }
-
-        /// <summary>
-        /// Gets the parent class Info object
-        /// </summary>
-        public TestClassInfo Parent { get; internal set; }
-
-        /// <summary>
         /// Gets a value indicating whether timeout is set.
         /// </summary>
         public bool IsTimeoutSet => this.TestMethodOptions.Timeout != TimeoutWhenNotSet;
@@ -63,15 +53,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// </summary>
         public bool IsRunnable => string.IsNullOrEmpty(this.NotRunnableReason);
 
-        internal TestMethodOptions TestMethodOptions { get; private set; }
-
-        #region ITestMethod implementation
-
-#pragma warning disable SA1202 // Elements must be ordered by access
-
         /// <inheritdoc/>
         public ParameterInfo[] ParameterTypes => this.TestMethod.GetParameters();
-#pragma warning restore SA1202 // Elements must be ordered by access
 
         /// <inheritdoc/>
         public Type ReturnType => this.TestMethod.ReturnType;
@@ -84,6 +67,21 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
         /// <inheritdoc/>
         public MethodInfo MethodInfo => this.TestMethod;
+
+        /// <summary>
+        /// Gets testMethod referred by this object
+        /// </summary>
+        internal MethodInfo TestMethod { get; private set; }
+
+        /// <summary>
+        /// Gets the parent class Info object
+        /// </summary>
+        internal TestClassInfo Parent { get; private set; }
+
+        /// <summary>
+        /// Gets the options for the test method in this environment.
+        /// </summary>
+        internal TestMethodOptions TestMethodOptions { get; private set; }
 
         /// <inheritdoc/>
         public Attribute[] GetAllAttributes(bool inherit)
@@ -159,7 +157,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             return result;
         }
-        #endregion
 
         /// <summary>
         /// Execute test without timeout.
@@ -234,7 +231,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 // if the user specified that the test was going to throw an exception, and
                 // it did not, we should fail the test
                 // We only perform this check if the test initialize passes and the test method is actually run.
-                if (hasTestInitializePassed && !isExceptionThrown && this.ExpectedException != null)
+                if (hasTestInitializePassed && !isExceptionThrown && this.TestMethodOptions.ExpectedException != null)
                 {
                     result.TestFailureException = new TestFailedException(
                         UnitTestOutcome.Failed,

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -93,8 +93,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         // Assembly or class initialize can throw exceptions in which case we need to ensure that we fail the test.
                         this.testMethodInfo.Parent.Parent.RunAssemblyInitialize(this.testContext.Context);
                         this.testMethodInfo.Parent.RunClassInitialize(this.testContext.Context);
-
-                        result = this.RunTestMethod();
                     }
                     finally
                     {
@@ -103,6 +101,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         errorLogs = logListener.StandardError;
                     }
                 }
+
+                // Listening to log messages when running the test method with its Test Initialize and cleanup later on in the stack.
+                // This allows us to differentiate logging when data driven methods are used.
+                result = this.RunTestMethod();
             }
             catch (TestFailedException ex)
             {
@@ -146,18 +148,18 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             UTF.TestResult[] results = null;
 
-            if (this.testMethodInfo.Executor != null)
+            if (this.testMethodInfo.TestMethodOptions.Executor != null)
             {
                 try
                 {
                     bool isDataDriven = PlatformServiceProvider.Instance.TestDataSource.HasDataDrivenTests(this.testMethodInfo);
                     if (isDataDriven)
                     {
-                        results = PlatformServiceProvider.Instance.TestDataSource.RunDataDrivenTest(this.testContext.Context, this.testMethodInfo, this.test, this.testMethodInfo.Executor);
+                        results = PlatformServiceProvider.Instance.TestDataSource.RunDataDrivenTest(this.testContext.Context, this.testMethodInfo, this.test, this.testMethodInfo.TestMethodOptions.Executor);
                     }
                     else
                     {
-                        results = this.testMethodInfo.Executor.Execute(this.testMethodInfo);
+                        results = this.testMethodInfo.TestMethodOptions.Executor.Execute(this.testMethodInfo);
                     }
                 }
                 catch (Exception ex)

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -116,8 +116,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// </summary>
         /// <param name="testMethod"> The test Method. </param>
         /// <param name="testContext"> The test Context. </param>
+        /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns> The <see cref="TestMethodInfo"/>. </returns>
-        public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext)
+        public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext, bool captureDebugTraces)
         {
             if (testMethod == null)
             {
@@ -140,7 +141,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             }
 
             // Get the testMethod
-            return this.ResolveTestMethod(testMethod, testClassInfo, testContext);
+            return this.ResolveTestMethod(testMethod, testClassInfo, testContext, captureDebugTraces);
         }
 
         /// <summary>
@@ -530,10 +531,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <param name="testMethod"> The test Method. </param>
         /// <param name="testClassInfo"> The test Class Info. </param>
         /// <param name="testContext"> The test Context. </param>
+        /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns>
         /// The TestMethodInfo for the given test method. Null if the test method could not be found.
         /// </returns>
-        private TestMethodInfo ResolveTestMethod(TestMethod testMethod, TestClassInfo testClassInfo, ITestContext testContext)
+        private TestMethodInfo ResolveTestMethod(TestMethod testMethod, TestClassInfo testClassInfo, ITestContext testContext, bool captureDebugTraces)
         {
             Debug.Assert(testMethod != null, "testMethod is Null");
             Debug.Assert(testClassInfo != null, "testClassInfo is Null");
@@ -548,7 +550,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             var expectedExceptionAttribute = this.reflectionHelper.ResolveExpectedExceptionHelper(methodInfo, testMethod);
             var timeout = this.GetTestTimeout(methodInfo, testMethod);
 
-            var testMethodInfo = new TestMethodInfo(methodInfo, timeout, this.GetTestMethodAttribute(methodInfo, testClassInfo), expectedExceptionAttribute, testClassInfo, testContext);
+            var testMethodOptions = new TestMethodOptions() { Timeout = timeout, Executor = this.GetTestMethodAttribute(methodInfo, testClassInfo), ExpectedException = expectedExceptionAttribute, TestContext = testContext, CaptureDebugTraces = captureDebugTraces };
+            var testMethodInfo = new TestMethodInfo(methodInfo, testClassInfo, testMethodOptions);
 
             this.SetCustomProperties(testMethodInfo, testContext);
 

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     testContext.SetOutcome(TestTools.UnitTesting.UnitTestOutcome.InProgress);
 
                     // Get the testMethod
-                    var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext);
+                    var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, this.captureDebugTraces);
 
                     // If the specified TestMethod could not be found, return a NotFound result.
                     if (testMethodInfo == null)

--- a/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
+++ b/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ObjectModel\TestMethod.cs" />
     <Compile Include="Execution\TestMethodInfo.cs" />
     <Compile Include="Execution\ThreadSafeStringWriter.cs" />
+    <Compile Include="ObjectModel\TestMethodOptions.cs" />
     <Compile Include="ObjectModel\TypeInspectionException.cs" />
     <Compile Include="Helpers\UnitTestOutcomeHelper.cs" />
     <Compile Include="ObjectModel\UnitTestOutcome.cs" />

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethodOptions.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethodOptions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
+{
+    using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    ///  A fascade service for options passed to a test method.
+    /// </summary>
+    internal class TestMethodOptions
+    {
+        /// <summary>
+        /// Gets or sets the timeout specified for a test method.
+        /// </summary>
+        internal int Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ExpectedException attribute adorned on a test method.
+        /// </summary>
+        internal ExpectedExceptionBaseAttribute ExpectedException { get; set; }
+
+        /// <summary>
+        /// Gets or sets the testcontext passed into the test method.
+        /// </summary>
+        internal ITestContext TestContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether debug traces should be captured when running the test.
+        /// </summary>
+        internal bool CaptureDebugTraces { get; set; }
+
+        /// <summary>
+        /// Gets or sets the test method executor that invokes the test.
+        /// </summary>
+        internal TestMethodAttribute Executor { get; set; }
+    }
+}

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/LogMessageListenerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/LogMessageListenerTests.cs
@@ -51,17 +51,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
-        public void LogMessageListenerShouldCaptureErrorMessages()
-        {
-            using (var logMessageListener = new LogMessageListener(false))
-            {
-                UTF.Logging.Logger.LogMessage("Error Message");
-
-                Assert.AreEqual("Error Message" + Environment.NewLine, logMessageListener.StandardError);
-            }
-        }
-
-        [TestMethod]
         public void NoTraceListenerOperationShouldBePerformedIfDebugTraceIsNotEnabled()
         {
             var logMessageListener = new LogMessageListener(false);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
@@ -495,7 +495,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClass.TestInitializeMethodBody = classInstance => { UTF.Assert.Fail("dummyFailMessage"); };
             this.testClassInfo.TestInitializeMethod = typeof(DummyTestClass).GetMethod("DummyTestInitializeMethod");
             const string ErrorMessage = "Assert.Fail failed. dummyFailMessage";
-            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+
+            this.testMethodOptions.ExpectedException = this.expectedException;
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
 
             // Act.
             var exception = testMethodInfo.Invoke(null).TestFailureException as TestFailedException;

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
@@ -10,8 +10,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Text;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
@@ -55,6 +57,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
         private readonly UTF.ExpectedExceptionAttribute expectedException;
 
+        private readonly TestMethodOptions testMethodOptions;
+
         public TestMethodInfoTests()
         {
             this.constructorInfo = typeof(DummyTestClass).GetConstructors().Single();
@@ -73,13 +77,18 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 classAttribute: this.classAttribute,
                 parent: this.testAssemblyInfo);
             this.expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
+            this.testMethodOptions = new TestMethodOptions()
+            {
+                Timeout = 3600 * 1000,
+                Executor = this.testMethodAttribute,
+                ExpectedException = null,
+                TestContext = this.testContextImplementation
+            };
+
             this.testMethodInfo = new TestMethodInfo(
                 this.methodInfo,
-                timeout: 3600 * 1000,
-                executor: this.testMethodAttribute,
-                expectedException: null,
                 parent: this.testClassInfo,
-                testContext: this.testContextImplementation);
+                testmethodOptions: this.testMethodOptions);
 
             // Reset test hooks
             DummyTestClass.TestConstructorMethodBody = () => { };
@@ -97,18 +106,66 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var methodCalled = false;
             DummyTestClass.DummyAsyncTestMethodBody = () => Task.Run(() => { methodCalled = true; });
             var asyncMethodInfo = typeof(DummyTestClass).GetMethod("DummyAsyncTestMethod");
+
             var method = new TestMethodInfo(
                 asyncMethodInfo,
-                3600 * 1000,
-                this.testMethodAttribute,
-                null,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             var result = method.Invoke(null);
 
             Assert.IsTrue(methodCalled);
             Assert.AreEqual(UTF.UnitTestOutcome.Passed, result.Outcome);
+        }
+
+        [TestMethodV1]
+        public void TestMethodInfoInvokeShouldListenForDebugAndTraceLogsWhenEnabled()
+        {
+            this.testMethodOptions.CaptureDebugTraces = true;
+
+            StringWriter writer = new StringWriter(new StringBuilder());
+            DummyTestClass.TestMethodBody = o => { writer.Write("Trace logs"); };
+
+            var method = new TestMethodInfo(
+                this.methodInfo,
+                this.testClassInfo,
+                this.testMethodOptions);
+
+            var testablePlatformServiceProvider = new TestablePlatformServiceProvider();
+            this.RunWithTestablePlatformService(testablePlatformServiceProvider, () =>
+            {
+                testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
+
+                PlatformServiceProvider.Instance = testablePlatformServiceProvider;
+                var result = method.Invoke(null);
+
+                Assert.AreEqual("Trace logs", result.DebugTrace);
+            });
+        }
+
+        [TestMethodV1]
+        public void TestMethodInfoInvokeShouldNotListenForDebugAndTraceLogsWhenDisabled()
+        {
+            this.testMethodOptions.CaptureDebugTraces = false;
+
+            var method = new TestMethodInfo(
+                this.methodInfo,
+                this.testClassInfo,
+                this.testMethodOptions);
+            StringWriter writer = new StringWriter(new StringBuilder());
+
+            DummyTestClass.TestMethodBody = o => { writer.Write("Trace logs"); };
+
+            var testablePlatformServiceProvider = new TestablePlatformServiceProvider();
+            this.RunWithTestablePlatformService(testablePlatformServiceProvider, () =>
+            {
+                testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
+
+                PlatformServiceProvider.Instance = testablePlatformServiceProvider;
+                var result = method.Invoke(null);
+
+                Assert.AreEqual(string.Empty, result.DebugTrace);
+            });
         }
 
         #endregion
@@ -157,7 +214,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             var ctorInfo = typeof(DummyTestClassWithParameterizedCtor).GetConstructors().Single();
             var testClass = new TestClassInfo(typeof(DummyTestClassWithParameterizedCtor), ctorInfo, this.testContextProperty, this.classAttribute, this.testAssemblyInfo);
-            var method = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, null, testClass, this.testContextImplementation);
+            var method = new TestMethodInfo(this.methodInfo, testClass, this.testMethodOptions);
 
             var result = method.Invoke(null);
             var errorMessage = string.Format(
@@ -187,7 +244,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             var ctorInfo = typeof(DummyTestClassWithParameterizedCtor).GetConstructors().Single();
             var testClass = new TestClassInfo(typeof(DummyTestClassWithParameterizedCtor), ctorInfo, this.testContextProperty, this.classAttribute, this.testAssemblyInfo);
-            var method = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, null, testClass, this.testContextImplementation);
+            var method = new TestMethodInfo(this.methodInfo, testClass, this.testMethodOptions);
 
             var exception = method.Invoke(null).TestFailureException as TestFailedException;
 
@@ -202,8 +259,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             Mock<ITestContext> testContext = new Mock<ITestContext>();
             testContext.Setup(tc => tc.GetResultFiles()).Returns(new List<string>() { "C:\\temp.txt" });
+            this.testMethodOptions.TestContext = testContext.Object;
 
-            var method = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, null, this.testClassInfo, testContext.Object);
+            var method = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
 
             var result = method.Invoke(null);
             CollectionAssert.Contains(result.ResultFiles.ToList(), "C:\\temp.txt");
@@ -216,7 +274,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void TestMethodInfoInvokeShouldNotThrowIfTestContextIsNotPresent()
         {
             var testClass = new TestClassInfo(typeof(DummyTestClass), this.constructorInfo, null, this.classAttribute, this.testAssemblyInfo);
-            var method = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, null, testClass, this.testContextImplementation);
+            var method = new TestMethodInfo(this.methodInfo, testClass, this.testMethodOptions);
 
             UTF.TestResult result = null;
             Action runMethod = () => result = method.Invoke(null);
@@ -230,7 +288,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             var testContext = typeof(DummyTestClassWithTestContextWithoutSetter).GetProperties().Single();
             var testClass = new TestClassInfo(typeof(DummyTestClass), this.constructorInfo, testContext, this.classAttribute, this.testAssemblyInfo);
-            var method = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, null, testClass, this.testContextImplementation);
+            var method = new TestMethodInfo(this.methodInfo, testClass, this.testMethodOptions);
 
             UTF.TestResult result = null;
             Action runMethod = () => result = method.Invoke(null);
@@ -579,7 +637,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClassWithDisposable.DisposeMethodBody = () => disposeCalled = true;
             var ctorInfo = typeof(DummyTestClassWithDisposable).GetConstructors().Single();
             var testClass = new TestClassInfo(typeof(DummyTestClassWithDisposable), ctorInfo, null, this.classAttribute, this.testAssemblyInfo);
-            var method = new TestMethodInfo(typeof(DummyTestClassWithDisposable).GetMethod("DummyTestMethod"), 3600 * 1000, this.testMethodAttribute, null, testClass, this.testContextImplementation);
+            var method = new TestMethodInfo(typeof(DummyTestClassWithDisposable).GetMethod("DummyTestMethod"), testClass, this.testMethodOptions);
 
             method.Invoke(null);
 
@@ -595,7 +653,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var ctorInfo = typeof(DummyTestClassWithDisposable).GetConstructors().Single();
             var testClass = new TestClassInfo(typeof(DummyTestClassWithDisposable), ctorInfo, null, this.classAttribute, this.testAssemblyInfo);
             testClass.TestCleanupMethod = typeof(DummyTestClassWithDisposable).GetMethod("DummyTestCleanupMethod");
-            var method = new TestMethodInfo(typeof(DummyTestClassWithDisposable).GetMethod("DummyTestMethod"), 3600 * 1000, this.testMethodAttribute, null, testClass, this.testContextImplementation);
+            var method = new TestMethodInfo(typeof(DummyTestClassWithDisposable).GetMethod("DummyTestMethod"), testClass, this.testMethodOptions);
 
             method.Invoke(null);
 
@@ -663,8 +721,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void TestMethodInfoInvokeShouldSetResultAsPassedIfExpectedExceptionIsThrown()
         {
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
-            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+            this.testMethodOptions.ExpectedException = this.expectedException;
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
+
             var result = testMethodInfo.Invoke(null);
+
             Assert.AreEqual(UTF.UnitTestOutcome.Passed, result.Outcome);
         }
 
@@ -672,8 +733,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void TestMethodInfoInvokeShouldSetResultAsFailedIfExceptionDifferentFromExpectedExceptionIsThrown()
         {
             DummyTestClass.TestMethodBody = o => { throw new IndexOutOfRangeException(); };
-            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+            this.testMethodOptions.ExpectedException = this.expectedException;
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
+
             var result = testMethodInfo.Invoke(null);
+
             Assert.AreEqual(UTF.UnitTestOutcome.Failed, result.Outcome);
             var message = "Test method threw exception System.IndexOutOfRangeException, but exception System.DivideByZeroException was expected. " +
                 "Exception message: System.IndexOutOfRangeException: Index was outside the bounds of the array.";
@@ -684,7 +748,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void TestMethodInfoInvokeShouldSetResultAsFailedWhenExceptionIsExpectedButIsNotThrown()
         {
             DummyTestClass.TestMethodBody = o => { return; };
-            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+            this.testMethodOptions.ExpectedException = this.expectedException;
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
             var result = testMethodInfo.Invoke(null);
             Assert.AreEqual(UTF.UnitTestOutcome.Failed, result.Outcome);
             var message = "Test method did not throw expected exception System.DivideByZeroException.";
@@ -695,7 +760,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void TestMethodInfoInvokeShouldSetResultAsInconclusiveWhenExceptionIsAssertInconclusiveException()
         {
             DummyTestClass.TestMethodBody = o => { throw new UTF.AssertInconclusiveException(); };
-            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+            this.testMethodOptions.ExpectedException = this.expectedException;
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
             var result = testMethodInfo.Invoke(null);
             Assert.AreEqual(UTF.UnitTestOutcome.Inconclusive, result.Outcome);
             var message = "Exception of type 'Microsoft.VisualStudio.TestTools.UnitTesting.AssertInconclusiveException' was thrown.";
@@ -715,7 +781,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                             }
                         };
             this.testClassInfo.TestCleanupMethod = typeof(DummyTestClass).GetMethod("DummyTestCleanupMethod");
-            var testMethodInfo = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, this.expectedException, this.testClassInfo, this.testContextImplementation);
+            this.testMethodOptions.ExpectedException = this.expectedException;
+            var testMethodInfo = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
 
             var result = testMethodInfo.Invoke(null);
 
@@ -726,13 +793,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void HandleMethodExceptionShouldInvokeVerifyOfCustomExpectedException()
         {
             CustomExpectedExceptionAttribute customExpectedException = new CustomExpectedExceptionAttribute(typeof(DivideByZeroException), "Attempted to divide by zero");
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = customExpectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                customExpectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
@@ -744,13 +810,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void HandleMethodExceptionShouldSetOutcomeAsFailedIfVerifyOfExpectedExceptionThrows()
         {
             CustomExpectedExceptionAttribute customExpectedException = new CustomExpectedExceptionAttribute(typeof(DivideByZeroException), "Custom Exception");
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = customExpectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                customExpectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
@@ -762,13 +827,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void HandleMethodExceptionShouldSetOutcomeAsInconclusveIfVerifyOfExpectedExceptionThrowsAssertInconclusiveException()
         {
             CustomExpectedExceptionAttribute customExpectedException = new CustomExpectedExceptionAttribute(typeof(DivideByZeroException), "Custom Exception");
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = customExpectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                customExpectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new UTF.AssertInconclusiveException(); };
             var result = method.Invoke(null);
@@ -781,13 +845,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void HandleMethodExceptionShouldInvokeVerifyOfDerivedCustomExpectedException()
         {
             DerivedCustomExpectedExceptionAttribute derivedCustomExpectedException = new DerivedCustomExpectedExceptionAttribute(typeof(DivideByZeroException), "Attempted to divide by zero");
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = derivedCustomExpectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                derivedCustomExpectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
@@ -800,13 +863,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(Exception));
             expectedException.AllowDerivedTypes = true;
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = expectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                expectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
@@ -818,13 +880,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException), "Custom Exception");
             expectedException.AllowDerivedTypes = true;
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = expectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                expectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new ArgumentNullException(); };
             var result = method.Invoke(null);
@@ -839,13 +900,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
             expectedException.AllowDerivedTypes = true;
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = expectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                expectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new UTF.AssertFailedException(); };
             var result = method.Invoke(null);
@@ -859,13 +919,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
             expectedException.AllowDerivedTypes = true;
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = expectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                expectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new UTF.AssertInconclusiveException(); };
             var result = method.Invoke(null);
@@ -878,13 +937,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void VerifyShouldThrowIfThrownExceptionIsNotSameAsExpectedException()
         {
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(Exception));
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = expectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                expectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
@@ -898,13 +956,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void VerifyShouldRethrowIfThrownExceptionIsAssertExceptionWhichIsNotSameAsExpectedException()
         {
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(Exception));
+            this.testMethodOptions.Timeout = 0;
+            this.testMethodOptions.ExpectedException = expectedException;
             var method = new TestMethodInfo(
                 this.methodInfo,
-                0,
-                this.testMethodAttribute,
-                expectedException,
                 this.testClassInfo,
-                this.testContextImplementation);
+                this.testMethodOptions);
 
             DummyTestClass.TestMethodBody = o => { throw new UTF.AssertInconclusiveException(); };
             var result = method.Invoke(null);
@@ -951,27 +1008,24 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         [TestMethodV1]
         public void TestMethodInfoInvokeShouldReturnTestFailureOnTimeout()
         {
-            try
+            var testablePlatformServiceProvider = new TestablePlatformServiceProvider();
+
+            this.RunWithTestablePlatformService(testablePlatformServiceProvider, () =>
             {
-                var testablePlatformServiceProvider = new TestablePlatformServiceProvider();
                 testablePlatformServiceProvider.MockThreadOperations.CallBase = true;
 
                 PlatformServiceProvider.Instance = testablePlatformServiceProvider;
 
                 testablePlatformServiceProvider.MockThreadOperations.Setup(
                  to => to.Execute(It.IsAny<Action>(), It.IsAny<int>())).Returns(false);
-
-                var method = new TestMethodInfo(this.methodInfo, 1, this.testMethodAttribute, null, this.testClassInfo, this.testContextImplementation);
+                this.testMethodOptions.Timeout = 1;
+                var method = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
 
                 var result = method.Invoke(null);
 
                 Assert.AreEqual(UTF.UnitTestOutcome.Timeout, result.Outcome);
                 StringAssert.Contains(result.TestFailureException.Message, "exceeded execution timeout period");
-            }
-            finally
-            {
-                PlatformServiceProvider.Instance = null;
-            }
+            });
         }
 
         [TestMethodV1]
@@ -981,11 +1035,39 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 {
                     /* do nothing */
                 };
-            var method = new TestMethodInfo(this.methodInfo, 3600 * 1000, this.testMethodAttribute, null, this.testClassInfo, this.testContextImplementation);
+
+            var method = new TestMethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions);
 
             var result = method.Invoke(null);
 
             Assert.AreEqual(UTF.UnitTestOutcome.Passed, result.Outcome);
+        }
+
+        #endregion
+
+        #region helper methods
+
+        private void RunWithTestablePlatformService(TestablePlatformServiceProvider testablePlatformServiceProvider, Action action)
+        {
+            try
+            {
+                testablePlatformServiceProvider.MockThreadOperations.
+                    Setup(tho => tho.Execute(It.IsAny<Action>(), It.IsAny<int>())).
+                    Returns(true).
+                    Callback((Action a, int timeout) =>
+                    {
+                        a.Invoke();
+                    });
+                testablePlatformServiceProvider.MockThreadOperations.
+                    Setup(tho => tho.ExecuteWithAbortSafety(It.IsAny<Action>())).
+                    Callback((Action a) => { a.Invoke(); });
+
+                action.Invoke();
+            }
+            finally
+            {
+                PlatformServiceProvider.Instance = null;
+            }
         }
 
         #endregion

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
@@ -64,7 +64,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethod = new TestMethod("M", "C", "A", isAsync: false);
             Action a = () => this.typeCache.GetTestMethodInfo(
                 null,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                false);
 
             ActionUtility.ActionShouldThrowExceptionOfType(a, typeof(ArgumentNullException));
         }
@@ -73,7 +74,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void GetTestMethodInfoShouldThrowIfTestContextIsNull()
         {
             var testMethod = new TestMethod("M", "C", "A", isAsync: false);
-            Action a = () => this.typeCache.GetTestMethodInfo(testMethod, null);
+            Action a = () => this.typeCache.GetTestMethodInfo(testMethod, null, false);
 
             ActionUtility.ActionShouldThrowExceptionOfType(a, typeof(ArgumentNullException));
         }
@@ -86,7 +87,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Assert.IsNull(
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>())));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false));
         }
 
         [TestMethodV1]
@@ -97,7 +99,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Assert.IsNull(
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>())));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false));
         }
 
         [TestMethodV1]
@@ -111,7 +114,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Action action = () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
 
@@ -129,7 +133,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Action action = () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
 
@@ -147,7 +152,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Action action = () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
 
@@ -165,7 +171,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Action action = () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
 
@@ -185,8 +192,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                                        testMethod,
+                                        new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                                        false);
 
             Assert.IsNotNull(testMethodInfo);
             Assert.IsNotNull(testMethodInfo.Parent.TestContextProperty);
@@ -203,8 +211,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                                    testMethod,
+                                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                                    false);
 
             Assert.IsNotNull(testMethodInfo);
             Assert.IsNull(testMethodInfo.Parent.TestContextProperty);
@@ -223,8 +232,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
         }
@@ -243,8 +253,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(typeof(DummyTestClassWithTestMethods), typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
         }
@@ -262,8 +273,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyInit"), typeof(UTF.AssemblyInitializeAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
             Assert.AreEqual(type.GetMethod("AssemblyInit"), this.typeCache.AssemblyInfoCache.ToArray()[0].AssemblyInitializeMethod);
@@ -282,8 +294,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.AssemblyCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
             Assert.AreEqual(type.GetMethod("AssemblyCleanup"), this.typeCache.AssemblyInfoCache.ToArray()[0].AssemblyCleanupMethod);
@@ -304,8 +317,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.AssemblyCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
             Assert.AreEqual(type.GetMethod("AssemblyCleanup"), this.typeCache.AssemblyInfoCache.ToArray()[0].AssemblyCleanupMethod);
@@ -328,7 +342,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
             Assert.IsNotNull(exception);
@@ -360,7 +375,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
             Assert.IsNotNull(exception);
@@ -387,12 +403,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             this.mockReflectHelper.Verify(rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true), Times.Once);
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
@@ -413,8 +431,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.IsNull(this.typeCache.ClassInfoCache.ToArray()[0].TestInitializeMethod);
@@ -434,8 +453,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyInit"), typeof(UTF.ClassInitializeAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(type.GetMethod("AssemblyInit"), this.typeCache.ClassInfoCache.ToArray()[0].ClassInitializeMethod);
@@ -454,8 +474,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.ClassCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(type.GetMethod("AssemblyCleanup"), this.typeCache.ClassInfoCache.ToArray()[0].ClassCleanupMethod);
@@ -476,8 +497,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.ClassCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(type.GetMethod("AssemblyInit"), this.typeCache.ClassInfoCache.ToArray()[0].ClassInitializeMethod);
@@ -500,7 +522,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
             Assert.IsNotNull(exception);
@@ -532,7 +555,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
             Assert.IsNotNull(exception);
@@ -561,8 +585,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("TestInit"), typeof(UTF.TestInitializeAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(type.GetMethod("TestInit"), this.typeCache.ClassInfoCache.ToArray()[0].TestInitializeMethod);
@@ -581,8 +606,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("TestCleanup"), typeof(UTF.TestCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(type.GetMethod("TestCleanup"), this.typeCache.ClassInfoCache.ToArray()[0].TestCleanupMethod);
@@ -604,7 +630,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
 
@@ -635,8 +662,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(baseType.GetMethod("TestInit"), typeof(UTF.TestInitializeAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(baseType.GetMethod("TestInit"), this.typeCache.ClassInfoCache.ToArray()[0].BaseTestInitializeMethodsQueue.Peek());
@@ -656,8 +684,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(baseType.GetMethod("TestCleanup"), typeof(UTF.TestCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
             Assert.AreEqual(baseType.GetMethod("TestCleanup"), this.typeCache.ClassInfoCache.ToArray()[0].BaseTestCleanupMethodsQueue.Peek());
@@ -674,12 +703,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             this.testablePlatformServiceProvider.MockFileOperations.Verify(fo => fo.LoadAssembly(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -700,7 +731,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 () =>
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
 
@@ -723,13 +755,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethod = new TestMethod(methodInfo.Name, type.FullName, "A", isAsync: false);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
-            Assert.AreEqual(0, testMethodInfo.Timeout);
+            Assert.AreEqual(0, testMethodInfo.TestMethodOptions.Timeout);
             Assert.AreEqual(this.typeCache.ClassInfoCache.ToArray()[0], testMethodInfo.Parent);
-            Assert.IsNotNull(testMethodInfo.Executor);
+            Assert.IsNotNull(testMethodInfo.TestMethodOptions.Executor);
         }
 
         [TestMethodV1]
@@ -743,13 +776,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 .Returns(true);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
-            Assert.AreEqual(10, testMethodInfo.Timeout);
+            Assert.AreEqual(10, testMethodInfo.TestMethodOptions.Timeout);
             Assert.AreEqual(this.typeCache.ClassInfoCache.ToArray()[0], testMethodInfo.Parent);
-            Assert.IsNotNull(testMethodInfo.Executor);
+            Assert.IsNotNull(testMethodInfo.TestMethodOptions.Executor);
         }
 
         [TestMethodV1]
@@ -763,8 +797,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 .Returns(true);
 
             Action a = () => this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
 
@@ -788,14 +823,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethod = new TestMethod(methodInfo.Name, type.FullName, "A", isAsync: false);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
-            Assert.AreEqual(0, testMethodInfo.Timeout);
+            Assert.AreEqual(0, testMethodInfo.TestMethodOptions.Timeout);
             Assert.AreEqual(this.typeCache.ClassInfoCache.ToArray()[0], testMethodInfo.Parent);
-            Assert.IsNotNull(testMethodInfo.Executor);
-            Assert.IsNotNull(testMethodInfo.Executor is DerivedTestMethodAttribute);
+            Assert.IsNotNull(testMethodInfo.TestMethodOptions.Executor);
+            Assert.IsNotNull(testMethodInfo.TestMethodOptions.Executor is DerivedTestMethodAttribute);
         }
 
         [TestMethodV1]
@@ -809,7 +845,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            this.typeCache.GetTestMethodInfo(testMethod, testContext);
+            this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
             var customProperty = testContext.Properties.FirstOrDefault(p => p.Key.Equals("WhoAmI"));
 
             Assert.IsNotNull(customProperty);
@@ -827,7 +863,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                  null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
 
             Assert.IsNotNull(testMethodInfo);
             var expectedMessage = string.Format(
@@ -849,7 +885,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
 
             Assert.IsNotNull(testMethodInfo);
             var expectedMessage = string.Format(
@@ -870,7 +906,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
 
             Assert.IsNotNull(testMethodInfo);
             var expectedMessage = string.Format(
@@ -891,7 +927,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
 
             Assert.IsNotNull(testMethodInfo);
 
@@ -909,13 +945,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethod = new TestMethod(methodInfo.Name, type.FullName, "A", isAsync: false);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
-            Assert.AreEqual(0, testMethodInfo.Timeout);
+            Assert.AreEqual(0, testMethodInfo.TestMethodOptions.Timeout);
             Assert.AreEqual(this.typeCache.ClassInfoCache.ToArray()[0], testMethodInfo.Parent);
-            Assert.IsNotNull(testMethodInfo.Executor);
+            Assert.IsNotNull(testMethodInfo.TestMethodOptions.Executor);
         }
 
         #endregion
@@ -947,8 +984,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("TestCleanup"), typeof(UTF.ClassCleanupAttribute), false)).Returns(false);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var cleanupMethods = this.typeCache.ClassInfoListWithExecutableCleanupMethods;
 
@@ -970,8 +1008,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.ClassCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var cleanupMethods = this.typeCache.ClassInfoListWithExecutableCleanupMethods;
 
@@ -1007,8 +1046,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.AssemblyCleanupAttribute), false)).Returns(false);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var cleanupMethods = this.typeCache.AssemblyInfoListWithExecutableCleanupMethods;
 
@@ -1030,8 +1070,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 rh => rh.IsAttributeDefined(type.GetMethod("AssemblyCleanup"), typeof(UTF.AssemblyCleanupAttribute), false)).Returns(true);
 
             this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             var cleanupMethods = this.typeCache.AssemblyInfoListWithExecutableCleanupMethods;
 
@@ -1057,10 +1098,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.ResolveExpectedExceptionHelper(methodInfo, testMethod)).Returns(expectedException);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
-            Assert.AreEqual(expectedException, testMethodInfo.ExpectedException);
+            Assert.AreEqual(expectedException, testMethodInfo.TestMethodOptions.ExpectedException);
         }
 
         [TestMethodV1]
@@ -1074,12 +1116,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 .Returns(true);
 
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
-                testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    testMethod,
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
 
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
 
-            Assert.AreEqual(null, testMethodInfo.ExpectedException);
+            Assert.AreEqual(null, testMethodInfo.TestMethodOptions.ExpectedException);
         }
 
         [TestMethodV1]
@@ -1096,7 +1139,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             {
                 var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
-                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()));
+                    new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    false);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
We were wrapping LogMessageListener over the test methods execution multiple times.
Fixing #114 .