### PR TITLE
Assertion fix up.

### DIFF
--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -14,11 +14,15 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     /// unit tests. If the condition being tested is not met, an exception
     /// is thrown.
     /// </summary>
-    public class Assert
+    public sealed class Assert
     {
         private static Assert that;
 
         #region Singleton constructor
+
+        private Assert()
+        {
+        }
 
         /// <summary>
         /// Gets the singleton instance of the Assert functionality.

--- a/src/TestFramework/MSTest.Core/Assertions/CollectionAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/CollectionAssert.cs
@@ -15,11 +15,15 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     /// with collections within unit tests. If the condition being tested is not
     /// met, an exception is thrown.
     /// </summary>
-    public class CollectionAssert
+    public sealed class CollectionAssert
     {
         private static CollectionAssert that;
 
         #region Singleton constructor
+
+        private CollectionAssert()
+        {
+        }
 
         /// <summary>
         /// Gets the singleton instance of the CollectionAssert functionality.

--- a/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
@@ -10,11 +10,15 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     /// <summary>
     /// The string assert.
     /// </summary>
-    public class StringAssert
+    public sealed class StringAssert
     {
         private static StringAssert that;
 
         #region Singleton constructor
+
+        private StringAssert()
+        {
+        }
 
         /// <summary>
         /// Gets the singleton instance of the CollectionAssert functionality.


### PR DESCRIPTION
Fix for #223.
Making all assert ctor's private and the classes sealed. We want users to extend from Assert.That instead and not by creating instances of the Assert class or extending from it.