### PR TITLE
Setting Option for marking not runnable tests as failed

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     continue;
                 }
 
-                var testResult = unitTestResult.ToTestResult(test, startTime, endTime, MSTestSettings.CurrentSettings.MapInconclusiveToFailed);
+                var testResult = unitTestResult.ToTestResult(test, startTime, endTime, MSTestSettings.CurrentSettings.MapInconclusiveToFailed, MSTestSettings.CurrentSettings.MapNotRunnableToFailed);
 
                 if (unitTestResult.DatarowIndex >= 0)
                 {

--- a/src/Adapter/MSTest.CoreAdapter/Helpers/UnitTestOutcomeHelper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Helpers/UnitTestOutcomeHelper.cs
@@ -15,8 +15,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers
         /// </summary>
         /// <param name="unitTestOutcome"> The unit Test Outcome. </param>
         /// <param name="mapInconclusiveToFailed">Should map inconclusive to failed.</param>
+        /// <param name="mapNotRunnableToFailed">Should map not runnable to failed</param>
         /// <returns>The Test platforms outcome.</returns>
-        internal static TestOutcome ToTestOutcome(UnitTestOutcome unitTestOutcome, bool mapInconclusiveToFailed)
+        internal static TestOutcome ToTestOutcome(UnitTestOutcome unitTestOutcome, bool mapInconclusiveToFailed, bool mapNotRunnableToFailed)
         {
             switch (unitTestOutcome)
             {
@@ -29,7 +30,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers
                     return TestOutcome.Failed;
 
                 case UnitTestOutcome.NotRunnable:
-                    return TestOutcome.None;
+                    {
+                        if (mapNotRunnableToFailed)
+                        {
+                            return TestOutcome.Failed;
+                        }
+
+                        return TestOutcome.None;
+                    }
 
                 case UnitTestOutcome.Ignored:
                     return TestOutcome.Skipped;

--- a/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
@@ -51,6 +51,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         {
             this.CaptureDebugTraces = true;
             this.MapInconclusiveToFailed = false;
+            this.MapNotRunnableToFailed = false;
             this.EnableBaseClassTestMethodsFromOtherAssemblies = true;
             this.ForcedLegacyMode = false;
             this.TestSettingsFile = null;
@@ -122,6 +123,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         public bool MapInconclusiveToFailed { get; private set; }
 
         /// <summary>
+        /// Gets a value indicating whether a not runnable result be mapped to failed test.
+        /// </summary>
+        public bool MapNotRunnableToFailed { get; private set; }
+
+        /// <summary>
         /// Gets a value indicating whether to enable discovery of test methods from base classes in a different assembly from the inheriting test class.
         /// </summary>
         public bool EnableBaseClassTestMethodsFromOtherAssemblies { get; private set; }
@@ -159,6 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             CurrentSettings.ForcedLegacyMode = settings.ForcedLegacyMode;
             CurrentSettings.TestSettingsFile = settings.TestSettingsFile;
             CurrentSettings.MapInconclusiveToFailed = settings.MapInconclusiveToFailed;
+            CurrentSettings.MapNotRunnableToFailed = settings.MapNotRunnableToFailed;
             CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies = settings.EnableBaseClassTestMethodsFromOtherAssemblies;
             CurrentSettings.ParallelizationWorkers = settings.ParallelizationWorkers;
             CurrentSettings.ParallelizationScope = settings.ParallelizationScope;
@@ -280,6 +287,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             // <MSTestV2>
             //     <CaptureTraceOutput>true</CaptureTraceOutput>
             //     <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
+            //     <MapNotRunnableToFailed>false</MapNotRunnableToFailed>
             //     <EnableBaseClassTestMethodsFromOtherAssemblies>false</EnableBaseClassTestMethodsFromOtherAssemblies>
             //     <TestTimeout>5000</TestTimeout>
             //     <Parallelize>
@@ -345,6 +353,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
                                 if (bool.TryParse(reader.ReadInnerXml(), out result))
                                 {
                                     settings.MapInconclusiveToFailed = result;
+                                }
+
+                                break;
+                            }
+
+                        case "MAPNOTRUNNABLETOFAILED":
+                            {
+                                if (bool.TryParse(reader.ReadInnerXml(), out result))
+                                {
+                                    settings.MapNotRunnableToFailed = result;
                                 }
 
                                 break;

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
@@ -148,8 +148,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         /// <param name="startTime"> The start Time.  </param>
         /// <param name="endTime"> The end Time.  </param>
         /// <param name="mapInconclusiveToFailed">Indication to map inconclusive tests to failed.</param>
+        /// <param name="mapNotRunnableToFailed">Indication to map not runnable to failed.</param>
         /// <returns> The <see cref="TestResult"/>. </returns>
-        internal TestResult ToTestResult(TestCase testCase, DateTimeOffset startTime, DateTimeOffset endTime, bool mapInconclusiveToFailed)
+        internal TestResult ToTestResult(TestCase testCase, DateTimeOffset startTime, DateTimeOffset endTime, bool mapInconclusiveToFailed, bool mapNotRunnableToFailed)
         {
             Debug.Assert(testCase != null, "testCase");
 
@@ -159,7 +160,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
                                             Duration = this.Duration,
                                             ErrorMessage = this.ErrorMessage,
                                             ErrorStackTrace = this.ErrorStackTrace,
-                                            Outcome = UnitTestOutcomeHelper.ToTestOutcome(this.Outcome, mapInconclusiveToFailed),
+                                            Outcome = UnitTestOutcomeHelper.ToTestOutcome(this.Outcome, mapInconclusiveToFailed, mapNotRunnableToFailed),
                                             StartTime = startTime,
                                             EndTime = endTime
             };

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestResultTest.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestResultTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var endTime = DateTimeOffset.Now;
 
             // Act
-            var testResult = result.ToTestResult(testCase, startTime, endTime, mapInconclusiveToFailed: false);
+            var testResult = result.ToTestResult(testCase, startTime, endTime, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
 
             // Validate
             Assert.AreEqual(testCase, testResult.TestCase);
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 StandardOut = "DummyOutput"
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, mapInconclusiveToFailed: false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.IsTrue(testresult.Messages.All(m => m.Text.Contains("DummyOutput") && m.Category.Equals("StdOutMsgs")));
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 DebugTrace = "DummyDebugTrace"
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, mapInconclusiveToFailed: false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.IsTrue(testresult.Messages.All(m => m.Text.Contains("\n\nDebug Trace:\nDummyDebugTrace") && m.Category.Equals("StdOutMsgs")));
         }
     }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Helpers/UnitTestOutcomeHelperTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Helpers/UnitTestOutcomeHelperTests.cs
@@ -22,63 +22,63 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Helpers
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomePassedShouldReturnTestOutcomePassed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Passed, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Passed, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.Passed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeFailedShouldReturnTestOutcomeFailed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Failed, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Failed, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeErrorShouldReturnTestOutcomeFailed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Error, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Error, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeNotRunnableShouldReturnTestOutcomeNone()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.None, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeTimeoutShouldReturnTestOutcomeFailed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Timeout, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Timeout, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeIgnoredShouldReturnTestOutcomeSkipped()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Ignored, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Ignored, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.Skipped, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeInconclusiveShouldReturnTestOutcomeSkipped()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.Skipped, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeNotFoundShouldReturnTestOutcomeNotFound()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotFound, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotFound, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.NotFound, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeInProgressShouldReturnTestOutcomeNone()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.InProgress, mapInconclusiveToFailed: false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.InProgress, mapInconclusiveToFailed: false, mapNotRunnableToFailed: false);
             Assert.AreEqual(TestOutcome.None, resultOutcome);
         }
     }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -65,6 +65,20 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
         }
 
         [TestMethod]
