### PR TITLE
switch arguments for expected and actual in Assert.AreEquals in multiple tests

### DIFF
--- a/test/UnitTests/MSTest.Core.Unit.Tests/GenericParameterHelperTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/GenericParameterHelperTests.cs
@@ -59,7 +59,7 @@ namespace UnitTestFramework.Tests
         {
             TestFrameworkV2.GenericParameterHelper objectToCompare = new TestFrameworkV2.GenericParameterHelper(10);
 
-            TestFrameworkV1.Assert.AreEqual(this.sut.CompareTo(objectToCompare), 0);
+            TestFrameworkV1.Assert.AreEqual(0, this.sut.CompareTo(objectToCompare));
         }
 
         [TestFrameworkV1.TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/LogMessageListenerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/LogMessageListenerTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var logMessageListener = new LogMessageListener(true);
             StringWriter writer = new StringWriter(new StringBuilder("DummyTrace"));
             this.testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
-            Assert.AreEqual(logMessageListener.DebugTrace, "DummyTrace");
+            Assert.AreEqual("DummyTrace", logMessageListener.DebugTrace);
         }
 
         #region Dispose Tests

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestAssemblySettingsProviderTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestAssemblySettingsProviderTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var settings = this.testAssemblySettingProvider.GetSettings("Foo");
 
             // Assert.
-            Assert.AreEqual(false, settings.CanParallelizeAssembly);
+            Assert.IsFalse(settings.CanParallelizeAssembly);
         }
     }
 }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestAssemblySettingsProviderTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestAssemblySettingsProviderTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var settings = this.testAssemblySettingProvider.GetSettings("Foo");
 
             // Assert.
-            Assert.AreEqual(true, settings.CanParallelizeAssembly);
+            Assert.IsTrue(settings.CanParallelizeAssembly);
         }
 
         [TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             var ret = this.testClassInfo.RunClassCleanup(); // call cleanup without calling init
 
-            Assert.AreEqual(null, ret);
+            Assert.IsNull(ret);
             Assert.AreEqual(0, classcleanupCallCount);
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             var ret = this.testClassInfo.RunClassCleanup(); // call cleanup without calling init
 
-            Assert.AreEqual(null, ret);
+            Assert.IsNull(ret);
             Assert.AreEqual(0, classcleanupCallCount);
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testClassInfo.RunClassInitialize(this.testContext);
             var ret = this.testClassInfo.RunClassCleanup(); // call cleanup without calling init
 
-            Assert.AreEqual(null, ret);
+            Assert.IsNull(ret);
             Assert.AreEqual(1, classcleanupCallCount);
         }
 
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.testClassInfo.RunClassInitialize(this.testContext);
             var ret = this.testClassInfo.RunClassCleanup();
 
-            Assert.AreEqual(null, ret);
+            Assert.IsNull(ret);
             Assert.AreEqual(1, classcleanupCallCount);
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             // Trigger another Run
             this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, new TestRunCancellationToken());
 
-            Assert.AreEqual(DummyTestClass.TestContextProperties["webAppUrl"], "http://updatedLocalHost");
+            Assert.AreEqual("http://updatedLocalHost", DummyTestClass.TestContextProperties["webAppUrl"]);
         }
 
         #endregion
@@ -426,7 +426,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             };
 
             testableTestExecutionmanager.RunTests(sources, this.runContext, this.frameworkHandle, this.cancellationToken);
-            Assert.AreEqual(testsCount, 4);
+            Assert.AreEqual(4, testsCount);
         }
 
         #endregion
@@ -440,8 +440,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             UnitTestResult unitTestResult1 = new UnitTestResult() { DatarowIndex = 0, DisplayName = "DummyTest" };
             UnitTestResult unitTestResult2 = new UnitTestResult() { DatarowIndex = 1, DisplayName = "DummyTest" };
             this.TestExecutionManager.SendTestResults(testCase, new UnitTestResult[] { unitTestResult1, unitTestResult2 }, default(DateTimeOffset), default(DateTimeOffset), this.frameworkHandle);
-            Assert.AreEqual(this.frameworkHandle.TestDisplayNameList[0], "DummyTest (Data Row 0)");
-            Assert.AreEqual(this.frameworkHandle.TestDisplayNameList[1], "DummyTest (Data Row 1)");
+            Assert.AreEqual("DummyTest (Data Row 0)", this.frameworkHandle.TestDisplayNameList[0]);
+            Assert.AreEqual("DummyTest (Data Row 1)", this.frameworkHandle.TestDisplayNameList[1]);
         }
 
         #endregion

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         public void PropertyProviderValueForInvalidTestCaseReturnsNull()
         {
             var result = this.TestMethodFilter.PropertyValueProvider(null, "Hello");
-            Assert.AreEqual(null, result);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             TestCase testCase = new TestCase(fullName, MSTest.TestAdapter.Constants.ExecutorUri, Assembly.GetExecutingAssembly().FullName);
 
             var result = this.TestMethodFilter.PropertyValueProvider(testCase, null);
-            Assert.AreEqual(null, result);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             TestCase testCase = new TestCase(fullName, MSTest.TestAdapter.Constants.ExecutorUri, Assembly.GetExecutingAssembly().FullName);
             var result = this.TestMethodFilter.PropertyValueProvider(testCase, "Priority");
-            Assert.AreEqual(null, result);
+            Assert.IsNull(result);
         }
 
         [TestMethod]
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             bool filterHasError;
             var filterExpression = this.TestMethodFilter.GetFilterExpression(null, recorder, out filterHasError);
 
-            Assert.AreEqual(null, filterExpression);
+            Assert.IsNull(filterExpression);
             Assert.IsFalse(filterHasError);
         }
 
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             bool filterHasError;
             var filterExpression = this.TestMethodFilter.GetFilterExpression(discoveryContext, recorder, out filterHasError);
 
