### PR TITLE
Compatibility fix by resetting appbase

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -170,7 +170,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelClassesTestProject"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataSourceTestProject", "test\E2ETests\TestAssets\DataSourceTestProject\DataSourceTestProject.csproj", "{5A4967CD-B527-4D43-81C2-4CA90EE10222}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DoNotParallelizeTestProject", "test\E2ETests\TestAssets\DoNotParallelizeTestProject\DoNotParallelizeTestProject.csproj", "{8080DE48-CFD9-4F33-908A-8B71108CA223}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DoNotParallelizeTestProject", "test\E2ETests\TestAssets\DoNotParallelizeTestProject\DoNotParallelizeTestProject.csproj", "{8080DE48-CFD9-4F33-908A-8B71108CA223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CompatTestProject", "test\E2ETests\TestAssets\CompatTestProject\CompatTestProject.csproj", "{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -961,6 +963,30 @@ Global
 		{8080DE48-CFD9-4F33-908A-8B71108CA223}.Release|x64.Build.0 = Release|Any CPU
 		{8080DE48-CFD9-4F33-908A-8B71108CA223}.Release|x86.ActiveCfg = Release|Any CPU
 		{8080DE48-CFD9-4F33-908A-8B71108CA223}.Release|x86.Build.0 = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|ARM.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|ARM.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|x64.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|x64.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Code Analysis Debug|x86.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|ARM.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|x64.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Debug|x86.Build.0 = Debug|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|ARM.ActiveCfg = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|ARM.Build.0 = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|x64.ActiveCfg = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|x64.Build.0 = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|x86.ActiveCfg = Release|Any CPU
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1017,6 +1043,7 @@ Global
 		{CD0CA7CD-CED3-45FF-9F36-B1C8DF7A9220} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 		{5A4967CD-B527-4D43-81C2-4CA90EE10222} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 		{8080DE48-CFD9-4F33-908A-8B71108CA223} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
