### PR TITLE
Add information for Timeout parameters/property of the scale.

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -722,7 +722,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// </summary>
         /// <param name="methodInfo"> The method Info. </param>
         /// <param name="testMethod"> The test Method. </param>
-        /// <returns> The timeout value if defined. 0 if not defined. </returns>
+        /// <returns> The timeout value if defined in milliseconds. 0 if not defined. </returns>
         private int GetTestTimeout(MethodInfo methodInfo, TestMethod testMethod)
         {
             Debug.Assert(methodInfo != null, "TestMethod should be non-null");

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopThreadOperations.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopThreadOperations.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// Execute the given action synchronously on a background thread in the given timeout.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        /// <param name="timeout">Timeout for the specified action in milliseconds.</param>
+        /// <param name="timeout">Timeout in milliseconds for the specified action.</param>
         /// <param name="cancelToken">Token to cancel the execution</param>
         /// <returns>Returns true if the action executed before the timeout. returns false otherwise.</returns>
         public bool Execute(Action action, int timeout, CancellationToken cancelToken)

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopThreadOperations.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopThreadOperations.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// Execute the given action synchronously on a background thread in the given timeout.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        /// <param name="timeout">Timeout in milliseconds for the specified action.</param>
+        /// <param name="timeout">Timeout for the specified action in milliseconds.</param>
         /// <param name="cancelToken">Token to cancel the execution</param>
         /// <returns>Returns true if the action executed before the timeout. returns false otherwise.</returns>
         public bool Execute(Action action, int timeout, CancellationToken cancelToken)

--- a/src/Adapter/PlatformServices.Interface/IThreadOperations.cs
+++ b/src/Adapter/PlatformServices.Interface/IThreadOperations.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         /// Execute the given action synchronously on a background thread in the given timeout.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        /// <param name="timeout">Timeout in milliseconds for the specified action.</param>
+        /// <param name="timeout">Timeout for the specified action in milliseconds.</param>
         /// <param name="cancelToken">Token to cancel the execution</param>
         /// <returns>Returns true if the action executed before the timeout. returns false otherwise.</returns>
         bool Execute(Action action, int timeout, CancellationToken cancelToken);

--- a/src/Adapter/PlatformServices.Interface/IThreadOperations.cs
+++ b/src/Adapter/PlatformServices.Interface/IThreadOperations.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
         /// Execute the given action synchronously on a background thread in the given timeout.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        /// <param name="timeout">Timeout for the specified action.</param>
+        /// <param name="timeout">Timeout in milliseconds for the specified action.</param>
         /// <param name="cancelToken">Token to cancel the execution</param>
         /// <returns>Returns true if the action executed before the timeout. returns false otherwise.</returns>
         bool Execute(Action action, int timeout, CancellationToken cancelToken);

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10ThreadOperations.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10ThreadOperations.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// Execute the given action synchronously on a background thread in the given timeout.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        /// <param name="timeout">Timeout in milliseconds for the specified action.</param>
+        /// <param name="timeout">Timeout for the specified action in milliseconds.</param>
         /// <param name="cancelToken">Token to cancel the execution</param>
         /// <returns>Returns true if the action executed before the timeout. returns false otherwise.</returns>
         public bool Execute(Action action, int timeout, CancellationToken cancelToken)

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10ThreadOperations.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10ThreadOperations.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// Execute the given action synchronously on a background thread in the given timeout.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        /// <param name="timeout">Timeout for the specified action.</param>
+        /// <param name="timeout">Timeout in milliseconds for the specified action.</param>
         /// <param name="cancelToken">Token to cancel the execution</param>
         /// <returns>Returns true if the action executed before the timeout. returns false otherwise.</returns>
         public bool Execute(Action action, int timeout, CancellationToken cancelToken)

--- a/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
@@ -391,7 +391,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Initializes a new instance of the <see cref="TimeoutAttribute"/> class.
         /// </summary>
         /// <param name="timeout">
-        /// The timeout.
+        /// The timeout in milliseconds.
         /// </param>
         public TimeoutAttribute(int timeout)
         {
@@ -414,7 +414,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         #region Properties
 
         /// <summary>
-        /// Gets the timeout.
+        /// Gets the timeout in milliseconds.
         /// </summary>
         public int Timeout { get; }
 


### PR DESCRIPTION
Because the timeout property is a plain int instead of an easily understandable TimeSpan, it's not clear what is the scale for timeout. The XMLDoc also helps nothing, it doesn't give anything new compared to what we already know from the code. And different part of .NET requires different scale (most millisecs, some part seconds - for example ADO.NET). 

For avoiding API break I updated the XML Doc to clear how the Timeout attribute work.