-            Assert.AreEqual(null, filterExpression);
+            Assert.IsNull(filterExpression);
             Assert.IsFalse(filterHasError);
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             bool filterHasError;
             var filterExpression = this.TestMethodFilter.GetFilterExpression(runContext, recorder, out filterHasError);
 
-            Assert.AreEqual(null, filterExpression);
+            Assert.IsNull(filterExpression);
             Assert.IsTrue(filterHasError);
             Assert.AreEqual("DummyException", recorder.Message);
             Assert.AreEqual(TestMessageLevel.Error, recorder.TestMessageLevel);
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             bool filterHasError;
             var filterExpression = this.TestMethodFilter.GetFilterExpression(discoveryContext, recorder, out filterHasError);
 
-            Assert.AreEqual(null, filterExpression);
+            Assert.IsNull(filterExpression);
             Assert.IsTrue(filterHasError);
             Assert.AreEqual("DummyException", recorder.Message);
             Assert.AreEqual(TestMessageLevel.Error, recorder.TestMessageLevel);

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var filterExpression = this.TestMethodFilter.GetFilterExpression(runContext, recorder, out filterHasError);
 
             Assert.AreEqual(null, filterExpression);
-            Assert.AreEqual(true, filterHasError);
+            Assert.IsTrue(filterHasError);
             Assert.AreEqual("DummyException", recorder.Message);
             Assert.AreEqual(TestMessageLevel.Error, recorder.TestMessageLevel);
         }
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var filterExpression = this.TestMethodFilter.GetFilterExpression(discoveryContext, recorder, out filterHasError);
 
             Assert.AreEqual(null, filterExpression);
-            Assert.AreEqual(true, filterHasError);
+            Assert.IsTrue(filterHasError);
             Assert.AreEqual("DummyException", recorder.Message);
             Assert.AreEqual(TestMessageLevel.Error, recorder.TestMessageLevel);
         }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodFilterTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var filterExpression = this.TestMethodFilter.GetFilterExpression(null, recorder, out filterHasError);
 
             Assert.AreEqual(null, filterExpression);
-            Assert.AreEqual(false, filterHasError);
+            Assert.IsFalse(filterHasError);
         }
 
         [TestMethod]
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var filterExpression = this.TestMethodFilter.GetFilterExpression(runContext, recorder, out filterHasError);
 
             Assert.AreEqual(dummyFilterExpression, filterExpression);
-            Assert.AreEqual(false, filterHasError);
+            Assert.IsFalse(filterHasError);
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var filterExpression = this.TestMethodFilter.GetFilterExpression(discoveryContext, recorder, out filterHasError);
 
             Assert.AreEqual(dummyFilterExpression, filterExpression);
-            Assert.AreEqual(false, filterHasError);
+            Assert.IsFalse(filterHasError);
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             var filterExpression = this.TestMethodFilter.GetFilterExpression(discoveryContext, recorder, out filterHasError);
 
             Assert.AreEqual(null, filterExpression);
-            Assert.AreEqual(false, filterHasError);
+            Assert.IsFalse(filterHasError);
         }
 
         [TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
@@ -1027,7 +1027,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
-            Assert.AreEqual(result.TestFailureException.Message, "The exception message doesn't contain the string defined in the exception attribute");
+            Assert.AreEqual("The exception message doesn't contain the string defined in the exception attribute", result.TestFailureException.Message);
             Assert.AreEqual(UTF.UnitTestOutcome.Failed, result.Outcome);
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodInfoTests.cs
@@ -1010,7 +1010,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
-            Assert.AreEqual(true, customExpectedException.IsVerifyInvoked);
+            Assert.IsTrue(customExpectedException.IsVerifyInvoked);
             Assert.AreEqual(UTF.UnitTestOutcome.Passed, result.Outcome);
         }
 
@@ -1062,7 +1062,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             DummyTestClass.TestMethodBody = o => { throw new DivideByZeroException(); };
             var result = method.Invoke(null);
-            Assert.AreEqual(true, derivedCustomExpectedException.IsVerifyInvoked);
+            Assert.IsTrue(derivedCustomExpectedException.IsVerifyInvoked);
             Assert.AreEqual(UTF.UnitTestOutcome.Passed, result.Outcome);
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestMethodRunnerTests.cs
@@ -132,8 +132,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.GetIgnoreMessage(typeof(DummyTestClass).GetTypeInfo())).Returns("IgnoreTestClassMessage");
 
             var results = testMethodRunner.Execute();
-            Assert.AreEqual(results[0].Outcome, AdapterTestOutcome.Ignored);
-            Assert.AreEqual(results[0].ErrorMessage, "IgnoreTestClassMessage");
+            Assert.AreEqual(AdapterTestOutcome.Ignored, results[0].Outcome);
+            Assert.AreEqual("IgnoreTestClassMessage", results[0].ErrorMessage);
         }
 
         [TestMethodV1]
@@ -148,8 +148,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.GetIgnoreMessage(typeof(DummyTestClass).GetTypeInfo())).Returns(string.Empty);
 
             var results = testMethodRunner.Execute();
-            Assert.AreEqual(results[0].Outcome, AdapterTestOutcome.Ignored);
-            Assert.AreEqual(results[0].ErrorMessage, string.Empty);
+            Assert.AreEqual(AdapterTestOutcome.Ignored, results[0].Outcome);
+            Assert.AreEqual(string.Empty, results[0].ErrorMessage);
         }
 
         [TestMethodV1]
@@ -164,8 +164,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.GetIgnoreMessage(this.methodInfo)).Returns("IgnoreMethodMessage");
 
             var results = testMethodRunner.Execute();
-            Assert.AreEqual(results[0].Outcome, AdapterTestOutcome.Ignored);
-            Assert.AreEqual(results[0].ErrorMessage, "IgnoreMethodMessage");
+            Assert.AreEqual(AdapterTestOutcome.Ignored, results[0].Outcome);
+            Assert.AreEqual("IgnoreMethodMessage", results[0].ErrorMessage);
         }
 
         [TestMethodV1]