+		{2D2C5B73-F1F1-47C8-BC5C-A172E9BB3D16} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31E0F4D5-975A-41CC-933E-545B2201FAF9}

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -140,9 +140,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
         {
             using (var isolationHost = PlatformServiceProvider.Instance.CreateTestSourceHost(fullFilePath, runSettings, frameworkHandle: null))
             {
-                var assemblyEnumerator =
-                    isolationHost.CreateInstanceForType(typeof(AssemblyEnumerator), new object[] { MSTestSettings.CurrentSettings }) as AssemblyEnumerator;
-                isolationHost.ModifyHostProperties();
+                // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain, then reset the domain's appbase
+                // to point to test source location
+                var assemblyEnumerator = isolationHost.CreateInstanceForAdapterTypeAndUpdateAppBase(
+                    typeof(AssemblyEnumerator), new object[] { MSTestSettings.CurrentSettings }) as AssemblyEnumerator;
                 return assemblyEnumerator.EnumerateAssembly(fullFilePath, out warnings);
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -162,6 +162,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
             {
                 var assemblyEnumerator =
                     isolationHost.CreateInstanceForType(typeof(AssemblyEnumerator), new object[] { MSTestSettings.CurrentSettings }) as AssemblyEnumerator;
+                isolationHost.ModifyHostProperties();
                 return assemblyEnumerator.EnumerateAssembly(fullFilePath, out warnings);
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -140,10 +140,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
         {
             using (var isolationHost = PlatformServiceProvider.Instance.CreateTestSourceHost(fullFilePath, runSettings, frameworkHandle: null))
             {
-                // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain, then reset the domain's appbase
-                // to point to test source location
-                var assemblyEnumerator = isolationHost.CreateInstanceForAdapterTypeAndUpdateAppBase(
+                // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain
+                var assemblyEnumerator = isolationHost.CreateInstanceForType(
                     typeof(AssemblyEnumerator), new object[] { MSTestSettings.CurrentSettings }) as AssemblyEnumerator;
+
+                // After loading adapter reset the child-domain's appbase to point to test source location
+                isolationHost.UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver();
+
                 return assemblyEnumerator.EnumerateAssembly(fullFilePath, out warnings);
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -217,10 +217,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             using (var isolationHost = PlatformServiceProvider.Instance.CreateTestSourceHost(source, runContext?.RunSettings, frameworkHandle))
             {
-                var testRunner = isolationHost.CreateInstanceForType(
+                // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain, then reset the domain's appbase
+                // to point to test source location
+                var testRunner = isolationHost.CreateInstanceForAdapterTypeAndUpdateAppBase(
                     typeof(UnitTestRunner),
                     new object[] { MSTestSettings.CurrentSettings }) as UnitTestRunner;
-                isolationHost.ModifyHostProperties();
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Created unit-test runner {0}", source);
 
                 // Default test set is filtered tests based on user provided filter criteria

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -217,11 +217,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             using (var isolationHost = PlatformServiceProvider.Instance.CreateTestSourceHost(source, runContext?.RunSettings, frameworkHandle))
             {
-                // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain, then reset the domain's appbase
-                // to point to test source location
-                var testRunner = isolationHost.CreateInstanceForAdapterTypeAndUpdateAppBase(
+                // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain
+                var testRunner = isolationHost.CreateInstanceForType(
                     typeof(UnitTestRunner),
                     new object[] { MSTestSettings.CurrentSettings }) as UnitTestRunner;
+
+                // After loading adapter reset the chils-domain's appbase to point to test source location
+                isolationHost.UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver();
+
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Created unit-test runner {0}", source);
 
                 // Default test set is filtered tests based on user provided filter criteria

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -220,6 +220,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 var testRunner = isolationHost.CreateInstanceForType(
                     typeof(UnitTestRunner),
                     new object[] { MSTestSettings.CurrentSettings }) as UnitTestRunner;
+                isolationHost.ModifyHostProperties();
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Created unit-test runner {0}", source);
 
                 // Default test set is filtered tests based on user provided filter criteria

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
             }
 
             // Case when DisableAppDomain setting is present in runsettings and no child-appdomain is created
-            if ()
+            if (this.AppDomainCreationDisabledInRunSettings())
             {
                 if (adapterSettings != null)
                 {

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
@@ -93,15 +93,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
             // Load objectModel before creating assembly resolver otherwise in 3.5 process, we run into a recurive assembly resolution
             // which is trigged by AppContainerUtilities.AttachEventToResolveWinmd method.
             EqtTrace.SetupRemoteEqtTraceListeners(this.domain);
-
-            ////this.domain.Load(typeof(TestSourceHost).Assembly.GetName());
-            ////Type type = typeof(Proxy);
-
-             ////var value = (Proxy)this.domain.CreateInstanceAndUnwrap(
-             ////   type.Assembly.FullName,
-             ////   type.FullName);
-
-             ////var assembly = value.GetAssembly(typeof(TestSourceHost).Assembly.Location);
         }
 
         /// <summary>
@@ -387,23 +378,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
             }
         }
     }
-
-////#pragma warning disable SA1402 // File may only contain a single class
-////    public class Proxy : MarshalByRefObject
-////#pragma warning restore SA1402 // File may only contain a single class
-////    {
-////        public Assembly GetAssembly(string assemblyPath)
-////        {
-////            try
-////            {
-////                return Assembly.LoadFrom(assemblyPath);
-////            }
-////            catch (Exception)
-////            {
-////                return null;
-////            }
-////        }
-////    }
 
 #pragma warning restore SA1649 // SA1649FileNameMustMatchTypeName
 }

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
@@ -167,8 +167,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
 
         public void ModifyHostProperties()
         {
-            ////this.domain.SetData("APPBASE", Path.GetDirectoryName(this.sourceFileName));
-
             // After adapter has been loaded, reset appdomains appbase.
             // The below logic of preferential setting the appdomains appbase is needed because:
             // 1. We set this to the location of the test source if it is built for Full CLR  -> Ideally this needs to be done in all situations.

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestSourceHost.cs
@@ -104,7 +104,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
             // Load objectModel before creating assembly resolver otherwise in 3.5 process, we run into a recurive assembly resolution
             // which is trigged by AppContainerUtilities.AttachEventToResolveWinmd method.
             EqtTrace.SetupRemoteEqtTraceListeners(this.domain);
-
         }
 
         /// <summary>

--- a/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
@@ -28,6 +28,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         /// <remarks> If a type is to be created in isolation then it needs to be a MarshalByRefObject. </remarks>
         object CreateInstanceForType(Type type, object[] args);
 
+        /// <summary>
+        /// Modifies properties of the isolation host that was created using SetupHost().
+        /// For instance, this can be used to change properties like appbase,framework version etc of the created appdomain.
+        /// </summary>
         void ModifyHostProperties();
     }
 }

--- a/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         /// <summary>
         /// Updates child-domain's appbase to point to test source location and sets up
         /// Assembly resolver for both parent and child appdomain
+        /// </summary>
         void UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver();
     }
 }

--- a/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
@@ -29,16 +29,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         object CreateInstanceForType(Type type, object[] args);
 
         /// <summary>
-        /// Creates an instance of a given adapter type in the test source host and updates domain's appbase to point to
-        /// test source location
-        /// </summary>
-        /// <param name="type"> The type that needs to be created in the host. </param>
-        /// <param name="args">The arguments to pass to the constructor.
-        /// This array of arguments must match in number, order, and type the parameters of the constructor to invoke.
-        /// Pass in null for a constructor with no arguments.
-        /// </param>
-        /// <returns> An instance of the type created in the host. </returns>
-        /// <remarks> If a type is to be created in isolation then it needs to be a MarshalByRefObject. </remarks>
-        object CreateInstanceForAdapterTypeAndUpdateAppBase(Type type, object[] args);
+        /// Updates child-domain's appbase to point to test source location and sets up
+        /// Assembly resolver for both parent and child appdomain
+        void UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver();
     }
 }

