### PR TITLE
MissingMethodException Fix

### DIFF
--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
@@ -118,11 +118,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         }
 
         /// <inheritdoc/>
-        public override IDictionary Properties
+        public override IDictionary<string, object> Properties
         {
             get
             {
-                return this.properties as IDictionary;
+                return this.properties as IDictionary<string, object>;
             }
         }
 

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         {
             get
             {
-                return this.properties as IDictionary<string, object>;
+                return this.properties;
             }
         }
 

--- a/src/TestFramework/Extension.Desktop/TestContext.cs
+++ b/src/TestFramework/Extension.Desktop/TestContext.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.VisualStudio.TestTools.UnitTesting
 {
     using System;
-    using System.Collections;
+    using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
     using System.Diagnostics;
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <summary>
         /// Gets test properties for a test.
         /// </summary>
-        public abstract IDictionary Properties { get; }
+        public abstract IDictionary<string, object> Properties { get; }
 
         /// <summary>
         /// Gets the current data row when test is used for data driven testing.

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
@@ -59,10 +59,10 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             Assert.IsNotNull(this.testContextImplementation.Properties);
 
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties,
+                this.testContextImplementation.Properties.ToList(),
                 new KeyValuePair<string, object>("FullyQualifiedTestClassName", "A.C.M"));
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties,
+                this.testContextImplementation.Properties.ToList(),
                 new KeyValuePair<string, object>("TestName", "M"));
         }
 
@@ -115,8 +115,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
 
             this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
 
-            CollectionAssert.Contains(this.testContextImplementation.Properties, property1);
-            CollectionAssert.Contains(this.testContextImplementation.Properties, property2);
+            CollectionAssert.Contains(this.testContextImplementation.Properties.ToList(), property1);
+            CollectionAssert.Contains(this.testContextImplementation.Properties.ToList(), property2);
         }
 
         [TestMethod]
@@ -162,7 +162,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             this.testContextImplementation.AddProperty("SomeNewProperty", "SomeValue");
 
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties,
+                this.testContextImplementation.Properties.ToList(),
                 new KeyValuePair<string, object>("SomeNewProperty", "SomeValue"));
         }
 


### PR DESCRIPTION
When running a test project compiled for netstandard, and running in full framework throws the following error:
 Error: System.MissingMethodException: Method not found: 'System.Collections.Generic.IDictionary`2<System.String,System.Object> Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.get_Properties()'..

It is expecting IDictionary`2<System.String,System.Object> hence causing run time error.