### PR TITLE
Added overloads to `Assert.ThrowsException` to check the parameter name of an `ArgumentException`

### DIFF
--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -37,10 +37,10 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         {
             get
             {
-               if (that == null)
-               {
-                   that = new Assert();
-               }
+                if (that == null)
+                {
+                    that = new Assert();
+                }
 
                 return that;
             }
@@ -2057,6 +2057,42 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <code>
         /// AssertFailedException
         /// </code>
+        /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/> or when the parameter does not match the <paramref name="paramName"/>.
+        /// </summary>
+        /// <param name="paramName">
+        /// The name of the parameter that causes this exception.
+        /// </param>
+        /// <param name="action">
+        /// Delegate to code to be tested and which is expected to throw exception.
+        /// </param>
+        /// <typeparam name="T">
+        /// Type of exception expected to be thrown.
+        /// </typeparam>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/> or when the parameter does not match the <paramref name="paramName"/>.
+        /// </exception>
+        /// <returns>
+        /// The exception that was thrown.
+        /// </returns>
+        public static T ThrowsException<T>(string paramName, Action action)
+            where T : ArgumentException
+        {
+            var exception = ThrowsException<T>(action, string.Empty, null);
+
+            if (exception.ParamName != paramName)
+            {
+                HandleFail("Assert.ThrowsException", FrameworkMessages.InvalidParameterName, paramName, exception.ParamName);
+            }
+
+            return exception;
+        }
+
+        /// <summary>
+        /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception of type <typeparamref name="T"/> (and not of derived type)
+        /// and throws
+        /// <code>
+        /// AssertFailedException
+        /// </code>
         /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
         /// </summary>
         /// <param name="action">
@@ -2173,6 +2209,42 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             where T : Exception
         {
             return await ThrowsExceptionAsync<T>(action, message, null);
+        }
+
+        /// <summary>
+        /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception of type <typeparamref name="T"/> (and not of derived type)
+        /// and throws
+        /// <code>
+        /// AssertFailedException
+        /// </code>
+        /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/> or when the parameter does not match the <paramref name="paramName"/>.
+        /// </summary>
+        /// <param name="paramName">
+        /// The name of the parameter that causes this exception.
+        /// </param>
+        /// <param name="action">
+        /// Delegate to code to be tested and which is expected to throw exception.
+        /// </param>
+        /// <typeparam name="T">
+        /// Type of exception expected to be thrown.
+        /// </typeparam>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/>.
+        /// </exception>
+        /// <returns>
+        /// The <see cref="Task"/> executing the delegate.
+        /// </returns>
+        public static async Task<T> ThrowsExceptionAsync<T>(string paramName, Func<Task> action)
+            where T : ArgumentException
+        {
+            var exception = await ThrowsExceptionAsync<T>(action, string.Empty, null);
+
+            if (exception.ParamName != paramName)
+            {
+                HandleFail("Assert.ThrowsException", FrameworkMessages.InvalidParameterName, paramName, exception.ParamName);
+            }
+
+            return exception;
         }
 
         /// <summary>

--- a/src/TestFramework/MSTest.Core/Resources/FrameworkMessages.Designer.cs
+++ b/src/TestFramework/MSTest.Core/Resources/FrameworkMessages.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class FrameworkMessages {
@@ -350,11 +350,11 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is invalid. {1}..
+        ///   Looks up a localized string similar to The parameter name of the exception is incorrect. Expected: &apos;{0}&apos;. Actual: &apos;{1}&apos;..
         /// </summary>
-        internal static string InvalidParameterToAssert {
+        internal static string InvalidParameterName {
             get {
-                return ResourceManager.GetString("InvalidParameterToAssert", resourceCulture);
+                return ResourceManager.GetString("InvalidParameterName", resourceCulture);
             }
         }
         

--- a/src/TestFramework/MSTest.Core/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/MSTest.Core/Resources/FrameworkMessages.resx
@@ -192,8 +192,8 @@
   <data name="InternalObjectNotValid" xml:space="preserve">
     <value>The internal object referenced is no longer valid.</value>
   </data>
-  <data name="InvalidParameterToAssert" xml:space="preserve">
-    <value>The parameter '{0}' is invalid. {1}.</value>
+  <data name="InvalidParameterName" xml:space="preserve">
+    <value>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</value>
   </data>
   <data name="IsInstanceOfFailMsg" xml:space="preserve">
     <value>{0} Expected type:&lt;{1}&gt;. Actual type:&lt;{2}&gt;.</value>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.cs.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Obě kolekce obsahují stejné elementy. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">Parametr '{0}' je neplatný. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Očekáván rozdíl, který je větší jak &lt;{3}&gt; mezi očekávanou hodnotou &lt;{1}&gt; a aktuální hodnotou &lt;{2}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Trasování zásobníku: {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">Hodnota vrácená vlastností nebo metodou {0} by neměla být null.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.de.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Beide Sammlungen enthalten dieselben Elemente. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">Der {0}-Parameter ist ungültig. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Es wurde eine Differenz größer als &lt;{3}&gt; zwischen dem erwarteten Wert &lt;{1}&gt; und dem tatsächlichen Wert &lt;{2}&gt; erwartet. {0}</target>
@@ -281,6 +276,11 @@ Stapelüberwachung: {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">Der von der Eigenschaft oder Methode "{0}" zurückgegebene Wert darf nicht NULL sein.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.es.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Ambas colecciones tienen los mismos elementos. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">El parámetro '{0}' no es válido. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Se esperaba una diferencia mayor que &lt;{3}&gt; entre el valor esperado &lt;{1}&gt; y el valor actual &lt;{2}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Seguimiento de la pila: {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">El valor devuelto por la propiedad o el método {0} no debe ser nulo.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.fr.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Les deux collections contiennent les mêmes éléments. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">Le paramètre '{0}' n'est pas valide. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Différence attendue supérieure à &lt;{3}&gt; comprise entre la valeur attendue &lt;{1}&gt; et la valeur réelle &lt;{2}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Trace de la pile : {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">La valeur retournée par la propriété ou la méthode {0} ne doit pas être Null.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.it.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Le raccolte contengono entrambe gli stessi elementi. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">Il parametro '{0}' non è valido. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">È prevista una differenza maggiore di &lt;{3}&gt; tra il valore previsto &lt;{1}&gt; e il valore effettivo &lt;{2}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Analisi dello stack: {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">Il valore restituito dalla proprietà o dal metodo {0} non deve essere Null.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.ja.xlf
@@ -42,11 +42,6 @@
         <target state="translated">両方のコレクションが同じ要素を含んでいます。{0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">パラメーター '{0}' は無効です。{1}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">指定する値 &lt;{1}&gt; と実際の値 &lt;{2}&gt; との間には、&lt;{3}&gt; を超える差が必要です。{0}</target>
@@ -281,6 +276,11 @@ Stack Trace: {4}</source>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">プロパティやメソッド {0} によって返される値を null にすることはできません。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.ko.xlf
@@ -42,11 +42,6 @@
         <target state="translated">두 컬렉션에 같은 요소가 포함되어 있습니다. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">'{0}' 매개 변수가 잘못되었습니다. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">예상 값 &lt;{1}&gt;과(와) 실제 값 &lt;{2}&gt;의 차이가 &lt;{3}&gt;보다 커야 합니다. {0}</target>
@@ -281,6 +276,11 @@ Stack Trace: {4}</source>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">속성 또는 메서드 {0}에 의해 반환된 값은 null일 수 없습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.pl.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Obie kolekcje zawierają te same elementy. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">Parametr „{0}” jest nieprawidłowy. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Oczekiwano różnicy większej niż &lt;{3}&gt; między oczekiwaną wartością &lt;{1}&gt; i wartością rzeczywistą &lt;{2}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Komunikat o wyjątku: {3}
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">Wartość zwracana przez właściwość lub metodę {0} nie powinna być równa null.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Ambas as coleções contêm os mesmos elementos. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">O parâmetro '{0}' é inválido. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">É esperada uma diferença maior que &lt;{3}&gt; entre o valor esperado &lt;{1}&gt; e o valor real &lt;{2}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Rastreamento de Pilha: {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">O valor retornado pela propriedade ou o método {0} não deve ser nulo null.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.ru.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Обе коллекции содержат одинаковые элементы. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">Параметр "{0}" является недопустимым. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Между ожидаемым значением (&lt;{1}&gt;) и фактическим значением (&lt;{2}&gt;) требуется разница более чем &lt;{3}&gt;. {0}</target>
@@ -281,6 +276,11 @@ Stack Trace: {4}</source>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">Значение, возвращаемое свойством или методом {0}, не должно быть равно NULL.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.tr.xlf
@@ -42,11 +42,6 @@
         <target state="translated">Her iki koleksiyon da aynı öğeleri içeriyor. {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">'{0}' parametresi geçersiz. {1}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Beklenen &lt;{1}&gt; değeri ile gerçek &lt;{2}&gt; değeri arasında, &lt;{3}&gt; değerinden büyük bir fark bekleniyor. {0}</target>
@@ -281,6 +276,11 @@ Yığın İzleme: {4}</target>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">{0} özelliği veya metodu tarafından döndürülen değer null olamaz.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.xlf
@@ -127,11 +127,6 @@
         <target state="translated">The internal object referenced is no longer valid.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">The parameter '{0}' is invalid. {1}.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="IsInstanceOfFailMsg">
         <source>{0} Expected type:&lt;{1}&gt;. Actual type:&lt;{2}&gt;.</source>
         <target state="translated">{0} Expected type:&lt;{1}&gt;. Actual type:&lt;{2}&gt;.</target>
@@ -280,6 +275,11 @@ Stack Trace: {4}</target>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="new">Value returned by property or method {0} shouldn't be null.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
         <note></note>
       </trans-unit>
     </body>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -42,11 +42,6 @@
         <target state="translated">这两个集合包含相同的元素。{0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">参数“{0}”无效。{1}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">预期值 &lt;{1}&gt; 和实际值 &lt;{2}&gt; 之间的差应大于 &lt;{3}&gt;。{0}</target>
@@ -281,6 +276,11 @@ Stack Trace: {4}</source>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">属性或方法 {0} 返回的值不能为 null。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/MSTest.Core/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -42,11 +42,6 @@
         <target state="translated">兩個集合含有相同的項目。{0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidParameterToAssert">
-        <source>The parameter '{0}' is invalid. {1}.</source>
-        <target state="translated">參數 '{0}' 無效。{1}。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AreNotEqualDeltaFailMsg">
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">預期值 &lt;{1}&gt; 和實際值 &lt;{2}&gt; 之間的預期差異大於 &lt;{3}&gt;。{0}</target>
@@ -281,6 +276,11 @@ Stack Trace: {4}</source>
         <source>Value returned by property or method {0} shouldn't be null.</source>
         <target state="translated">屬性或方法 {0} 傳回的值不可為 null。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="InvalidParameterName">
+        <source>The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</source>
+        <target state="new">The parameter name of the exception is incorrect. Expected: '{0}'. Actual: '{1}'.</target>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
@@ -61,6 +61,59 @@ namespace UnitTestFramework.Tests
             StringAssert.Contains(ex.Message, "Assert.ThrowsException failed. Threw exception FormatException, but exception ArgumentException was expected.");
         }
 
+        [TestMethod]
+        public void ThrowsExceptionWithParameterNameShouldThrowAssertionOnNoException()
+        {
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.ThrowsException<ArgumentException>("foobar", () => { }));
+
+            Assert.IsNotNull(ex);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), ex.GetType());
+            StringAssert.Contains(ex.Message, "Assert.ThrowsException failed. No exception thrown. ArgumentException exception was expected.");
+        }
+
+        [TestMethod]
+        public void ThrowsExceptionWithParameterNameShouldThrowAssertionOnWrongException()
+        {
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.ThrowsException<ArgumentException>(
+                "foobar",
+                 () =>
+                 {
+                     throw new FormatException();
+                 }));
+
+            Assert.IsNotNull(ex);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), ex.GetType());
+            StringAssert.Contains(ex.Message, "Assert.ThrowsException failed. Threw exception FormatException, but exception ArgumentException was expected.");
+        }
+
+        [TestMethod]
+        public void ThrowsExceptionWithParameterNameShouldThrowAssertionOnWrongParameterName()
+        {
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.ThrowsException<ArgumentException>(
+                "foobar",
+                 () =>
+                 {
+                     throw new ArgumentException("Message", "barfoo");
+                 }));
+
+            Assert.IsNotNull(ex);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), ex.GetType());
+            StringAssert.Contains(ex.Message, "The parameter name of the exception is incorrect. Expected: 'foobar'. Actual: 'barfoo'.");
+        }
+
+        [TestMethod]
+        public void ThrowsExceptionShouldNotThrowAssertionOnRightExceptionAndParameterName()
+        {
+            var ex = TestFrameworkV2.Assert.ThrowsException<ArgumentException>(
+                "foobar",
+                () =>
+                {
+                    throw new ArgumentException("Message", "foobar");
+                });
+
+            Assert.IsNotNull(ex);
+        }
+
         #endregion
 
         #region ThrowsExceptionAsync tests.
