### PR TITLE
Safely Invoke methods which are called via reflection

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/TestMethodFilter.cs
+++ b/src/Adapter/MSTest.CoreAdapter/TestMethodFilter.cs
@@ -96,6 +96,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             return null;
         }
 
+        private static object SafeInvoke<T>(Func<T> action)
+        {
+            try
+            {
+                return action.Invoke();
+            }
+            catch (Exception)
+            {
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Gets filter expression from run context.
         /// </summary>
@@ -117,7 +130,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             {
                 // GetTestCaseFilter is present in DiscoveryContext but not in IDiscoveryContext interface.
                 MethodInfo methodGetTestCaseFilter = context.GetType().GetRuntimeMethod("GetTestCaseFilter", new[] { typeof(IEnumerable<string>), typeof(Func<string, TestProperty>) });
-                return (ITestCaseFilterExpression)methodGetTestCaseFilter?.Invoke(context, new object[] { this.supportedProperties.Keys, (Func<string, TestProperty>)this.PropertyProvider });
+                return SafeInvoke(() => methodGetTestCaseFilter?.Invoke(context, new object[] { this.supportedProperties.Keys, (Func<string, TestProperty>)this.PropertyProvider })) as ITestCaseFilterExpression;
             }
             catch (TargetInvocationException ex)
             {

--- a/src/Adapter/MSTest.CoreAdapter/TestMethodFilter.cs
+++ b/src/Adapter/MSTest.CoreAdapter/TestMethodFilter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             {
                 try
                 {
-                    filter = (context is IRunContext) ? this.GetTestCaseFilterFromRunContext(context as IRunContext) : this.GetTestCaseFilterFromDiscoveryContext(context);
+                    filter = (context is IRunContext) ? this.GetTestCaseFilterFromRunContext(context as IRunContext) : this.GetTestCaseFilterFromDiscoveryContext(context, logger);
                 }
                 catch (TestPlatformFormatException ex)
                 {
@@ -96,14 +96,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             return null;
         }
 
-        private static object SafeInvoke<T>(Func<T> action)
+        private static object SafeInvoke<T>(Func<T> action, IMessageLogger logger)
         {
             try
             {
                 return action.Invoke();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                logger.SendMessage(TestMessageLevel.Warning, ex.Message);
             }
 
             return null;
@@ -123,14 +124,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         /// Gets filter expression from discovery context.
         /// </summary>
         /// <param name="context">Discovery context</param>
+        /// <param name="logger">Handler to report error messages.</param>
         /// <returns>Filter expression.</returns>
-        private ITestCaseFilterExpression GetTestCaseFilterFromDiscoveryContext(IDiscoveryContext context)
+        private ITestCaseFilterExpression GetTestCaseFilterFromDiscoveryContext(IDiscoveryContext context, IMessageLogger logger)
         {
             try
             {
                 // GetTestCaseFilter is present in DiscoveryContext but not in IDiscoveryContext interface.
                 MethodInfo methodGetTestCaseFilter = context.GetType().GetRuntimeMethod("GetTestCaseFilter", new[] { typeof(IEnumerable<string>), typeof(Func<string, TestProperty>) });
-                return SafeInvoke(() => methodGetTestCaseFilter?.Invoke(context, new object[] { this.supportedProperties.Keys, (Func<string, TestProperty>)this.PropertyProvider })) as ITestCaseFilterExpression;
+                return SafeInvoke(() => methodGetTestCaseFilter?.Invoke(context, new object[] { this.supportedProperties.Keys, (Func<string, TestProperty>)this.PropertyProvider }), logger) as ITestCaseFilterExpression;
             }
             catch (TargetInvocationException ex)
             {


### PR DESCRIPTION
The exception is thrown in UWP release with .net native compilation being enabled.
The exception is "Arg_NotImplementedException" which means that the request method was not implemented. https://github.com/dotnet/corert/blob/35f68948d5ef585b67f820efd5936091f67b5418/src/System.Private.CoreLib/src/Resources/Strings.resx#L369