### PR TITLE
Allow Task-returning test methods without async keyword

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Extensions/MethodInfoExtensions.cs
@@ -114,8 +114,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions
         /// <returns>True if the method has a void/task return type..</returns>
         internal static bool IsVoidOrTaskReturnType(this MethodInfo method)
         {
-            return method.GetAsyncTypeName() == null ? ReflectHelper.MatchReturnType(method, typeof(void))
-                : ReflectHelper.MatchReturnType(method, typeof(Task));
+            return ReflectHelper.MatchReturnType(method, typeof(Task))
+                || (ReflectHelper.MatchReturnType(method, typeof(void)) && method.GetAsyncTypeName() == null);
         }
 
         /// <summary>

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/TestMethodValidatorTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/TestMethodValidatorTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
         {
             this.SetupTestMethod();
             var methodInfo = typeof(DummyTestClass).GetMethod(
-                "MethodWithTaskReturnType",
+                "MethodWithIntReturnType",
                 BindingFlags.Instance | BindingFlags.Public);
 
             Assert.IsFalse(this.testMethodValidator.IsValidTestMethod(methodInfo, typeof(DummyTestClass), this.warnings));
@@ -146,6 +146,17 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
             this.SetupTestMethod();
             var methodInfo = typeof(DummyTestClass).GetMethod(
                 "AsyncMethodWithTaskReturnType",
+                BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.IsTrue(this.testMethodValidator.IsValidTestMethod(methodInfo, this.type, this.warnings));
+        }
+
+        [TestMethod]
+        public void IsValidTestMethodShouldReturnTrueForNonAsyncMethodsWithTaskReturnType()
+        {
+            this.SetupTestMethod();
+            var methodInfo = typeof(DummyTestClass).GetMethod(
+                "MethodWithTaskReturnType",
                 BindingFlags.Instance | BindingFlags.Public);
 
             Assert.IsTrue(this.testMethodValidator.IsValidTestMethod(methodInfo, this.type, this.warnings));
@@ -199,6 +210,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
         public Task MethodWithTaskReturnType()
         {
             return Task.Delay(TimeSpan.Zero);
+        }
+
+        public int MethodWithIntReturnType()
+        {
+            return 0;
         }
 
         public void MethodWithVoidReturnType()

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/MethodInfoExtensionsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/MethodInfoExtensionsTests.cs
@@ -75,6 +75,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
         }
 
         [TestMethod]
+        public void HasCorrectClassOrAssemblyInitializeSignatureShouldReturnTrueForTestMethodsWithoutAsync()
+        {
+            var methodInfo = typeof(DummyTestClass).GetMethod("PublicStaticNonAsyncTaskMethodWithTC");
+            Assert.IsTrue(methodInfo.HasCorrectClassOrAssemblyInitializeSignature());
+        }
+
+        [TestMethod]
         public void HasCorrectClassOrAssemblyInitializeSignatureShouldReturnFalseForAsyncTestMethodsWithNonTaskReturnTypes()
         {
             var methodInfo = typeof(DummyTestClass).GetMethod("PublicStaticAsyncVoidMethodWithTC");
@@ -128,6 +135,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
         }
 
         [TestMethod]
+        public void HasCorrectClassOrAssemblyCleanupSignatureShouldReturnTrueForTestMethodsWithoutAsync()
+        {
+            var methodInfo = typeof(DummyTestClass).GetMethod("PublicStaticNonAsyncTaskMethod");
+            Assert.IsTrue(methodInfo.HasCorrectClassOrAssemblyCleanupSignature());
+        }
+
+        [TestMethod]
         public void HasCorrectClassOrAssemblyCleanupSignatureShouldReturnFalseForAsyncTestMethodsWithNonTaskReturnTypes()
         {
             var methodInfo = typeof(DummyTestClass).GetMethod("PublicStaticAsyncVoidMethod");
@@ -177,6 +191,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
         public void HasCorrectTestInitializeOrCleanupSignatureShouldReturnTrueForAsyncTestMethods()
         {
             var methodInfo = typeof(DummyTestClass).GetMethod("PublicAsyncTaskMethod");
+            Assert.IsTrue(methodInfo.HasCorrectTestInitializeOrCleanupSignature());
+        }
+
+        [TestMethod]
+        public void HasCorrectTestInitializeOrCleanupSignatureShouldReturnTrueForTestMethodsWithoutAsync()
+        {
+            var methodInfo = typeof(DummyTestClass).GetMethod("PublicNonAsyncTaskMethod");
             Assert.IsTrue(methodInfo.HasCorrectTestInitializeOrCleanupSignature());
         }
 
@@ -248,6 +269,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
         }
 
         [TestMethod]
+        public void HasCorrectTestMethodSignatureShouldReturnTrueForTaskTestMethodsWithoutAsync()
+        {
+            var methodInfo = typeof(DummyTestClass).GetMethod("PublicNonAsyncTaskMethod");
+            Assert.IsTrue(methodInfo.HasCorrectTestMethodSignature(false));
+        }
+
+        [TestMethod]
         public void HasCorrectTestMethodSignatureShouldReturnFalseForAsyncTestMethodsWithNonTaskReturnTypes()
         {
             var methodInfo = typeof(DummyTestClass).GetMethod("PublicAsyncVoidMethod");
@@ -294,6 +322,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
         public void IsVoidOrTaskReturnTypeShouldReturnTrueForAsyncTaskMethods()
         {
             var methodInfo = typeof(DummyTestClass).GetMethod("PublicAsyncTaskMethod");
+            Assert.IsTrue(methodInfo.IsVoidOrTaskReturnType());
+        }
+
+        [TestMethod]
+        public void IsVoidOrTaskReturnTypeShouldReturnTrueForTaskMethodsWithoutAsync()
+        {
+            var methodInfo = typeof(DummyTestClass).GetMethod("PublicNonAsyncTaskMethod");
             Assert.IsTrue(methodInfo.IsVoidOrTaskReturnType());
         }
 
@@ -453,6 +488,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
                 await Task.FromResult(true);
             }
 
+            public static Task PublicStaticNonAsyncTaskMethodWithTC(UTFExtension.TestContext tc)
+            {
+                return Task.FromResult(true);
+            }
+
             public static async void PublicStaticAsyncVoidMethodWithTC(UTFExtension.TestContext tc)
             {
                 await Task.FromResult(true);
@@ -471,6 +511,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
             public static async void PublicStaticAsyncVoidMethod()
             {
                 await Task.FromResult(true);
+            }
+
+            public static Task PublicStaticNonAsyncTaskMethod()
+            {
+                return Task.FromResult(true);
             }
 
             public void PublicMethod()
@@ -500,6 +545,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
             public async void PublicAsyncVoidMethod()
             {
                 await Task.FromResult(true);
+            }
+
+            public Task PublicNonAsyncTaskMethod()
+            {
+                return Task.FromResult(true);
             }
 
             [UTF.Timeout(-11)]


### PR DESCRIPTION
Enables asynchronous tests that don't use the async state machine while
still rejecting async void methods.

Fixes #500. Discussion on the issue hasn't concluded whether this behavior is intentional or not, but it was requested that I go ahead and open a pull request for it.