### PR TITLE
Fix build script to work with VS2019

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -223,8 +223,8 @@ function Invoke-Build([string] $solution, $hasVsixExtension = "false")
   $solutionFailureLog = Join-Path -path $solutionDir -childPath "msbuild.err"
 
 	Write-Log "    Building $solution..."
-	Write-Verbose "$msbuild /t:$Target /p:Configuration=$configuration /tv:$msbuildVersion /v:m /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionFailureLog /p:IsLocalizedBuild=$TFB_IsLocalizedBuild /p:UpdateXlf=$TFB_UpdateXlf /p:BuildVersion=$TFB_BuildVersion $solutionPath"
-	& $msbuild /t:$Target /p:Configuration=$configuration /tv:$msbuildVersion /v:m /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionFailureLog /p:IsLocalizedBuild=$TFB_IsLocalizedBuild /p:UpdateXlf=$TFB_UpdateXlf /p:BuildVersion=$TFB_BuildVersion $solutionPath
+	Write-Verbose "$msbuild /t:$Target /p:Configuration=$configuration /v:m /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionFailureLog /p:IsLocalizedBuild=$TFB_IsLocalizedBuild /p:UpdateXlf=$TFB_UpdateXlf /p:BuildVersion=$TFB_BuildVersion $solutionPath"
+	& $msbuild /t:$Target /p:Configuration=$configuration /v:m /flp1:Summary`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionSummaryLog /flp2:WarningsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionWarningLog /flp3:ErrorsOnly`;Verbosity=diagnostic`;Encoding=UTF-8`;LogFile=$solutionFailureLog /p:IsLocalizedBuild=$TFB_IsLocalizedBuild /p:UpdateXlf=$TFB_UpdateXlf /p:BuildVersion=$TFB_BuildVersion $solutionPath
   
 	if ($lastExitCode -ne 0) {
 		throw "Build failed with an exit code of '$lastExitCode'."

--- a/scripts/common.lib.ps1
+++ b/scripts/common.lib.ps1
@@ -54,8 +54,18 @@ function Locate-MSBuild($hasVsixExtension = "false") {
 
 function Locate-MSBuildPath($hasVsixExtension = "false") {
   $vsInstallPath = Locate-VsInstallPath -hasVsixExtension $hasVsixExtension
-  $msbuildPath = Join-Path -path $vsInstallPath -childPath "MSBuild\$msbuildVersion\Bin"
-  return Resolve-Path -path $msbuildPath
+
+  # first try to find the VS2019+ path
+  $msbuildPath = Join-Path -path $vsInstallPath -childPath "MSBuild\Current\Bin"
+  $msbuildPath = Resolve-Path $msbuildPath
+
+  # otherwise fall back to the VS2017 path
+  if(!(Test-Path -path $msbuildPath)) {
+    $msbuildPath = Join-Path -path $vsInstallPath -childPath "MSBuild\$msbuildVersion\Bin"
+    $msbuildPath = Resolve-Path $msbuildPath
+  }
+
+  return $msbuildPath
 }
 
 function Locate-NuGet {
@@ -117,6 +127,7 @@ function Locate-VsInstallPath($hasVsixExtension ="false"){
 
   $requiredPackageIds += "Microsoft.Component.MSBuild" 
   $requiredPackageIds += "Microsoft.Net.Component.4.6.TargetingPack"
+  $requiredPackageIds += "Microsoft.VisualStudio.Windows.Build"
 
   if($hasVsixExtension -eq 'true')
   {

--- a/scripts/common.lib.ps1
+++ b/scripts/common.lib.ps1
@@ -56,11 +56,12 @@ function Locate-MSBuildPath($hasVsixExtension = "false") {
   $vsInstallPath = Locate-VsInstallPath -hasVsixExtension $hasVsixExtension
 
   # first try to find the VS2019+ path
-  $msbuildPath = Join-Path -path $vsInstallPath -childPath "MSBuild\Current\Bin"
-  $msbuildPath = Resolve-Path $msbuildPath
-
-  # otherwise fall back to the VS2017 path
-  if(!(Test-Path -path $msbuildPath)) {
+  try {
+    $msbuildPath = Join-Path -path $vsInstallPath -childPath "MSBuild\Current\Bin"
+    $msbuildPath = Resolve-Path $msbuildPath
+  }
+  catch {
+    # Resolve-Path throws if the path does not exist, so use the VS2017 path as a fallback
     $msbuildPath = Join-Path -path $vsInstallPath -childPath "MSBuild\$msbuildVersion\Bin"
     $msbuildPath = Resolve-Path $msbuildPath
   }


### PR DESCRIPTION
The main change is to try to find msbuild using the 'Current' version
instead of the '15.0' version.  The MSBuild team has stated that
'Current' will be used going forward to avoid a breaking change to the
path when the version revs.

Also necessary in this change was to drop the /toolsVersion flag from
msbuild.  It was passing 15.0 but that tools version is not recognized in the
current MSBuild.

Lastly, added the UWP.Support component as a required build component.
When the build script picks an instance of VS missing this feature, the build
will fail when trying to import Microsoft.Windows.UI.Xaml.CSharp.Targets.