### PR TITLE
TestContext Properties type fixed to be IDictionary

### DIFF
--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
@@ -118,11 +118,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         }
 
         /// <inheritdoc/>
-        public override IDictionary<string, object> Properties
+        public override IDictionary Properties
         {
             get
             {
-                return this.properties;
+                return this.properties as IDictionary;
             }
         }
 

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestContextImplementation.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
@@ -115,11 +116,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// An System.Collections.IDictionary object that contains key/value pairs that
         ///  represent the test properties.
         /// </returns>
-        public override IDictionary<string, object> Properties
+        public override IDictionary Properties
         {
             get
             {
-                return this.properties as IDictionary<string, object>;
+                return this.properties as IDictionary;
             }
         }
 

--- a/src/TestFramework/Extension.Desktop/TestContext.cs
+++ b/src/TestFramework/Extension.Desktop/TestContext.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestTools.UnitTesting
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Data;
     using System.Data.Common;
@@ -19,7 +20,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <summary>
         /// Gets test properties for a test.
         /// </summary>
-        public abstract IDictionary<string, object> Properties { get; }
+        public abstract IDictionary Properties { get; }
 
         /// <summary>
         /// Gets the current data row when test is used for data driven testing.

--- a/src/TestFramework/Extension.Shared/TestContext.cs
+++ b/src/TestFramework/Extension.Shared/TestContext.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestTools.UnitTesting
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <summary>
         /// Gets test properties for a test.
         /// </summary>
-        public abstract IDictionary<string, object> Properties { get; }
+        public abstract IDictionary Properties { get; }
 
         /// <summary>
         /// Gets Fully-qualified name of the class containing the test method currently being executed
@@ -29,32 +30,17 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// in the test results. Users can benefit from messages that include the fully-qualified
         /// class name in addition to the name of the test method currently being executed.
         /// </remarks>
-        public virtual string FullyQualifiedTestClassName
-        {
-            get
-            {
-                return this.GetProperty<string>("FullyQualifiedTestClassName");
-            }
-        }
+        public virtual string FullyQualifiedTestClassName => this.GetProperty<string>("FullyQualifiedTestClassName");
 
         /// <summary>
         /// Gets the Name of the test method currently being executed
         /// </summary>
-        public virtual string TestName
-        {
-            get
-            {
-                return this.GetProperty<string>("TestName");
-            }
-        }
+        public virtual string TestName => this.GetProperty<string>("TestName");
 
         /// <summary>
         /// Gets the current test outcome.
         /// </summary>
-        public virtual UnitTestOutcome CurrentTestOutcome
-        {
-            get { return UnitTestOutcome.Unknown; }
-        }
+        public virtual UnitTestOutcome CurrentTestOutcome => UnitTestOutcome.Unknown;
 
         /// <summary>
         /// Used to write trace messages while the test is running
@@ -72,21 +58,18 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         private T GetProperty<T>(string name)
             where T : class
         {
-            object o;
-
-            if (!this.Properties.TryGetValue(name, out o))
+            if (!((IDictionary<string, object>)this.Properties).TryGetValue(name, out object propertyValue))
             {
                 return null;
             }
 
-            if (o != null && !(o is T))
+            if (propertyValue != null && !(propertyValue is T))
             {
                 // If o has a value, but it's not the right type
-                Debug.Assert(false, "How did an invalid value get in here?");
-                throw new InvalidCastException(string.Format(CultureInfo.CurrentCulture, FrameworkMessages.InvalidPropertyType, name, o.GetType(), typeof(T)));
+                throw new InvalidCastException(string.Format(CultureInfo.CurrentCulture, FrameworkMessages.InvalidPropertyType, name, propertyValue.GetType(), typeof(T)));
             }
 
-            return (T)o;
+            return (T)propertyValue;
         }
     }
 }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -883,7 +883,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             [UTF.TestCategory("Foo")]
             public void PassingTest()
             {
-                TestContextProperties = this.TestContext.Properties;
+                TestContextProperties = this.TestContext.Properties as IDictionary<string, object>;
             }
 
             [UTF.TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
@@ -922,7 +922,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 new Dictionary<string, object>());
 
             this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