@@ -180,8 +180,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.GetIgnoreMessage(this.methodInfo)).Returns(string.Empty);
 
             var results = testMethodRunner.Execute();
-            Assert.AreEqual(results[0].Outcome, AdapterTestOutcome.Ignored);
-            Assert.AreEqual(results[0].ErrorMessage, string.Empty);
+            Assert.AreEqual(AdapterTestOutcome.Ignored, results[0].Outcome);
+            Assert.AreEqual(string.Empty, results[0].ErrorMessage);
         }
 
         [TestMethodV1]
@@ -198,8 +198,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.GetIgnoreMessage(this.methodInfo)).Returns("IgnoreMethodMessage");
 
             var results = testMethodRunner.Execute();
-            Assert.AreEqual(results[0].Outcome, AdapterTestOutcome.Ignored);
-            Assert.AreEqual(results[0].ErrorMessage, "IgnoreTestClassMessage");
+            Assert.AreEqual(AdapterTestOutcome.Ignored, results[0].Outcome);
+            Assert.AreEqual("IgnoreTestClassMessage", results[0].ErrorMessage);
         }
 
         [TestMethodV1]
@@ -216,8 +216,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
             this.mockReflectHelper.Setup(rh => rh.GetIgnoreMessage(this.methodInfo)).Returns("IgnoreMethodMessage");
 
             var results = testMethodRunner.Execute();
-            Assert.AreEqual(results[0].Outcome, AdapterTestOutcome.Ignored);
-            Assert.AreEqual(results[0].ErrorMessage, "IgnoreMethodMessage");
+            Assert.AreEqual(AdapterTestOutcome.Ignored, results[0].Outcome);
+            Assert.AreEqual("IgnoreMethodMessage", results[0].ErrorMessage);
         }
 
         [TestMethodV1]
@@ -552,10 +552,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             // check for datarowIndex
             // 1st is parent result.
-            Assert.AreEqual(results[0].DatarowIndex, -1);
-            Assert.AreEqual(results[1].DatarowIndex, 0);
-            Assert.AreEqual(results[2].DatarowIndex, 1);
-            Assert.AreEqual(results[3].DatarowIndex, 2);
+            Assert.AreEqual(-1, results[0].DatarowIndex);
+            Assert.AreEqual(0, results[1].DatarowIndex);
+            Assert.AreEqual(1, results[2].DatarowIndex);
+            Assert.AreEqual(2, results[3].DatarowIndex);
         }
 
         [TestMethodV1]
@@ -581,10 +581,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             // check for datarowIndex as only DataSource Tests are Run
             // 1st is parent result.
-            Assert.AreEqual(results[0].DatarowIndex, -1);
-            Assert.AreEqual(results[1].DatarowIndex, 0);
-            Assert.AreEqual(results[2].DatarowIndex, 1);
-            Assert.AreEqual(results[3].DatarowIndex, 2);
+            Assert.AreEqual(-1, results[0].DatarowIndex);
+            Assert.AreEqual(0, results[1].DatarowIndex);
+            Assert.AreEqual(1, results[2].DatarowIndex);
+            Assert.AreEqual(2, results[3].DatarowIndex);
         }
 
         [TestMethodV1]
@@ -610,7 +610,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             // 1st results should be parent result.
             Assert.AreEqual(2, results.Length);
-            Assert.AreEqual(results[1].DisplayName, "DataRowTestDisplayName");
+            Assert.AreEqual("DataRowTestDisplayName", results[1].DisplayName);
         }
 
         [TestMethodV1]
@@ -635,7 +635,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             // 1st results should be parent result.
             Assert.AreEqual(2, results.Length);
-            Assert.AreEqual(results[1].DisplayName, "DummyTestMethod (2,DummyString)");
+            Assert.AreEqual("DummyTestMethod (2,DummyString)", results[1].DisplayName);
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TypeCacheTests.cs
@@ -1408,7 +1408,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             UTF.ExpectedExceptionAttribute expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
 
-            Assert.AreEqual(null, testMethodInfo.TestMethodOptions.ExpectedException);
+            Assert.IsNull(testMethodInfo.TestMethodOptions.ExpectedException);
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -204,8 +204,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
 
             exception.TryGetUnitTestAssertException(out outcome, out exceptionMessage, out stackTraceInfo);
 
-            Assert.AreEqual(outcome, UTF.UnitTestOutcome.Inconclusive);
-            Assert.AreEqual(exceptionMessage, "Dummy Message");
+            Assert.AreEqual(UTF.UnitTestOutcome.Inconclusive, outcome);
+            Assert.AreEqual("Dummy Message", exceptionMessage);
         }
 
         [TestMethod]
@@ -218,8 +218,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
 
             exception.TryGetUnitTestAssertException(out outcome, out exceptionMessage, out stackTraceInfo);
 
-            Assert.AreEqual(outcome, UTF.UnitTestOutcome.Failed);
-            Assert.AreEqual(exceptionMessage, "Dummy Message");
+            Assert.AreEqual(UTF.UnitTestOutcome.Failed, outcome);
+            Assert.AreEqual("Dummy Message", exceptionMessage);
         }
         #endregion
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/TestCaseExtensionsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/TestCaseExtensionsTests.cs
@@ -31,13 +31,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
 
             var resultUnitTestElement = testCase.ToUnitTestElement(testCase.Source);
 
-            Assert.AreEqual(true, resultUnitTestElement.IsAsync);
+            Assert.IsTrue(resultUnitTestElement.IsAsync);
             Assert.AreEqual(2, resultUnitTestElement.Priority);
             Assert.AreEqual(testCategories, resultUnitTestElement.TestCategory);
             Assert.AreEqual("DummyDisplayName", resultUnitTestElement.DisplayName);
             Assert.AreEqual("DummyMethod", resultUnitTestElement.TestMethod.Name);
             Assert.AreEqual("DummyClassName", resultUnitTestElement.TestMethod.FullClassName);
