### PR TITLE
Fix where Deployment Item attribute was not deploying items.

### DIFF
--- a/src/Adapter/PlatformServices.Desktop/Constants.cs
+++ b/src/Adapter/PlatformServices.Desktop/Constants.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
 
         public const string PrivateAssemblies = "PrivateAssemblies";
 
-        public static readonly TestProperty DeploymentItemsProperty = TestProperty.Register("MSTestDiscoverer2.DeploymentItems", DeploymentItemsLabel, typeof(KeyValuePair<string, string>[]), TestPropertyAttributes.Hidden, typeof(TestCase));
+        public static readonly TestProperty DeploymentItemsProperty = TestProperty.Register("MSTestDiscoverer.DeploymentItems", DeploymentItemsLabel, typeof(KeyValuePair<string, string>[]), TestPropertyAttributes.Hidden, typeof(TestCase));
 
         internal const string DllExtension = ".dll";
         internal const string ExeExtension = ".exe";

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Utilities/DeploymentItemUtilityTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Utilities/DeploymentItemUtilityTests.cs
@@ -31,7 +31,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Utilities
     public class DeploymentItemUtilityTests
     {
         internal static readonly TestProperty DeploymentItemsProperty = TestProperty.Register(
-            "MSTestDiscoverer2.DeploymentItems",
+            "MSTestDiscoverer.DeploymentItems",
             "DeploymentItems",
             typeof(KeyValuePair<string, string>[]),
             TestPropertyAttributes.Hidden,


### PR DESCRIPTION
The deploymentItem Attribute was doing string comparison while deploying items, it was expecting "MSTestDiscoverer2" but test property name has been changed to "MSTestDiscoverer" in recent commit.
[(https://github.com/Microsoft/testfx/pull/221)]