+        public void MapNotRunnableToFailedIsByDefaultFalseWhenNotSpecified()
+        {
+            string runSettingxml =
+                @"<RunSettings>
+                    <MSTestV2>
+                    </MSTestV2>
+                  </RunSettings>";
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, false);
+        }
+
+        [TestMethod]
         public void MapInconclusiveToFailedShouldBeConsumedFromRunSettingsWhenSpecified()
         {
             string runSettingxml =
@@ -77,6 +91,21 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+        }
+
+        [TestMethod]
+        public void MapNotRunnableToFailedShouldBeConsumedFromRunSettingsWhenSpecified()
+        {
+            string runSettingxml =
+                @"<RunSettings>
+                    <MSTestV2>
+                        <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
+                    </MSTestV2>
+                  </RunSettings>";
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
         }
 
         [TestMethod]
@@ -566,6 +595,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                   @"<RunSettings>
                       <MSTest>
                         <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                        <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                         <DummyPlatformSpecificSetting>True</DummyPlatformSpecificSetting>
                         <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
                       </MSTest>
@@ -608,6 +638,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual("DummyPath\\\\TestSettings1.testsettings", adapterSettings.TestSettingsFile);
         }
 
@@ -618,6 +649,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                   @"<RunSettings>
                       <MSTest>
                         <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                        <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                         <UnReadableSetting>foobar</UnReadableSetting>
                         <ForcedLegacyMode>true</ForcedLegacyMode>
                         <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
