### PR TITLE
Make GenericParameterHelper's behavior same between running and debugging

### DIFF
--- a/src/TestFramework/MSTest.Core/GenericParameterHelper.cs
+++ b/src/TestFramework/MSTest.Core/GenericParameterHelper.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     public class GenericParameterHelper : IComparable, IEnumerable
     {
         #region Private Fields
+        private static readonly Random Randomizer = new Random();
         private int data;
         private IList ienumerableStore;
 
@@ -40,8 +41,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </remarks>
         public GenericParameterHelper()
         {
-            Random randomizer = new Random();
-            this.Data = randomizer.Next();
+            this.Data = Randomizer.Next();
         }
 
         /// <summary>

--- a/test/UnitTests/MSTest.Core.Unit.Tests/GenericParameterHelperTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/GenericParameterHelperTests.cs
@@ -30,6 +30,15 @@ namespace UnitTestFramework.Tests
         }
 
         [TestFrameworkV1.TestMethod]
+        public void EqualsShouldReturnFalseIfEachObjectHasDefaultDataValue()
+        {
+            TestFrameworkV2.GenericParameterHelper firstObject = new TestFrameworkV2.GenericParameterHelper();
+            TestFrameworkV2.GenericParameterHelper secondObject = new TestFrameworkV2.GenericParameterHelper();
+
+            TestFrameworkV1.Assert.IsFalse(firstObject.Equals(secondObject));
+        }
+
+        [TestFrameworkV1.TestMethod]
         public void EqualsShouldReturnTrueIfTwoObjectHasSameDataValue()
         {
             TestFrameworkV2.GenericParameterHelper objectToCompare = new TestFrameworkV2.GenericParameterHelper(10);


### PR DESCRIPTION
See #361 for more details.

I make a static `Random` instance so that it would return a different value every time when calling `Next`. This can fix the different behavior between running and step-by-step debugging unit tests.