### PR TITLE
Add "privateNetworkClientServer" capability to UWP test templates

### DIFF
--- a/Templates/CSharp/UWP/ProjectTemplates/CSharp/Windows UAP/Package.appxmanifest
+++ b/Templates/CSharp/UWP/ProjectTemplates/CSharp/Windows UAP/Package.appxmanifest
@@ -41,5 +41,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClientServer" />
+    <Capability Name="privateNetworkClientServer" />
   </Capabilities>
 </Package>

--- a/Templates/VisualBasic/UWP/ProjectTemplates/VisualBasic/Windows UAP/Package.appxmanifest
+++ b/Templates/VisualBasic/UWP/ProjectTemplates/VisualBasic/Windows UAP/Package.appxmanifest
@@ -41,5 +41,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClientServer" />
+    <Capability Name="privateNetworkClientServer" />
   </Capabilities> 
 </Package>


### PR DESCRIPTION
This is needed to allow tcp connections on Xbox, SurfaceHub, etc
(Ported from 1.2.1 branch into master)