### PR TITLE
Today even if classInit wasnt called we used to call class cleanup. f…

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
@@ -108,11 +108,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         public bool IsClassInitializeExecuted { get; internal set; }
 
         /// <summary>
-        /// Gets a value indicating whether class cleanup has executed.
-        /// </summary>
-        public bool IsClassCleanupExecuted { get; private set; }
-
-        /// <summary>
         /// Gets the exception thrown during <see cref="ClassInitializeAttribute"/> method invocation.
         /// </summary>
         public Exception ClassInitializationException { get; internal set; }
@@ -313,7 +308,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             lock (this.testClassExecuteSyncObject)
             {
-                if (this.IsClassInitializeExecuted)
+                if (this.IsClassInitializeExecuted || this.ClassInitializeMethod == null)
                 {
                     try
                     {
@@ -345,10 +340,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                             this.ClassCleanupMethod.Name,
                             errorMessage,
                             StackTraceHelper.GetStackTraceInformation(realException)?.ErrorStackTrace);
-                    }
-                    finally
-                    {
-                        this.IsClassCleanupExecuted = true;
                     }
                 }
             }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -307,6 +307,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
+        public void RunClassCleanupShouldInvokeIfClassCleanupMethod()
+        {
+           var classcleanupCallCount = 0;
+            DummyTestClass.ClassCleanupMethodBody = () => classcleanupCallCount++;
+            this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
+            Assert.IsNull(this.testClassInfo.RunClassCleanup());
+            Assert.AreEqual(1, classcleanupCallCount);
+        }
+
+        [TestMethod]
         public void RunAssemblyInitializeShouldPassOnTheTestContextToAssemblyInitMethod()
         {
             DummyTestClass.ClassInitializeMethodBody = (tc) => { Assert.AreEqual(tc, this.testContext); };

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -362,7 +362,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClass.ClassCleanupMethodBody = () => UTF.Assert.Inconclusive("Test Inconclusive.");
 
             this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
-
             StringAssert.StartsWith(
                 this.testClassInfo.RunClassCleanup(),
                 "Class Cleanup method DummyTestClass.ClassCleanupMethod failed. Error Message: Assert.Inconclusive failed. Test Inconclusive.. Stack Trace:    at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestClassInfoTests.<>c.<RunClassCleanupShouldReturnAssertInconclusiveExceptionDetails>");
@@ -374,7 +373,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClass.ClassCleanupMethodBody = () => { throw new ArgumentException("Argument Exception"); };
 
             this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
-
             StringAssert.StartsWith(
                 this.testClassInfo.RunClassCleanup(),
                 "Class Cleanup method DummyTestClass.ClassCleanupMethod failed. Error Message: System.ArgumentException: Argument Exception. Stack Trace:     at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestClassInfoTests.<>c.<RunClassCleanupShouldReturnExceptionDetailsOfNonAssertExceptions>");

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -124,6 +124,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
+        public void TestClassInfoClassCleanupMethodShouldInvokeWhenTestClassInitializedIsCalled()
+        {
+            this.testClassInfo.ClassCleanupMethod = this.testClassType.GetMethods().First();
+            this.testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod");
+
+            this.testClassInfo.RunClassInitialize(this.testContext);
+            var ret = this.testClassInfo.RunClassCleanup(); // call cleanup without calling init
+
+            Assert.AreEqual(null, ret);
+            Assert.AreEqual(true, this.testClassInfo.IsClassCleanupExecuted);
+        }
+
+        [TestMethod]
         public void TestClassInfoHasExecutableCleanupMethodShouldReturnFalseIfClassDoesNotHaveCleanupMethod()
         {
             Assert.IsFalse(this.testClassInfo.HasExecutableCleanupMethod);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -112,6 +112,18 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
+        public void TestClassInfoClassCleanupMethodShouldNotInvokeWhenNoTestClassInitializedIsCalled()
+        {
+            this.testClassInfo.ClassCleanupMethod = this.testClassType.GetMethods().First();
+            this.testClassInfo.ClassInitializeMethod = this.testClassType.GetMethods()[1];
+
+            var ret = this.testClassInfo.RunClassCleanup(); // call cleanup without calling init
+
+            Assert.AreEqual(null, ret);
+            Assert.AreEqual(false, this.testClassInfo.IsClassCleanupExecuted);
+        }
+
+        [TestMethod]
         public void TestClassInfoHasExecutableCleanupMethodShouldReturnFalseIfClassDoesNotHaveCleanupMethod()
         {
             Assert.IsFalse(this.testClassInfo.HasExecutableCleanupMethod);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -346,10 +346,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             DummyTestClass.ClassCleanupMethodBody = () => UTF.Assert.Fail("Test Failure.");
 
-            this.testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod");
             this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
-
-            this.testClassInfo.RunClassInitialize(this.testContext);
 
             StringAssert.StartsWith(
                 this.testClassInfo.RunClassCleanup(),

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -362,9 +362,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClass.ClassCleanupMethodBody = () => UTF.Assert.Inconclusive("Test Inconclusive.");
 
             this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
-            this.testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod");
-
-            this.testClassInfo.RunClassInitialize(this.testContext);
 
             StringAssert.StartsWith(
                 this.testClassInfo.RunClassCleanup(),
@@ -377,9 +374,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClass.ClassCleanupMethodBody = () => { throw new ArgumentException("Argument Exception"); };
 
             this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
-            this.testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod");
-
-            this.testClassInfo.RunClassInitialize(this.testContext);
 
             StringAssert.StartsWith(
                 this.testClassInfo.RunClassCleanup(),

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using System.Reflection;
     using System.Text;
     using System.Xml;
-
     using global::MSTestAdapter.TestUtilities;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
@@ -27,6 +26,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using Assert = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
     using TestClass = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
     using TestCleanup = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanupAttribute;
+    using TestContextV1 = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestContext;
     using TestInitialize = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute;
     using TestMethodV1 = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
     using UnitTestOutcome = Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestOutcome;
@@ -253,6 +253,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
+            DummyTestClassWithCleanupMethods.ClassInitMethodBody = () =>
+            {
+            };
+
             this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
 
             var assemblyCleanupCount = 0;
@@ -392,6 +396,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             public static Action ClassCleanupMethodBody { get; set; }
 
+            public static Action ClassInitMethodBody { get; set; }
+
             [UTF.AssemblyCleanup]
             public static void AssemblyCleanup()
             {
@@ -405,6 +411,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             public static void ClassCleanup()
             {
                 ClassCleanupMethodBody.Invoke();
+            }
+
+            [UTF.ClassInitialize]
+            public static void ClassInit(UTFExtension.TestContext context)
+            {
+                if (ClassInitMethodBody != null)
+                {
+                    ClassInitMethodBody.Invoke();
+                }
             }
 
             [UTF.TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
@@ -253,10 +253,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
-            DummyTestClassWithCleanupMethods.ClassInitMethodBody = () =>
-            {
-            };
-
             this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
 
             var assemblyCleanupCount = 0;
@@ -396,8 +392,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             public static Action ClassCleanupMethodBody { get; set; }
 
-            public static Action ClassInitMethodBody { get; set; }
-
             [UTF.AssemblyCleanup]
             public static void AssemblyCleanup()
             {
@@ -411,15 +405,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             public static void ClassCleanup()
             {
                 ClassCleanupMethodBody.Invoke();
-            }
-
-            [UTF.ClassInitialize]
-            public static void ClassInit(UTFExtension.TestContext context)
-            {
-                if (ClassInitMethodBody != null)
-                {
-                    ClassInitMethodBody.Invoke();
-                }
             }
 
             [UTF.TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using Assert = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
     using TestClass = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
     using TestCleanup = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestCleanupAttribute;
-    using TestContextV1 = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestContext;
     using TestInitialize = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute;
     using TestMethodV1 = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
     using UnitTestOutcome = Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestOutcome;


### PR DESCRIPTION
Today even if classInit wasnt called we used to call class cleanup. fixing that and adding a test to cover the scenario

#355 