### PR TITLE
Record test start/end events for data driven tests

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestAssemblyInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestAssemblyInfo.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 {
     using System;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Reflection;
@@ -25,10 +26,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <summary>
         /// Initializes a new instance of the <see cref="TestAssemblyInfo"/> class.
         /// </summary>
-        internal TestAssemblyInfo()
+        /// <param name="assemblyLocation">The test assembly location</param>
+        internal TestAssemblyInfo(string assemblyLocation)
         {
+            Debug.Assert(!string.IsNullOrEmpty(assemblyLocation), "AssemblyLocation should not be null or empty");
+
             this.assemblyInfoExecuteSyncObject = new object();
+            this.AssemblyName = assemblyLocation;
         }
+
+        /// <summary>
+        /// Gets the assembly name.
+        /// </summary>
+        public string AssemblyName { get; }
 
         /// <summary>
         /// Gets <c>AssemblyInitialize</c> method for the assembly.

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -154,6 +154,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 return;
             }
 
+            Guid orginalTestCaseId = test.Id;
             foreach (var unitTestResult in unitTestResults)
             {
                 if (test == null)
@@ -161,6 +162,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     continue;
                 }
 
+                test.Id = unitTestResult.TestId == Guid.Empty ? orginalTestCaseId : unitTestResult.TestId;
                 var testResult = unitTestResult.ToTestResult(test, startTime, endTime, MSTestSettings.CurrentSettings);
 
                 if (unitTestResult.DatarowIndex >= 0)
@@ -183,6 +185,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     // Ignore this exception
                 }
             }
+
+            test.Id = orginalTestCaseId;
         }
 
         private static bool MatchTestFilter(ITestCaseFilterExpression filterExpression, TestCase test, TestMethodFilter testMethodFilter)

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 test.Id = unitTestResult.TestId == Guid.Empty ? orginalTestCaseId : unitTestResult.TestId;
                 var testResult = unitTestResult.ToTestResult(test, startTime, endTime, MSTestSettings.CurrentSettings);
 
-                if (unitTestResult.DatarowIndex >= 0 && string.IsNullOrEmpty(unitTestResult.DisplayName))
+                if (unitTestResult.DatarowIndex >= 0)
                 {
                     testResult.DisplayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, test.DisplayName, unitTestResult.DatarowIndex);
                 }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -172,6 +172,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     testResult.DisplayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, test.DisplayName, unitTestResult.DatarowIndex);
                 }
 
+                // Fire a RecordEnd here even though we also fire RecordEnd inside TestMethodInfo
+                // this is to ensure we fire end events for error cases. This is acceptable because
+                // vstest ignores multiple end events.
+                testExecutionRecorder.RecordEnd(test, testResult.Outcome);
+
                 if (testResult.Outcome == TestOutcome.Failed)
                 {
                     PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor:Test {0} failed. ErrorMessage:{1}, ErrorStackTrace:{2}.", testResult.TestCase.FullyQualifiedName, testResult.ErrorMessage, testResult.ErrorStackTrace);
@@ -369,6 +374,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 }
 
                 var unitTestElement = currentTest.ToUnitTestElement(source);
+
+                // Fire a RecordStart here even though we also fire RecordStart inside TestMethodInfo
+                // this is to ensure we fire start events for error cases. This is acceptable because
+                // vstest ignores multiple start events.
+                testExecutionRecorder.RecordStart(currentTest);
 
                 var startTime = DateTimeOffset.Now;
 

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 return;
             }
 
-            Guid orginalTestCaseId = test.Id;
+            Guid originalTestCaseId = test.Id;
             foreach (var unitTestResult in unitTestResults)
             {
                 if (test == null)
@@ -162,7 +162,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     continue;
                 }
 
-                test.Id = unitTestResult.TestId == Guid.Empty ? orginalTestCaseId : unitTestResult.TestId;
+                // If the result has a TestId set then update the TestCase to have that id
+                // this is done for data driven results so we can fire unique start/end events for each iteration
+                test.Id = unitTestResult.TestId == Guid.Empty ? originalTestCaseId : unitTestResult.TestId;
                 var testResult = unitTestResult.ToTestResult(test, startTime, endTime, MSTestSettings.CurrentSettings);
 
                 if (unitTestResult.DatarowIndex >= 0)
@@ -186,7 +188,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 }
             }
 
-            test.Id = orginalTestCaseId;
+            // Reset the test id back to the original id in case we changed it above
+            test.Id = originalTestCaseId;
         }
 
         private static bool MatchTestFilter(ITestCaseFilterExpression filterExpression, TestCase test, TestMethodFilter testMethodFilter)

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -168,8 +168,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     testResult.DisplayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, test.DisplayName, unitTestResult.DatarowIndex);
                 }
 
-                testExecutionRecorder.RecordEnd(test, testResult.Outcome);
-
                 if (testResult.Outcome == TestOutcome.Failed)
                 {
                     PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor:Test {0} failed. ErrorMessage:{1}, ErrorStackTrace:{2}.", testResult.TestCase.FullyQualifiedName, testResult.ErrorMessage, testResult.ErrorStackTrace);
@@ -363,7 +361,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 }
 
                 var unitTestElement = currentTest.ToUnitTestElement(source);
-                testExecutionRecorder.RecordStart(currentTest);
 
                 var startTime = DateTimeOffset.Now;
 
@@ -374,7 +371,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 // Run single test passing test context properties to it.
                 var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
                 var testContextProperties = this.GetTestContextProperties(tcmProperties, sourceLevelParameters);
-                var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, testContextProperties);
+                var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, testExecutionRecorder, testContextProperties);
 
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo(
                     "Executed test {0}",

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 test.Id = unitTestResult.TestId == Guid.Empty ? orginalTestCaseId : unitTestResult.TestId;
                 var testResult = unitTestResult.ToTestResult(test, startTime, endTime, MSTestSettings.CurrentSettings);
 
-                if (unitTestResult.DatarowIndex >= 0)
+                if (unitTestResult.DatarowIndex >= 0 && string.IsNullOrEmpty(unitTestResult.DisplayName))
                 {
                     testResult.DisplayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, test.DisplayName, unitTestResult.DatarowIndex);
                 }
