### PR TITLE
Fixed IsNotInstanceOfType failing when objected being asserted on is null

### DIFF
--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -1758,7 +1758,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             {
                 HandleFail("Assert.IsNotInstanceOfType", message, parameters);
             }
-            
+
             // Null is not an instance of any type.
             if (value == null)
             {

--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -1754,9 +1754,14 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void IsNotInstanceOfType(object value, Type wrongType, string message, params object[] parameters)
         {
-            if (wrongType == null || value == null)
+            if (wrongType == null)
             {
                 HandleFail("Assert.IsNotInstanceOfType", message, parameters);
+            }
+            
+            if (value == null)
+            {
+                return;
             }
 
             var elementTypeInfo = value.GetType().GetTypeInfo();

--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -1758,7 +1758,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             {
                 HandleFail("Assert.IsNotInstanceOfType", message, parameters);
             }
-            
+
             if (value == null)
             {
                 return;

--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -1758,7 +1758,8 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             {
                 HandleFail("Assert.IsNotInstanceOfType", message, parameters);
             }
-
+            
+            // Null is not an instance of any type.
             if (value == null)
             {
                 return;

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
@@ -278,7 +278,6 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests
         public void InstanceNotOfTypeShouldFailWhenValueIsNull()
         {
             Action action = () => TestFrameworkV2.Assert.IsNotInstanceOfType(null, typeof(AssertTests));
-            ActionUtility.ActionShouldThrowExceptionOfType(action, typeof(TestFrameworkV2.AssertFailedException));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixed IsNotInstanceOfType failing when objected being asserted on is null

Null is not an instance of any type.

Issue #617