### PR TITLE
Honor settings in App domain

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumerator.cs
@@ -22,6 +22,25 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
     internal class AssemblyEnumerator : MarshalByRefObject
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="AssemblyEnumerator"/> class.
+        /// </summary>
+        public AssemblyEnumerator()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssemblyEnumerator"/> class.
+        /// </summary>
+        /// <param name="settings">The settings for the session.</param>
+        /// <remarks>Use this constructor when creating this object in a new app domain so the settings for this app domain are set.</remarks>
+        public AssemblyEnumerator(MSTestSettings settings)
+        {
+            // Populate the settings into the domain(Desktop workflow) performing discovery.
+            // This would just be resettings the settings to itself in non desktop workflows.
+            MSTestSettings.PopulateSettings(settings);
+        }
+
+        /// <summary>
         /// Returns object to be used for controlling lifetime, null means infinite lifetime.
         /// </summary>
         /// <returns>

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
             using (var isolationHost = PlatformServiceProvider.Instance.CreateTestSourceHost(fullFilePath, runSettings, frameworkHandle: null))
             {
                 var assemblyEnumerator =
-                    isolationHost.CreateInstanceForType(typeof(AssemblyEnumerator), null) as AssemblyEnumerator;
+                    isolationHost.CreateInstanceForType(typeof(AssemblyEnumerator), new object[] { MSTestSettings.CurrentSettings }) as AssemblyEnumerator;
                 return assemblyEnumerator.EnumerateAssembly(fullFilePath, out warnings);
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             {
                 var testRunner = isolationHost.CreateInstanceForType(
                     typeof(UnitTestRunner),
-                    new object[] { MSTestSettings.CurrentSettings.CaptureDebugTraces }) as UnitTestRunner;
+                    new object[] { MSTestSettings.CurrentSettings }) as UnitTestRunner;
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Created unit-test runner {0}", source);
 
                 this.ExecuteTestsWithTestRunner(tests, runContext, frameworkHandle, source, testRunner);

--- a/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
@@ -67,9 +67,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether capture debug traces.
+        /// Gets a value indicating whether capture debug traces.
         /// </summary>
-        public bool CaptureDebugTraces { get; set; }
+        public bool CaptureDebugTraces { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether user wants the adapter to run in legacy mode or not.
@@ -239,11 +239,21 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
                     string elementName = reader.Name.ToUpperInvariant();
                     switch (elementName)
                     {
-                        case "MAPINCONCLUSIVETOFAILED":
+                        case "CAPTURETRACEOUTPUT":
                             {
                                 if (bool.TryParse(reader.ReadInnerXml(), out result))
                                 {
-                                    settings.MapInconclusiveToFailed = result;
+                                    settings.CaptureDebugTraces = result;
+                                }
+
+                                break;
+                            }
+
+                        case "ENABLEBASECLASSTESTMETHODSFROMOTHERASSEMBLIES":
+                            {
+                                if (bool.TryParse(reader.ReadInnerXml(), out result))
+                                {
+                                    settings.EnableBaseClassTestMethodsFromOtherAssemblies = result;
                                 }
 
                                 break;
@@ -259,11 +269,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
                                 break;
                             }
 
-                        case "ENABLEBASECLASSTESTMETHODSFROMOTHERASSEMBLIES":
+                        case "MAPINCONCLUSIVETOFAILED":
                             {
                                 if (bool.TryParse(reader.ReadInnerXml(), out result))
                                 {
-                                    settings.EnableBaseClassTestMethodsFromOtherAssemblies = result;
+                                    settings.MapInconclusiveToFailed = result;
                                 }
 
                                 break;

--- a/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
     /// <summary>
     /// Adapter Settings for the run
     /// </summary>
+    [Serializable]
     public class MSTestSettings
     {
         /// <summary>
@@ -90,6 +91,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         /// Gets a value indicating whether to enable discovery of test methods from base classes in a different assembly from the inheriting test class.
         /// </summary>
         public bool EnableBaseClassTestMethodsFromOtherAssemblies { get; private set; }
+
+        /// <summary>
+        /// Populate settings based on existing settings object.
+        /// </summary>
+        /// <param name="settings">The existing settings object.</param>
+        public static void PopulateSettings(MSTestSettings settings)
+        {
+            CurrentSettings.CaptureDebugTraces = settings.CaptureDebugTraces;
+            CurrentSettings.ForcedLegacyMode = settings.ForcedLegacyMode;
+            CurrentSettings.TestSettingsFile = settings.TestSettingsFile;
+            CurrentSettings.MapInconclusiveToFailed = settings.MapInconclusiveToFailed;
+            CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies = settings.EnableBaseClassTestMethodsFromOtherAssemblies;
+        }
 
         /// <summary>
         /// Populate adapter settings from the context

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
     using System.Linq;
     using System.Reflection;
     using System.Text;
+    using System.Xml;
 
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
@@ -50,6 +51,38 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
         {
             PlatformServiceProvider.Instance = null;
         }
+
+        #region  Constructor tests
+
+        [TestMethodV1]
+        public void ConstructorShouldPopulateSettings()
+        {
+            string runSettingxml =
+                 @"<RunSettings>
+                     <MSTest>
+                        <ForcedLegacyMode>True</ForcedLegacyMode>
+                        <SettingsFile>DummyPath\TestSettings1.testsettings</SettingsFile>
+                     </MSTest>
+                   </RunSettings>";
+
+            this.testablePlatformServiceProvider.MockSettingsProvider.Setup(sp => sp.Load(It.IsAny<XmlReader>()))
+                .Callback((XmlReader actualReader) =>
+                {
+                    if (actualReader != null)
+                    {
+                        actualReader.Read();
+                        actualReader.ReadInnerXml();
+                    }
+                });
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsName);
+            var assemblyEnumerator = new AssemblyEnumerator(adapterSettings);
+
+            Assert.IsTrue(MSTestSettings.CurrentSettings.ForcedLegacyMode);
+            Assert.AreEqual("DummyPath\\TestSettings1.testsettings", MSTestSettings.CurrentSettings.TestSettingsFile);
+        }
+
+        #endregion
 
         #region GetTypes tests
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorWrapperTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorWrapperTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
 
             this.testableAssemblyEnumeratorWrapper.GetTests(assemblyName, null, out this.warnings);
 
-            this.testablePlatformServiceProvider.MockTestSourceHost.Verify(ih => ih.CreateInstanceForType(typeof(AssemblyEnumerator), null), Times.Once);
+            this.testablePlatformServiceProvider.MockTestSourceHost.Verify(ih => ih.CreateInstanceForType(typeof(AssemblyEnumerator), It.IsAny<object[]>()), Times.Once);
         }
 
         #region Exception handling tests.
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly(assemblyName, It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
             this.testablePlatformServiceProvider.MockTestSourceHost.Setup(
-                ih => ih.CreateInstanceForType(typeof(AssemblyEnumerator), null))
+                ih => ih.CreateInstanceForType(typeof(AssemblyEnumerator), It.IsAny<object[]>()))
                 .Returns(new AssemblyEnumerator());
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/UnitTestDiscovererTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.CreateNavigationSession(source))
                 .Returns((object)null);
             this.testablePlatformServiceProvider.MockTestSourceHost.Setup(
-                ih => ih.CreateInstanceForType(It.IsAny<Type>(), null))
+                ih => ih.CreateInstanceForType(It.IsAny<Type>(), It.IsAny<object[]>()))
                 .Returns(new AssemblyEnumerator());
 
             this.unitTestDiscoverer.DiscoverTestsInSource(source, this.mockMessageLogger.Object, this.mockTestCaseDiscoverySink.Object, this.mockRunSettings.Object);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestDiscovererTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestDiscovererTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.CreateNavigationSession(source))
                 .Returns((object)null);
             this.testablePlatformServiceProvider.MockTestSourceHost.Setup(
-                ih => ih.CreateInstanceForType(It.IsAny<Type>(), null))
+                ih => ih.CreateInstanceForType(It.IsAny<Type>(), It.IsAny<object[]>()))
                 .Returns(new AssemblyEnumerator());
 
             this.discoverer.DiscoverTests(new List<string> { source }, this.mockDiscoveryContext.Object, this.mockMessageLogger.Object, this.mockTestCaseDiscoverySink.Object);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -162,6 +162,35 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
         }
 
