### PR TITLE
Upgrade VSSDK

### DIFF
--- a/Templates/CSharp/Desktop/packages.config
+++ b/Templates/CSharp/Desktop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.8.3247" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Templates/CSharp/UWP/packages.config
+++ b/Templates/CSharp/UWP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.8.3247" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Templates/VisualBasic/Desktop/packages.config
+++ b/Templates/VisualBasic/Desktop/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.8.3247" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Templates/VisualBasic/UWP/packages.config
+++ b/Templates/VisualBasic/UWP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.8.3247" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/WizardExtensions/MSTestv2IntelliTestExtensionPackage/packages.config
+++ b/WizardExtensions/MSTestv2IntelliTestExtensionPackage/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.8.3247" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/WizardExtensions/MSTestv2UnitTestExtensionPackage/packages.config
+++ b/WizardExtensions/MSTestv2UnitTestExtensionPackage/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.8.3247" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/scripts/build/TestFx.Settings.targets
+++ b/scripts/build/TestFx.Settings.targets
@@ -7,7 +7,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') and $(FrameworkIdentifier) != 'NetCore'" />
   <!-- Import props/targets with $(RepoRoot) since msbuild takes the relative path based on settings.targets and not with respect to the project. -->
   <Import Project="$(RepoRoot)packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('$(RepoRoot)packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
-  <Import Project="$(RepoRoot)packages\microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props" Condition=" $(IsVsixProj) == 'true' and Exists('$(RepoRoot)packages\microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" />
+  <Import Project="$(RepoRoot)packages\microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.props" Condition=" $(IsVsixProj) == 'true' and Exists('$(RepoRoot)packages\microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.props')" />
 
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>

--- a/scripts/build/TestFx.targets
+++ b/scripts/build/TestFx.targets
@@ -19,7 +19,7 @@
   <!-- Import localization specific Targets if enabled. -->
   <Import Project="$(RepoRoot)scripts\build\TestFx.Loc.targets" Condition="($(IsTest) == '' or $(IsTest) == 'false') and $(IsLocalizationEnabled) == 'true'"/>
 
-  <Import Project="$(RepoRoot)packages\microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets" Condition="$(IsVsixProj) == 'true' and Exists('$(RepoRoot)packages\microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" />
+  <Import Project="$(RepoRoot)packages\microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.targets" Condition="$(IsVsixProj) == 'true' and Exists('$(RepoRoot)packages\microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.targets')" />
 
   <ItemGroup>
     <None Include="$(TestFxRoot)scripts\build\key.snk">
@@ -68,8 +68,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.props'))" />
-    <Error Condition="!Exists('$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.0.26201\build\Microsoft.VSSDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.props'))" />
+    <Error Condition="!Exists('$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(TestFxPackagesRoot)microsoft.vssdk.buildtools.15.8.3247\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
 
   <Target Name="GatherLocalizedOutputsForSigning" DependsOnTargets="TestFxLocalization">


### PR DESCRIPTION
Upgrading the version of VSSDK Build tools nuget, because the older one is incompatible with the latest VSSDK.