### PR TITLE
Fixing CI build

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -50,7 +50,7 @@ $TFT_Pattern = $Pattern
 $TFT_Parallel = $Parallel
 $TFT_All = $All
 $TestFramework = ".NETCoreApp,Version=v1.0"
-$VSTestConsoleRelativePath = "Microsoft.TestPlatform.15.0.1\tools\net46\vstest.console.exe"
+$VSTestConsoleRelativePath = "Microsoft.TestPlatform.15.3.0\tools\net46\vstest.console.exe"
 
 #
 # Prints help text for the switches this script supports.

--- a/test/E2ETests/Automation.CLI/CLITestBase.cs
+++ b/test/E2ETests/Automation.CLI/CLITestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.MSTestV2.CLIAutomation
         private const string TestAssetsFolder = "TestAssets";
         private const string ArtifactsFolder = "artifacts";
         private const string PackagesFolder = "packages";
-        private const string TestPlatformCLIPackage = @"Microsoft.TestPlatform.15.0.1";
+        private const string TestPlatformCLIPackage = @"Microsoft.TestPlatform.15.3.0";
         private const string VstestConsoleRelativePath = @"tools\net46\vstest.console.exe";
 
         private static VsTestConsoleWrapper vsTestConsoleWrapper;

--- a/test/E2ETests/Automation.CLI/packages.config
+++ b/test/E2ETests/Automation.CLI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.TestPlatform" version="15.0.1" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform" version="15.3.0" targetFramework="net46" />
   <package id="Microsoft.TestPlatform.TranslationLayer" version="15.0.0-preview-20170130-01" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net46" developmentDependency="true" />


### PR DESCRIPTION
Dotnet Tests are failing because Test.cmd is using older version of vstest.console.exe whiling running tests.