+        [TestMethod]
+        public void CaptureDebugTracesShouldBeTrueByDefault()
+        {
+            string runSettingxml =
+                @"<RunSettings>
+                    <MSTestV2>
+                    </MSTestV2>
+                  </RunSettings>";
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+            Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
+        }
+
+        [TestMethod]
+        public void CaptureDebugTracesShouldBeConsumedFromRunSettingsWhenSpecified()
+        {
+            string runSettingxml =
+                @"<RunSettings>
+                    <MSTestV2>
+                        <CaptureTraceOutput>False</CaptureTraceOutput>
+                    </MSTestV2>
+                  </RunSettings>";
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+            Assert.AreEqual(adapterSettings.CaptureDebugTraces, false);
+        }
+
         #endregion
 
         #region GetSettings Tests
@@ -475,6 +504,31 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
         #endregion
 
         #region PopulateSettings tests.
+
+        [TestMethod]
+        public void PopulateSettingsShouldFillInSettingsFromSettingsObject()
+        {
+            string runsettingsXml =
+            @"<RunSettings>
+                 <MSTest>
+                   <CaptureTraceOutput>False</CaptureTraceOutput> 
+                   <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                   <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
+                   <ForcedLegacyMode>true</ForcedLegacyMode>
+                   <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
+                 </MSTest>
+               </RunSettings>";
+
+            var settings = MSTestSettings.GetSettings(runsettingsXml, MSTestSettings.SettingsName);
+
+            MSTestSettings.PopulateSettings(settings);
+
+            Assert.AreEqual(MSTestSettings.CurrentSettings.CaptureDebugTraces, false);
+            Assert.AreEqual(MSTestSettings.CurrentSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(MSTestSettings.CurrentSettings.ForcedLegacyMode, true);
+            Assert.AreEqual(MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.IsFalse(string.IsNullOrEmpty(MSTestSettings.CurrentSettings.TestSettingsFile));
+        }
 
         [TestMethod]
         public void PopulateSettingsShouldInitializeDefaultAdapterSettingsWhenDiscoveryContextIsNull()

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -479,7 +479,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
         [TestMethod]
         public void PopulateSettingsShouldInitializeDefaultAdapterSettingsWhenDiscoveryContextIsNull()
         {
-            MSTestSettings.PopulateSettings(null);
+            MSTestSettings.PopulateSettings((IDiscoveryContext)null);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
@@ -624,7 +624,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
         [TestMethod]
         public void IsLegacyScenarioReturnsFalseWhenDiscoveryContextIsNull()
         {
-            MSTestSettings.PopulateSettings(null);
+            MSTestSettings.PopulateSettings((IDiscoveryContext)null);
             Assert.IsFalse(MSTestSettings.IsLegacyScenario(null));
         }
 


### PR DESCRIPTION
Tied to #23. We were not honoring these settings in the app domains that discover/execute tests. Doing so now.