@@ -357,6 +357,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             IDictionary<string, object> sourceLevelParameters,
             UnitTestRunner testRunner)
         {
+            var testExecutionRecorderWrapper = new TestExecutionRecorderWrapper(testExecutionRecorder);
             foreach (var currentTest in tests)
             {
                 if (this.cancellationToken != null && this.cancellationToken.Canceled)
@@ -375,7 +376,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 // Run single test passing test context properties to it.
                 var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
                 var testContextProperties = this.GetTestContextProperties(tcmProperties, sourceLevelParameters);
-                var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, testExecutionRecorder, testContextProperties);
+                var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, testExecutionRecorderWrapper, testContextProperties);
 
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo(
                     "Executed test {0}",

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 {
     using System;
+    using System.Diagnostics;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -15,9 +16,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
     {
         private readonly ITestExecutionRecorder recorder;
 
-        public TestExecutionRecorderWrapper(ITestExecutionRecorder recorder)
+        public TestExecutionRecorderWrapper(ITestExecutionRecorder testExecutionRecorder)
         {
-            this.recorder = recorder;
+            Debug.Assert(testExecutionRecorder != null, "TestExecutionRecorder should not be null");
+
+            this.recorder = testExecutionRecorder;
         }
 
         /// <summary>

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
@@ -44,12 +44,5 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         {
             this.recorder.RecordStart(test.ToTestCase());
         }
-
-        public void RecordStartAndEnd(UnitTestElement test, UnitTestOutcome outcome)
-        {
-            TestCase testCase = test.ToTestCase();
-            this.recorder.RecordStart(testCase);
-            this.recorder.RecordEnd(testCase, UnitTestOutcomeHelper.ToTestOutcome(outcome, MSTestSettings.CurrentSettings));
-        }
     }
 }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 {
     using System;
     using System.Diagnostics;
+    using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -34,14 +35,21 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             return null;
         }
 
-        public void RecordEnd(UnitTestElement test, TestOutcome outcome)
+        public void RecordEnd(UnitTestElement test, UnitTestOutcome outcome)
         {
-            this.recorder.RecordEnd(test.ToTestCase(), outcome);
+            this.recorder.RecordEnd(test.ToTestCase(), UnitTestOutcomeHelper.ToTestOutcome(outcome, MSTestSettings.CurrentSettings));
         }
 
         public void RecordStart(UnitTestElement test)
         {
             this.recorder.RecordStart(test.ToTestCase());
+        }
+
+        public void RecordStartAndEnd(UnitTestElement test, UnitTestOutcome outcome)
+        {
+            TestCase testCase = test.ToTestCase();
+            this.recorder.RecordStart(testCase);
+            this.recorder.RecordEnd(testCase, UnitTestOutcomeHelper.ToTestOutcome(outcome, MSTestSettings.CurrentSettings));
         }
     }
 }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionRecorderWrapper.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
+{
+    using System;
+    using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+    /// <summary>
+    /// Wraps calls to ITestExecutionRecorder using types that can be serialized across AppDomains.
+    /// </summary>
+    internal class TestExecutionRecorderWrapper : MarshalByRefObject
+    {
+        private readonly ITestExecutionRecorder recorder;
+
+        public TestExecutionRecorderWrapper(ITestExecutionRecorder recorder)
+        {
+            this.recorder = recorder;
+        }
+
+        /// <summary>
+        /// Returns object to be used for controlling lifetime, null means infinite lifetime.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="object"/>.
+        /// </returns>
+        public override object InitializeLifetimeService()
+        {
+            return null;
+        }
+
+        public void RecordEnd(UnitTestElement test, TestOutcome outcome)
+        {
+            this.recorder.RecordEnd(test.ToTestCase(), outcome);
+        }
+
+        public void RecordStart(UnitTestElement test)
+        {
+            this.recorder.RecordStart(test.ToTestCase());
+        }
+    }
+}

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -94,7 +94,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// </summary>
         internal TestMethodOptions TestMethodOptions { get; private set; }
 
-        private TestExecutionRecorderWrapper TestExecutionRecorder { get; }
+        /// <summary>
+        /// Gets the test execution recorder used to log test execution.
+        /// </summary>
+        internal TestExecutionRecorderWrapper TestExecutionRecorder { get; }
 
         public Attribute[] GetAllAttributes(bool inherit)
         {
@@ -182,9 +185,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                     this.TestExecutionRecorder.RecordEnd(
                         testElement,
-                        UnitTestOutcomeHelper.ToTestOutcome(
-                            result?.Outcome.ToUnitTestOutcome() ?? UnitTestOutcome.Error,
-                            MSTestSettings.CurrentSettings));
+                        result?.Outcome.ToUnitTestOutcome() ?? UnitTestOutcome.Error);
                 }
             }
 

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -48,6 +48,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         }
 
         /// <summary>
+        /// Gets or sets the id of the test.
+        /// </summary>
+        public Guid TestId { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether timeout is set.
         /// </summary>
         public bool IsTimeoutSet => this.TestMethodOptions.Timeout != TimeoutWhenNotSet;
@@ -144,6 +149,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             using (LogMessageListener listener = new LogMessageListener(this.TestMethodOptions.CaptureDebugTraces))
             {
                 var testCase = new UnitTestElement(new TestMethod(this)).ToTestCase();
+                if (this.TestId != Guid.Empty)
+                {
+                    testCase.Id = this.TestId;
+                }
 
                 watch.Start();
                 try
@@ -172,6 +181,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         result.LogError = listener.StandardError;
                         result.TestContextMessages = this.TestMethodOptions.TestContext.GetAndClearDiagnosticMessages();
                         result.ResultFiles = this.TestMethodOptions.TestContext.GetResultFiles();
+                        result.TestId = testCase.Id;
                     }
 
                     this.TestExecutionRecorder.RecordEnd(

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             this.TestMethod = testMethod;
             this.Parent = parent;
             this.TestMethodOptions = testmethodOptions;
+            this.TestExecutionRecorder = testExecutionRecorder;
         }
 
         /// <summary>

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -145,7 +145,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             if (isIgnoreAttributeOnClass || isIgnoreAttributeOnMethod)
             {
-                this.testMethodInfo.TestExecutionRecorder.RecordStartAndEnd(new UnitTestElement(this.test), UnitTestOutcome.Ignored);
                 return new[] { new UnitTestResult(UnitTestOutcome.Ignored, ignoreMessage) };
             }
 
@@ -162,7 +161,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     }
                     catch
                     {
-                        this.testMethodInfo.TestExecutionRecorder.RecordStartAndEnd(new UnitTestElement(this.test), UnitTestOutcome.Error);
                         throw;
                     }
                     finally

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -145,6 +145,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             if (isIgnoreAttributeOnClass || isIgnoreAttributeOnMethod)
             {
+                this.testMethodInfo.TestExecutionRecorder.RecordStartAndEnd(new UnitTestElement(this.test), UnitTestOutcome.Ignored);
                 return new[] { new UnitTestResult(UnitTestOutcome.Ignored, ignoreMessage) };
             }
 
@@ -158,6 +159,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         // Assembly or class initialize can throw exceptions in which case we need to ensure that we fail the test.
                         this.testMethodInfo.Parent.Parent.RunAssemblyInitialize(this.testContext.Context);
                         this.testMethodInfo.Parent.RunClassInitialize(this.testContext.Context);
