### PR TITLE
Fix paths to xlftool to make it work with VS 15.4

### DIFF
--- a/scripts/build/TestFx.Loc.targets
+++ b/scripts/build/TestFx.Loc.targets
@@ -29,15 +29,15 @@
     <CreateItem Include="@(ResxResources)" AdditionalMetadata="Language=%(ResxLang.Identity)">
       <Output ItemName="LocResourceFile" TaskParameter="Include"/>
     </CreateItem>
-    <Exec Command="$(TestFxPackagesRoot)fmdev.xlftool\0.1.3\tools\xlftool.exe update -Resx %(LocResourceFile.Identity) -Xlf $(ResourceDirectory)\xlf\%(LocResourceFile.Filename).%(LocResourceFile.Language).xlf" />
-    <Exec Command="$(TestFxPackagesRoot)fmdev.xlftool\0.1.3\tools\xlftool.exe update -Resx %(ResxResources.Identity) -Xlf $(ResourceDirectory)\xlf\%(ResxResources.Filename).xlf" />
+    <Exec Command="$(TestFxPackagesRoot)fmdev.xlftool.0.1.3\tools\xlftool.exe update -Resx %(LocResourceFile.Identity) -Xlf $(ResourceDirectory)\xlf\%(LocResourceFile.Filename).%(LocResourceFile.Language).xlf" />
+    <Exec Command="$(TestFxPackagesRoot)fmdev.xlftool.0.1.3\tools\xlftool.exe update -Resx %(ResxResources.Identity) -Xlf $(ResourceDirectory)\xlf\%(ResxResources.Filename).xlf" />
   </Target>
 
   <Target Name="CreateLocalizeResx" Condition="'$(IsLocalizedBuild)' == 'true'">
     <CreateItem Include="@(ResxResources)" AdditionalMetadata="Language=%(ResxLang.Identity)">
       <Output ItemName="LocResourceFile" TaskParameter="Include"/>
     </CreateItem>
-    <Exec Command="$(TestFxPackagesRoot)fmdev.xlftool\0.1.3\tools\xlftool.exe  writeTarget -Xlf $(ResourceDirectory)\xlf\%(LocResourceFile.Filename).%(LocResourceFile.Language).xlf -Resx $(ResourceDirectory)\%(LocResourceFile.Filename).%(LocResourceFile.Language).resx -verbose" />
+    <Exec Command="$(TestFxPackagesRoot)fmdev.xlftool.0.1.3\tools\xlftool.exe  writeTarget -Xlf $(ResourceDirectory)\xlf\%(LocResourceFile.Filename).%(LocResourceFile.Language).xlf -Resx $(ResourceDirectory)\%(LocResourceFile.Filename).%(LocResourceFile.Language).resx -verbose" />
     <ItemGroup>
       <EmbeddedResource Include="$(ResourceDirectory)\%(LocResourceFile.Filename).%(LocResourceFile.Language).resx" />
     </ItemGroup>
@@ -45,7 +45,7 @@
   
   <!-- Localization for documentation files. -->
   <Target Name="CopyLocalizedXmls" BeforeTargets="BeforeBuild" Condition="$(LocDocumentationSubPath) != ''">
-    <Exec Command="xcopy /Y /I /S /E $(TestFxPackagesRoot)MSTest.Internal.TestFx.Localized.Documentation\1.0.0-build-20170420-1\contentFiles\any\any\$(LocDocumentationSubPath) $(OutDir)" />
+    <Exec Command="xcopy /Y /I /S /E $(TestFxPackagesRoot)MSTest.Internal.TestFx.Localized.Documentation.1.0.0-build-20170420-1\contentFiles\any\any\$(LocDocumentationSubPath) $(OutDir)" />
   </Target>
 
   <!-- Localization for vsix files.-->

--- a/test/UnitTests/PlatformServices.Universal.Unit.Tests/PlatformServices.Universal.Unit.Tests.csproj
+++ b/test/UnitTests/PlatformServices.Universal.Unit.Tests/PlatformServices.Universal.Unit.Tests.csproj
@@ -49,7 +49,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="$(TestFxRoot)packages\Microsoft.Internal.TestPlatform.ObjectModel\14.0.0\lib\uap10.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
+    <Reference Include="$(TestFxRoot)packages\Microsoft.Internal.TestPlatform.ObjectModel.14.0.0\lib\uap10.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/test/UnitTests/PlatformServices.Universal.Unit.Tests/packages.config
+++ b/test/UnitTests/PlatformServices.Universal.Unit.Tests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.8" targetFramework="net452" />
+  <package id="Microsoft.Internal.TestPlatform.ObjectModel" version="14.0.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Since I don't closely monitor changes in the NuGet behavior I could not say is this a settled fix, or it will not cover all cases and both ways should be supported.
Without that change I receive errors when run `Build.cmd`