### PR TITLE
Fix bugs in parent class init/cleanup logic

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
@@ -149,6 +149,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         {
             get
             {
+                if (this.BaseClassCleanupMethodsStack.Any())
+                {
+                    // If any base cleanups were pushed to the stack we need to run them
+                    return true;
+                }
+
                 // If no class cleanup, then continue with the next one.
                 if (this.ClassCleanupMethod == null)
                 {
@@ -274,7 +280,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         var baseInitCleanupMethods = baseClassInitializeStack.Pop();
                         initializeMethod = baseInitCleanupMethods.Item1;
                         initializeMethod?.InvokeAsSynchronousTask(null, testContext);
-                        this.BaseClassCleanupMethodsStack.Push(baseInitCleanupMethods.Item2);
+
+                        if (baseInitCleanupMethods.Item2 != null)
+                        {
+                            this.BaseClassCleanupMethodsStack.Push(baseInitCleanupMethods.Item2);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -355,16 +365,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Requirement is to handle all kinds of user exceptions and message appropriately.")]
         public string RunClassCleanup()
         {
-            if (this.ClassCleanupMethod is null && !this.BaseClassInitAndCleanupMethods.Any(p => p.Item2 != null))
+            if (this.ClassCleanupMethod is null && !this.BaseClassCleanupMethodsStack.Any())
             {
                 return null;
             }
 
             if (this.IsClassInitializeExecuted || this.ClassInitializeMethod is null || this.BaseClassCleanupMethodsStack.Any())
             {
-                var classCleanupMethod = this.ClassCleanupMethod;
                 try
                 {
+                    var classCleanupMethod = this.ClassCleanupMethod;
                     classCleanupMethod?.InvokeAsSynchronousTask(null);
                     var baseClassCleanupQueue = new Queue<MethodInfo>(this.BaseClassCleanupMethodsStack);
                     while (baseClassCleanupQueue.Count > 0)

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
@@ -365,7 +365,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Requirement is to handle all kinds of user exceptions and message appropriately.")]
         public string RunClassCleanup()
         {
-            if (this.ClassCleanupMethod is null && !this.BaseClassCleanupMethodsStack.Any())
+            if (this.ClassCleanupMethod is null && !this.BaseClassInitAndCleanupMethods.Any(p => p.Item2 != null))
             {
                 return null;
             }

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TypeCache.cs
@@ -485,17 +485,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             TestClassInfo classInfo,
             ref MethodInfo[] initAndCleanupMethods)
         {
-            if (initAndCleanupMethods is null)
+            if (initAndCleanupMethods.Any(x => x != null))
             {
-                return;
+                classInfo.BaseClassInitAndCleanupMethods.Enqueue(
+                        new Tuple<MethodInfo, MethodInfo>(
+                            initAndCleanupMethods.FirstOrDefault(),
+                            initAndCleanupMethods.LastOrDefault()));
             }
 
-            classInfo.BaseClassInitAndCleanupMethods.Enqueue(
-                    new Tuple<MethodInfo, MethodInfo>(
-                        initAndCleanupMethods.FirstOrDefault(),
-                        initAndCleanupMethods.LastOrDefault()));
-
-            initAndCleanupMethods = null;
+            initAndCleanupMethods = new MethodInfo[2];
         }
 
         /// <summary>

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -509,6 +509,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testClassInfo.ClassCleanupMethod = null;
             this.testClassInfo.BaseClassCleanupMethodsStack.Push(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod"));
 
+            Assert.IsTrue(this.testClassInfo.HasExecutableCleanupMethod);
             Assert.IsNull(this.testClassInfo.RunClassCleanup());
             Assert.AreEqual(1, classcleanupCallCount, "DummyBaseTestClass.CleanupClassMethod call count");
         }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -432,16 +432,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
-        public void RunClassCleanupShouldInvokeIfClassCleanupMethod()
-        {
-           var classcleanupCallCount = 0;
-            DummyTestClass.ClassCleanupMethodBody = () => classcleanupCallCount++;
-            this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
-            Assert.IsNull(this.testClassInfo.RunClassCleanup());
-            Assert.AreEqual(1, classcleanupCallCount);
-        }
-
-        [TestMethod]
         public void RunAssemblyInitializeShouldPassOnTheTestContextToAssemblyInitMethod()
         {
             DummyTestClass.ClassInitializeMethodBody = (tc) => { Assert.AreEqual(tc, this.testContext); };
@@ -453,6 +443,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         #endregion
 
         #region Run Class Cleanup tests
+
+        [TestMethod]
+        public void RunClassCleanupShouldInvokeIfClassCleanupMethod()
+        {
+            var classcleanupCallCount = 0;
+            DummyTestClass.ClassCleanupMethodBody = () => classcleanupCallCount++;
+            this.testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod");
+            Assert.IsNull(this.testClassInfo.RunClassCleanup());
+            Assert.AreEqual(1, classcleanupCallCount);
+        }
 
         [TestMethod]
         public void RunClassCleanupShouldNotInvokeIfClassCleanupIsNull()
@@ -498,6 +498,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             StringAssert.StartsWith(
                 this.testClassInfo.RunClassCleanup(),
                 "Class Cleanup method DummyTestClass.ClassCleanupMethod failed. Error Message: System.ArgumentException: Argument Exception. Stack Trace:     at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestClassInfoTests.<>c.<RunClassCleanupShouldReturnExceptionDetailsOfNonAssertExceptions>");
+        }
+
+        [TestMethod]
+        public void RunBaseClassCleanupEvenIfThereIsNoTopLevelClassCleanup()
+        {
+            var classcleanupCallCount = 0;
+            DummyBaseTestClass.ClassCleanupMethodBody = () => classcleanupCallCount++;
+
+            this.testClassInfo.ClassCleanupMethod = null;
+            this.testClassInfo.BaseClassCleanupMethodsStack.Push(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod"));
+
+            Assert.IsNull(this.testClassInfo.RunClassCleanup());
+            Assert.AreEqual(1, classcleanupCallCount, "DummyBaseTestClass.CleanupClassMethod call count");
         }
 
         #endregion

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -501,12 +501,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
-        public void RunBaseClassCleanupEvenIfThereIsNoTopLevelClassCleanup()
+        public void RunBaseClassCleanupEvenIfThereIsNoDerivedClassCleanup()
         {
             var classcleanupCallCount = 0;
             DummyBaseTestClass.ClassCleanupMethodBody = () => classcleanupCallCount++;
 
             this.testClassInfo.ClassCleanupMethod = null;
+            this.testClassInfo.BaseClassInitAndCleanupMethods.Enqueue(
+                Tuple.Create((MethodInfo)null, typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod")));
             this.testClassInfo.BaseClassCleanupMethodsStack.Push(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod"));
 
             Assert.IsTrue(this.testClassInfo.HasExecutableCleanupMethod);


### PR DESCRIPTION
Fixing two bugs related to feature #143 
- Call base class cleanup even if top level test class doesn't have class cleanup
- Fix null ref when a class more than 1 level of inheritance has a class init/cleanup method.