+                    }
+                    catch
+                    {
+                        this.testMethodInfo.TestExecutionRecorder.RecordStartAndEnd(new UnitTestElement(this.test), UnitTestOutcome.Error);
+                        throw;
                     }
                     finally
                     {
@@ -333,10 +339,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                                 foreach (var testResult in testResults)
                                 {
-                                    if (string.IsNullOrEmpty(testResult.DisplayName))
-                                    {
-                                        testResult.DisplayName = testDataSource.GetDisplayName(this.testMethodInfo.MethodInfo, data);
-                                    }
+                                    testResult.DisplayName = testDataSource.GetDisplayName(this.testMethodInfo.MethodInfo, data);
                                 }
 
                                 results.AddRange(testResults);

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -258,6 +258,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                                     watch.Reset();
                                     watch.Start();
 
+                                    // Create a unique ID for each iteration so data collectors can attach results to specific iterations
+                                    this.testMethodInfo.TestId = Guid.NewGuid();
                                     this.testContext.SetDataRow(dataRow);
                                     UTF.TestResult[] testResults;
 
@@ -313,6 +315,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         {
                             foreach (var data in testDataSource.GetData(this.testMethodInfo.MethodInfo))
                             {
+                                // Create a unique ID for each iteration so data collectors can attach results to specific iterations
+                                this.testMethodInfo.TestId = Guid.NewGuid();
                                 this.testMethodInfo.SetArguments(data);
                                 UTF.TestResult[] testResults;
                                 try
@@ -329,7 +333,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                                 foreach (var testResult in testResults)
                                 {
-                                    testResult.DisplayName = testDataSource.GetDisplayName(this.testMethodInfo.MethodInfo, data);
+                                    if (string.IsNullOrEmpty(testResult.DisplayName))
+                                    {
+                                        testResult.DisplayName = testDataSource.GetDisplayName(this.testMethodInfo.MethodInfo, data);
+                                    }
                                 }
 
                                 results.AddRange(testResults);

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -159,10 +159,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         this.testMethodInfo.Parent.Parent.RunAssemblyInitialize(this.testContext.Context);
                         this.testMethodInfo.Parent.RunClassInitialize(this.testContext.Context);
                     }
-                    catch
-                    {
-                        throw;
-                    }
                     finally
                     {
                         initLogs = logListener.StandardOutput;

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// </summary>
         /// <param name="testMethod"> The test Method. </param>
         /// <param name="testContext"> The test Context. </param>
-        /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
+        /// <param name="testExecutionRecorder">A instance of TestExecutionRecorderWrapper used to log test execution.</param>
         /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns> The <see cref="TestMethodInfo"/>. </returns>
         public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext, TestExecutionRecorderWrapper testExecutionRecorder, bool captureDebugTraces)
@@ -633,7 +633,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <param name="testMethod"> The test Method. </param>
         /// <param name="testClassInfo"> The test Class Info. </param>
         /// <param name="testContext"> The test Context. </param>
-        /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
+        /// <param name="testExecutionRecorder">A instance of TestExecutionRecorderWrapper used to log test execution.</param>
         /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns>
         /// The TestMethodInfo for the given test method. Null if the test method could not be found.

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             var testContextProperty = this.ResolveTestContext(classType);
 
-            var assemblyInfo = this.GetAssemblyInfo(classType);
+            var assemblyInfo = this.GetAssemblyInfo(classType, testMethod.AssemblyName);
 
             var classInfo = new TestClassInfo(classType, constructor, testContextProperty, this.reflectionHelper.GetDerivedAttribute<TestClassAttribute>(classType, false), assemblyInfo);
 
@@ -360,9 +360,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// Get the assembly info for the parameter type
         /// </summary>
         /// <param name="type"> The type. </param>
+        /// <param name="assemblyLocation">The location of the assembly</param>
         /// <returns> The <see cref="TestAssemblyInfo"/> instance. </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Discoverer should continue with remaining sources.")]
-        private TestAssemblyInfo GetAssemblyInfo(Type type)
+        private TestAssemblyInfo GetAssemblyInfo(Type type, string assemblyLocation)
         {
             var assembly = type.GetTypeInfo().Assembly;
 
@@ -380,7 +381,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     var assemblyInitializeType = typeof(AssemblyInitializeAttribute);
                     var assemblyCleanupType = typeof(AssemblyCleanupAttribute);
 
-                    assemblyInfo = new TestAssemblyInfo();
+                    assemblyInfo = new TestAssemblyInfo(assemblyLocation);
 
                     var types = new AssemblyEnumerator().GetTypes(assembly, assembly.FullName, null);
 

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
         /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns> The <see cref="TestMethodInfo"/>. </returns>
-        public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext, ITestExecutionRecorder testExecutionRecorder, bool captureDebugTraces)
+        public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext, TestExecutionRecorderWrapper testExecutionRecorder, bool captureDebugTraces)
         {
             if (testMethod == null)
             {
@@ -638,7 +638,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <returns>
         /// The TestMethodInfo for the given test method. Null if the test method could not be found.
         /// </returns>
-        private TestMethodInfo ResolveTestMethod(TestMethod testMethod, TestClassInfo testClassInfo, ITestContext testContext, ITestExecutionRecorder testExecutionRecorder, bool captureDebugTraces)
+        private TestMethodInfo ResolveTestMethod(TestMethod testMethod, TestClassInfo testClassInfo, ITestContext testContext, TestExecutionRecorderWrapper testExecutionRecorder, bool captureDebugTraces)
         {
             Debug.Assert(testMethod != null, "testMethod is Null");
             Debug.Assert(testClassInfo != null, "testClassInfo is Null");

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     /// <summary>
@@ -121,9 +122,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// </summary>
         /// <param name="testMethod"> The test Method. </param>
         /// <param name="testContext"> The test Context. </param>
+        /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
         /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns> The <see cref="TestMethodInfo"/>. </returns>
-        public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext, bool captureDebugTraces)
+        public TestMethodInfo GetTestMethodInfo(TestMethod testMethod, ITestContext testContext, ITestExecutionRecorder testExecutionRecorder, bool captureDebugTraces)
         {
             if (testMethod == null)
             {
@@ -146,7 +148,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             }
 
             // Get the testMethod
-            return this.ResolveTestMethod(testMethod, testClassInfo, testContext, captureDebugTraces);
+            return this.ResolveTestMethod(testMethod, testClassInfo, testContext, testExecutionRecorder, captureDebugTraces);
         }
 
         /// <summary>
@@ -631,11 +633,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <param name="testMethod"> The test Method. </param>
         /// <param name="testClassInfo"> The test Class Info. </param>
         /// <param name="testContext"> The test Context. </param>
+        /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
         /// <param name="captureDebugTraces"> Indicates whether the test method should capture debug traces.</param>
         /// <returns>
         /// The TestMethodInfo for the given test method. Null if the test method could not be found.
         /// </returns>
-        private TestMethodInfo ResolveTestMethod(TestMethod testMethod, TestClassInfo testClassInfo, ITestContext testContext, bool captureDebugTraces)
+        private TestMethodInfo ResolveTestMethod(TestMethod testMethod, TestClassInfo testClassInfo, ITestContext testContext, ITestExecutionRecorder testExecutionRecorder, bool captureDebugTraces)
         {
             Debug.Assert(testMethod != null, "testMethod is Null");
             Debug.Assert(testClassInfo != null, "testClassInfo is Null");
@@ -651,7 +654,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             var timeout = this.GetTestTimeout(methodInfo, testMethod);
 
             var testMethodOptions = new TestMethodOptions() { Timeout = timeout, Executor = this.GetTestMethodAttribute(methodInfo, testClassInfo), ExpectedException = expectedExceptionAttribute, TestContext = testContext, CaptureDebugTraces = captureDebugTraces };
-            var testMethodInfo = new TestMethodInfo(methodInfo, testClassInfo, testMethodOptions);
+            var testMethodInfo = new TestMethodInfo(methodInfo, testClassInfo, testMethodOptions, testExecutionRecorder);
 
             this.SetCustomProperties(testMethodInfo, testContext);
 

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
     /// <summary>
     /// The runner that runs a single unit test. Also manages the assembly and class cleanup methods at the end of the run.
@@ -92,12 +92,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     // If the specified TestMethod could not be found, return a NotFound result.
                     if (testMethodInfo == null)
                     {
+                        testExecutionRecorder.RecordStartAndEnd(new UnitTestElement(testMethod), UnitTestOutcome.NotFound);
                         return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.NotFound, string.Format(CultureInfo.CurrentCulture, Resource.TestNotFound, testMethod.Name)) };
                     }
 
                     // If test cannot be executed, then bail out.
                     if (!testMethodInfo.IsRunnable)
                     {
+                        testExecutionRecorder.RecordStartAndEnd(new UnitTestElement(testMethod), UnitTestOutcome.NotRunnable);
                         return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.NotRunnable, testMethodInfo.NotRunnableReason) };
                     }
 
