### PR TITLE
Parent test result support for data driven tests

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Constants.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Constants.cs
@@ -44,6 +44,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
 
         internal static readonly TestProperty DoNotParallelizeProperty = TestProperty.Register("MSTestDiscoverer.DoNotParallelize", DoNotParallelizeLabel, typeof(bool), TestPropertyAttributes.Hidden, typeof(TestCase));
 
+        internal static readonly TestProperty ExecutionIdProperty = TestProperty.Register("ExecutionId", ExecutionIdLabel, typeof(Guid), TestPropertyAttributes.Hidden, typeof(TestResult));
+
+        internal static readonly TestProperty ParentExecIdProperty = TestProperty.Register("ParentExecId", ParentExecIdLabel, typeof(Guid), TestPropertyAttributes.Hidden, typeof(TestResult));
+
         #endregion
 
         #region Private Constants
@@ -59,6 +63,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         private const string PriorityLabel = "Priority";
         private const string DeploymentItemsLabel = "DeploymentItems";
         private const string DoNotParallelizeLabel = "DoNotParallelize";
+        private const string ExecutionIdLabel = "ExecutionId";
+        private const string ParentExecIdLabel = "ParentExecId";
 
         #endregion
     }

--- a/src/Adapter/MSTest.CoreAdapter/Constants.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Constants.cs
@@ -48,6 +48,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
 
         internal static readonly TestProperty ParentExecIdProperty = TestProperty.Register("ParentExecId", ParentExecIdLabel, typeof(Guid), TestPropertyAttributes.Hidden, typeof(TestResult));
 
+        internal static readonly TestProperty InnerResultsCountProperty = TestProperty.Register("InnerResultsCount", InnerResultsCountLabel, typeof(int), TestPropertyAttributes.Hidden, typeof(TestResult));
+
         #endregion
 
         #region Private Constants
@@ -65,6 +67,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         private const string DoNotParallelizeLabel = "DoNotParallelize";
         private const string ExecutionIdLabel = "ExecutionId";
         private const string ParentExecIdLabel = "ParentExecId";
+        private const string InnerResultsCountLabel = "InnerResultsCount";
 
         #endregion
     }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -272,9 +272,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                                     currentResult.ParentExecId = parentResult.ExecutionId;
                                     watch.Stop();
                                     currentResult.Duration = watch.Elapsed;
+                                    results.Add(currentResult);
 
                                     parentResult.Outcome = UnitTestOutcomeExtensions.GetMoreImportantOutcome(parentResult.Outcome, currentResult.Outcome);
-                                    results.Add(currentResult);
+                                    parentResult.InnerResultsCount++;
                                 }
                             }
                             finally
@@ -330,9 +331,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                                 currentResult.DisplayName = testDataSource.GetDisplayName(this.testMethodInfo.MethodInfo, data);
                                 currentResult.ParentExecId = parentResult.ExecutionId;
+                                results.Add(currentResult);
 
                                 parentResult.Outcome = UnitTestOutcomeExtensions.GetMoreImportantOutcome(parentResult.Outcome, currentResult.Outcome);
-                                results.Add(currentResult);
+                                parentResult.InnerResultsCount++;
                                 this.testMethodInfo.SetArguments(null);
                             }
                         }

--- a/src/Adapter/MSTest.CoreAdapter/Extensions/TestResultExtensions.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Extensions/TestResultExtensions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions
                 unitTestResult.ResultFiles = testResults[i].ResultFiles;
                 unitTestResult.ExecutionId = testResults[i].ExecutionId;
                 unitTestResult.ParentExecId = testResults[i].ParentExecId;
+                unitTestResult.InnerResultsCount = testResults[i].InnerResultsCount;
                 unitTestResults[i] = unitTestResult;
             }
 

--- a/src/Adapter/MSTest.CoreAdapter/Extensions/TestResultExtensions.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Extensions/TestResultExtensions.cs
@@ -47,6 +47,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions
                 unitTestResult.DisplayName = testResults[i].DisplayName;
                 unitTestResult.DatarowIndex = testResults[i].DatarowIndex;
                 unitTestResult.ResultFiles = testResults[i].ResultFiles;