@@ -663,6 +695,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
             Assert.AreEqual("DummyPath\\\\TestSettings1.testsettings", adapterSettings.TestSettingsFile);
@@ -724,6 +757,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                       <MSTest>
                         <!-- Map inconclusive -->
                         <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                        <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                         <DummyPlatformSpecificSetting>True</DummyPlatformSpecificSetting>
                         <!-- Force Legacy mode -->
                         <ForcedLegacyMode>true</ForcedLegacyMode>
@@ -770,6 +804,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
         }
@@ -825,6 +860,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                  <MSTest>
                    <CaptureTraceOutput>False</CaptureTraceOutput> 
                    <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                   <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                    <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
                    <ForcedLegacyMode>true</ForcedLegacyMode>
                    <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
@@ -837,6 +873,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.AreEqual(MSTestSettings.CurrentSettings.CaptureDebugTraces, false);
             Assert.AreEqual(MSTestSettings.CurrentSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(MSTestSettings.CurrentSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual(MSTestSettings.CurrentSettings.ForcedLegacyMode, true);
             Assert.AreEqual(MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
             Assert.IsFalse(string.IsNullOrEmpty(MSTestSettings.CurrentSettings.TestSettingsFile));
@@ -850,6 +887,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, false);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
         }
 
@@ -861,6 +899,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, false);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
         }
 
@@ -873,6 +912,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, false);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
         }
 
@@ -905,6 +945,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             @"<RunSettings>
                  <MSTest>
                    <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                   <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                    <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
                    <ForcedLegacyMode>true</ForcedLegacyMode>
                    <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