@@ -107,6 +109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             catch (TypeInspectionException ex)
             {
                 // Catch any exception thrown while inspecting the test method and return failure.
+                testExecutionRecorder.RecordStartAndEnd(new UnitTestElement(testMethod), UnitTestOutcome.Failed);
                 return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.Failed, ex.Message) };
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
         /// <param name="testContextProperties"> The test context properties. </param>
         /// <returns> The <see cref="UnitTestResult"/>. </returns>
-        internal UnitTestResult[] RunSingleTest(TestMethod testMethod, ITestExecutionRecorder testExecutionRecorder, IDictionary<string, object> testContextProperties)
+        internal UnitTestResult[] RunSingleTest(TestMethod testMethod, TestExecutionRecorderWrapper testExecutionRecorder, IDictionary<string, object> testContextProperties)
         {
             if (testMethod == null)
             {

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
     /// <summary>
     /// The runner that runs a single unit test. Also manages the assembly and class cleanup methods at the end of the run.
@@ -62,9 +63,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// Runs a single test.
         /// </summary>
         /// <param name="testMethod"> The test Method. </param>
+        /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
         /// <param name="testContextProperties"> The test context properties. </param>
         /// <returns> The <see cref="UnitTestResult"/>. </returns>
-        internal UnitTestResult[] RunSingleTest(TestMethod testMethod, IDictionary<string, object> testContextProperties)
+        internal UnitTestResult[] RunSingleTest(TestMethod testMethod, ITestExecutionRecorder testExecutionRecorder, IDictionary<string, object> testContextProperties)
         {
             if (testMethod == null)
             {
@@ -80,7 +82,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     testContext.SetOutcome(TestTools.UnitTesting.UnitTestOutcome.InProgress);
 
                     // Get the testMethod
-                    var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, MSTestSettings.CurrentSettings.CaptureDebugTraces);
+                    var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, testExecutionRecorder, MSTestSettings.CurrentSettings.CaptureDebugTraces);
 
                     // If the specified TestMethod could not be found, return a NotFound result.
                     if (testMethodInfo == null)

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -92,14 +92,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     // If the specified TestMethod could not be found, return a NotFound result.
                     if (testMethodInfo == null)
                     {
-                        testExecutionRecorder.RecordStartAndEnd(new UnitTestElement(testMethod), UnitTestOutcome.NotFound);
                         return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.NotFound, string.Format(CultureInfo.CurrentCulture, Resource.TestNotFound, testMethod.Name)) };
                     }
 
                     // If test cannot be executed, then bail out.
                     if (!testMethodInfo.IsRunnable)
                     {
-                        testExecutionRecorder.RecordStartAndEnd(new UnitTestElement(testMethod), UnitTestOutcome.NotRunnable);
                         return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.NotRunnable, testMethodInfo.NotRunnableReason) };
                     }
 
@@ -109,7 +107,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             catch (TypeInspectionException ex)
             {
                 // Catch any exception thrown while inspecting the test method and return failure.
-                testExecutionRecorder.RecordStartAndEnd(new UnitTestElement(testMethod), UnitTestOutcome.Failed);
                 return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.Failed, ex.Message) };
             }
         }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// Runs a single test.
         /// </summary>
         /// <param name="testMethod"> The test Method. </param>
-        /// <param name="testExecutionRecorder">A instance of ITestExecutionRecorder to log test execution.</param>
+        /// <param name="testExecutionRecorder">A instance of TestExecutionRecorderWrapper used to log test execution.</param>
         /// <param name="testContextProperties"> The test context properties. </param>
         /// <returns> The <see cref="UnitTestResult"/>. </returns>
         internal UnitTestResult[] RunSingleTest(TestMethod testMethod, TestExecutionRecorderWrapper testExecutionRecorder, IDictionary<string, object> testContextProperties)

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -73,6 +73,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                 throw new ArgumentNullException("testMethod");
             }
 
+            if (testExecutionRecorder == null)
+            {
+                throw new ArgumentNullException(nameof(testExecutionRecorder));
+            }
+
             try
             {
                 using (var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture))

--- a/src/Adapter/MSTest.CoreAdapter/Extensions/TestResultExtensions.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Extensions/TestResultExtensions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions
                 unitTestResult.DisplayName = testResults[i].DisplayName;
                 unitTestResult.DatarowIndex = testResults[i].DatarowIndex;
                 unitTestResult.ResultFiles = testResults[i].ResultFiles;