-            Assert.AreEqual(true, resultUnitTestElement.TestMethod.IsAsync);
+            Assert.IsTrue(resultUnitTestElement.TestMethod.IsAsync);
             Assert.IsNull(resultUnitTestElement.TestMethod.DeclaringClassFullName);
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/TestCaseExtensionsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/TestCaseExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
             var resultUnitTestElement = testCase.ToUnitTestElement(testCase.Source);
 
             // These are set for testCase by default by ObjectModel.
-            Assert.AreEqual(false, resultUnitTestElement.IsAsync);
+            Assert.IsFalse(resultUnitTestElement.IsAsync);
             Assert.AreEqual(0, resultUnitTestElement.Priority);
             Assert.AreEqual(null, resultUnitTestElement.TestCategory);
         }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/TestCaseExtensionsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Extensions/TestCaseExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
             // These are set for testCase by default by ObjectModel.
             Assert.IsFalse(resultUnitTestElement.IsAsync);
             Assert.AreEqual(0, resultUnitTestElement.Priority);
-            Assert.AreEqual(null, resultUnitTestElement.TestCategory);
+            Assert.IsNull(resultUnitTestElement.TestCategory);
         }
 
         [TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Helpers/RunSettingsUtilitiesTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Helpers/RunSettingsUtilitiesTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Helpers
 
             // Verify Parameter Values.
             Assert.IsTrue(trp.ContainsKey("webAppUrl"));
-            Assert.AreEqual(trp["webAppUrl"], "http://localhost");
+            Assert.AreEqual("http://localhost", trp["webAppUrl"]);
         }
 
         [TestMethod]
@@ -114,11 +114,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Helpers
 
             // Verify Parameter Values.
             Assert.IsTrue(trp.ContainsKey("webAppUrl"));
-            Assert.AreEqual(trp["webAppUrl"], "http://localhost");
+            Assert.AreEqual("http://localhost", trp["webAppUrl"]);
             Assert.IsTrue(trp.ContainsKey("webAppUserName"));
-            Assert.AreEqual(trp["webAppUserName"], "Admin");
+            Assert.AreEqual("Admin", trp["webAppUserName"]);
             Assert.IsTrue(trp.ContainsKey("webAppPassword"));
-            Assert.AreEqual(trp["webAppPassword"], "Password");
+            Assert.AreEqual("Password", trp["webAppPassword"]);
         }
 
         [TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
+            Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
         }
 
         [TestMethod]
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsName);
 
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, false);
+            Assert.IsFalse(adapterSettings.ForcedLegacyMode);
         }
 
         [TestMethod]
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsName);
 
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
+            Assert.IsTrue(adapterSettings.ForcedLegacyMode);
         }
 
         [TestMethod]
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
+            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
         }
 
         [TestMethod]
@@ -221,7 +221,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.CaptureDebugTraces, false);
+            Assert.AreEqual(false, adapterSettings.CaptureDebugTraces);
         }
 
         [TestMethod]
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.TestTimeout, 4000);
+            Assert.AreEqual(4000, adapterSettings.TestTimeout);
         }
 
         [TestMethod]
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(adapterSettings.TestTimeout, 0);
+            Assert.AreEqual(0, adapterSettings.TestTimeout);
         }
 
         [TestMethod]
@@ -637,8 +637,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
+            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
             Assert.AreEqual("DummyPath\\\\TestSettings1.testsettings", adapterSettings.TestSettingsFile);
         }
 
@@ -694,10 +694,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.AreEqual("DummyPath\\\\TestSettings1.testsettings", adapterSettings.TestSettingsFile);
         }
 
@@ -803,10 +803,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         #endregion
@@ -822,7 +822,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, false);
+            Assert.AreEqual(false, adapterSettings.ForcedLegacyMode);
         }
 
         [TestMethod]
@@ -871,11 +871,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings.PopulateSettings(settings);
 
-            Assert.AreEqual(MSTestSettings.CurrentSettings.CaptureDebugTraces, false);
-            Assert.AreEqual(MSTestSettings.CurrentSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(MSTestSettings.CurrentSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(MSTestSettings.CurrentSettings.ForcedLegacyMode, true);
-            Assert.AreEqual(MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(false, MSTestSettings.CurrentSettings.CaptureDebugTraces);
+            Assert.AreEqual(true, MSTestSettings.CurrentSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, MSTestSettings.CurrentSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, MSTestSettings.CurrentSettings.ForcedLegacyMode);
+            Assert.AreEqual(true, MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(string.IsNullOrEmpty(MSTestSettings.CurrentSettings.TestSettingsFile));
         }
 
@@ -885,10 +885,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings((IDiscoveryContext)null);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
-            Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.AreEqual(false, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -897,10 +897,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(this.mockDiscoveryContext.Object);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
-            Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.AreEqual(false, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -910,10 +910,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(this.mockDiscoveryContext.Object);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
-            Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, false);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.AreEqual(false, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -935,7 +935,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, false);
+            Assert.AreEqual(false, adapterSettings.ForcedLegacyMode);
         }
 
         [TestMethod]
@@ -960,10 +960,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.IsNotNull(adapterSettings);
 
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }
 
@@ -989,10 +989,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.IsNotNull(adapterSettings);
 
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
+            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }
 
@@ -1021,11 +1021,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.IsNotNull(adapterSettings);
 
-            Assert.AreEqual(adapterSettings.MapInconclusiveToFailed, true);
-            Assert.AreEqual(adapterSettings.MapNotRunnableToFailed, true);
-            Assert.AreEqual(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies, true);
-            Assert.AreEqual(adapterSettings.ForcedLegacyMode, false);
-            Assert.AreEqual(adapterSettings.CaptureDebugTraces, true);
+            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
+            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.AreEqual(false, adapterSettings.ForcedLegacyMode);
+            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
             Assert.IsTrue(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.IsTrue(adapterSettings.CaptureDebugTraces);
         }
 
         [TestMethod]
@@ -637,8 +637,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
-            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
             Assert.AreEqual("DummyPath\\\\TestSettings1.testsettings", adapterSettings.TestSettingsFile);
         }
 