+                unitTestResult.ExecutionId = testResults[i].ExecutionId;
+                unitTestResult.ParentExecId = testResults[i].ParentExecId;
                 unitTestResults[i] = unitTestResult;
             }
 

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
@@ -86,6 +86,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         public Guid ParentExecId { get; internal set; }
 
         /// <summary>
+        /// Gets the inner results count of the result
+        /// </summary>
+        public int InnerResultsCount { get; internal set; }
+
+        /// <summary>
         /// Gets the duration of the result
         /// </summary>
         public TimeSpan Duration { get; internal set; }
@@ -161,6 +166,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
 
             testResult.SetPropertyValue<Guid>(Constants.ExecutionIdProperty, this.ExecutionId);
             testResult.SetPropertyValue<Guid>(Constants.ParentExecIdProperty, this.ParentExecId);
+            testResult.SetPropertyValue<int>(Constants.InnerResultsCountProperty, this.InnerResultsCount);
 
             if (!string.IsNullOrEmpty(this.StandardOut))
             {

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
@@ -76,6 +76,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         public string ErrorStackTrace { get; internal set; }
 
         /// <summary>
+        /// Gets the execution id of the result
+        /// </summary>
+        public Guid ExecutionId { get; internal set; }
+
+        /// <summary>
+        /// Gets the parent execution id of the result
+        /// </summary>
+        public Guid ParentExecId { get; internal set; }
+
+        /// <summary>
         /// Gets the duration of the result
         /// </summary>
         public TimeSpan Duration { get; internal set; }
@@ -148,6 +158,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
                                             StartTime = startTime,
                                             EndTime = endTime
             };
+
+            testResult.SetPropertyValue<Guid>(Constants.ExecutionIdProperty, this.ExecutionId);
+            testResult.SetPropertyValue<Guid>(Constants.ParentExecIdProperty, this.ParentExecId);
 
             if (!string.IsNullOrEmpty(this.StandardOut))
             {

--- a/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
@@ -412,6 +412,16 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         public string TestContextMessages { get; set; }
 
         /// <summary>
+        /// Gets or sets the execution id of the result.
+        /// </summary>
+        public Guid ExecutionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent execution id of the result.
+        /// </summary>
+        public Guid ParentExecId { get; set; }
+
+        /// <summary>
         /// Gets or sets the duration of test execution.
         /// </summary>
         public TimeSpan Duration { get; set; }

--- a/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
@@ -422,6 +422,11 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         public Guid ParentExecId { get; set; }
 
         /// <summary>
+        /// Gets or sets the inner results count of the result.
+        /// </summary>
+        public int InnerResultsCount { get; set; }
+
+        /// <summary>
         /// Gets or sets the duration of test execution.
         /// </summary>
         public TimeSpan Duration { get; set; }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Assert.AreEqual("PassingTest  Passed", this.frameworkHandle.ResultsList[0]);
             StringAssert.Contains(
                 this.frameworkHandle.ResultsList[1],
-                "FailingTest  Failed\r\n  Message: Assert.Fail failed. \r\n  StackTrace:\n   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestExecutionManagerTests.DummyTestClass.FailingTest()");
+                "FailingTest  Failed\r\n  Message: Assert.Fail failed. \r\n  StackTrace:\r\n   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestExecutionManagerTests.DummyTestClass.FailingTest()");
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Assert.AreEqual("PassingTest  Passed", this.frameworkHandle.ResultsList[0]);
             StringAssert.Contains(
                 this.frameworkHandle.ResultsList[1],
-                "FailingTest  Failed\r\n  Message: Assert.Fail failed. \r\n  StackTrace:\r\n   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestExecutionManagerTests.DummyTestClass.FailingTest()");
+                "FailingTest  Failed\r\n  Message: Assert.Fail failed. \r\n  StackTrace:\n   at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestExecutionManagerTests.DummyTestClass.FailingTest()");
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
@@ -516,9 +516,31 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var results = testMethodRunner.RunTestMethod();
 
             // check for datarowIndex