+                unitTestResult.TestId = testResults[i].TestId;
                 unitTestResult.ExecutionId = testResults[i].ExecutionId;
                 unitTestResult.ParentExecId = testResults[i].ParentExecId;
                 unitTestResult.InnerResultsCount = testResults[i].InnerResultsCount;

--- a/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
+++ b/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Discovery\TestMethodValidator.cs" />
     <Compile Include="Execution\RunCleanupResult.cs" />
     <Compile Include="Execution\TcmTestPropertiesProvider.cs" />
+    <Compile Include="Execution\TestExecutionRecorderWrapper.cs" />
     <Compile Include="Extensions\TestContextExtensions.cs" />
     <Compile Include="Extensions\TestResultExtensions.cs" />
     <Compile Include="Extensions\UnitTestOutcomeExtensions.cs" />

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -46,6 +46,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
             this.IsAsync = isAsync;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestMethod"/> class from the given <see cref="TestMethod"/> instance (i.e. clone).
+        /// </summary>
+        /// <param name="testMethodInfo">The <see cref="TestMethod"/> instance to clone values from.</param>
         internal TestMethod(TestMethodInfo testMethodInfo)
         {
             Debug.Assert(testMethodInfo != null, "TestMethodInfo can't be null");

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -5,7 +5,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
 {
     using System;
     using System.Diagnostics;
-
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+    using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using MSTestAdapter.PlatformServices.Interface.ObjectModel;
 
     /// <summary>
@@ -42,6 +44,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
             this.FullClassName = fullClassName;
             this.AssemblyName = assemblyName;
             this.IsAsync = isAsync;
+        }
+
+        internal TestMethod(TestMethodInfo testMethodInfo)
+        {
+            Debug.Assert(testMethodInfo != null, "TestMethodInfo can't be null");
+
+            this.Name = testMethodInfo.TestMethodName;
+            this.FullClassName = testMethodInfo.TestClassName;
+            this.AssemblyName = testMethodInfo.Parent.ClassType.AssemblyQualifiedName;
+            this.IsAsync = ReflectHelper.MatchReturnType(testMethodInfo.MethodInfo, typeof(Task));
         }
 
         /// <summary>

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -5,7 +5,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
 {
     using System;
     using System.Diagnostics;
-    using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
@@ -53,8 +52,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
 
             this.Name = testMethodInfo.TestMethodName;
             this.FullClassName = testMethodInfo.TestClassName;
-            this.AssemblyName = PlatformServiceProvider.Instance.FileOperations.GetAssemblyPath(
-                testMethodInfo.Parent.ClassType.GetTypeInfo().Assembly);
+            this.AssemblyName = testMethodInfo.Parent.Parent.AssemblyName;
             this.IsAsync = ReflectHelper.MatchReturnType(testMethodInfo.MethodInfo, typeof(Task));
         }
 

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
 {
     using System;
     using System.Diagnostics;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
@@ -52,7 +53,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
 
             this.Name = testMethodInfo.TestMethodName;
             this.FullClassName = testMethodInfo.TestClassName;
-            this.AssemblyName = testMethodInfo.Parent.ClassType.AssemblyQualifiedName;
+            this.AssemblyName = PlatformServiceProvider.Instance.FileOperations.GetAssemblyPath(
+                testMethodInfo.Parent.ClassType.GetTypeInfo().Assembly);
             this.IsAsync = ReflectHelper.MatchReturnType(testMethodInfo.MethodInfo, typeof(Task));
         }
 

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestElement.cs
@@ -98,6 +98,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         internal string[] WorkItemIds { get; set; }
 
         /// <summary>
+        /// Gets or sets the id of the test.
+        /// </summary>
+        internal Guid TestId { get; set; }
+
+        /// <summary>
         /// Convert the UnitTestElement instance to an Object Model testCase instance.
         /// </summary>
         /// <returns> An instance of <see cref="TestCase"/>. </returns>
@@ -175,6 +180,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
                 testCase.SetPropertyValue(
                     TestAdapter.Constants.DoNotParallelizeProperty,
                     this.DoNotParallelize);
+            }
+
+            if (this.TestId != Guid.Empty)
+            {
+                testCase.Id = this.TestId;
             }
 
             return testCase;

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestResult.cs
@@ -76,6 +76,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         public string ErrorStackTrace { get; internal set; }
 
         /// <summary>
+        /// Gets the id of the test case this result is for
+        /// </summary>
+        public Guid TestId { get; internal set; }
+
+        /// <summary>
         /// Gets the execution id of the result
         /// </summary>
         public Guid ExecutionId { get; internal set; }

--- a/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
@@ -471,6 +471,11 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         public string TestContextMessages { get; set; }
 
         /// <summary>
+        /// Gets or sets the id of the test case this result is for.
+        /// </summary>
+        public Guid TestId { get; set; }
+
+        /// <summary>
         /// Gets or sets the execution id of the result.
         /// </summary>
         public Guid ExecutionId { get; set; }

