### PR TITLE
Add missing Microsoft.Internal.TestPlatform.ObjectModel

### DIFF
--- a/test/UnitTests/PlatformServices.Universal.Unit.Tests/packages.config
+++ b/test/UnitTests/PlatformServices.Universal.Unit.Tests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.8" targetFramework="net452" />
+  <package id="Microsoft.Internal.TestPlatform.ObjectModel" version="14.0.0" targetFramework="net452" /> 
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This is part of #301 which could be accepted according to review. 
Since I still want to be able build project on my computer, I probably try to find way build project on my computer if needed and find way which will work both on your CI and on my PC.