### PR TITLE
Dont throw exception if target framework is ".NETPortable,Version=v4.5,Profile=Profile259"

### DIFF
--- a/scripts/common.lib.ps1
+++ b/scripts/common.lib.ps1
@@ -126,8 +126,17 @@ function Locate-VsInstallPath($hasVsixExtension ="false"){
   Write-Verbose "$vswhere -latest -products * -requires $requiredPackageIds -property installationPath"
   try
   {
-    $vsInstallPath =  & $vswhere -latest -products * -requires $requiredPackageIds -property installationPath
-  }catch [System.Management.Automation.MethodInvocationException]
+       if ($Official)
+	   {
+           $vsInstallPath = & $vswhere -latest -products * -requires $requiredPackageIds -property installationPath
+       }
+       else
+	   {
+           # Allow using pre release versions of VS for dev builds
+           $vsInstallPath = & $vswhere -latest -prerelease -products * -requires $requiredPackageIds -property installationPath
+       }
+  }
+  catch [System.Management.Automation.MethodInvocationException]
   {
     Write-Error "Failed to find VS installation with requirements : $requiredPackageIds."
   }

--- a/src/Adapter/PlatformServices.Desktop/Utilities/AppDomainUtilities.cs
+++ b/src/Adapter/PlatformServices.Desktop/Utilities/AppDomainUtilities.cs
@@ -230,12 +230,20 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
         /// </summary>
         /// <param name="version">Target framework string</param>
         /// <returns>Framework Version</returns>
-        private static Version GetTargetFrameworkVersionFromVersionString(string version)
+        internal static Version GetTargetFrameworkVersionFromVersionString(string version)
         {
-            if (version.Length > PlatformServices.Constants.DotNetFrameWorkStringPrefix.Length + 1)
+            try
             {
-                string versionPart = version.Substring(PlatformServices.Constants.DotNetFrameWorkStringPrefix.Length + 1);
-                return new Version(versionPart);
+                if (version.Length > PlatformServices.Constants.DotNetFrameWorkStringPrefix.Length + 1)
+                {
+                    string versionPart = version.Substring(PlatformServices.Constants.DotNetFrameWorkStringPrefix.Length + 1);
+                    return new Version(versionPart);
+                }
+            }
+            catch (FormatException ex)
+            {
+                // if the version is ".NETPortable,Version=v4.5,Profile=Profile259", then above code will throw exception.
+                EqtTrace.Info(string.Format("AppDomainUtilities.GetTargetFrameworkVersionFromVersionString: Could not create version object from version string '{0}' due to error '{1}':", version, ex.Message));
             }
 
             return defaultVersion;

--- a/src/Adapter/PlatformServices.Desktop/Utilities/AppDomainUtilities.cs
+++ b/src/Adapter/PlatformServices.Desktop/Utilities/AppDomainUtilities.cs
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
             catch (FormatException ex)
             {
                 // if the version is ".NETPortable,Version=v4.5,Profile=Profile259", then above code will throw exception.
-                EqtTrace.Info(string.Format("AppDomainUtilities.GetTargetFrameworkVersionFromVersionString: Could not create version object from version string '{0}' due to error '{1}':", version, ex.Message));
+                EqtTrace.Warning(string.Format("AppDomainUtilities.GetTargetFrameworkVersionFromVersionString: Could not create version object from version string '{0}' due to error '{1}':", version, ex.Message));
             }
 
             return defaultVersion;

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Utilities/AppDomainUtilitiesTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Utilities/AppDomainUtilitiesTests.cs
@@ -88,7 +88,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Utilities
         {
             var expected = new Version("4.5");
 
-            var version = AppDomainUtilities.GetTargetFrameworkVersionFromVersionString(".Framework,Version=v4.5");
+            var version = AppDomainUtilities.GetTargetFrameworkVersionFromVersionString(".NETFramework,Version=v4.5");
 
             Assert.AreEqual(expected.Major, version.Major);
             Assert.AreEqual(expected.Minor, version.Minor);

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Utilities/AppDomainUtilitiesTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Utilities/AppDomainUtilitiesTests.cs
@@ -72,6 +72,28 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Utilities
             Assert.IsNull(setup.GetConfigurationBytes());
         }
 
+        [TestMethod]
+        public void GetTargetFrameworkVersionFromVersionStringShouldReturnDefaultVersionIfversionIsPortable()
+        {
+            var expected = new Version();
+
+            var version = AppDomainUtilities.GetTargetFrameworkVersionFromVersionString(".NETPortable,Version=v4.5,Profile=Profile259");
+
+            Assert.AreEqual(expected.Major, version.Major);
+            Assert.AreEqual(expected.Minor, version.Minor);
+        }
+
+        [TestMethod]
+        public void GetTargetFrameworkVersionFromVersionStringShouldReturnCurrectVersion()
+        {
+            var expected = new Version("4.5");
+
+            var version = AppDomainUtilities.GetTargetFrameworkVersionFromVersionString(".Framework,Version=v4.5");
+
+            Assert.AreEqual(expected.Major, version.Major);
+            Assert.AreEqual(expected.Minor, version.Minor);
+        }
+
         #region Testable Implementations
 
         internal class TestableXmlUtilities : XmlUtilities


### PR DESCRIPTION
Issue: https://devdiv.visualstudio.com/DevDiv/VS.in%20Agile%20Testing%20IDE/_workitems/edit/507887

Fix: Dont throw exception if target framework is ".NETPortable,Version=v4.5,Profile=Profile259"