--- a/src/TestFramework/MSTest.Core/Interfaces/ITestMethod.cs
+++ b/src/TestFramework/MSTest.Core/Interfaces/ITestMethod.cs
@@ -12,6 +12,11 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     public interface ITestMethod
     {
         /// <summary>
+        /// Gets or sets the id of the test.
+        /// </summary>
+        Guid TestId { get; set; }
+
+        /// <summary>
         /// Gets the name of test method.
         /// </summary>
         string TestMethodName { get; }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestAssemblyInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestAssemblyInfoTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
         public TestAssemblyInfoTests()
         {
-            this.testAssemblyInfo = new TestAssemblyInfo();
+            this.testAssemblyInfo = new TestAssemblyInfo(@"C:\test.dll");
             this.dummyMethodInfo = typeof(TestAssemblyInfoTests).GetMethods().First();
             this.testContext = new Mock<UTFExtension.TestContext>().Object;
         }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testClassConstructor = this.testClassType.GetConstructors().First();
             this.testContextProperty = this.testClassType.GetProperties().First();
             this.testClassAttribute = (UTF.TestClassAttribute)this.testClassType.GetCustomAttributes().First();
-            this.testAssemblyInfo = new TestAssemblyInfo();
+            this.testAssemblyInfo = new TestAssemblyInfo(@"C:\test.dll");
 
             this.testClassInfo = new TestClassInfo(
                 this.testClassType,

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -194,6 +194,25 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethodV1]
+        public void RunTestsForDataRowTestShouldSendMulipleResults()
+        {
+            var testCase = this.GetTestCase(typeof(DummyTestClass), "DataRowTest");
+            TestCase[] tests = new[] { testCase };
+
+            this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, this.cancellationToken);
+
+            var expectedTestCaseStartList = new[] { "DataRowTest", "DataRowTest" };
+            var expectedTestCaseEndList = new[] { "DataRowTest:Passed", "DataRowTest:Passed" };
+            var expectedResultList = new[] { "DataRowTest  Passed", "DataRowTest  Passed", "DataRowTest  Passed" };
+            var expectedDisplayNameList = new[] { null, "DataRowTest (True)", "DataRowTest (False)" };
+
+            CollectionAssert.AreEqual(expectedTestCaseStartList, this.frameworkHandle.TestCaseStartList);
+            CollectionAssert.AreEqual(expectedTestCaseEndList, this.frameworkHandle.TestCaseEndList);
+            CollectionAssert.AreEqual(expectedResultList, this.frameworkHandle.ResultsList);
+            CollectionAssert.AreEqual(expectedDisplayNameList, this.frameworkHandle.TestDisplayNameList);
+        }
+
+        [TestMethodV1]
         public void RunTestsShouldLogResultCleanupWarnings()
         {
             var testCase = this.GetTestCase(typeof(DummyTestClassWithCleanupMethods), "TestMethod");
@@ -898,6 +917,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             public void IgnoredTest()
             {
                 UTF.Assert.Fail();
+            }
+
+            [UTF.DataTestMethod]
+            [UTF.DataRow(true)]
+            [UTF.DataRow(false)]
+            public void DataRowTest(bool data)
+            {
             }
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -117,13 +117,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, this.cancellationToken);
 
             // FailingTest should be skipped because it does not match the filter criteria.
-            List<string> expectedTestCaseStartList = new List<string>() { "PassingTest" };
-            List<string> expectedTestCaseEndList = new List<string>() { "PassingTest:Passed" };
-            List<string> expectedResultList = new List<string>() { "PassingTest  Passed" };
+            CollectionAssert.DoesNotContain(this.frameworkHandle.TestCaseStartList, "FailingTest");
+            CollectionAssert.DoesNotContain(this.frameworkHandle.TestCaseEndList, "FailingTest:Failed");
+            CollectionAssert.DoesNotContain(this.frameworkHandle.ResultsList, "FailingTest  Failed");
 
-            CollectionAssert.AreEqual(expectedTestCaseStartList, this.frameworkHandle.TestCaseStartList);
-            CollectionAssert.AreEqual(expectedTestCaseEndList, this.frameworkHandle.TestCaseEndList);
-            CollectionAssert.AreEqual(expectedResultList, this.frameworkHandle.ResultsList);
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseStartList, "PassingTest");
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseEndList, "PassingTest:Passed");
+            CollectionAssert.Contains(this.frameworkHandle.ResultsList, "PassingTest  Passed");
         }
 
         [TestMethodV1]
@@ -148,13 +148,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, new TestRunCancellationToken());
 
-            List<string> expectedTestCaseStartList = new List<string>() { "PassingTest" };
-            List<string> expectedTestCaseEndList = new List<string>() { "PassingTest:Passed" };
-            List<string> expectedResultList = new List<string>() { "PassingTest  Passed" };
-
-            CollectionAssert.AreEqual(expectedTestCaseStartList, this.frameworkHandle.TestCaseStartList);
-            CollectionAssert.AreEqual(expectedTestCaseEndList, this.frameworkHandle.TestCaseEndList);
-            CollectionAssert.AreEqual(expectedResultList, this.frameworkHandle.ResultsList);
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseStartList, "PassingTest");
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseEndList, "PassingTest:Passed");
+            CollectionAssert.Contains(this.frameworkHandle.ResultsList, "PassingTest  Passed");
         }
 
         [TestMethodV1]
@@ -166,14 +162,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, this.cancellationToken);
 
-            List<string> expectedTestCaseStartList = new List<string>() { "PassingTest", "FailingTest" };
-            List<string> expectedTestCaseEndList = new List<string>() { "PassingTest:Passed", "FailingTest:Failed" };
-            List<string> expectedResultList = new List<string>() { "PassingTest  Passed", "FailingTest  Failed\r\n  Message: Assert.Fail failed." };
-
-            CollectionAssert.AreEqual(expectedTestCaseStartList, this.frameworkHandle.TestCaseStartList);
-            CollectionAssert.AreEqual(expectedTestCaseEndList, this.frameworkHandle.TestCaseEndList);
-            Assert.AreEqual(expectedResultList[0], this.frameworkHandle.ResultsList[0]);
-            StringAssert.Contains(this.frameworkHandle.ResultsList[1], expectedResultList[1]);
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseStartList, "PassingTest");
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseStartList, "FailingTest");
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseEndList, "PassingTest:Passed");
+            CollectionAssert.Contains(this.frameworkHandle.TestCaseEndList, "FailingTest:Failed");
+            CollectionAssert.Contains(this.frameworkHandle.ResultsList, "PassingTest  Passed");
+            Assert.IsNotNull(
+                this.frameworkHandle.ResultsList.FirstOrDefault(x => x.Contains("FailingTest  Failed\r\n  Message: Assert.Fail failed.")),
+                "ResultsList contains failed result");
         }
 
         [TestMethodV1]
@@ -201,15 +197,17 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, this.cancellationToken);
 
-            var expectedTestCaseStartList = new[] { "DataRowTest", "DataRowTest" };
-            var expectedTestCaseEndList = new[] { "DataRowTest:Passed", "DataRowTest:Passed" };
+            // Even though there are only 2 data rows we fire a start event and results for the parent result
+            var expectedTestCaseStartList = new[] { "DataRowTest", "DataRowTest", "DataRowTest" };
             var expectedResultList = new[] { "DataRowTest  Passed", "DataRowTest  Passed", "DataRowTest  Passed" };
             var expectedDisplayNameList = new[] { null, "DataRowTest (True)", "DataRowTest (False)" };
 
             CollectionAssert.AreEqual(expectedTestCaseStartList, this.frameworkHandle.TestCaseStartList);
-            CollectionAssert.AreEqual(expectedTestCaseEndList, this.frameworkHandle.TestCaseEndList);
             CollectionAssert.AreEqual(expectedResultList, this.frameworkHandle.ResultsList);
             CollectionAssert.AreEqual(expectedDisplayNameList, this.frameworkHandle.TestDisplayNameList);
+
+            // End events get duplicated
+            Assert.IsTrue(this.frameworkHandle.TestCaseEndList.Count(x => x.Equals("DataRowTest:Passed")) >= 3, "At least 3 end events");
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testMethodAttribute = new UTF.TestMethodAttribute();
             this.testContextProperty = typeof(DummyTestClass).GetProperty("TestContext");
 
