### PR TITLE
Enabling tcm properties flow to test context

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Constants.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Constants.cs
@@ -50,6 +50,36 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
 
         internal static readonly TestProperty InnerResultsCountProperty = TestProperty.Register("InnerResultsCount", InnerResultsCountLabel, typeof(int), TestPropertyAttributes.Hidden, typeof(TestResult));
 
+        internal static readonly TestProperty TestRunIdProperty = TestProperty.Register(TestRunId, TestRunId, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TestPlanIdProperty = TestProperty.Register(TestPlanId, TestPlanId, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TestCaseIdProperty = TestProperty.Register(TestCaseId, TestCaseId, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TestPointIdProperty = TestProperty.Register(TestPointId, TestPointId, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TestConfigurationIdProperty = TestProperty.Register(TestConfigurationId, TestConfigurationId, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TestConfigurationNameProperty = TestProperty.Register(TestConfigurationName, TestConfigurationName, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty IsInLabEnvironmentProperty = TestProperty.Register(IsInLabEnvironment, IsInLabEnvironment, typeof(bool), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty BuildConfigurationIdProperty = TestProperty.Register(BuildConfigurationId, BuildConfigurationId, typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty BuildDirectoryProperty = TestProperty.Register(BuildDirectory, BuildDirectory, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty BuildFlavorProperty = TestProperty.Register(BuildFlavor, BuildFlavor, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty BuildNumberProperty = TestProperty.Register(BuildNumber, BuildNumber, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty BuildPlatformProperty = TestProperty.Register(BuildPlatform, BuildPlatform, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty BuildUriProperty = TestProperty.Register(BuildUri, BuildUri, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TfsServerCollectionUrlProperty = TestProperty.Register(TfsServerCollectionUrl, TfsServerCollectionUrl, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
+        internal static readonly TestProperty TfsTeamProjectProperty = TestProperty.Register(TfsTeamProject, TfsTeamProject, typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));
+
         #endregion
 
         #region Private Constants
@@ -68,6 +98,22 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         private const string ExecutionIdLabel = "ExecutionId";
         private const string ParentExecIdLabel = "ParentExecId";
         private const string InnerResultsCountLabel = "InnerResultsCount";
+
+        private const string TestRunId = "__Tfs_TestRunId__";
+        private const string TestPlanId = "__Tfs_TestPlanId__";
+        private const string TestCaseId = "__Tfs_TestCaseId__";
+        private const string TestPointId = "__Tfs_TestPointId__";
+        private const string TestConfigurationId = "__Tfs_TestConfigurationId__";
+        private const string TestConfigurationName = "__Tfs_TestConfigurationName__";
+        private const string IsInLabEnvironment = "__Tfs_IsInLabEnvironment__";
+        private const string BuildConfigurationId = "__Tfs_BuildConfigurationId__";
+        private const string BuildDirectory = "__Tfs_BuildDirectory__";
+        private const string BuildFlavor = "__Tfs_BuildFlavor__";
+        private const string BuildNumber = "__Tfs_BuildNumber__";
+        private const string BuildPlatform = "__Tfs_BuildPlatform__";
+        private const string BuildUri = "__Tfs_BuildUri__";
+        private const string TfsServerCollectionUrl = "__Tfs_TfsServerCollectionUrl__";
+        private const string TfsTeamProject = "__Tfs_TeamProject__";
 
         #endregion
     }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TcmTestPropertiesProvider.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TcmTestPropertiesProvider.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
+{
+    using System.Collections.Generic;
+    using TestPlatformObjectModel = Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+    /// <summary>
+    /// Reads and parses the TcmTestProperties in order to populate them in TestRunParameters.
+    /// </summary>
+    internal static class TcmTestPropertiesProvider
+    {
+        /// <summary>
+        /// Gets tcm properties from test case.
+        /// </summary>
+        /// <param name="testCase">Test case.</param>
+        /// <returns>Tcm properties.</returns>
+        public static IDictionary<TestPlatformObjectModel.TestProperty, object> GetTcmProperties(TestPlatformObjectModel.TestCase testCase)
+        {
+            var tcmProperties = new Dictionary<TestPlatformObjectModel.TestProperty, object>();
+
+            // Return empty proeprties when testCase is null or when test case id is zero.
+            if (testCase == null ||
+                testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default(int)) == 0)
+            {
+                return tcmProperties;
+            }
+
+            // Step 1: Add common properties.
+            tcmProperties[Constants.TestRunIdProperty] = testCase.GetPropertyValue<int>(Constants.TestRunIdProperty, default(int));
+            tcmProperties[Constants.TestPlanIdProperty] = testCase.GetPropertyValue<int>(Constants.TestPlanIdProperty, default(int));
+            tcmProperties[Constants.BuildConfigurationIdProperty] = testCase.GetPropertyValue<int>(Constants.BuildConfigurationIdProperty, default(int));
+            tcmProperties[Constants.BuildDirectoryProperty] = testCase.GetPropertyValue<string>(Constants.BuildDirectoryProperty, default(string));
+            tcmProperties[Constants.BuildFlavorProperty] = testCase.GetPropertyValue<string>(Constants.BuildFlavorProperty, default(string));
+            tcmProperties[Constants.BuildNumberProperty] = testCase.GetPropertyValue<string>(Constants.BuildNumberProperty, default(string));
+            tcmProperties[Constants.BuildPlatformProperty] = testCase.GetPropertyValue<string>(Constants.BuildPlatformProperty, default(string));
+            tcmProperties[Constants.BuildUriProperty] = testCase.GetPropertyValue<string>(Constants.BuildUriProperty, default(string));
+            tcmProperties[Constants.TfsServerCollectionUrlProperty] = testCase.GetPropertyValue<string>(Constants.TfsServerCollectionUrlProperty, default(string));
+            tcmProperties[Constants.TfsTeamProjectProperty] = testCase.GetPropertyValue<string>(Constants.TfsTeamProjectProperty, default(string));
+            tcmProperties[Constants.IsInLabEnvironmentProperty] = testCase.GetPropertyValue<bool>(Constants.IsInLabEnvironmentProperty, default(bool));
+
+            // Step 2: Add test case specific properties.
+            tcmProperties[Constants.TestCaseIdProperty] = testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default(int));
+            tcmProperties[Constants.TestConfigurationIdProperty] = testCase.GetPropertyValue<int>(Constants.TestConfigurationIdProperty, default(int));
+            tcmProperties[Constants.TestConfigurationNameProperty] = testCase.GetPropertyValue<string>(Constants.TestConfigurationNameProperty, default(string));
+            tcmProperties[Constants.TestPointIdProperty] = testCase.GetPropertyValue<int>(Constants.TestPointIdProperty, default(int));
+
+            return tcmProperties;
+        }
+    }
+}

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TcmTestPropertiesProvider.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TcmTestPropertiesProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         {
             var tcmProperties = new Dictionary<TestPlatformObjectModel.TestProperty, object>();
 
-            // Return empty proeprties when testCase is null or when test case id is zero.
+            // Return empty properties when testCase is null or when test case id is zero.
             if (testCase == null ||
                 testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default(int)) == 0)
             {

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -371,7 +371,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     "Executing test {0}",
                     unitTestElement.TestMethod.Name);
 
-                var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, sourceLevelParameters);
+                // Run single test passing test context properties to it.
+                var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
+                var testContextProperties = this.GetTestContextProperties(tcmProperties, sourceLevelParameters);
+                var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, testContextProperties);
 
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo(
                     "Executed test {0}",
@@ -381,6 +384,31 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                 this.SendTestResults(currentTest, unitTestResult, startTime, endTime, testExecutionRecorder);
             }
+        }
+
+        /// <summary>
+        /// Get test context properties.
+        /// </summary>
+        /// <param name="tcmProperties">Tcm properties.</param>
+        /// <param name="sourceLevelParameters">Source level parameters.</param>
+        /// <returns>Test context properties.</returns>
+        private IDictionary<string, object> GetTestContextProperties(IDictionary<TestProperty, object> tcmProperties, IDictionary<string, object> sourceLevelParameters)
+        {
+            var testContextProperties = new Dictionary<string, object>();
+
+            // Add tcm properties.
+            foreach (var propertyPair in tcmProperties)
+            {
+                testContextProperties[propertyPair.Key.Id] = propertyPair.Value;
+            }
+
+            // Add source level parameters.
+            foreach (var propertyPair in sourceLevelParameters)
+            {
+                testContextProperties[propertyPair.Key] = propertyPair.Value;
+            }
+
+            return testContextProperties;
         }
 
         private void RunCleanup(

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -62,9 +62,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// Runs a single test.
         /// </summary>
         /// <param name="testMethod"> The test Method. </param>
-        /// <param name="testRunParameters"> The test Run Parameters. </param>
+        /// <param name="testContextProperties"> The test context properties. </param>
         /// <returns> The <see cref="UnitTestResult"/>. </returns>
-        internal UnitTestResult[] RunSingleTest(TestMethod testMethod, IDictionary<string, object> testRunParameters)
+        internal UnitTestResult[] RunSingleTest(TestMethod testMethod, IDictionary<string, object> testContextProperties)
         {
             if (testMethod == null)
             {
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             {
                 using (var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture))
                 {
-                    var properties = new Dictionary<string, object>(testRunParameters);
+                    var properties = new Dictionary<string, object>(testContextProperties);
                     var testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties);
                     testContext.SetOutcome(TestTools.UnitTesting.UnitTestOutcome.InProgress);
 

--- a/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
+++ b/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Discovery\AssemblyEnumeratorWrapper.cs" />
     <Compile Include="Discovery\TestMethodValidator.cs" />
     <Compile Include="Execution\RunCleanupResult.cs" />
+    <Compile Include="Execution\TcmTestPropertiesProvider.cs" />
     <Compile Include="Extensions\TestContextExtensions.cs" />
     <Compile Include="Extensions\TestResultExtensions.cs" />
     <Compile Include="Extensions\UnitTestOutcomeExtensions.cs" />

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TcmTestPropertiesProviderTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TcmTestPropertiesProviderTests.cs
@@ -20,11 +20,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     [TestClass]
     public class TcmTestPropertiesProviderTests
     {
-        private const string PropertiesJsonWithDuplicateNamedTestCases = "{ \"TestPlanId\":1, \"TestRunId\":4, \"BuildConfigurationId\":0, \"BuildDirectory\":\"C:\\\\deployment\", \"BuildFlavor\":null, \"BuildNumber\":\"4\", \"BuildPlatform\":null, \"BuildUri\":\"vstfs:///Build/Build/4\", \"TfsServerCollectionUrl\":\"http://server/tfs/DefaultCollection/\", \"TeamProject\":\"teamproject\", \"IsInLabEnvironment\":false, \"LabEnvironment\":null, \"TestCases\":[{\"FullyQualifiedName\":\"PassingTest\",\"Source\":\"unittestproject1.dll\",\"TestCaseId\":1311,\"TestPointId\":11,\"TestConfigurationId\":1,\"TestConfigurationName\":\"Windows 10\"},{\"FullyQualifiedName\":\"PassingTest\",\"Source\":\"unittestproject1.dll\",\"TestCaseId\":1312,\"TestPointId\":12,\"TestConfigurationId\":2,\"TestConfigurationName\":\"Windows 8\"},{\"FullyQualifiedName\":\"PassingTest2\",\"Source\":\"unittestproject2.dll\",\"TestCaseId\":1313,\"TestPointId\":13,\"TestConfigurationId\":2,\"TestConfigurationName\":\"Windows 8\"}]}";
-
-        private const string TestParam = "testparam";
-        private const string TestValue = "testvalue";
-
         private TestProperty[] tcmKnownProperties = new TestProperty[]
         {
             TestAdapterConstants.TestRunIdProperty,
@@ -55,7 +50,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIdIsZero()
         {
             var testCase = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
-            var propertiesValue = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 0, 54, "sample configuration name", 345 };
+            var propertiesValue = new object[]
+            {
+                32, 534, 5, "sample build directory", "sample build flavor",
+                "132456", "sample build platform", "http://sampleBuildUri/",
+                "http://samplecollectionuri/", "sample team project", false,
+                0, 54, "sample configuration name", 345
+            };
             this.SetTestCaseProperties(testCase, propertiesValue);
 
             var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
@@ -66,7 +67,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void GetTcmPropertiesShouldGetAllPropertiesFromTestCase()
         {
             var testCase = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
-            var propertiesValue = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 1401, 54, "sample configuration name", 345 };
+            var propertiesValue = new object[]
+            {
+                32, 534, 5, "sample build directory", "sample build flavor",
+                "132456", "sample build platform", "http://sampleBuildUri/",
+                "http://samplecollectionuri/", "sample team project", false,
+                1401, 54, "sample configuration name", 345
+            };
             this.SetTestCaseProperties(testCase, propertiesValue);
 
             var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
@@ -79,14 +86,26 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             // Verify 1st call.
             var testCase1 = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
-            var propertiesValue1 = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 1401, 54, "sample configuration name", 345 };
+            var propertiesValue1 = new object[]
+            {
+                32, 534, 5, "sample build directory", "sample build flavor",
+                "132456", "sample build platform", "http://sampleBuildUri/",
+                "http://samplecollectionuri/", "sample team project", false,
+                1401, 54, "sample configuration name", 345
+            };
             this.SetTestCaseProperties(testCase1, propertiesValue1);
             var tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
             this.VerifyTcmProperties(tcmProperties1, testCase1);
 
             // Verify 2nd call.
             var testCase2 = new TestCase("PassingTestFomTestCase2", new Uri("http://sampleUri2/"), "unittestproject2.dll");
-            var propertiesValue2 = new object[] { 33, 535, 6, "sample build directory 2", "sample build flavor 2", "132457", "sample build platform 2", "http://sampleBuildUri2/", "http://samplecollectionuri2/", "sample team project", true, 1403, 55, "sample configuration name 2", 346 };
+            var propertiesValue2 = new object[]
+            {
+                33, 535, 6, "sample build directory 2", "sample build flavor 2",
+                "132457", "sample build platform 2", "http://sampleBuildUri2/",
+                "http://samplecollectionuri2/", "sample team project", true,
+                1403, 55, "sample configuration name 2", 346
+            };
             this.SetTestCaseProperties(testCase2, propertiesValue2);
             var tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
             this.VerifyTcmProperties(tcmProperties2, testCase2);
@@ -97,21 +116,39 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         {
             // Verify 1st call.
             var testCase1 = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
-            var propertiesValue1 = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 1401, 54, "sample configuration name", 345 };
+            var propertiesValue1 = new object[]
+            {
+                32, 534, 5, "sample build directory", "sample build flavor",
+                "132456", "sample build platform", "http://sampleBuildUri/",
+                "http://samplecollectionuri/", "sample team project", false,
+                1401, 54, "sample configuration name", 345
+            };
             this.SetTestCaseProperties(testCase1, propertiesValue1);
             var tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
             this.VerifyTcmProperties(tcmProperties1, testCase1);
 
             // Verify 2nd call.
             var testCase2 = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
-            var propertiesValue2 = new object[] { 33, 535, 6, "sample build directory 2", "sample build flavor 2", "132457", "sample build platform 2", "http://sampleBuildUri2/", "http://samplecollectionuri2/", "sample team project", true, 1403, 55, "sample configuration name 2", 346 };
+            var propertiesValue2 = new object[]
+            {
+                33, 535, 6, "sample build directory 2", "sample build flavor 2",
+                "132457", "sample build platform 2", "http://sampleBuildUri2/",
+                "http://samplecollectionuri2/", "sample team project", true,
+                1403, 55, "sample configuration name 2", 346
+            };
             this.SetTestCaseProperties(testCase2, propertiesValue2);
             var tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
             this.VerifyTcmProperties(tcmProperties2, testCase2);
 
             // Verify 3rd call.
             var testCase3 = new TestCase("PassingTestFomTestCase2", new Uri("http://sampleUri/"), "unittestproject2.dll");
-            var propertiesValue3 = new object[] { 34, 536, 7, "sample build directory 3", "sample build flavor 3", "132458", "sample build platform 3", "http://sampleBuildUri3/", "http://samplecollectionuri3/", "sample team project2", true, 1404, 55, "sample configuration name 3", 347 };
+            var propertiesValue3 = new object[]
+            {
+                34, 536, 7, "sample build directory 3", "sample build flavor 3",
+                "132458", "sample build platform 3", "http://sampleBuildUri3/",
+                "http://samplecollectionuri3/", "sample team project2", true,
+                1404, 55, "sample configuration name 3", 347
+            };
             this.SetTestCaseProperties(testCase3, propertiesValue3);
             var tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
             this.VerifyTcmProperties(tcmProperties3, testCase3);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TcmTestPropertiesProviderTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TcmTestPropertiesProviderTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
+{
+    extern alias FrameworkV1;
+    extern alias FrameworkV2;
+    extern alias FrameworkV2CoreExtension;
+
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+    using Assert = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+    using TestAdapterConstants = Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Constants;
+    using TestClass = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+    using TestMethod = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
+
+    [TestClass]
+    public class TcmTestPropertiesProviderTests
+    {
+        private const string PropertiesJsonWithDuplicateNamedTestCases = "{ \"TestPlanId\":1, \"TestRunId\":4, \"BuildConfigurationId\":0, \"BuildDirectory\":\"C:\\\\deployment\", \"BuildFlavor\":null, \"BuildNumber\":\"4\", \"BuildPlatform\":null, \"BuildUri\":\"vstfs:///Build/Build/4\", \"TfsServerCollectionUrl\":\"http://server/tfs/DefaultCollection/\", \"TeamProject\":\"teamproject\", \"IsInLabEnvironment\":false, \"LabEnvironment\":null, \"TestCases\":[{\"FullyQualifiedName\":\"PassingTest\",\"Source\":\"unittestproject1.dll\",\"TestCaseId\":1311,\"TestPointId\":11,\"TestConfigurationId\":1,\"TestConfigurationName\":\"Windows 10\"},{\"FullyQualifiedName\":\"PassingTest\",\"Source\":\"unittestproject1.dll\",\"TestCaseId\":1312,\"TestPointId\":12,\"TestConfigurationId\":2,\"TestConfigurationName\":\"Windows 8\"},{\"FullyQualifiedName\":\"PassingTest2\",\"Source\":\"unittestproject2.dll\",\"TestCaseId\":1313,\"TestPointId\":13,\"TestConfigurationId\":2,\"TestConfigurationName\":\"Windows 8\"}]}";
+
+        private const string TestParam = "testparam";
+        private const string TestValue = "testvalue";
+
+        private TestProperty[] tcmKnownProperties = new TestProperty[]
+        {
+            TestAdapterConstants.TestRunIdProperty,
+            TestAdapterConstants.TestPlanIdProperty,
+            TestAdapterConstants.BuildConfigurationIdProperty,
+            TestAdapterConstants.BuildDirectoryProperty,
+            TestAdapterConstants.BuildFlavorProperty,
+            TestAdapterConstants.BuildNumberProperty,
+            TestAdapterConstants.BuildPlatformProperty,
+            TestAdapterConstants.BuildUriProperty,
+            TestAdapterConstants.TfsServerCollectionUrlProperty,
+            TestAdapterConstants.TfsTeamProjectProperty,
+            TestAdapterConstants.IsInLabEnvironmentProperty,
+            TestAdapterConstants.TestCaseIdProperty,
+            TestAdapterConstants.TestConfigurationIdProperty,
+            TestAdapterConstants.TestConfigurationNameProperty,
+            TestAdapterConstants.TestPointIdProperty
+        };
+
+        [TestMethod]
+        public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIsNull()
+        {
+            var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(null);
+            Assert.AreEqual(0, tcmProperties.Count);
+        }
+
+        [TestMethod]
+        public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIdIsZero()
+        {
+            var testCase = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
+            var propertiesValue = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 0, 54, "sample configuration name", 345 };
+            this.SetTestCaseProperties(testCase, propertiesValue);
+
+            var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+            Assert.AreEqual(0, tcmProperties.Count);
+        }
+
+        [TestMethod]
+        public void GetTcmPropertiesShouldGetAllPropertiesFromTestCase()
+        {
+            var testCase = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
+            var propertiesValue = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 1401, 54, "sample configuration name", 345 };
+            this.SetTestCaseProperties(testCase, propertiesValue);
+
+            var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+
+            this.VerifyTcmProperties(tcmProperties, testCase);
+        }
+
+        [TestMethod]
+        public void GetTcmPropertiesShouldCopyMultiplePropertiesCorrectlyFromTestCase()
+        {
+            // Verify 1st call.
+            var testCase1 = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
+            var propertiesValue1 = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 1401, 54, "sample configuration name", 345 };
+            this.SetTestCaseProperties(testCase1, propertiesValue1);
+            var tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+            this.VerifyTcmProperties(tcmProperties1, testCase1);
+
+            // Verify 2nd call.
+            var testCase2 = new TestCase("PassingTestFomTestCase2", new Uri("http://sampleUri2/"), "unittestproject2.dll");
+            var propertiesValue2 = new object[] { 33, 535, 6, "sample build directory 2", "sample build flavor 2", "132457", "sample build platform 2", "http://sampleBuildUri2/", "http://samplecollectionuri2/", "sample team project", true, 1403, 55, "sample configuration name 2", 346 };
+            this.SetTestCaseProperties(testCase2, propertiesValue2);
+            var tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+            this.VerifyTcmProperties(tcmProperties2, testCase2);
+        }
+
+        [TestMethod]
+        public void GetTcmPropertiesShouldHandleDuplicateTestsProperlyFromTestCase()
+        {
+            // Verify 1st call.
+            var testCase1 = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
+            var propertiesValue1 = new object[] { 32, 534, 5, "sample build directory", "sample build flavor", "132456", "sample build platform", "http://sampleBuildUti/", "http://samplecollectionuri/", "sample team project", false, 1401, 54, "sample configuration name", 345 };
+            this.SetTestCaseProperties(testCase1, propertiesValue1);
+            var tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+            this.VerifyTcmProperties(tcmProperties1, testCase1);
+
+            // Verify 2nd call.
+            var testCase2 = new TestCase("PassingTestFomTestCase", new Uri("http://sampleUri/"), "unittestproject1.dll");
+            var propertiesValue2 = new object[] { 33, 535, 6, "sample build directory 2", "sample build flavor 2", "132457", "sample build platform 2", "http://sampleBuildUri2/", "http://samplecollectionuri2/", "sample team project", true, 1403, 55, "sample configuration name 2", 346 };
+            this.SetTestCaseProperties(testCase2, propertiesValue2);
+            var tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+            this.VerifyTcmProperties(tcmProperties2, testCase2);
+
+            // Verify 3rd call.
+            var testCase3 = new TestCase("PassingTestFomTestCase2", new Uri("http://sampleUri/"), "unittestproject2.dll");
+            var propertiesValue3 = new object[] { 34, 536, 7, "sample build directory 3", "sample build flavor 3", "132458", "sample build platform 3", "http://sampleBuildUri3/", "http://samplecollectionuri3/", "sample team project2", true, 1404, 55, "sample configuration name 3", 347 };
+            this.SetTestCaseProperties(testCase3, propertiesValue3);
+            var tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
+            this.VerifyTcmProperties(tcmProperties3, testCase3);
+        }
+
+        private void SetTestCaseProperties(TestCase testCase, object[] propertiesValue)
+        {
+            var tcmKnownPropertiesEnumerator = this.tcmKnownProperties.GetEnumerator();
+
+            var propertiesValueEnumerator = propertiesValue.GetEnumerator();
+            while (tcmKnownPropertiesEnumerator.MoveNext() && propertiesValueEnumerator.MoveNext())
+            {
+                var property = tcmKnownPropertiesEnumerator.Current;
+                var value = propertiesValueEnumerator.Current;
+                testCase.SetPropertyValue(property as TestProperty, value);
+            }
+        }
+
+        private void VerifyTcmProperties(IDictionary<TestProperty, object> tcmProperties, TestCase testCase)
+        {
+            foreach (var property in this.tcmKnownProperties)
+            {
+                Assert.AreEqual(testCase.GetPropertyValue(property), tcmProperties[property]);
+            }
+        }
+    }
+}

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTest.CoreAdapter.Unit.Tests.csproj
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTest.CoreAdapter.Unit.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Execution\TestAssemblySettingsProviderTests.cs" />
     <Compile Include="Execution\TestCaseDiscoverySinkTests.cs" />
     <Compile Include="Execution\TestClassInfoTests.cs" />
+    <Compile Include="Execution\TcmTestPropertiesProviderTests.cs" />
     <Compile Include="Execution\TestExecutionManagerTests.cs" />
     <Compile Include="Execution\TestMethodFilterTests.cs" />
     <Compile Include="Execution\TestMethodInfoTests.cs" />


### PR DESCRIPTION
**Description**:
VS IDE has support of association in test explorer. Currently this support is disabled for mstest v2. 
Support for mstest v2 will be enabled with this PR: https://devdiv.visualstudio.com/DevDiv/Automated%20Testing/_git/VS/pullrequest/135489?_a=overview

When association is enabled for mstest v2 tests, user can associate mstest v2 tests with a test case and then run it via test plan flow.

In test plan flow, user might need to use tcm properties (like test case id, test run id, test plan id etc) in test method code. This PR contains changes to allow tcm properties to flow to test context.

**Validation Scenarios**:
Validated that for full framework and net core, tcm properties are properly passed to test context.

**Note**: In talk with @PBoraMSFT if RFC is required in mstest v2 or not as the flow is controled from IDE. There is a plan to add the documentation on association window in test explorer.