@@ -694,10 +694,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
-            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.ForcedLegacyMode);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.AreEqual("DummyPath\\\\TestSettings1.testsettings", adapterSettings.TestSettingsFile);
         }
 
@@ -803,10 +803,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             // Assert.
             Assert.IsTrue(dummyPlatformSpecificSetting);
-            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.ForcedLegacyMode);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         #endregion
@@ -872,10 +872,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(settings);
 
             Assert.IsFalse(MSTestSettings.CurrentSettings.CaptureDebugTraces);
-            Assert.AreEqual(true, MSTestSettings.CurrentSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, MSTestSettings.CurrentSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, MSTestSettings.CurrentSettings.ForcedLegacyMode);
-            Assert.AreEqual(true, MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(MSTestSettings.CurrentSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(MSTestSettings.CurrentSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(MSTestSettings.CurrentSettings.ForcedLegacyMode);
+            Assert.IsTrue(MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(string.IsNullOrEmpty(MSTestSettings.CurrentSettings.TestSettingsFile));
         }
 
@@ -885,10 +885,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings((IDiscoveryContext)null);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
-            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.IsTrue(adapterSettings.CaptureDebugTraces);
             Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -897,10 +897,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(this.mockDiscoveryContext.Object);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
-            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.IsTrue(adapterSettings.CaptureDebugTraces);
             Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -910,10 +910,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(this.mockDiscoveryContext.Object);
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
-            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.IsTrue(adapterSettings.CaptureDebugTraces);
             Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
 
         [TestMethod]
@@ -960,10 +960,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.IsNotNull(adapterSettings);
 
-            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.ForcedLegacyMode);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }
 
@@ -989,10 +989,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.IsNotNull(adapterSettings);
 
-            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.ForcedLegacyMode);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.ForcedLegacyMode);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }
 
@@ -1021,11 +1021,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             Assert.IsNotNull(adapterSettings);
 
-            Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
-            Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
-            Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(adapterSettings.MapInconclusiveToFailed);
+            Assert.IsTrue(adapterSettings.MapNotRunnableToFailed);
+            Assert.IsTrue(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
             Assert.IsFalse(adapterSettings.ForcedLegacyMode);
-            Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
+            Assert.IsTrue(adapterSettings.CaptureDebugTraces);
             Assert.IsTrue(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
 
-            Assert.AreEqual(false, adapterSettings.CaptureDebugTraces);
+            Assert.IsFalse(adapterSettings.CaptureDebugTraces);
         }
 
         [TestMethod]
@@ -822,7 +822,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(false, adapterSettings.ForcedLegacyMode);
+            Assert.IsFalse(adapterSettings.ForcedLegacyMode);
         }
 
         [TestMethod]
@@ -871,7 +871,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings.PopulateSettings(settings);
 
-            Assert.AreEqual(false, MSTestSettings.CurrentSettings.CaptureDebugTraces);
+            Assert.IsFalse(MSTestSettings.CurrentSettings.CaptureDebugTraces);
             Assert.AreEqual(true, MSTestSettings.CurrentSettings.MapInconclusiveToFailed);
             Assert.AreEqual(true, MSTestSettings.CurrentSettings.MapNotRunnableToFailed);
             Assert.AreEqual(true, MSTestSettings.CurrentSettings.ForcedLegacyMode);
@@ -886,7 +886,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
-            Assert.AreEqual(false, adapterSettings.MapInconclusiveToFailed);
+            Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
             Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
             Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
@@ -898,7 +898,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
-            Assert.AreEqual(false, adapterSettings.MapInconclusiveToFailed);
+            Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
             Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
             Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
@@ -911,7 +911,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
 
             MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
             Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
-            Assert.AreEqual(false, adapterSettings.MapInconclusiveToFailed);
+            Assert.IsFalse(adapterSettings.MapInconclusiveToFailed);
             Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
             Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
         }
@@ -935,7 +935,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(adapterSettings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(false, adapterSettings.ForcedLegacyMode);
+            Assert.IsFalse(adapterSettings.ForcedLegacyMode);
         }
 
         [TestMethod]
@@ -1024,7 +1024,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.AreEqual(true, adapterSettings.MapInconclusiveToFailed);
             Assert.AreEqual(true, adapterSettings.MapNotRunnableToFailed);
             Assert.AreEqual(true, adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
-            Assert.AreEqual(false, adapterSettings.ForcedLegacyMode);
+            Assert.IsFalse(adapterSettings.ForcedLegacyMode);
             Assert.AreEqual(true, adapterSettings.CaptureDebugTraces);
             Assert.IsTrue(string.IsNullOrEmpty(adapterSettings.TestSettingsFile));
         }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestElementTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
             this.unitTestElement.IsAsync = false;
             testCase = this.unitTestElement.ToTestCase();
 
-            Assert.AreEqual(false, testCase.GetPropertyValue(Constants.AsyncTestProperty));
+            Assert.IsFalse(testCase.GetPropertyValue(Constants.AsyncTestProperty));
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestElementTests.cs
@@ -113,12 +113,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
             this.unitTestElement.IsAsync = true;
             var testCase = this.unitTestElement.ToTestCase();
 
-            Assert.IsTrue(testCase.GetPropertyValue(Constants.AsyncTestProperty));
+            Assert.AreEqual(true, testCase.GetPropertyValue(Constants.AsyncTestProperty));
 
             this.unitTestElement.IsAsync = false;
             testCase = this.unitTestElement.ToTestCase();
 