-            this.testAssemblyInfo = new TestAssemblyInfo();
+            this.testAssemblyInfo = new TestAssemblyInfo("dummyAssemblyName");
             var testMethod = new TestMethod("dummyTestName", "dummyClassName", "dummyAssemblyName", false);
             this.testContextImplementation = new TestContextImplementation(testMethod, new StringWriter(), new Dictionary<string, object>());
             this.testClassInfo = new TestClassInfo(

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testMethodAttribute = new UTF.TestMethodAttribute();
             var testContextProperty = typeof(DummyTestClass).GetProperty("TestContext");
 
-            var testAssemblyInfo = new TestAssemblyInfo();
+            var testAssemblyInfo = new TestAssemblyInfo("dummyAssemblyName");
             this.testMethod = new TestMethod("dummyTestName", "dummyClassName", "dummyAssemblyName", false);
             this.testContextImplementation = new TestContextImplementation(this.testMethod, new StringWriter(), new Dictionary<string, object>());
             this.testClassInfo = new TestClassInfo(
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void ExecuteForAssemblyInitializeThrowingExceptionShouldReturnUnitTestResultWithFailedOutcome()
         {
             // Arrange.
-            var tai = new TestAssemblyInfo
+            var tai = new TestAssemblyInfo(this.testMethod.AssemblyName)
             {
                 AssemblyInitializeMethod = typeof(TestMethodRunnerTests).GetMethod(
                 "InitMethodThrowingException",
@@ -258,7 +258,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void ExecuteForClassInitializeThrowingExceptionShouldReturnUnitTestResultWithFailedOutcome()
         {
             // Arrange.
-            var tai = new TestAssemblyInfo();
+            var tai = new TestAssemblyInfo(this.testMethod.AssemblyName);
 
             var constructorInfo = typeof(DummyTestClass).GetConstructors().Single();
             var classAttribute = new UTF.TestClassAttribute();

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Moq;
     using MSTest.TestAdapter;
     using TestableImplementations;
@@ -84,7 +85,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var globalTestMethodInfo = new TestMethodInfo(
                 this.methodInfo,
                 this.testClassInfo,
-                this.globaltestMethodOptions);
+                this.globaltestMethodOptions,
+                new TestExecutionRecorderWrapper(new Mock<ITestExecutionRecorder>().Object));
             var testMethodInfo = new TestableTestmethodInfo(this.methodInfo, this.testClassInfo, this.testMethodOptions, null);
             this.globalTestMethodRunner = new TestMethodRunner(globalTestMethodInfo, this.testMethod, this.testContextImplementation, false);
 
@@ -887,7 +889,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             private readonly Func<UTF.TestResult> invokeTest;
 
             internal TestableTestmethodInfo(MethodInfo testMethod, TestClassInfo parent, TestMethodOptions testMethodOptions, Func<UTF.TestResult> invoke)
-                : base(testMethod, parent, testMethodOptions)
+                : base(testMethod, parent, testMethodOptions, new TestExecutionRecorderWrapper(new Mock<ITestExecutionRecorder>().Object))
             {
                 this.invokeTest = invoke;
             }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Moq;
     using static TestMethodInfoTests;
     using Assert = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
@@ -38,6 +39,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
         private TestablePlatformServiceProvider testablePlatformServiceProvider;
 
+        private TestExecutionRecorderWrapper executionRecorderWrapper;
+
         [TestInitialize]
         public void TestInit()
         {
@@ -46,6 +49,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             this.testablePlatformServiceProvider = new TestablePlatformServiceProvider();
             PlatformServiceProvider.Instance = this.testablePlatformServiceProvider;
+
+            this.executionRecorderWrapper = new TestExecutionRecorderWrapper(new Mock<ITestExecutionRecorder>().Object);
 
             this.SetupMocks();
         }
@@ -66,6 +71,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Action a = () => this.typeCache.GetTestMethodInfo(
                 null,
                 new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                this.executionRecorderWrapper,
                 false);
 
             ActionUtility.ActionShouldThrowExceptionOfType(a, typeof(ArgumentNullException));
@@ -75,7 +81,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void GetTestMethodInfoShouldThrowIfTestContextIsNull()
         {
             var testMethod = new TestMethod("M", "C", "A", isAsync: false);
-            Action a = () => this.typeCache.GetTestMethodInfo(testMethod, null, false);
+            Action a = () => this.typeCache.GetTestMethodInfo(testMethod, null, this.executionRecorderWrapper, false);
 
             ActionUtility.ActionShouldThrowExceptionOfType(a, typeof(ArgumentNullException));
         }
@@ -89,6 +95,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false));
         }
 
@@ -101,6 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false));
         }
 
@@ -116,6 +124,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
@@ -135,6 +144,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
@@ -154,6 +164,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
@@ -173,6 +184,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(action);
@@ -195,6 +207,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                                         testMethod,
                                         new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                                         false);
 
             Assert.IsNotNull(testMethodInfo);
@@ -214,6 +227,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                                     testMethod,
                                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                                     false);
 
             Assert.IsNotNull(testMethodInfo);
@@ -235,6 +249,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
@@ -256,6 +271,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
@@ -276,6 +292,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
@@ -297,6 +314,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
@@ -320,6 +338,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.AssemblyInfoCache.Count());
@@ -344,6 +363,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -377,6 +397,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -406,11 +427,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             this.mockReflectHelper.Verify(rh => rh.IsAttributeDefined(type, typeof(UTF.TestClassAttribute), true), Times.Once);
@@ -434,6 +457,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -456,6 +480,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -485,6 +510,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                 testMethod,
                 new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                 false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -508,6 +534,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -533,6 +560,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                 testMethod,
                 new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                 false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -558,6 +586,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -597,6 +626,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -625,6 +655,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -658,6 +689,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -689,6 +721,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -710,6 +743,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -733,6 +767,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -766,6 +801,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -788,6 +824,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(1, this.typeCache.ClassInfoCache.Count());
