### PR TITLE
Making TestContext property name more generic

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -24,11 +24,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
     internal class TypeCache : MarshalByRefObject
     {
         /// <summary>
-        /// Test context property name
-        /// </summary>
-        private const string TestContextPropertyName = "TestContext";
-
-        /// <summary>
         /// Predefined test Attribute names.
         /// </summary>
         private static readonly string[] PredefinedNames = new string[] { "Priority", "TestCategory", "Owner" };
@@ -310,29 +305,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <returns> The <see cref="PropertyInfo"/> for TestContext property. Null if not defined. </returns>
         private PropertyInfo ResolveTestContext(Type classType)
         {
-            try
-            {
-                var testContextProperty = classType.GetRuntimeProperty(TestContextPropertyName);
-                if (testContextProperty == null)
-                {
-                    // that's okay may be the property was not defined
-                    return null;
-                }
-
-                // check if testContextProperty is of correct type
-                if (!testContextProperty.PropertyType.FullName.Equals(typeof(TestContext).FullName, StringComparison.Ordinal))
-                {
-                    var errorMessage = string.Format(CultureInfo.CurrentCulture, Resource.UTA_TestContextTypeMismatchLoadError, classType.FullName);
-                    throw new TypeInspectionException(errorMessage);
-                }
-
-                return testContextProperty;
-            }
-            catch (AmbiguousMatchException ex)
-            {
-                var errorMessage = string.Format(CultureInfo.CurrentCulture, Resource.UTA_TestContextLoadError, classType.FullName, ex.Message);
-                throw new TypeInspectionException(errorMessage);
-            }
+            return classType.
+                            GetRuntimeProperties().
+                            Where(p => p != null && p.PropertyType.FullName.Equals(typeof(TestContext).FullName, StringComparison.Ordinal)).
+                            FirstOrDefault();
         }
 
         #endregion

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -531,29 +531,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find property {0}.TestContext. Error:{1}..
-        /// </summary>
-        internal static string UTA_TestContextLoadError {
-            get {
-                return ResourceManager.GetString("UTA_TestContextLoadError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to set TestContext property for the class {0}. Error: {1}..
         /// </summary>
         internal static string UTA_TestContextSetError {
             get {
                 return ResourceManager.GetString("UTA_TestContextSetError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The {0}.TestContext has incorrect type..
-        /// </summary>
-        internal static string UTA_TestContextTypeMismatchLoadError {
-            get {
-                return ResourceManager.GetString("UTA_TestContextTypeMismatchLoadError", resourceCulture);
             }
         }
         

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
@@ -237,12 +237,6 @@
   <data name="UTA_NoDefaultConstructor" xml:space="preserve">
     <value>Unable to get default constructor for class {0}.</value>
   </data>
-  <data name="UTA_TestContextLoadError" xml:space="preserve">
-    <value>Unable to find property {0}.TestContext. Error:{1}.</value>
-  </data>
-  <data name="UTA_TestContextTypeMismatchLoadError" xml:space="preserve">
-    <value>The {0}.TestContext has incorrect type.</value>
-  </data>
   <data name="UTA_TestInitializeAndCleanupMethodHasWrongSignature" xml:space="preserve">
     <value>Method {0}.{1} has wrong signature. The method must be non-static, public, does not return a value and should not take any parameter. Additionally, if you are using async-await in method then return-type must be Task.</value>
   </data>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Nepodařilo se vytvořit instanci třídy {0}. Chyba: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext má nesprávný typ.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Trasování ladění:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Pro třídu {0} se nepodařilo najít výchozí konstruktor.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Nepodařilo se najít vlastnost {0}.TestContext. Chyba:{1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Es kann keine Instanz der Klasse '{0}' erstellt werden. Fehler: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">"{0}.TestContext" weist einen falschen Typ auf.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Debugablaufverfolgung:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Der Standardkonstruktor für die Klasse "{0}" kann nicht abgerufen werden.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Die Eigenschaft "{0}.TestContext" wurde nicht gefunden. Fehler: {1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
@@ -156,11 +156,6 @@
         <target state="translated">No se puede crear una instancia de la clase {0}. Error: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">Tipo {0}.TestContext no es correcto.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Seguimiento de depuración:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">No se puede obtener el constructor predeterminado para la clase {0}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">No se puede encontrar la propiedad {0}.TestContext. Error:{1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Impossible de créer une instance de la classe {0}. Erreur : {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext possède un type incorrect.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Trace du débogage :</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Impossible d'obtenir le constructeur par défaut de la classe {0}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Propriété {0}.TestContext introuvable. Erreur :{1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Non è possibile creare un'istanza della classe {0}. Errore: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">Il tipo di {0}.TestContext non è corretto.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Traccia di debug:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Non è possibile ottenere il costruttore predefinito per la classe {0}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">La proprietà {0}.TestContext non è stata trovata. Errore: {1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
@@ -156,11 +156,6 @@
         <target state="translated">クラス {0} のインスタンスを作成できません。エラー: {1}。</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext は不適切な型を含んでいます。</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">デバッグ トレース:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">クラス {0} の既定コンストラクターを取得できません。</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">プロパティ {0}.TestContext が見つかりません。エラー: {1}。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
@@ -156,11 +156,6 @@
         <target state="translated">{0} 클래스의 인스턴스를 만들 수 없습니다. 오류: {1}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext의 형식이 잘못되었습니다.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">디버그 추적:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">{0} 클래스의 기본 생성자를 가져올 수 없습니다.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">{0}.TestContext 속성을 찾을 수 없습니다. 오류: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Nie można utworzyć wystąpienia klasy {0}. Błąd: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">Właściwość {0}.TestContext ma niepoprawny typ.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Śledzenie debugowania:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Nie można pobrać domyślnego konstruktora dla klasy {0}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Nie można odnaleźć właściwości {0}.TestContext. Błąd:{1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Não é possível criar instância da classe {0}. Erro: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">O {0}.TestContext é do tipo incorreto.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Rastreamento de Depuração:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Não é possível obter o construtor padrão para a classe {0}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Não é possível encontrar propriedade {0}.TestContext. Erro:{1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
@@ -156,11 +156,6 @@
         <target state="translated">Не удалось создать экземпляр класса {0}. Ошибка: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">Для свойства {0}.TestContext указан неправильный тип.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Трассировка отладки:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">Не удается получить конструктор по умолчанию для класса {0}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Не удается найти свойство {0}.TestContext. Ошибка: {1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
@@ -156,11 +156,6 @@
         <target state="translated">{0} sınıfının örneği oluşturulamıyor. Hata: {1}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext yanlış türe sahip.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">Hata Ayıklama İzleyici:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">{0} sınıfı için varsayılan oluşturucu alınamıyor.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">{0}.TestContext özelliği bulunamıyor. Hata:{1}.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
@@ -202,16 +202,6 @@
         <target state="translated">Unable to get default constructor for class {0}.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">Unable to find property {0}.TestContext. Error:{1}.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">The {0}.TestContext has incorrect type.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="UTA_TestInitializeAndCleanupMethodHasWrongSignature">
         <source>Method {0}.{1} has wrong signature. The method must be non-static, public, does not return a value and should not take any parameter. Additionally, if you are using async-await in method then return-type must be Task.</source>
         <target state="translated">Method {0}.{1} has wrong signature. The method must be non-static, public, does not return a value and should not take any parameter. Additionally, if you are using async-await in method then return-type must be Task.</target>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
@@ -156,11 +156,6 @@
         <target state="translated">无法创建类 {0} 的实例。错误: {1}。</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext 的类型不正确。</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">调试跟踪:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">无法获取类 {0} 的默认构造函数。</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">无法找到属性 {0}.TestContext。错误: {1}。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
@@ -156,11 +156,6 @@
         <target state="translated">無法建立類別 {0} 的執行個體。錯誤: {1}。</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="UTA_TestContextTypeMismatchLoadError">
-        <source>The {0}.TestContext has incorrect type.</source>
-        <target state="translated">{0}.TestContext 有不正確的類型。</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DebugTraceBanner">
         <source>Debug Trace:</source>
         <target state="translated">偵錯追蹤:</target>
@@ -239,11 +234,6 @@
       <trans-unit id="UTA_NoDefaultConstructor">
         <source>Unable to get default constructor for class {0}.</source>
         <target state="translated">無法取得類別 {0} 的預設建構函式。</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="UTA_TestContextLoadError">
-        <source>Unable to find property {0}.TestContext. Error:{1}.</source>
-        <target state="translated">找不到屬性 {0}.TestContext。錯誤: {1}。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="EnumeratorLoadTypeErrorFormat">


### PR DESCRIPTION
Picking up any property that is of a TestContext type instead. Reduces the confusion users run into when declaring a TestContext property.
In part stemmed out of #255 and a few off band reports.