### PR TITLE
Prettify Test Method Display Name

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -109,6 +109,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         /// </summary>
         public bool IsAsync { get; private set; }
         
-        string GetFriendlyName(string name) => name?.Replace('_', ' ');
+        string GetFriendlyName(string name) => name?.Replace('_', ' ')?.Trim();
     }
 }

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -44,12 +44,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
             this.AssemblyName = assemblyName;
             this.IsAsync = isAsync;
         }
-        
+
         /// <summary>
         /// Gets the name of the test method
         /// </summary>
         public string Name { get; private set; }
-        
+
         /// <summary>
         /// Gets the display name of the test method
         /// </summary>
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         /// Gets a value indicating whether specifies test method is async
         /// </summary>
         public bool IsAsync { get; private set; }
-        
-        string GetFriendlyName(string name) => name?.Replace('_', ' ')?.Trim();
+
+        private string GetFriendlyName(string name) => name?.Replace('_', ' ')?.Trim();
     }
 }

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
             Debug.Assert(!string.IsNullOrEmpty(fullClassName), "Full className cannot be empty");
 
             this.Name = name;
-            this.DisplayName = GetFriendlyName(name);
+            this.DisplayName = this.GetFriendlyName(name);
             this.FullClassName = fullClassName;
             this.AssemblyName = assemblyName;
             this.IsAsync = isAsync;

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -39,15 +39,21 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
             Debug.Assert(!string.IsNullOrEmpty(fullClassName), "Full className cannot be empty");
 
             this.Name = name;
+            this.DisplayName = GetFriendlyName(name);
             this.FullClassName = fullClassName;
             this.AssemblyName = assemblyName;
             this.IsAsync = isAsync;
         }
-
+        
         /// <summary>
         /// Gets the name of the test method
         /// </summary>
         public string Name { get; private set; }
+        
+        /// <summary>
+        /// Gets the display name of the test method
+        /// </summary>
+        public string DisplayName { get; private set; }
 
         /// <summary>
         /// Gets the full classname of the test method
@@ -102,5 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         /// Gets a value indicating whether specifies test method is async
         /// </summary>
         public bool IsAsync { get; private set; }
+        
+        string GetFriendlyName(string name) => name?.Replace('_', ' ');
     }
 }

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestElement.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
                 this.TestMethod.Name);
 
             TestCase testCase = new TestCase(fullName, TestAdapter.Constants.ExecutorUri, this.TestMethod.AssemblyName);
-            testCase.DisplayName = this.TestMethod.Name;
+            testCase.DisplayName = this.TestMethod.DisplayName;
 
             testCase.SetPropertyValue(TestAdapter.Constants.TestClassNameProperty, this.TestMethod.FullClassName);
 


### PR DESCRIPTION
Friendly "Display Name" for test method names 

```csharp
[TestMethod]
void Method_names_should_be_readable_when_hinted()
{
}

"Method_names_should_be_readable_when_hinted" => "Method names should be readable when hinted"


[TestMethod]
void Say_What_You_Have_Spaces_in_Your_CSharp_Test_Names()
{
}

"Say_What_You_Have_Spaces_in_Your_CSharp_Test_Names" => "Say What You Have Spaces in Your CSharp Test Names"
```
similar to

![image](https://user-images.githubusercontent.com/7012074/65716142-f0113b00-e074-11e9-8449-5789df9d75df.png)

Complements #466

This spec can be improved for other cases PascalCase, CamelCase.
and specified DisplayName should be favoured