@@ -807,11 +844,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             this.testablePlatformServiceProvider.MockFileOperations.Verify(fo => fo.LoadAssembly(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
@@ -834,6 +873,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -859,6 +899,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
@@ -880,6 +921,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
@@ -901,6 +943,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             Action a = () => this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var exception = ActionUtility.PerformActionAndReturnException(a);
@@ -936,6 +979,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(4000, testMethodInfo.TestMethodOptions.Timeout);
@@ -963,6 +1007,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(10, testMethodInfo.TestMethodOptions.Timeout);
@@ -987,6 +1032,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(0, testMethodInfo.TestMethodOptions.Timeout);
@@ -1002,6 +1048,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
@@ -1022,7 +1069,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
+            this.typeCache.GetTestMethodInfo(testMethod, testContext, this.executionRecorderWrapper, false);
             var customProperty = ((IDictionary<string, object>)testContext.Properties).FirstOrDefault(p => p.Key.Equals("WhoAmI"));
 
             Assert.IsNotNull(customProperty);
@@ -1040,7 +1087,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                  null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, this.executionRecorderWrapper, false);
 
             Assert.IsNotNull(testMethodInfo);
             var expectedMessage = string.Format(
@@ -1062,7 +1109,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, this.executionRecorderWrapper, false);
 
             Assert.IsNotNull(testMethodInfo);
             var expectedMessage = string.Format(
@@ -1083,7 +1130,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, this.executionRecorderWrapper, false);
 
             Assert.IsNotNull(testMethodInfo);
             var expectedMessage = string.Format(
@@ -1104,7 +1151,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 null,
                 new Dictionary<string, object>());
 
-            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, false);
+            var testMethodInfo = this.typeCache.GetTestMethodInfo(testMethod, testContext, this.executionRecorderWrapper, false);
 
             Assert.IsNotNull(testMethodInfo);
 
@@ -1124,6 +1171,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
@@ -1142,6 +1190,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(methodInfo, testMethodInfo.TestMethod);
@@ -1164,6 +1213,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             // The two MethodInfo instances will have different ReflectedType properties,
@@ -1205,6 +1255,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var cleanupMethods = this.typeCache.ClassInfoListWithExecutableCleanupMethods;
@@ -1229,6 +1280,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var cleanupMethods = this.typeCache.ClassInfoListWithExecutableCleanupMethods;
@@ -1267,6 +1319,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var cleanupMethods = this.typeCache.AssemblyInfoListWithExecutableCleanupMethods;
@@ -1291,6 +1344,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             var cleanupMethods = this.typeCache.AssemblyInfoListWithExecutableCleanupMethods;
@@ -1319,6 +1373,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             Assert.AreEqual(expectedException, testMethodInfo.TestMethodOptions.ExpectedException);
@@ -1337,6 +1392,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
 
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
@@ -1359,6 +1415,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 var testMethodInfo = this.typeCache.GetTestMethodInfo(
                     testMethod,
                     new TestContextImplementation(testMethod, null, new Dictionary<string, object>()),
+                    this.executionRecorderWrapper,
                     false);
             }
             catch (Exception ex)

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/UnitTestRunnerTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
-
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
     using Moq;
 
     using Assert = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
@@ -37,6 +37,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
     {
         private UnitTestRunner unitTestRunner;
 
+        private TestExecutionRecorderWrapper executionRecorderWrapper;
+
         private Dictionary<string, object> testRunParameters;
 
         private TestablePlatformServiceProvider testablePlatformServiceProvider;
@@ -44,6 +46,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         [TestInitialize]
         public void TestInit()
         {
+            this.executionRecorderWrapper = new TestExecutionRecorderWrapper(new Mock<ITestExecutionRecorder>().Object);
+
             this.testRunParameters = new Dictionary<string, object>();
             this.testablePlatformServiceProvider = new TestablePlatformServiceProvider();
 
@@ -95,7 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         [TestMethodV1]
         public void RunSingleTestShouldThrowIfTestMethodIsNull()
         {
-            Action a = () => this.unitTestRunner.RunSingleTest(null, null);
+            Action a = () => this.unitTestRunner.RunSingleTest(null, this.executionRecorderWrapper, null);
             ActionUtility.ActionShouldThrowExceptionOfType(a, typeof(ArgumentNullException));
         }
 
@@ -103,7 +107,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void RunSingleTestShouldThrowIfTestRunParamtersIsNull()
         {
             var testMethod = new TestMethod("M", "C", "A", isAsync: false);
-            Action a = () => this.unitTestRunner.RunSingleTest(testMethod, null);
+            Action a = () => this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, null);
             ActionUtility.ActionShouldThrowExceptionOfType(a, typeof(ArgumentNullException));
         }
 
@@ -115,7 +119,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
-            var results = this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            var results = this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             Assert.IsNotNull(results);
             Assert.AreEqual(1, results.Length);
@@ -133,7 +137,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
-            var results = this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            var results = this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             var expectedMessage = string.Format(
                 "UTA021: {0}: Null or empty custom property defined on method {1}. The custom property must have a valid name.",
@@ -155,7 +159,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
-            var results = this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            var results = this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             var expectedMessage = string.Format(
                 "Method {0}.{1} does not exist.",
@@ -178,7 +182,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
-            var results = this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            var results = this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             Assert.IsNotNull(results);
             Assert.AreEqual(1, results.Length);
@@ -197,7 +201,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
                 .Returns(Assembly.GetExecutingAssembly());
 
             // Asserting in the test method execution flow itself.
-            var results = this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            var results = this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             Assert.IsNotNull(results);
             Assert.AreEqual(1, results.Length);
@@ -227,7 +231,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             DummyTestClassWithInitializeMethods.AssemblyInitializeMethodBody = () => { validator = validator << 2; };
             DummyTestClassWithInitializeMethods.ClassInitializeMethodBody = () => { validator = validator >> 2; };
 
-            this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             Assert.AreEqual(1, validator);
         }
@@ -252,7 +256,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A", It.IsAny<bool>()))
                 .Returns(Assembly.GetExecutingAssembly());
 
-            this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             var assemblyCleanupCount = 0;
             var classCleanupCount = 0;
@@ -291,7 +295,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             StringWriter writer = new StringWriter(new StringBuilder("DummyTrace"));
             this.testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
 
-            this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             var cleanupresult = this.unitTestRunner.RunCleanup();
             Assert.AreEqual(cleanupresult.DebugTrace, "DummyTrace");
@@ -310,7 +314,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             StringWriter writer = new StringWriter(new StringBuilder("DummyTrace"));
             this.testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
 
-            this.unitTestRunner.RunSingleTest(testMethod, this.testRunParameters);
+            this.unitTestRunner.RunSingleTest(testMethod, this.executionRecorderWrapper, this.testRunParameters);
 
             var cleanupresult = this.unitTestRunner.RunCleanup();
             Assert.AreEqual(cleanupresult.DebugTrace, string.Empty);


### PR DESCRIPTION
This is a fix for #340 so that data collectors can get start/end events for individual execution of data driven tests. Also solves to allow the custom test execution extension to run a test multiple times and get multiple start/end events. 

Solving for #464 might be a better approach but seems like a much bigger change. 

One side effect of this change is ClassInitialize happens before any start event gets fired. IMO this is fine, it always seemed weird that this execution would be lumped into the first test that happened to execute. This also make it so ClassInitialize is now identical to ClassCleanup which doesn't get captured.