-            Assert.IsFalse(testCase.GetPropertyValue(Constants.AsyncTestProperty));
+            Assert.AreEqual(false, testCase.GetPropertyValue(Constants.AsyncTestProperty));
         }
 
         [TestMethodV1]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestElementTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
             this.unitTestElement.IsAsync = true;
             var testCase = this.unitTestElement.ToTestCase();
 
-            Assert.AreEqual(true, testCase.GetPropertyValue(Constants.AsyncTestProperty));
+            Assert.IsTrue(testCase.GetPropertyValue(Constants.AsyncTestProperty));
 
             this.unitTestElement.IsAsync = false;
             testCase = this.unitTestElement.ToTestCase();

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestResultTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/ObjectModel/UnitTestResultTests.cs
@@ -190,8 +190,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
 
             var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, adapterSettings);
 
-            Assert.AreEqual(testresult.Attachments.Count, 1);
-            Assert.AreEqual(testresult.Attachments[0].Attachments[0].Description, "dummy://DummyFile.txt");
+            Assert.AreEqual(1, testresult.Attachments.Count);
+            Assert.AreEqual("dummy://DummyFile.txt", testresult.Attachments[0].Attachments[0].Description);
         }
 
         [TestMethod]
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.ObjectMode
 
             var testresult = result.ToTestResult(testCase, DateTimeOffset.Now, DateTimeOffset.Now, adapterSettings);
 
-            Assert.AreEqual(testresult.Attachments.Count, 0);
+            Assert.AreEqual(0, testresult.Attachments.Count);
         }
 
         [TestMethod]

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/RunConfigurationSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/RunConfigurationSettingsTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                   </RunSettings>";
 
             RunConfigurationSettings configurationSettings = RunConfigurationSettings.GetSettings(runSettingxml, RunConfigurationSettings.SettingsName);
-            Assert.AreEqual(configurationSettings.CollectSourceInformation, true);
+            Assert.IsTrue(configurationSettings.CollectSourceInformation);
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                 </RunSettings>";
 
             RunConfigurationSettings configurationSettings = RunConfigurationSettings.GetSettings(runSettingxml, RunConfigurationSettings.SettingsName);
-            Assert.AreEqual(configurationSettings.CollectSourceInformation, false);
+            Assert.IsFalse(configurationSettings.CollectSourceInformation);
         }
 
         #endregion
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(settings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(settings.CollectSourceInformation, true);
+            Assert.IsTrue(settings.CollectSourceInformation);
         }
 
         #endregion
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings((IDiscoveryContext)null);
 
             RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
-            Assert.AreEqual(settings.CollectSourceInformation, true);
+            Assert.IsTrue(settings.CollectSourceInformation);
         }
 
         [TestMethod]
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(this.mockDiscoveryContext.Object);
 
             RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
-            Assert.AreEqual(settings.CollectSourceInformation, true);
+            Assert.IsTrue(settings.CollectSourceInformation);
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             MSTestSettings.PopulateSettings(this.mockDiscoveryContext.Object);
 
             RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
-            Assert.AreEqual(settings.CollectSourceInformation, true);
+            Assert.IsTrue(settings.CollectSourceInformation);
         }
 
         [TestMethod]
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(settings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(settings.CollectSourceInformation, true);
+            Assert.IsTrue(settings.CollectSourceInformation);
         }
 
         [TestMethod]
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsNotNull(settings);
 
             // Validating the default value of a random setting.
-            Assert.AreEqual(settings.CollectSourceInformation, false);
+            Assert.IsFalse(settings.CollectSourceInformation);
         }
 
         #endregion

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/AssemblyResolverTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/AssemblyResolverTests.cs
@@ -59,7 +59,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             assemblyResolver.AddSubdirectories(path, searchDirectories);
 
             // Assert.
-            Assert.AreEqual(searchDirectories.Count, 4, "searchDirectories should have only 5 elements");
+            Assert.AreEqual(4, searchDirectories.Count, "searchDirectories should have only 5 elements");
 
             CollectionAssert.AreEqual(resultDirectories, searchDirectories, StringComparer.OrdinalIgnoreCase);
         }