@@ -225,6 +278,83 @@ namespace UnitTestFramework.Tests
             Assert.IsNotNull(innerException);
             Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), innerException.GetType());
             StringAssert.Contains(innerException.Message, "Assert.ThrowsException failed. Threw exception FormatException, but exception ArgumentException was expected. Happily ever after. The End.");
+        }
+
+        [TestMethod]
+        public void ThrowsExceptionAsyncWithParameterNameShouldThrowAssertionOnNoException()
+        {
+            Task t = TestFrameworkV2.Assert.ThrowsExceptionAsync<ArgumentException>(
+                "foobar",
+                async () =>
+                {
+                    await Task.Delay(5);
+                });
+            var ex = ActionUtility.PerformActionAndReturnException(() => t.Wait());
+
+            Assert.IsNotNull(ex);
+
+            var innerException = ex.InnerException;
+
+            Assert.IsNotNull(innerException);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), innerException.GetType());
+            StringAssert.Contains(innerException.Message, "Assert.ThrowsException failed. No exception thrown. ArgumentException exception was expected.");
+        }
+
+        [TestMethod]
+        public void ThrowsExceptionAsyncWithParameterNameShouldThrowAssertionOnWrongException()
+        {
+            Task t = TestFrameworkV2.Assert.ThrowsExceptionAsync<ArgumentException>(
+                "foobar",
+                async () =>
+                {
+                    await Task.Delay(5);
+                    throw new FormatException();
+                });
+            var ex = ActionUtility.PerformActionAndReturnException(() => t.Wait());
+
+            Assert.IsNotNull(ex);
+
+            var innerException = ex.InnerException;
+
+            Assert.IsNotNull(innerException);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), innerException.GetType());
+            StringAssert.Contains(innerException.Message, "Assert.ThrowsException failed. Threw exception FormatException, but exception ArgumentException was expected.");
+        }
+
+        [TestMethod]
+        public void ThrowsExceptionAsyncWithParameterNameShouldThrowAssertionOnWrongParameterName()
+        {
+            Task t = TestFrameworkV2.Assert.ThrowsExceptionAsync<ArgumentException>(
+                "foobar",
+                async () =>
+                {
+                    await Task.Delay(5);
+                    throw new ArgumentException("Message", "barfoo");
+                });
+            var ex = ActionUtility.PerformActionAndReturnException(() => t.Wait());
+
+            Assert.IsNotNull(ex);
+
+            var innerException = ex.InnerException;
+
+            Assert.IsNotNull(innerException);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), innerException.GetType());
+            StringAssert.Contains(innerException.Message, "The parameter name of the exception is incorrect. Expected: 'foobar'. Actual: 'barfoo'.");
+        }
+
+        [TestMethod]
+        public async Task ThrowsExceptionAsyncShouldNotThrowAssertionOnRightExceptionAndParameterName()
+        {
+            Task t = TestFrameworkV2.Assert.ThrowsExceptionAsync<ArgumentException>(
+                "foobar",
+                async () =>
+                {
+                    await Task.Delay(5);
+                    throw new ArgumentException("Message", "foobar");
+                });
+
+            // Should not throw an exception.
+            await t;
         }
 
         #endregion


### PR DESCRIPTION
This pull requests allows a simpler way to check if an `ArgumentException` uses the correct `ParameterName`. With the current code you will need to do this:

```C#
var exception = Assert.ThrowsException<ArgumentNullException>(() =>
{
    new FooBar(null);
});

Assert.AreEqual("myParam", exception.ParamName);
```

This pull request adds a patch to allow the following notation:

```C#
Assert.ThrowsException<ArgumentNullException>("myParam", () =>
{
    new FooBar(null);
});
```

This patch has also been applied to `Assert.ThrowsExceptionAsync`.

I renamed the `InvalidParameterToAssert` resource because it was unused. I can revert that if the original value should be preserved.