### PR TITLE
Put prefix of [MSTest][Discovery][<source>] for warning messages during discovery

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/UnitTestDiscoverer.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
 {
     using System.Collections.Generic;
+    using System.Globalization;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
@@ -69,7 +70,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
                     "MSTestDiscoverer: Warning during discovery from {0}. {1} ",
                     source,
                     warning);
-                logger.SendMessage(TestMessageLevel.Warning, warning);
+                var message = string.Format(CultureInfo.CurrentCulture, Resource.DiscoveryWarning, source, warning);
+                logger.SendMessage(TestMessageLevel.Warning, message);
             }
 
             // No tests found => nothing to do

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
@@ -125,6 +125,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [MSTest][Discovery][{0}] {1}.
+        /// </summary>
+        internal static string DiscoveryWarning {
+            get {
+                return ResourceManager.GetString("DiscoveryWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}: {1}.
         /// </summary>
         internal static string EnumeratorLoadTypeErrorFormat {

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
@@ -296,4 +296,7 @@
   <data name="UTA_CleanupStackTrace" xml:space="preserve">
     <value>TestCleanup Stack Trace</value>
   </data>
+  <data name="DiscoveryWarning" xml:space="preserve">
+    <value>[MSTest][Discovery][{0}] {1}</value>
+  </data>
 </root>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">Metoda TestCleanup {0}.{1} způsobila výjimku. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">Metoda TestCleanup {0}.{1} způsobila výjimku. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">Die {0}.{1}-Methode für 'TestCleanup' hat eine Ausnahme ausgelöst. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">Die {0}.{1}-Methode für 'TestCleanup' hat eine Ausnahme ausgelöst. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">El método TestCleanup {0}.{1} devolvió una excepción. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">El método TestCleanup {0}.{1} devolvió una excepción. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">La méthode TestCleanup {0}.{1} a levé une exception. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">La méthode TestCleanup {0}.{1} a levé une exception. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">Il metodo TestCleanup {0}.{1} ha generato un'eccezione. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">Il metodo TestCleanup {0}.{1} ha generato un'eccezione. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">TestCleanup メソッド {0}.{1} は例外をスローしました。{2}。</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">TestCleanup メソッド {0}.{1} は例外をスローしました。{2}。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">TestCleanup 메서드 {0}.{1}에서 예외를 throw했습니다. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">TestCleanup 메서드 {0}.{1}에서 예외를 throw했습니다. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">Metoda TestCleanup {0}.{1} zgłosiła wyjątek. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">Metoda TestCleanup {0}.{1} zgłosiła wyjątek. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">O método TestCleanup {0}.{1} gerou exceção. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">O método TestCleanup {0}.{1} gerou exceção. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">Метод TestCleanup {0}.{1} вызвал исключение. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">Метод TestCleanup {0}.{1} вызвал исключение. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">TestCleanup metodu {0}.{1} özel durum oluşturdu. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">TestCleanup metodu {0}.{1} özel durum oluşturdu. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
@@ -13,8 +13,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">TestCleanup method {0}.{1} threw exception. {2}.</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">TestCleanup method {0}.{1} threw exception. {2}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_EndOfInnerExceptionTrace">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">TestCleanup 方法 {0}.{1} 引发异常。{2}。</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">TestCleanup 方法 {0}.{1} 引发异常。{2}。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
@@ -147,8 +147,8 @@
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_CleanupMethodThrows">
-        <source>TestCleanup method {0}.{1} threw exception. {2}.</source>
-        <target state="translated">TestCleanup 方法 {0}.{1} 擲回例外狀況。{2}。</target>
+        <source>TestCleanup method {0}.{1} threw exception. {2}: {3}.</source>
+        <target state="new">TestCleanup 方法 {0}.{1} 擲回例外狀況。{2}。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_InstanceCreationError">
@@ -289,6 +289,21 @@
       <trans-unit id="TestContextMessageBanner">
         <source>TestContext Messages:</source>
         <target state="new">TestContext Messages:</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupMethodThrowsGeneralError">
+        <source>Error calling Test Cleanup method for test class {0}: {1}</source>
+        <target state="new">Error calling Test Cleanup method for test class {0}: {1}</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="UTA_CleanupStackTrace">
+        <source>TestCleanup Stack Trace</source>
+        <target state="new">TestCleanup Stack Trace</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="DiscoveryWarning">
+        <source>[MSTest][Discovery][{0}] {1}</source>
+        <target state="new">[MSTest][Discovery][{0}] {1}</target>
         <note></note>
       </trans-unit>
     </body>


### PR DESCRIPTION
Put prefix of [MSTest][Discovery][<source>] for warning messages during discovery

Warning message as reported by the user https://developercommunity.visualstudio.com/content/problem/114611/visual-studio-20173-unit-test-do-not-appear-random.html -- does not have right contextual info.