--- a/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
@@ -29,9 +29,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         object CreateInstanceForType(Type type, object[] args);
 
         /// <summary>
-        /// Modifies properties of the isolation host that was created using SetupHost().
-        /// For instance, this can be used to change properties like appbase,framework version etc of the created appdomain.
+        /// Creates an instance of a given adapter type in the test source host and updates domain's appbase to point to
+        /// test source location
         /// </summary>
-        void ModifyHostProperties();
+        /// <param name="type"> The type that needs to be created in the host. </param>
+        /// <param name="args">The arguments to pass to the constructor.
+        /// This array of arguments must match in number, order, and type the parameters of the constructor to invoke.
+        /// Pass in null for a constructor with no arguments.
+        /// </param>
+        /// <returns> An instance of the type created in the host. </returns>
+        /// <remarks> If a type is to be created in isolation then it needs to be a MarshalByRefObject. </remarks>
+        object CreateInstanceForAdapterTypeAndUpdateAppBase(Type type, object[] args);
     }
 }

--- a/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Interface/ITestSourceHost.cs
@@ -27,5 +27,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         /// <returns> An instance of the type created in the host. </returns>
         /// <remarks> If a type is to be created in isolation then it needs to be a MarshalByRefObject. </remarks>
         object CreateInstanceForType(Type type, object[] args);
+
+        void ModifyHostProperties();
     }
 }

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestSourceHost.cs
@@ -53,6 +53,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         {
             // Do nothing.
         }
+
+        public void ModifyHostProperties()
+        {
+            // Do nothing.
+        }
     }
 
 #pragma warning restore SA1649 // SA1649FileNameMustMatchTypeName

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestSourceHost.cs
@@ -55,20 +55,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         }
 
         /// <summary>
-        /// Creates an instance of a given adapter type in the test source host and updates domain's appbase to point to
-        /// test source location
+        /// Updates child-domain's appbase to point to test source location and sets up
+        /// Assembly resolver for both parent and child appdomain
         /// </summary>