@@ -920,6 +961,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
             Assert.IsFalse(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
@@ -932,6 +974,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             @"<RunSettings>
                  <MSTestV2>
                    <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                   <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                    <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
                    <ForcedLegacyMode>true</ForcedLegacyMode>
                    <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
@@ -947,6 +990,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
             Assert.IsFalse(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
@@ -959,6 +1003,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             @"<RunSettings>
                  <MSTestV2>
                    <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+                   <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                    <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
                  </MSTestV2>
                  <MSTest>
@@ -977,6 +1022,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
             Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
             Assert.AreEqual(adapterSettings.ForcedLegacyMode, false);
             Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestResultTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestResultTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
             var endTime = DateTimeOffset.Now;
 
             // Act
-            var testResult = result.ToTestResult(testCase, startTime, endTime, false);
+            var testResult = result.ToTestResult(testCase, startTime, endTime, false, false);
 
             // Validate
             Assert.AreEqual(testCase, testResult.TestCase);
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 StandardOut = "DummyOutput"
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
             Assert.IsTrue(testresult.Messages.All(m => m.Text.Contains("DummyOutput") && m.Category.Equals("StdOutMsgs")));
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 StandardError = "DummyError"
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
             Assert.IsTrue(testresult.Messages.All(m => m.Text.Contains("DummyError") && m.Category.Equals("StdErrMsgs")));
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 DebugTrace = "DummyDebugTrace"
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
             Assert.IsTrue(testresult.Messages.All(m => m.Text.Contains("\n\nDebug Trace:\nDummyDebugTrace") && m.Category.Equals("StdOutMsgs")));
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 TestContextMessages = "KeepMovingForward"
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
             Assert.IsTrue(testresult.Messages.All(m => m.Text.Contains("\n\nTestContext Messages:\nKeepMovingForward") && m.Category.Equals("StdOutMsgs")));
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 ResultFiles = new List<string>() { "dummy://DummyFile.txt" }
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
 
             Assert.AreEqual(testresult.Attachments.Count, 1);
             Assert.AreEqual(testresult.Attachments[0].Attachments[0].Description, "dummy://DummyFile.txt");
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 ResultFiles = null
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
 
             Assert.AreEqual(testresult.Attachments.Count, 0);
         }
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
                 InnerResultsCount = innerResultsCount
             };
             TestCase testCase = new TestCase("Foo", new Uri("Uri", UriKind.Relative), Assembly.GetExecutingAssembly().FullName);
-            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false);
+            var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, false, false);
 
             Assert.AreEqual(executionId, testresult.GetPropertyValue(MSTest.TestAdapter.Constants.ExecutionIdProperty));
             Assert.AreEqual(parentExecId, testresult.GetPropertyValue(MSTest.TestAdapter.Constants.ParentExecIdProperty));
@@ -178,71 +178,78 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomePassedShouldReturnTestOutcomePassed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Passed, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Passed, false, false);
             Assert.AreEqual(TestOutcome.Passed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeFailedShouldReturnTestOutcomeFailed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Failed, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Failed, false, false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeErrorShouldReturnTestOutcomeFailed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Error, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Error, false, false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
-        public void UniTestHelperToTestOutcomeForUnitTestOutcomeNotRunnableShouldReturnTestOutcomeNone()
+        public void UniTestHelperToTestOutcomeForUnitTestOutcomeNotRunnableShouldReturnTestOutcomeNoneWhenNotSpecified()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, false, false);
             Assert.AreEqual(TestOutcome.None, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeTimeoutShouldReturnTestOutcomeFailed()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Timeout, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Timeout, false, false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeIgnoredShouldReturnTestOutcomeSkipped()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Ignored, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Ignored, false, false);
             Assert.AreEqual(TestOutcome.Skipped, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeInconclusiveShouldReturnTestOutcomeSkipped()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, false, false);
             Assert.AreEqual(TestOutcome.Skipped, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeInconclusiveShouldReturnTestOutcomeFailedWhenSpecifiedSo()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, true);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, true, false);
             Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeNotFoundShouldReturnTestOutcomeNotFound()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotFound, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotFound, false, false);
             Assert.AreEqual(TestOutcome.NotFound, resultOutcome);
         }
 
         [TestMethod]
         public void UniTestHelperToTestOutcomeForUnitTestOutcomeInProgressShouldReturnTestOutcomeNone()
         {
-            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.InProgress, false);
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.InProgress, false, false);
             Assert.AreEqual(TestOutcome.None, resultOutcome);
+        }
+
+        [TestMethod]
+        public void UniTestHelperToTestOutcomeForUnitTestOutcomeNotRunnableShouldReturnTestOutcomeFailedWhenSpecifiedSo()
+        {
+            var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, false, true);
+            Assert.AreEqual(TestOutcome.Failed, resultOutcome);
         }
     }
 }


### PR DESCRIPTION
Issue related #499 
1. Adding setting option **<MapNotRunnableToFailed>** for marking not runnable test outcome as failed when specified.
2. Modified UTs for the same