@@ -104,37 +104,37 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
                     {
                         // First time SearchAssemblyInTheFollowingLocation should get call with one directory which is in
                         // m_searchDirectories variable
-                        Assert.AreEqual(listPath.Count, 1);
-                        Assert.AreEqual(string.Compare(listPath[0], dummyDirectories[0], true), 0);
+                        Assert.AreEqual(1, listPath.Count);
+                        Assert.AreEqual(0, string.Compare(listPath[0], dummyDirectories[0], true));
                         count++;
                     }
                     else if (count == 1)
                     {
                         // Second time SearchAssemblyInTheFollowingLocation should get call with directory C:\unitTesting
                         // and with all its sub directory, as its isRecursive property is true
-                        Assert.AreEqual(listPath.Count, 3);
-                        Assert.AreEqual(string.Compare(listPath[0], @"C:\unitTesting", true), 0);
-                        Assert.AreEqual(string.Compare(listPath[1], @"C:\unitTesting\a", true), 0);
-                        Assert.AreEqual(string.Compare(listPath[2], @"C:\unitTesting\b", true), 0);
+                        Assert.AreEqual(3, listPath.Count);
+                        Assert.AreEqual(0, string.Compare(listPath[0], @"C:\unitTesting", true));
+                        Assert.AreEqual(0, string.Compare(listPath[1], @"C:\unitTesting\a", true));
+                        Assert.AreEqual(0, string.Compare(listPath[2], @"C:\unitTesting\b", true));
                         count++;
                     }
                     else if (count == 2)
                     {
                         // Third time SearchAssemblyInTheFollowingLocation should get call with directory C:\FunctionalTesting
                         // as its isRecursive property is false
-                        Assert.AreEqual(listPath.Count, 1);
-                        Assert.AreEqual(string.Compare(listPath[0], @"C:\FunctionalTesting", true), 0);
+                        Assert.AreEqual(1, listPath.Count);
+                        Assert.AreEqual(0, string.Compare(listPath[0], @"C:\FunctionalTesting", true));
                         count++;
                     }
                     else if (count == 3)
                     {
                         // call will come here when we will call onResolve second time.
-                        Assert.AreEqual(listPath.Count, 5);
-                        Assert.AreEqual(string.Compare(listPath[0], dummyDirectories[0], true), 0);
-                        Assert.AreEqual(string.Compare(listPath[1], @"C:\unitTesting", true), 0);
-                        Assert.AreEqual(string.Compare(listPath[2], @"C:\unitTesting\a", true), 0);
-                        Assert.AreEqual(string.Compare(listPath[3], @"C:\unitTesting\b", true), 0);
-                        Assert.AreEqual(string.Compare(listPath[4], @"C:\FunctionalTesting", true), 0);
+                        Assert.AreEqual(5, listPath.Count);
+                        Assert.AreEqual(0, string.Compare(listPath[0], dummyDirectories[0], true));
+                        Assert.AreEqual(0, string.Compare(listPath[1], @"C:\unitTesting", true));
+                        Assert.AreEqual(0, string.Compare(listPath[2], @"C:\unitTesting\a", true));
+                        Assert.AreEqual(0, string.Compare(listPath[3], @"C:\unitTesting\b", true));
+                        Assert.AreEqual(0, string.Compare(listPath[4], @"C:\FunctionalTesting", true));
                         count++;
                     }
 

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -37,8 +37,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.AreEqual(result.Contains(VSInstallationUtilities.PathToPublicAssemblies), true);
-            Assert.AreEqual(result.Contains(VSInstallationUtilities.PathToPrivateAssemblies), true);
+            Assert.AreEqual(true, result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
+            Assert.AreEqual(true, result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
         }
 
         [TestMethod]
@@ -52,8 +52,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: true);
 
             // Assert
-            Assert.AreEqual(result.Contains(VSInstallationUtilities.PathToPublicAssemblies), false);
-            Assert.AreEqual(result.Contains(VSInstallationUtilities.PathToPrivateAssemblies), false);
+            Assert.AreEqual(false, result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
+            Assert.AreEqual(false, result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.AreEqual(result.Contains(typeof(TestSourceHost).Assembly.Location), false);
+            Assert.AreEqual(false, result.Contains(typeof(TestSourceHost).Assembly.Location));
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.AreEqual(result.Contains(typeof(AssemblyHelper).Assembly.Location), false);
+            Assert.AreEqual(false, result.Contains(typeof(AssemblyHelper).Assembly.Location));
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -52,8 +52,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: true);
 
             // Assert
-            Assert.AreEqual(false, result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
-            Assert.AreEqual(false, result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
+            Assert.IsFalse(result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
+            Assert.IsFalse(result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.AreEqual(false, result.Contains(typeof(TestSourceHost).Assembly.Location));
+            Assert.IsFalse(result.Contains(typeof(TestSourceHost).Assembly.Location));
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.AreEqual(false, result.Contains(typeof(AssemblyHelper).Assembly.Location));
+            Assert.IsFalse(result.Contains(typeof(AssemblyHelper).Assembly.Location));
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -37,8 +37,8 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.AreEqual(true, result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
-            Assert.AreEqual(true, result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
+            Assert.IsTrue(result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
+            Assert.IsTrue(result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/Services/ns10MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/Services/ns10MSTestAdapterSettingsTests.cs
@@ -244,7 +244,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             MSTestAdapterSettings adapterSettings = MSTestAdapterSettings.ToSettings(reader);
-            Assert.AreEqual(true, adapterSettings.DeploymentEnabled);
+            Assert.IsTrue(adapterSettings.DeploymentEnabled);
         }
 
         [TestMethod]
@@ -275,7 +275,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             MSTestAdapterSettings adapterSettings = MSTestAdapterSettings.ToSettings(reader);
-            Assert.AreEqual(true, adapterSettings.DeployTestSourceDependencies);
+            Assert.IsTrue(adapterSettings.DeployTestSourceDependencies);
         }
 
         [TestMethod]
@@ -303,7 +303,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             MSTestAdapterSettings adapterSettings = MSTestAdapterSettings.ToSettings(reader);
-            Assert.AreEqual(true, adapterSettings.DeployTestSourceDependencies);
+            Assert.IsTrue(adapterSettings.DeployTestSourceDependencies);
         }
 
 #endregion

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/Services/ns10MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/Services/ns10MSTestAdapterSettingsTests.cs
@@ -53,7 +53,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             string result = adapterSettings.ResolveEnvironmentVariableAndReturnFullPathIfExist(path, baseDirectory);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(string.Compare(result, expectedResult, true), 0);
+            Assert.AreEqual(0, string.Compare(result, expectedResult, true), 0);
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             string result = adapterSettings.ResolveEnvironmentVariableAndReturnFullPathIfExist(path, baseDirectory);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(string.Compare(result, expectedResult, true), 0);
+            Assert.AreEqual(0, string.Compare(result, expectedResult, true));
         }
 
         [TestMethod]
@@ -86,7 +86,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             string result = adapterSettings.ResolveEnvironmentVariableAndReturnFullPathIfExist(path, baseDirectory);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(string.Compare(result, expectedResult, true), 0);
+            Assert.AreEqual(0, string.Compare(result, expectedResult, true));
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             string result = adapterSettings.ResolveEnvironmentVariableAndReturnFullPathIfExist(path, baseDirectory);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(string.Compare(result, expectedResult, true), 0);
+            Assert.AreEqual(0, string.Compare(result, expectedResult, true));
         }
 
         [TestMethod]
@@ -124,7 +124,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             string result = adapterSettings.ResolveEnvironmentVariableAndReturnFullPathIfExist(path, baseDirectory);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(string.Compare(result, expectedResult, true), 0);
+            Assert.AreEqual(0, string.Compare(result, expectedResult, true));
         }
 
         [TestMethod]
@@ -141,7 +141,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             string result = adapterSettings.ResolveEnvironmentVariableAndReturnFullPathIfExist(path, baseDirectory);
 
             Assert.IsNotNull(result);
-            Assert.AreEqual(string.Compare(result, expectedResult, true), 0);
+            Assert.AreEqual(0, string.Compare(result, expectedResult, true));
         }
 
         [TestMethod]
@@ -174,11 +174,11 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
 
             IList<RecursiveDirectoryPath> result = adapterSettings.GetDirectoryListWithRecursiveProperty(baseDirectory);
             Assert.IsNotNull(result);
-            Assert.AreEqual(result.Count, 2);
+            Assert.AreEqual(2, result.Count);
 
             for (int i = 0; i < 2; i++)
             {
-                Assert.AreEqual(string.Compare(result[i].DirectoryPath, expectedResult[i].DirectoryPath, StringComparison.OrdinalIgnoreCase), 0);
+                Assert.AreEqual(0, string.Compare(result[i].DirectoryPath, expectedResult[i].DirectoryPath, StringComparison.OrdinalIgnoreCase));
                 Assert.AreEqual(result[i].IncludeSubDirectories, expectedResult[i].IncludeSubDirectories);
             }
         }

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/Services/ns10MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/Services/ns10MSTestAdapterSettingsTests.cs
@@ -258,7 +258,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             MSTestAdapterSettings adapterSettings = MSTestAdapterSettings.ToSettings(reader);
-            Assert.AreEqual(false, adapterSettings.DeploymentEnabled);
+            Assert.IsFalse(adapterSettings.DeploymentEnabled);
         }
 
 #endregion
