### PR TITLE
Fix masking assembly load failure error message

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -76,33 +76,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                     fullFilePath,
                     ex);
 
-                // Loading a WinPRT dll on the phone produces a
-                // FileNotFoundException. We check if we get FileNotFoundException
-                // in spite of the dll existing and try and load the dll from the full path in this case.
-                try
-                {
-                    if (PlatformServiceProvider.Instance.FileOperations.DoesFileExist(assemblyFileName))
-                    {
-                        var assembly = Assembly.Load(new AssemblyName(assemblyFileName));
-                    }
-                }
-                catch (Exception e)
-                {
-                    var winrtFailureMessage = string.Format(
-                        CultureInfo.CurrentCulture,
-                        Resource.TestAssembly_AssemblyDiscoveryFailure,
-                        assemblyFileName,
-                        e.Message);
-                    warnings.Add(winrtFailureMessage);
-                    return null;
-                }
-
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
                     Resource.TestAssembly_AssemblyDiscoveryFailure,
                     fullFilePath,
                     ex.Message);
                 warnings.Add(message);
+
                 return null;
             }
             catch (ReflectionTypeLoadException ex)


### PR DESCRIPTION
- Show the right error message on assembly load failures.
- Remove [SILVERLIGHT](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2Fvset%2FAgile%2FTestPlatform%2FMSTest%2Fv1%2FMSAppContainerAdapter%2FCoreSystem%2FMSPhoneTestDiscoverer.cs&version=GBlab%2Fvsumain&_a=contents&line=196&lineStyle=plain&lineEnd=200&lineStartColumn=1&lineEndColumn=20) specific code.

**Before fix**
```
[MSTest][Discovery][D:\g\samples\Test Explorer fails to show tests\ClassLibrary.Tests\bin\Debug\ClassLibrary.Tests.dll] Failed to discover tests from assembly D:\g\samples\Test Explorer fails to show tests\ClassLibrary.Tests\bin\Debug\ClassLibrary.Tests.dll. Reason:The given assembly name or codebase was invalid. (Exception from HRESULT: 0x80131047)
No test is available in D:\g\samples\Test Explorer fails to show tests\ClassLibrary.Tests\bin\Debug\ClassLibrary.Tests.dll. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.

Additionally, path to test adapters can be specified using /TestAdapterPath command. Example  /TestAdapterPath:<pathToCustomAdapters>.
```

**After fix** (Displays assembly name in warning.)
```
[MSTest][Discovery][D:\g\samples\Test Explorer fails to show tests\ClassLibrary.Tests\bin\Debug\ClassLibrary.Tests.dll] Failed to discover tests from assembly D:\g\samples\Test Explorer fails to show tests\ClassLibrary.Tests\bin\Debug\ClassLibrary.Tests.dll. Reason:Could not load file or assembly 'System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
No test is available in D:\g\samples\Test Explorer fails to show tests\ClassLibrary.Tests\bin\Debug\ClassLibrary.Tests.dll. Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.

Additionally, path to test adapters can be specified using /TestAdapterPath command. Example  /TestAdapterPath:<pathToCustomAdapters>.
```