-        /// <param name="type"> The type that needs to be created in the host. </param>
-        /// <param name="args">The arguments to pass to the constructor.
-        /// This array of arguments must match in number, order, and type the parameters of the constructor to invoke.
-        /// Pass in null for a constructor with no arguments.
-        /// </param>
-        /// <returns> An instance of the type created in the host. </returns>
-        /// <remarks> If a type is to be created in isolation then it needs to be a MarshalByRefObject. </remarks>
-        public object CreateInstanceForAdapterTypeAndUpdateAppBase(Type type, object[] args)
+        public void UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver()
         {
-            // Do nothing
-            return null;
+            // Do nothing.
         }
     }
 

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestSourceHost.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestSourceHost.cs
@@ -54,9 +54,21 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
             // Do nothing.
         }
 
-        public void ModifyHostProperties()
+        /// <summary>
+        /// Creates an instance of a given adapter type in the test source host and updates domain's appbase to point to
+        /// test source location
+        /// </summary>
+        /// <param name="type"> The type that needs to be created in the host. </param>
+        /// <param name="args">The arguments to pass to the constructor.
+        /// This array of arguments must match in number, order, and type the parameters of the constructor to invoke.
+        /// Pass in null for a constructor with no arguments.
+        /// </param>
+        /// <returns> An instance of the type created in the host. </returns>
+        /// <remarks> If a type is to be created in isolation then it needs to be a MarshalByRefObject. </remarks>
+        public object CreateInstanceForAdapterTypeAndUpdateAppBase(Type type, object[] args)
         {
-            // Do nothing.
+            // Do nothing
+            return null;
         }
     }
 

--- a/test/E2ETests/Smoke.E2E.Tests/CompatTests.cs
+++ b/test/E2ETests/Smoke.E2E.Tests/CompatTests.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MSTestAdapter.Smoke.E2ETests
+{
+    class CompatTests
+    {
+    }
+}

--- a/test/E2ETests/Smoke.E2E.Tests/CompatTests.cs
+++ b/test/E2ETests/Smoke.E2E.Tests/CompatTests.cs
@@ -1,12 +1,49 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace MSTestAdapter.Smoke.E2ETests
 {
-    class CompatTests
+    using Microsoft.MSTestV2.CLIAutomation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CompatTests : CLITestBase
     {
+        private const string OldAdapterTestProject = "CompatTests\\CompatTestProject.dll";
+        private const string LatestAdapterTestProject = "DesktopTestProjectx86Debug.dll";
+
+        [TestMethod]
+        public void DiscoverCompatTests()
+        {
+            this.InvokeVsTestForDiscovery(new string[] { OldAdapterTestProject, LatestAdapterTestProject });
+            var listOfTests = new string[]
+            {
+                "CompatTestProject.UnitTest1.PassingTest",
+                "CompatTestProject.UnitTest1.FailingTest",
+                "CompatTestProject.UnitTest1.SkippingTest",
+                "SampleUnitTestProject.UnitTest1.PassingTest",
+                "SampleUnitTestProject.UnitTest1.FailingTest",
+                "SampleUnitTestProject.UnitTest1.SkippingTest"
+            };
+            this.ValidateDiscoveredTests(listOfTests);
+        }
+
+        [TestMethod]
+        public void RunAllCompatTests()
+        {
+            this.InvokeVsTestForExecution(new string[] { OldAdapterTestProject, LatestAdapterTestProject });
+
+            this.ValidatePassedTestsContain(
+                "CompatTestProject.UnitTest1.PassingTest",
+                 "SampleUnitTestProject.UnitTest1.PassingTest");
+
+            this.ValidateFailedTestsContain(
+                "CompatTestProject.UnitTest1.FailingTest",
+                "SampleUnitTestProject.UnitTest1.FailingTest");
+
+            this.ValidateSkippedTestsContain(
+                "CompatTestProject.UnitTest1.SkippingTest",
+                "SampleUnitTestProject.UnitTest1.SkippingTest");
+        }
     }
 }

