### PR TITLE
Adding filtering support at discovery

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 var logger = (IMessageLogger)frameworkHandle;
 
                 // discover the tests
-                this.GetUnitTestDiscoverer().DiscoverTestsInSource(source, logger, discoverySink, runContext?.RunSettings);
+                this.GetUnitTestDiscoverer().DiscoverTestsInSource(source, logger, discoverySink, runContext);
                 tests.AddRange(discoverySink.Tests);
 
                 // Clear discoverSinksTests so that it just stores test for one source at one point of time

--- a/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
+++ b/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
@@ -50,7 +50,7 @@
     <Compile Include="Execution\TestAssemblyInfo.cs" />
     <Compile Include="Execution\TestClassInfo.cs" />
     <Compile Include="ObjectModel\TestFailedException.cs" />
-    <Compile Include="Execution\TestMethodFilter.cs" />
+    <Compile Include="TestMethodFilter.cs" />
     <Compile Include="Execution\TestMethodRunner.cs" />
     <Compile Include="Execution\TypeCache.cs" />
     <Compile Include="Execution\UnitTestRunner.cs" />

--- a/src/Adapter/MSTest.CoreAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/MSTestDiscoverer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
                 return;
             }
 
-            new UnitTestDiscoverer().DiscoverTests(sources, logger, discoverySink, discoveryContext?.RunSettings);
+            new UnitTestDiscoverer().DiscoverTests(sources, logger, discoverySink, discoveryContext);
         }
 
         /// <summary>

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
@@ -155,7 +155,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void GetFilterExpressionForDiscoveryContextWithoutGetTestCaseFilterReturnsNullTestCaseFilterExpression()
         {
             TestableTestExecutionRecorder recorder = new TestableTestExecutionRecorder();
-            var dummyFilterExpression = new TestableTestCaseFilterExpression();
             TestableDiscoveryContextWithoutGetTestCaseFilter discoveryContext = new TestableDiscoveryContextWithoutGetTestCaseFilter();
             bool filterHasError;
             var filterExpression = this.TestMethodFilter.GetFilterExpression(discoveryContext, recorder, out filterHasError);


### PR DESCRIPTION
TPv2 now exposes filtering support at discovery. 
Using that support via reflection (As filtering support is not exposed to IDiscoveryContext)