### PR TITLE
Update ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Description
-> Describe the issue you've observed
+> **IMPORTANT**: if the defect is reproduced only in a workflow from within the Visual Studio IDE then do not report the issue here - instead, please report it using Visual Studio's "Send Feedback" option that can be accessed from the Help menu OR using this link https://developercommunity.visualstudio.com.
+>
+> For a defect specific to the MSTest V2 test framework, describe the issue you've observed.
 
 ## Steps to reproduce
 > What steps can reproduce the defect?


### PR DESCRIPTION
Added a note calling out that this template is only to file issues specific to MSTest V2 test framework, and where to file IDE related issues. A similar change has been made to the vstest issue template as well.