-            Assert.AreEqual(results[0].DatarowIndex, 0);
-            Assert.AreEqual(results[1].DatarowIndex, 1);
-            Assert.AreEqual(results[2].DatarowIndex, 2);
+            Assert.AreEqual(results[0].DatarowIndex, -1);
+            Assert.AreEqual(results[1].DatarowIndex, 0);
+            Assert.AreEqual(results[2].DatarowIndex, 1);
+            Assert.AreEqual(results[3].DatarowIndex, 2);
+        }
+
+        [TestMethodV1]
+        public void RunTestMethodShouldReturnParentResultForDataDrivenTests()
+        {
+            var testMethodInfo = new TestableTestmethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions, () => new UTF.TestResult());
+            var testMethodRunner = new TestMethodRunner(testMethodInfo, this.testMethod, this.testContextImplementation, false);
+
+            UTF.DataSourceAttribute dataSourceAttribute = new UTF.DataSourceAttribute("DummyConnectionString", "DummyTableName");
+
+            var attribs = new Attribute[] { dataSourceAttribute };
+
+            // Setup mocks
+            this.testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(this.methodInfo, It.IsAny<Type>(), It.IsAny<bool>())).Returns(attribs);
+            this.testablePlatformServiceProvider.MockTestDataSource.Setup(tds => tds.GetData(testMethodInfo, this.testContextImplementation)).Returns(new object[] { 1, 2, 3 });
+
+            var results = testMethodRunner.RunTestMethod();
+
+            // check for parent result
+            Assert.AreEqual(4, results.Length);
+            Assert.AreEqual(results[0].ExecutionId, results[1].ParentExecId);
         }
 
         [TestMethodV1]
@@ -543,9 +565,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var results = testMethodRunner.RunTestMethod();
 
             // check for datarowIndex as only DataSource Tests are Run
-            Assert.AreEqual(results[0].DatarowIndex, 0);
-            Assert.AreEqual(results[1].DatarowIndex, 1);
-            Assert.AreEqual(results[2].DatarowIndex, 2);
+            Assert.AreEqual(results[0].DatarowIndex, -1);
+            Assert.AreEqual(results[1].DatarowIndex, 0);
+            Assert.AreEqual(results[2].DatarowIndex, 1);
+            Assert.AreEqual(results[3].DatarowIndex, 2);
         }
 
         [TestMethodV1]
@@ -568,7 +591,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockReflectionOperations.Setup(ro => ro.GetCustomAttributes(this.methodInfo, It.IsAny<Type>(), It.IsAny<bool>())).Returns(attribs);
 
             var results = testMethodRunner.RunTestMethod();
-            Assert.AreEqual(results[0].DisplayName, "DataRowTestDisplayName");
+            Assert.AreEqual(results[1].DisplayName, "DataRowTestDisplayName");
         }
 
         [TestMethodV1]
@@ -590,7 +613,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(this.methodInfo, It.IsAny<Type>(), It.IsAny<bool>())).Returns(attribs);
 
             var results = testMethodRunner.RunTestMethod();
-            Assert.AreEqual(results[0].DisplayName, "DummyTestMethod (2,DummyString)");
+            Assert.AreEqual(results[1].DisplayName, "DummyTestMethod (2,DummyString)");
         }
 
         [TestMethodV1]
@@ -613,8 +636,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(this.methodInfo, It.IsAny<Type>(), It.IsAny<bool>())).Returns(attribs);
 
             var results = testMethodRunner.RunTestMethod();
-            CollectionAssert.Contains(results[0].ResultFiles.ToList(), "C:\\temp.txt");
             CollectionAssert.Contains(results[1].ResultFiles.ToList(), "C:\\temp.txt");
+            CollectionAssert.Contains(results[2].ResultFiles.ToList(), "C:\\temp.txt");
         }
 
         #region Test data


### PR DESCRIPTION
Mstest v2 adapter changes:

1. Created parent test result for mstest v1 data driven tests
2. passing execution id and parent exeuction id to test platform via test result’s properties.