@@ -289,7 +289,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             MSTestAdapterSettings adapterSettings = MSTestAdapterSettings.ToSettings(reader);
-            Assert.AreEqual(false, adapterSettings.DeployTestSourceDependencies);
+            Assert.IsFalse(adapterSettings.DeployTestSourceDependencies);
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10FileOperationsTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10FileOperationsTests.cs
@@ -66,7 +66,7 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         [TestMethod]
         public void GetFullFilePathShouldReturnAssemblyFileName()
         {
-            Assert.AreEqual(null, this.fileOperations.GetFullFilePath(null));
+            Assert.IsNull(this.fileOperations.GetFullFilePath(null));
             Assert.AreEqual("assemblyFileName", this.fileOperations.GetFullFilePath("assemblyFileName"));
         }
     }

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/Services/ns13MSTestSettingsProviderTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/Services/ns13MSTestSettingsProviderTests.cs
@@ -55,7 +55,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             var settings = MSTestSettingsProvider.Settings;
 
             Assert.IsNotNull(settings);
-            Assert.AreEqual(true, settings.DeploymentEnabled);
+            Assert.IsTrue(settings.DeploymentEnabled);
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/Services/ns13MSTestSettingsProviderTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/Services/ns13MSTestSettingsProviderTests.cs
@@ -69,7 +69,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             this.settingsProvider.Load(reader);
-            Assert.AreEqual(false, MSTestSettingsProvider.Settings.DeploymentEnabled);
+            Assert.IsFalse(MSTestSettingsProvider.Settings.DeploymentEnabled);
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             this.settingsProvider.Load(reader);
-            Assert.AreEqual(false, MSTestSettingsProvider.Settings.DeploymentEnabled);
+            Assert.IsFalse(MSTestSettingsProvider.Settings.DeploymentEnabled);
         }
     }
 }

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/Services/ns13MSTestSettingsProviderTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/Services/ns13MSTestSettingsProviderTests.cs
@@ -69,7 +69,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             this.settingsProvider.Load(reader);
-            Assert.AreEqual(MSTestSettingsProvider.Settings.DeploymentEnabled, false);
+            Assert.AreEqual(false, MSTestSettingsProvider.Settings.DeploymentEnabled);
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
             XmlReader reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
             reader.Read();
             this.settingsProvider.Load(reader);
-            Assert.AreEqual(MSTestSettingsProvider.Settings.DeploymentEnabled, false);
+            Assert.AreEqual(false, MSTestSettingsProvider.Settings.DeploymentEnabled);
         }
     }
 }

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/ns13TraceListenerTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.3/ns13TraceListenerTests.cs
@@ -30,7 +30,7 @@ namespace MSTestAdapter.PlatformServices.UnitTests.Services
             StringWriter writer = new StringWriter(new StringBuilder("DummyTrace"));
             var traceListener = new TraceListenerWrapper(writer);
             var returnedWriter = traceListener.GetWriter();
-            Assert.AreEqual(returnedWriter.ToString(), "DummyTrace");
+            Assert.AreEqual("DummyTrace", returnedWriter.ToString());
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.Universal.Unit.Tests/Services/UniversalFileOperationsTests.cs
+++ b/test/UnitTests/PlatformServices.Universal.Unit.Tests/Services/UniversalFileOperationsTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.UWP
         [TestMethod]
         public void GetFullFilePathShouldReturnAssemblyFileName()
         {
-            Assert.AreEqual(null, this.fileOperations.GetFullFilePath(null));
+            Assert.IsNull(this.fileOperations.GetFullFilePath(null));
             Assert.AreEqual("assemblyFileName", this.fileOperations.GetFullFilePath("assemblyFileName"));
         }
     }


### PR DESCRIPTION
## Description
This PR is to fix some asserts in the TestPlatform.sln solution, the expected and actual are round the wrong way.

e.g.

`Assert.AreEqual(aggregator.RunContextAttachments.Count, 1, "RunContextAttachments List must have data.");`

should be

`Assert.AreEqual(1, aggregator.RunContextAttachments.Count, "RunContextAttachments List must have data.");`

## Related issue
Fixes #684

