### PR TITLE
Add information about which assembly failed to discover test into

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -144,11 +144,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                     "MSTestDiscoverer.TryGetTests: Failed to discover tests from {0}. Reason:{1}",
                     assemblyFileName,
                     ex);
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    Resource.TestAssembly_AssemblyDiscoveryFailure,
-                    fullFilePath,
-                    ex.Message);
+                var message = ex is FileNotFoundException fileNotFoundEx
+                    ? fileNotFoundEx.Message
+                    : string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resource.TestAssembly_AssemblyDiscoveryFailure,
+                        fullFilePath,
+                        ex.Message);
                 warnings.Add(message);
                 return null;
             }

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -90,8 +90,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                 {
                     var winrtFailureMessage = string.Format(
                         CultureInfo.CurrentCulture,
-                        Resource.TestAssembly_WinRTAssemblyDiscoveryFailure,
-                        fullFilePath,
+                        Resource.TestAssembly_AssemblyDiscoveryFailure,
+                        assemblyFileName,
                         e.Message);
                     warnings.Add(winrtFailureMessage);
                     return null;
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                     Resource.TestAssembly_AssemblyDiscoveryFailure,
                     fullFilePath,
                     ex.Message);
-                warnings.Add(ex.Message);
+                warnings.Add(message);
                 return null;
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -88,16 +88,31 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                 }
                 catch (Exception e)
                 {
-                    warnings.Add(e.Message);
+                    var winrtFailureMessage = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resource.TestAssembly_WinRTAssemblyDiscoveryFailure,
+                        fullFilePath,
+                        e.Message);
+                    warnings.Add(winrtFailureMessage);
                     return null;
                 }
 
-                warnings.Add(ex.Message);
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resource.TestAssembly_AssemblyDiscoveryFailure,
+                    fullFilePath,
+                    ex.Message);
+                warnings.Add(message);
                 return null;
             }
             catch (ReflectionTypeLoadException ex)
             {
-                warnings.Add(ex.Message);
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resource.TestAssembly_AssemblyDiscoveryFailure,
+                    fullFilePath,
+                    ex.Message);
+                warnings.Add(message);
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogWarning(
                     "MSPhoneTestDiscoverer.TryGetTests: Failed to discover tests from {0}. Reason:{1}",
                     assemblyFileName,
@@ -129,6 +144,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                     "MSTestDiscoverer.TryGetTests: Failed to discover tests from {0}. Reason:{1}",
                     assemblyFileName,
                     ex);
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resource.TestAssembly_AssemblyDiscoveryFailure,
+                    fullFilePath,
+                    ex.Message);
                 warnings.Add(ex.Message);
                 return null;
             }

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to discover tests from assembly located at {0}. Reason:{1}.
+        ///   Looks up a localized string similar to Failed to discover tests from assembly {0}. Reason:{1}.
         /// </summary>
         internal static string TestAssembly_AssemblyDiscoveryFailure {
             get {
@@ -220,15 +220,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         internal static string TestAssembly_FileDoesNotExist {
             get {
                 return ResourceManager.GetString("TestAssembly_FileDoesNotExist", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to discover tests from WinRT assembly located at {0}. Reason:{1}.
-        /// </summary>
-        internal static string TestAssembly_WinRTAssemblyDiscoveryFailure {
-            get {
-                return ResourceManager.GetString("TestAssembly_WinRTAssemblyDiscoveryFailure", resourceCulture);
             }
         }
         

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
@@ -206,11 +206,29 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to discover tests from assembly located at {0}. Reason:{1}.
+        /// </summary>
+        internal static string TestAssembly_AssemblyDiscoveryFailure {
+            get {
+                return ResourceManager.GetString("TestAssembly_AssemblyDiscoveryFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File does not exist: {0}.
         /// </summary>
         internal static string TestAssembly_FileDoesNotExist {
             get {
                 return ResourceManager.GetString("TestAssembly_FileDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to discover tests from WinRT assembly located at {0}. Reason:{1}.
+        /// </summary>
+        internal static string TestAssembly_WinRTAssemblyDiscoveryFailure {
+            get {
+                return ResourceManager.GetString("TestAssembly_WinRTAssemblyDiscoveryFailure", resourceCulture);
             }
         }
         

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
@@ -311,9 +311,6 @@
     <comment>`Workers` is a setting name that shouldn't be localized.</comment>
   </data>
   <data name="TestAssembly_AssemblyDiscoveryFailure" xml:space="preserve">
-    <value>Failed to discover tests from assembly located at {0}. Reason:{1}</value>
-  </data>
-  <data name="TestAssembly_WinRTAssemblyDiscoveryFailure" xml:space="preserve">
-    <value>Failed to discover tests from WinRT assembly located at {0}. Reason:{1}</value>
+    <value>Failed to discover tests from assembly {0}. Reason:{1}</value>
   </data>
 </root>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
@@ -310,4 +310,10 @@
     <value>Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</value>
     <comment>`Workers` is a setting name that shouldn't be localized.</comment>
   </data>
+  <data name="TestAssembly_AssemblyDiscoveryFailure" xml:space="preserve">
+    <value>Failed to discover tests from assembly located at {0}. Reason:{1}</value>
+  </data>
+  <data name="TestAssembly_WinRTAssemblyDiscoveryFailure" xml:space="preserve">
+    <value>Failed to discover tests from WinRT assembly located at {0}. Reason:{1}</value>
+  </data>
 </root>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
@@ -321,6 +321,11 @@
         <target state="new">Invalid value '{0}' specified for 'Workers'. The value should be a non-negative integer.</target>
         <note>`Workers` is a setting name that shouldn't be localized.</note>
       </trans-unit>
+      <trans-unit id="TestAssembly_AssemblyDiscoveryFailure">
+        <source>Failed to discover tests from assembly {0}. Reason:{1}</source>
+        <target state="new">Failed to discover tests from assembly {0}. Reason:{1}</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorWrapperTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorWrapperTests.cs
@@ -78,10 +78,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
 
             // Also validate that we give a warning when this happens.
             Assert.IsNotNull(this.warnings);
-            var message = string.Format(
+            var innerMessage = string.Format(
                 CultureInfo.CurrentCulture,
                 Resource.TestAssembly_FileDoesNotExist,
                 assemblyName);
+            var message = string.Format(
+                CultureInfo.CurrentCulture,
+                Resource.TestAssembly_AssemblyDiscoveryFailure,
+                assemblyName,
+                innerMessage);
             CollectionAssert.Contains(this.warnings.ToList(), message);
         }
 


### PR DESCRIPTION
Having indicate location of the assembly from which discovery happens allow developer reason about possible failures, and manually troubleshoot his configuration issues which cause asembly to fail

This allow simplify resolution of the issues like #295 and similar where it is not clear what exactly happens. For example when you run tests from multiple assemblies, like in VSTS CI build