### PR TITLE
Create Write() in TestContext

### DIFF
--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopTestContextImplementation.cs
@@ -254,6 +254,53 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         ///     test is running.
         /// </summary>
         /// <param name="message">The formatted string that contains the trace message.</param>
+        public override void Write(string message)
+        {
+            if (this.stringWriterDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                var msg = message?.Replace("\0", "\\0");
+                this.stringWriter.Write(msg);
+            }
+            catch (ObjectDisposedException)
+            {
+                this.stringWriterDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, used to write trace messages while the
+        ///     test is running.
+        /// </summary>
+        /// <param name="format">The string that contains the trace message.</param>
+        /// <param name="args">Arguments to add to the trace message.</param>
+        public override void Write(string format, params object[] args)
+        {
+            if (this.stringWriterDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                string message = string.Format(CultureInfo.CurrentCulture, format?.Replace("\0", "\\0"), args);
+                this.stringWriter.Write(message);
+            }
+            catch (ObjectDisposedException)
+            {
+                this.stringWriterDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, used to write trace messages while the
+        ///     test is running.
+        /// </summary>
+        /// <param name="message">The formatted string that contains the trace message.</param>
         public override void WriteLine(string message)
         {
             if (this.stringWriterDisposed)

--- a/src/Adapter/PlatformServices.NetCore/Services/NetCoreTestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.NetCore/Services/NetCoreTestContextImplementation.cs
@@ -294,6 +294,53 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         ///     test is running.
         /// </summary>
         /// <param name="message">The formatted string that contains the trace message.</param>
+        public override void Write(string message)
+        {
+            if (this.stringWriterDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                var msg = message?.Replace("\0", "\\0");
+                this.stringWriter.Write(msg);
+            }
+            catch (ObjectDisposedException)
+            {
+                this.stringWriterDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, used to write trace messages while the
+        ///     test is running.
+        /// </summary>
+        /// <param name="format">The string that contains the trace message.</param>
+        /// <param name="args">Arguments to add to the trace message.</param>
+        public override void Write(string format, params object[] args)
+        {
+            if (this.stringWriterDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                string message = string.Format(CultureInfo.CurrentCulture, format?.Replace("\0", "\\0"), args);
+                this.stringWriter.Write(message);
+            }
+            catch (ObjectDisposedException)
+            {
+                this.stringWriterDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, used to write trace messages while the
+        ///     test is running.
+        /// </summary>
+        /// <param name="message">The formatted string that contains the trace message.</param>
         public override void WriteLine(string message)
         {
             if (this.stringWriterDisposed)

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestContextImplementation.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TestContextImplementation.cs
@@ -192,6 +192,53 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         ///     test is running.
         /// </summary>
         /// <param name="message">The formatted string that contains the trace message.</param>
+        public override void Write(string message)
+        {
+            if (this.stringWriterDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                var msg = message?.Replace("\0", "\\0");
+                this.stringWriter.Write(msg);
+            }
+            catch (ObjectDisposedException)
+            {
+                this.stringWriterDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, used to write trace messages while the
+        ///     test is running.
+        /// </summary>
+        /// <param name="format">The string that contains the trace message.</param>
+        /// <param name="args">Arguments to add to the trace message.</param>
+        public override void Write(string format, params object[] args)
+        {
+            if (this.stringWriterDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                string message = string.Format(CultureInfo.CurrentCulture, format?.Replace("\0", "\\0"), args);
+                this.stringWriter.Write(message);
+            }
+            catch (ObjectDisposedException)
+            {
+                this.stringWriterDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, used to write trace messages while the
+        ///     test is running.
+        /// </summary>
+        /// <param name="message">The formatted string that contains the trace message.</param>
         public override void WriteLine(string message)
         {
             if (this.stringWriterDisposed)

--- a/src/TestFramework/Extension.Core/NetCoreTestContext.cs
+++ b/src/TestFramework/Extension.Core/NetCoreTestContext.cs
@@ -109,6 +109,19 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Used to write trace messages while the test is running
         /// </summary>
         /// <param name="message">formatted message string</param>
+        public abstract void Write(string message);
+
+        /// <summary>
+        /// Used to write trace messages while the test is running
+        /// </summary>
+        /// <param name="format">format string</param>
+        /// <param name="args">the arguments</param>
+        public abstract void Write(string format, params object[] args);
+
+        /// <summary>
+        /// Used to write trace messages while the test is running
+        /// </summary>
+        /// <param name="message">formatted message string</param>
         public abstract void WriteLine(string message);
 
         /// <summary>

--- a/src/TestFramework/Extension.Desktop/DesktopTestContext.cs
+++ b/src/TestFramework/Extension.Desktop/DesktopTestContext.cs
@@ -115,6 +115,19 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Used to write trace messages while the test is running
         /// </summary>
         /// <param name="message">formatted message string</param>
+        public abstract void Write(string message);
+
+        /// <summary>
+        /// Used to write trace messages while the test is running
+        /// </summary>
+        /// <param name="format">format string</param>
+        /// <param name="args">the arguments</param>
+        public abstract void Write(string format, params object[] args);
+
+        /// <summary>
+        /// Used to write trace messages while the test is running
+        /// </summary>
+        /// <param name="message">formatted message string</param>
         public abstract void WriteLine(string message);
 
         /// <summary>

--- a/src/TestFramework/Extension.Shared/TestContext.cs
+++ b/src/TestFramework/Extension.Shared/TestContext.cs
@@ -52,6 +52,19 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Used to write trace messages while the test is running
         /// </summary>
         /// <param name="message">formatted message string</param>
+        public abstract void Write(string message);
+
+        /// <summary>
+        /// Used to write trace messages while the test is running
+        /// </summary>
+        /// <param name="format">format string</param>
+        /// <param name="args">the arguments</param>
+        public abstract void Write(string format, params object[] args);
+
+        /// <summary>
+        /// Used to write trace messages while the test is running
+        /// </summary>
+        /// <param name="message">formatted message string</param>
         public abstract void WriteLine(string message);
 
         /// <summary>

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestContextImplTests.cs
@@ -25,7 +25,7 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
     using UnitTestOutcome = FrameworkV2::Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome;
 
     [TestClass]
-    public class DEsktopTestContextImplTests
+    public class DesktopTestContextImplTests
     {
         private Mock<ITestMethod> testMethod;
 
@@ -213,6 +213,76 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests.Services
 
             CollectionAssert.Contains(resultsFiles.ToList(), "C:\\temp.txt");
             CollectionAssert.Contains(resultsFiles.ToList(), "C:\\temp2.txt");
+        }
+
+        [TestMethod]
+        public void WriteShouldWriteToStringWriter()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("{0} Testing write", 1);
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteShouldWriteToStringWriterForNullCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("{0} Testing \0 write \0", 1);
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing \\0 write \\0");
+        }
+
+        [TestMethod]
+        public void WriteShouldNotThrowIfStringWriterIsDisposed()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            stringWriter.Dispose();
+            this.testContextImplementation.Write("{0} Testing write", 1);
+
+            // Calling it twice to cover the direct return when we know the object has been disposed.
+            this.testContextImplementation.Write("{0} Testing write", 1);
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriter()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("1 Testing write");
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriterForNullCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("1 Testing \0 write \0");
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing \\0 write \\0");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldNotThrowIfStringWriterIsDisposed()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            stringWriter.Dispose();
+            this.testContextImplementation.Write("1 Testing write");
+
+            // Calling it twice to cover the direct return when we know the object has been disposed.
+            this.testContextImplementation.Write("1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriterForReturnCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("2 Testing write \n\r");
+            this.testContextImplementation.Write("3 Testing write\n\r");
+            StringAssert.Equals(stringWriter.ToString(), "2 Testing write 3 Testing write");
         }
 
         [TestMethod]

--- a/test/UnitTests/PlatformServices.NetCore.Unit.Tests/Services/NetCoreTestContextImplementationTests.cs
+++ b/test/UnitTests/PlatformServices.NetCore.Unit.Tests/Services/NetCoreTestContextImplementationTests.cs
@@ -165,6 +165,76 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         }
 
         [TestMethod]
+        public void WriteShouldWriteToStringWriter()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("{0} Testing write", 1);
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteShouldWriteToStringWriterForNullCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("{0} Testing \0 write \0", 1);
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing \\0 write \\0");
+        }
+
+        [TestMethod]
+        public void WriteShouldNotThrowIfStringWriterIsDisposed()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            stringWriter.Dispose();
+            this.testContextImplementation.Write("{0} Testing write", 1);
+
+            // Calling it twice to cover the direct return when we know the object has been disposed.
+            this.testContextImplementation.Write("{0} Testing write", 1);
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriter()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("1 Testing write");
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriterForNullCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("1 Testing \0 write \0");
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing \\0 write \\0");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldNotThrowIfStringWriterIsDisposed()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            stringWriter.Dispose();
+            this.testContextImplementation.Write("1 Testing write");
+
+            // Calling it twice to cover the direct return when we know the object has been disposed.
+            this.testContextImplementation.Write("1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriterForReturnCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("2 Testing write \n\r");
+            this.testContextImplementation.Write("3 Testing write\n\r");
+            StringAssert.Equals(stringWriter.ToString(), "2 Testing write 3 Testing write");
+        }
+
+        [TestMethod]
         public void WriteLineShouldWriteToStringWriter()
         {
             var stringWriter = new StringWriter();

--- a/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10TestContextImplementationTests.cs
+++ b/test/UnitTests/PlatformServices.Shared.Unit.Tests/netstandard1.0/ns10TestContextImplementationTests.cs
@@ -162,6 +162,76 @@ namespace MSTestAdapter.PlatformServices.Tests.Services
         }
 
         [TestMethod]
+        public void WriteShouldWriteToStringWriter()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("{0} Testing write", 1);
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteShouldWriteToStringWriterForNullCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("{0} Testing \0 write \0", 1);
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing \\0 write \\0");
+        }
+
+        [TestMethod]
+        public void WriteShouldNotThrowIfStringWriterIsDisposed()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            stringWriter.Dispose();
+            this.testContextImplementation.Write("{0} Testing write", 1);
+
+            // Calling it twice to cover the direct return when we know the object has been disposed.
+            this.testContextImplementation.Write("{0} Testing write", 1);
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriter()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("1 Testing write");
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriterForNullCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("1 Testing \0 write \0");
+            StringAssert.Contains(stringWriter.ToString(), "1 Testing \\0 write \\0");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldNotThrowIfStringWriterIsDisposed()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            stringWriter.Dispose();
+            this.testContextImplementation.Write("1 Testing write");
+
+            // Calling it twice to cover the direct return when we know the object has been disposed.
+            this.testContextImplementation.Write("1 Testing write");
+        }
+
+        [TestMethod]
+        public void WriteWithMessageShouldWriteToStringWriterForReturnCharacters()
+        {
+            var stringWriter = new StringWriter();
+            this.testContextImplementation = new TestContextImplementation(this.testMethod.Object, stringWriter, this.properties);
+            this.testContextImplementation.Write("2 Testing write \n\r");
+            this.testContextImplementation.Write("3 Testing write\n\r");
+            StringAssert.Equals(stringWriter.ToString(), "2 Testing write 3 Testing write");
+        }
+
+        [TestMethod]
         public void WriteLineShouldWriteToStringWriter()
         {
             var stringWriter = new StringWriter();


### PR DESCRIPTION
Created Write() method.
Created some tests for the testing of newline and carriage return.

It's basically a carbon copy of the WriteLine implementation but calling the StringWriter.Write 

Resolves Issue:
#645

NOTE: I'm pretty inexperienced in C# i might struggle with advanced concepts if i've missed something.