-            var customProperty = testContext.Properties.FirstOrDefault(p => p.Key.Equals("WhoAmI"));
+            var customProperty = ((IDictionary<string, object>)testContext.Properties).FirstOrDefault(p => p.Key.Equals("WhoAmI"));
 
             Assert.IsNotNull(customProperty);
             Assert.AreEqual("Me", customProperty.Value);
@@ -1009,7 +1009,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             // Verify that the first value gets set.
             object value;
-            Assert.IsTrue(testContext.Properties.TryGetValue("WhoAmI", out value));
+            Assert.IsTrue(((IDictionary<string, object>)testContext.Properties).TryGetValue("WhoAmI", out value));
             Assert.AreEqual("Me", value);
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/PlatformServiceProviderTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/PlatformServiceProviderTests.cs
@@ -94,7 +94,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             // Assert.
             Assert.AreEqual("A.C.M", testContext.Context.FullyQualifiedTestClassName);
             Assert.AreEqual("M", testContext.Context.TestName);
-            Assert.IsTrue(testContext.Context.Properties.Contains(properties.ToArray()[0]));
+            Assert.IsTrue(testContext.Context.Properties.Contains(properties.ToArray()[0].Key));
+            Assert.IsTrue(((IDictionary<string, object>)testContext.Context.Properties).Contains(properties.ToArray()[0]));
         }
     }
 }

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
@@ -59,10 +59,10 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             Assert.IsNotNull(this.testContextImplementation.Properties);
 
             CollectionAssert.Contains(
-                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
+                this.testContextImplementation.Properties,
                 new KeyValuePair<string, object>("FullyQualifiedTestClassName", "A.C.M"));
             CollectionAssert.Contains(
-                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
+                this.testContextImplementation.Properties,
                 new KeyValuePair<string, object>("TestName", "M"));
         }
 
@@ -115,9 +115,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
 
             this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
 
-            var propertyList = ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList();
-            CollectionAssert.Contains(propertyList, property1);
-            CollectionAssert.Contains(propertyList, property2);
+            CollectionAssert.Contains(this.testContextImplementation.Properties, property1);
+            CollectionAssert.Contains(this.testContextImplementation.Properties, property2);
         }
 
         [TestMethod]
@@ -162,7 +161,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             this.testContextImplementation.AddProperty("SomeNewProperty", "SomeValue");
 
             CollectionAssert.Contains(
-                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
+                this.testContextImplementation.Properties,
                 new KeyValuePair<string, object>("SomeNewProperty", "SomeValue"));
         }
 

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
@@ -59,10 +59,10 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             Assert.IsNotNull(this.testContextImplementation.Properties);
 
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties.ToList(),
+                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
                 new KeyValuePair<string, object>("FullyQualifiedTestClassName", "A.C.M"));
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties.ToList(),
+                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
                 new KeyValuePair<string, object>("TestName", "M"));
         }
 
@@ -115,8 +115,9 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
 
             this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
 
-            CollectionAssert.Contains(this.testContextImplementation.Properties.ToList(), property1);
-            CollectionAssert.Contains(this.testContextImplementation.Properties.ToList(), property2);
+            var propertyList = ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList();
+            CollectionAssert.Contains(propertyList, property1);
+            CollectionAssert.Contains(propertyList, property2);
         }
 
         [TestMethod]
@@ -158,11 +159,10 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
         public void AddPropertyShouldAddPropertiesToThePropertyBag()
         {
             this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
-
             this.testContextImplementation.AddProperty("SomeNewProperty", "SomeValue");
 
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties.ToList(),
+                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
                 new KeyValuePair<string, object>("SomeNewProperty", "SomeValue"));
         }
 

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10TestContextImplementationTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10TestContextImplementationTests.cs
@@ -23,7 +23,6 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
     using System.Linq;
 
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
-    using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel;
     using Moq;
     using ITestMethod = Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel.ITestMethod;
 
@@ -48,7 +47,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         [TestMethod]
         public void TestContextConstructorShouldInitializeProperties()
         {
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             Assert.IsNotNull(this.testContextImplementation.Properties);
         }
@@ -59,22 +58,22 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
             this.testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
             this.testMethod.Setup(tm => tm.Name).Returns("M");
 
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             Assert.IsNotNull(this.testContextImplementation.Properties);
 
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties.ToList(),
+                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
                 new KeyValuePair<string, object>("FullyQualifiedTestClassName", "A.C.M"));
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties.ToList(),
+                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
                 new KeyValuePair<string, object>("TestName", "M"));
         }
 
         [TestMethod]
         public void CurrentTestOutcomeShouldReturnDefaultOutcome()
         {
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             Assert.AreEqual(UnitTestOutcome.Failed, this.testContextImplementation.CurrentTestOutcome);
         }