--- a/test/E2ETests/Smoke.E2E.Tests/Smoke.E2E.Tests.csproj
+++ b/test/E2ETests/Smoke.E2E.Tests/Smoke.E2E.Tests.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssertExtensibilityTests.cs" />
+    <Compile Include="CompatTests.cs" />
     <Compile Include="DataSourceTests.cs" />
     <Compile Include="DesktopCSharpCLITests.cs" />
     <Compile Include="ParallelExecutionTests.cs" />

--- a/test/E2ETests/TestAssets/CompatTestProject/CompatTestProject.csproj
+++ b/test/E2ETests/TestAssets/CompatTestProject/CompatTestProject.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TestFxRoot Condition="$(TestFxRoot) == ''">..\..\..\..\</TestFxRoot>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(TestFxRoot)artifacts\TestAssets\CompatTests</OutputPath>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/E2ETests/TestAssets/CompatTestProject/UnitTest1.cs
+++ b/test/E2ETests/TestAssets/CompatTestProject/UnitTest1.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CompatTestProject
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class UnitTest1
+    {
+        /// <summary>
+        /// The passing test.
+        /// </summary>
+        [TestMethod]
+        public void PassingTest()
+        {
+            Assert.AreEqual(2, 2);
+        }
+
+        /// <summary>
+        /// The failing test.
+        /// </summary>
+        [TestMethod]
+        public void FailingTest()
+        {
+            Assert.AreEqual(2, 3);
+        }
+
+        /// <summary>
+        /// The skipping test.
+        /// </summary>
+        [Ignore]
+        [TestMethod]
+        public void SkippingTest()
+        {
+        }
+    }
+}

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -108,7 +108,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
         /// Leaving the test running till then.
         /// </summary>
         [TestMethod]
-        public void CreateInstanceForAdapterTypeAndUpdateAppBaseShouldSetDomainsAppBaseToTestSourceLocationForFullCLRTestss()
+        public void UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolverShouldSetDomainsAppBaseToTestSourceLocationForFullCLRTestss()
         {
             // Arrange
             DummyClass dummyclass = new DummyClass();
@@ -136,7 +136,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
         }
 
         [TestMethod]
