### PR TITLE
Assert.IsTrue() & False() to handle nullable bools

### DIFF
--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -162,14 +162,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void IsTrue(bool? condition, string message, params object[] parameters)
         {
-            if (condition == false)
+            if (condition == false || condition == null)
             {
                 HandleFail("Assert.IsTrue", message, parameters);
-            }
-
-            if (condition == null)
-            {
-                HandleFail("Assert.IsNull", message, parameters);
             }
         }
 
@@ -285,14 +280,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void IsFalse(bool? condition, string message, params object[] parameters)
         {
-            if (condition == true)
+            if (condition == true || condition == null)
             {
                 HandleFail("Assert.IsFalse", message, parameters);
-            }
-
-            if (condition == null)
-            {
-                HandleFail("Assert.IsNull", message, parameters);
             }
         }
 

--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -72,6 +72,21 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// <param name="condition">
         /// The condition the test expects to be true.
         /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="condition"/> is false.
+        /// </exception>
+        public static void IsTrue(bool? condition)
+        {
+            IsTrue(condition, string.Empty, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified condition is true and throws an exception
+        /// if the condition is false.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition the test expects to be true.
+        /// </param>
         /// <param name="message">
         /// The message to include in the exception when <paramref name="condition"/>
         /// is false. The message is shown in test results.
@@ -80,6 +95,25 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Thrown if <paramref name="condition"/> is false.
         /// </exception>
         public static void IsTrue(bool condition, string message)
+        {
+            IsTrue(condition, message, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified condition is true and throws an exception
+        /// if the condition is false.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition the test expects to be true.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="condition"/>
+        /// is false. The message is shown in test results.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="condition"/> is false.
+        /// </exception>
+        public static void IsTrue(bool? condition, string message)
         {
             IsTrue(condition, message, null);
         }
@@ -110,6 +144,36 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         }
 
         /// <summary>
+        /// Tests whether the specified condition is true and throws an exception
+        /// if the condition is false.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition the test expects to be true.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="condition"/>
+        /// is false. The message is shown in test results.
+        /// </param>
+        /// <param name="parameters">
+        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="condition"/> is false.
+        /// </exception>
+        public static void IsTrue(bool? condition, string message, params object[] parameters)
+        {
+            if (condition == false)
+            {
+                HandleFail("Assert.IsTrue", message, parameters);
+            }
+
+            if (condition == null)
+            {
+                HandleFail("Assert.IsNull", message, parameters);
+            }
+        }
+
+        /// <summary>
         /// Tests whether the specified condition is false and throws an exception
         /// if the condition is true.
         /// </summary>
@@ -120,6 +184,21 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Thrown if <paramref name="condition"/> is true.
         /// </exception>
         public static void IsFalse(bool condition)
+        {
+            IsFalse(condition, string.Empty, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified condition is false and throws an exception
+        /// if the condition is true.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition the test expects to be false.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="condition"/> is true.
+        /// </exception>
+        public static void IsFalse(bool? condition)
         {
             IsFalse(condition, string.Empty, null);
         }
@@ -154,6 +233,25 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// The message to include in the exception when <paramref name="condition"/>
         /// is true. The message is shown in test results.
         /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="condition"/> is true.
+        /// </exception>
+        public static void IsFalse(bool? condition, string message)
+        {
+            IsFalse(condition, message, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified condition is false and throws an exception
+        /// if the condition is true.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition the test expects to be false.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="condition"/>
+        /// is true. The message is shown in test results.
+        /// </param>
         /// <param name="parameters">
         /// An array of parameters to use when formatting <paramref name="message"/>.
         /// </param>
@@ -165,6 +263,36 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             if (condition)
             {
                 HandleFail("Assert.IsFalse", message, parameters);
+            }
+        }
+
+        /// <summary>
+        /// Tests whether the specified condition is false and throws an exception
+        /// if the condition is true.
+        /// </summary>
+        /// <param name="condition">
+        /// The condition the test expects to be false.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="condition"/>
+        /// is true. The message is shown in test results.
+        /// </param>
+        /// <param name="parameters">
+        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="condition"/> is true.
+        /// </exception>
+        public static void IsFalse(bool? condition, string message, params object[] parameters)
+        {
+            if (condition == true)
+            {
+                HandleFail("Assert.IsFalse", message, parameters);
+            }
+
+            if (condition == null)
+            {
+                HandleFail("Assert.IsNull", message, parameters);
             }
         }
 

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
@@ -300,5 +300,27 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests
         }
 
         #endregion
+
+        #region Nullable Booleans tests.
+
+        [TestMethod]
+        public void IsFalseNullableBooleansShouldFailWithNull()
+        {
+            bool? nullBool = null;
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.IsFalse(nullBool));
+            Assert.IsNotNull(ex);
+            StringAssert.Contains(ex.Message, "Assert.IsFalse failed");
+        }
+
+        [TestMethod]
+        public void IsTrueNullableBooleansShouldFailWithNull()
+        {
+            bool? nullBool = null;
+
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.IsTrue(nullBool));
+            Assert.IsNotNull(ex);
+            StringAssert.Contains(ex.Message, "Assert.IsTrue failed");
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Description:
An attempt on handling nullable bools for Assert.IsTrue() Assert.IsFalse()

Implemented these overrides and added some tests for them

`public static void IsTrue(bool? condition);`
`public static void IsTrue(bool? condition, string message);`
`public static void IsTrue(bool? condition, string message, params object[] parameters);`
`public static void IsFalse(bool? condition);`
`public static void IsFalse(bool? condition, string message);`
`public static void IsFalse(bool? condition, string message, params object[] parameters);`

Resolves #652 