@@ -82,7 +81,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         [TestMethod]
         public void CurrentTestOutcomeShouldReturnOutcomeSet()
         {
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             this.testContextImplementation.SetOutcome(UnitTestOutcome.InProgress);
 
@@ -94,7 +93,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         {
             this.testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
 
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             Assert.AreEqual("A.C.M", this.testContextImplementation.FullyQualifiedTestClassName);
         }
@@ -104,7 +103,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         {
             this.testMethod.Setup(tm => tm.Name).Returns("M");
 
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             Assert.AreEqual("M", this.testContextImplementation.TestName);
         }
@@ -118,10 +117,10 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
             this.properties.Add(property1);
             this.properties.Add(property2);
 
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
-            CollectionAssert.Contains(this.testContextImplementation.Properties.ToList(), property1);
-            CollectionAssert.Contains(this.testContextImplementation.Properties.ToList(), property2);
+            CollectionAssert.Contains(((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(), property1);
+            CollectionAssert.Contains(((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(), property2);
         }
 
         [TestMethod]
@@ -129,7 +128,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         {
             this.testMethod.Setup(tm => tm.Name).Returns("M");
 
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             Assert.IsNotNull(this.testContextImplementation.Context);
             Assert.AreEqual("M", this.testContextImplementation.Context.TestName);
@@ -140,34 +139,28 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         {
             this.testMethod.Setup(tm => tm.Name).Returns("M");
 
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
-
-            object propValue;
-
-            Assert.IsTrue(this.testContextImplementation.TryGetPropertyValue("TestName", out propValue));
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
+            Assert.IsTrue(this.testContextImplementation.TryGetPropertyValue("TestName", out object propValue));
             Assert.AreEqual("M", propValue);
         }
 
         [TestMethod]
         public void TryGetPropertyValueShouldReturnFalseIfPropertyIsNotPresent()
         {
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
-
-            object propValue;
-
-            Assert.IsFalse(this.testContextImplementation.TryGetPropertyValue("Random", out propValue));
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
+            Assert.IsFalse(this.testContextImplementation.TryGetPropertyValue("Random", out object propValue));
             Assert.IsNull(propValue);
         }
 
         [TestMethod]
         public void AddPropertyShouldAddPropertiesToThePropertyBag()
         {
-            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new System.IO.StringWriter(), this.properties);
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
             this.testContextImplementation.AddProperty("SomeNewProperty", "SomeValue");
 
             CollectionAssert.Contains(
-                this.testContextImplementation.Properties.ToList(),
+                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
                 new KeyValuePair<string, object>("SomeNewProperty", "SomeValue"));
         }
 

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10TestContextImplementationTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10TestContextImplementationTests.cs
@@ -63,10 +63,10 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
             Assert.IsNotNull(this.testContextImplementation.Properties);
 
             CollectionAssert.Contains(
-                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
+                this.testContextImplementation.Properties,
                 new KeyValuePair<string, object>("FullyQualifiedTestClassName", "A.C.M"));
             CollectionAssert.Contains(
-                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
+                this.testContextImplementation.Properties,
                 new KeyValuePair<string, object>("TestName", "M"));
         }
 
@@ -119,8 +119,8 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
 
             this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, new StringWriter(), this.properties);
 
-            CollectionAssert.Contains(((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(), property1);
-            CollectionAssert.Contains(((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(), property2);
+            CollectionAssert.Contains(this.testContextImplementation.Properties, property1);
+            CollectionAssert.Contains(this.testContextImplementation.Properties, property2);
         }
 
         [TestMethod]
@@ -160,7 +160,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
             this.testContextImplementation.AddProperty("SomeNewProperty", "SomeValue");
 
             CollectionAssert.Contains(
-                ((IDictionary<string, object>)this.testContextImplementation.Properties).ToList(),
+                this.testContextImplementation.Properties,
                 new KeyValuePair<string, object>("SomeNewProperty", "SomeValue"));
         }
 


### PR DESCRIPTION
Ensured that the TestContext exposed is always IDictionary for backcompat reasons.