### PR TITLE
Fix where Unit Tests were failing on local machine.

### DIFF
--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/UnitTestDiscovererTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
             this.test = null;
             this.testElements = null;
             PlatformServiceProvider.Instance = null;
+            MSTestSettings.PopulateSettings(new Mock<IDiscoveryContext>().Object);
         }
 
         [TestMethodV1]
@@ -240,7 +241,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
         }
 
         [TestMethodV1]
-        public void SendTestCasesShouldSendTestCasesWithNaigationDataForAsyncMethods()
+        public void SendTestCasesShouldSendTestCasesWithNavigationDataForAsyncMethods()
         {
             // Setup mocks.
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.CreateNavigationSession(Source))

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/UnitTestDiscovererTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
             this.test = null;
             this.testElements = null;
             PlatformServiceProvider.Instance = null;
-            MSTestSettings.PopulateSettings(new Mock<IDiscoveryContext>().Object);
+            MSTestSettings.Reset();
         }
 
         [TestMethodV1]


### PR DESCRIPTION
The Unit Tests were failing on local machine due to static field dependency.Added that field in Test Cleanup.