-        public void CreateInstanceForAdapterTypeAndUpdateAppBaseShouldSetDomainsAppBaseToAdaptersLocationForNonFullCLRTests()
+        public void UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolverShouldSetDomainsAppBaseToAdaptersLocationForNonFullCLRTests()
         {
             // Arrange
             DummyClass dummyclass = new DummyClass();

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -122,9 +122,9 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
                 // Act
                 sourceHost.Object.SetupHost();
-                ////sourceHost.Object.ModifyHostProperties();
                 var expectedObject =
-                    sourceHost.Object.CreateInstanceForAdapterTypeAndUpdateAppBase(typeof(DummyClass), null) as DummyClass;
+                    sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
+                sourceHost.Object.UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver();
 
                 // Assert
                 Assert.AreEqual(Path.GetDirectoryName(location), expectedObject.AppDomainAppBase);
@@ -150,8 +150,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
                 // Act
                 sourceHost.Object.SetupHost();
-                ////sourceHost.Object.ModifyHostProperties();
-                var expectedObject = sourceHost.Object.CreateInstanceForAdapterTypeAndUpdateAppBase(typeof(DummyClass), null) as DummyClass;
+                var expectedObject = sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
+                sourceHost.Object.UpdateAppBaseToTestSourceLocationAndSetupAssemblyResolver();
 
                 // Assert
                 Assert.AreEqual(Path.GetDirectoryName(location), expectedObject.AppDomainAppBase);

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -108,7 +108,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
         /// Leaving the test running till then.
         /// </summary>
         [TestMethod]
-        public void ModifyHostPropertiesShouldSetDomainsAppBaseToTestSourceLocationForFullCLRTestss()
+        public void CreateInstanceForAdapterTypeAndUpdateAppBaseShouldSetDomainsAppBaseToTestSourceLocationForFullCLRTestss()
         {
             // Arrange
             DummyClass dummyclass = new DummyClass();
@@ -122,9 +122,9 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
                 // Act
                 sourceHost.Object.SetupHost();
-                sourceHost.Object.ModifyHostProperties();
+                ////sourceHost.Object.ModifyHostProperties();
                 var expectedObject =
-                    sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
+                    sourceHost.Object.CreateInstanceForAdapterTypeAndUpdateAppBase(typeof(DummyClass), null) as DummyClass;
 
                 // Assert
                 Assert.AreEqual(Path.GetDirectoryName(location), expectedObject.AppDomainAppBase);
@@ -136,7 +136,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
         }
 
         [TestMethod]
-        public void ModifyHostPropertiesShouldSetDomainsAppBaseToAdaptersLocationForNonFullCLRTests()
+        public void CreateInstanceForAdapterTypeAndUpdateAppBaseShouldSetDomainsAppBaseToAdaptersLocationForNonFullCLRTests()
         {
             // Arrange
             DummyClass dummyclass = new DummyClass();
@@ -150,8 +150,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
                 // Act
                 sourceHost.Object.SetupHost();
-                sourceHost.Object.ModifyHostProperties();
-                var expectedObject = sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
+                ////sourceHost.Object.ModifyHostProperties();
+                var expectedObject = sourceHost.Object.CreateInstanceForAdapterTypeAndUpdateAppBase(typeof(DummyClass), null) as DummyClass;
 
                 // Assert
                 Assert.AreEqual(Path.GetDirectoryName(location), expectedObject.AppDomainAppBase);

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -150,6 +150,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
                 // Act
                 sourceHost.Object.SetupHost();
+                sourceHost.Object.ModifyHostProperties();
                 var expectedObject = sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
 
                 // Assert

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -78,13 +78,37 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             Assert.AreNotEqual(currentAppDomainId, newAppDomainId);
         }
 
+        [TestMethod]
+        public void SetupHostShouldSetNewDomainsAppBaseToAdapterLocation()
+        {
+            // Arrange
+            DummyClass dummyclass = new DummyClass();
+
+            var location = typeof(TestSourceHost).Assembly.Location;
+            Mock<TestSourceHost> sourceHost = new Mock<TestSourceHost>(location, null, null) { CallBase = true };
+
+            try
+            {
+                // Act
+                sourceHost.Object.SetupHost();
+                var expectedObject = sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
+
+                // Assert
+                Assert.AreEqual(Path.GetDirectoryName(location), expectedObject.AppDomainAppBase);
+            }
+            finally
+            {
+                sourceHost.Object.Dispose();
+            }
+        }
+
         /// <summary>
         /// This test should ideally be choosing a different path for the test source. Currently both the test source and the adapter
         /// are in the same location. However when we move to run these tests with the V2 itself, then this would be valid.
         /// Leaving the test running till then.
         /// </summary>
         [TestMethod]
-        public void SetupHostShouldSetNewDomainsAppBaseToTestSourceLocationForFullCLRTests()
+        public void ModifyHostPropertiesShouldSetDomainsAppBaseToTestSourceLocationForFullCLRTestss()
         {
             // Arrange
             DummyClass dummyclass = new DummyClass();
@@ -98,6 +122,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
                 // Act
                 sourceHost.Object.SetupHost();
+                sourceHost.Object.ModifyHostProperties();
                 var expectedObject =
                     sourceHost.Object.CreateInstanceForType(typeof(DummyClass), null) as DummyClass;
 
@@ -111,7 +136,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
         }
 
         [TestMethod]
-        public void SetupHostShouldSetNewDomainsAppBaseToAdaptersLocationForNonFullCLRTests()
+        public void ModifyHostPropertiesShouldSetDomainsAppBaseToAdaptersLocationForNonFullCLRTests()
         {
             // Arrange
             DummyClass dummyclass = new DummyClass();


### PR DESCRIPTION
Temporarily we are restting appbase to point to location where adapter is getting picked up from. Then we reset the appbase later to point to test source location.
https://github.com/Microsoft/testfx/issues/384