### PR TITLE
Added StringComparison to StringAssert Contains(), EndsWith() & StartsWith()

### DIFF
--- a/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
@@ -116,9 +116,40 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring, string message, params object[] parameters)
         {
+            Contains(value, substring, message, StringComparison.Ordinal, parameters);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string contains the specified substring
+        /// and throws an exception if the substring does not occur within the
+        /// test string.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to contain <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to occur within <paramref name="value"/>.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="substring"/>
+        /// is not in <paramref name="value"/>. The message is shown in
+        /// test results.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <param name="parameters">
+        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="substring"/> is not found in
+        /// <paramref name="value"/>.
+        /// </exception>
+        public static void Contains(string value, string substring, string message, StringComparison comparisonType, params object[] parameters)
+        {
             Assert.CheckParameterNotNull(value, "StringAssert.Contains", "value", string.Empty);
             Assert.CheckParameterNotNull(substring, "StringAssert.Contains", "substring", string.Empty);
-            if (value.IndexOf(substring, StringComparison.Ordinal) < 0)
+            if (value.IndexOf(substring, comparisonType) < 0)
             {
                 string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.ContainsFail, value, substring, message);
                 Assert.HandleFail("StringAssert.Contains", finalMessage, parameters);
@@ -195,9 +226,40 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, string message, params object[] parameters)
         {
+            StartsWith(value, substring, message, StringComparison.Ordinal, parameters);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string begins with the specified substring
+        /// and throws an exception if the test string does not start with the
+        /// substring.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to begin with <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to be a prefix of <paramref name="value"/>.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="value"/>
+        /// does not begin with <paramref name="substring"/>. The message is
+        /// shown in test results.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <param name="parameters">
+        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="value"/> does not begin with
+        /// <paramref name="substring"/>.
+        /// </exception>
+        public static void StartsWith(string value, string substring, string message, StringComparison comparisonType, params object[] parameters)
+        {
             Assert.CheckParameterNotNull(value, "StringAssert.StartsWith", "value", string.Empty);
             Assert.CheckParameterNotNull(substring, "StringAssert.StartsWith", "substring", string.Empty);
-            if (!value.StartsWith(substring, StringComparison.Ordinal))
+            if (!value.StartsWith(substring, comparisonType))
             {
                 string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.StartsWithFail, value, substring, message);
                 Assert.HandleFail("StringAssert.StartsWith", finalMessage, parameters);
@@ -274,9 +336,40 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, string message, params object[] parameters)
         {
+            EndsWith(value, substring, message, StringComparison.Ordinal, parameters);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string ends with the specified substring
+        /// and throws an exception if the test string does not end with the
+        /// substring.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to end with <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to be a suffix of <paramref name="value"/>.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="value"/>
+        /// does not end with <paramref name="substring"/>. The message is
+        /// shown in test results.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <param name="parameters">
+        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="value"/> does not end with
+        /// <paramref name="substring"/>.
+        /// </exception>
+        public static void EndsWith(string value, string substring, string message, StringComparison comparisonType, params object[] parameters)
+        {
             Assert.CheckParameterNotNull(value, "StringAssert.EndsWith", "value", string.Empty);
             Assert.CheckParameterNotNull(substring, "StringAssert.EndsWith", "substring", string.Empty);
-            if (!value.EndsWith(substring, StringComparison.Ordinal))
+            if (!value.EndsWith(substring, comparisonType))
             {
                 string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.EndsWithFail, value, substring, message);
                 Assert.HandleFail("StringAssert.EndsWith", finalMessage, parameters);

--- a/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
@@ -12,6 +12,8 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
     /// </summary>
     public sealed class StringAssert
     {
+        private static readonly object[] Empty = new object[0];
+
         private static StringAssert that;
 
         #region Singleton constructor
@@ -139,7 +141,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring, string message, StringComparison comparisonType)
         {
-            Contains(value, substring, message, comparisonType);
+            Contains(value, substring, message, comparisonType, Empty);
         }
 
         /// <summary>
@@ -247,7 +249,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, StringComparison comparisonType)
         {
-            StartsWith(value, substring, string.Empty, comparisonType);
+            StartsWith(value, substring, string.Empty, comparisonType, Empty);
         }
 
         /// <summary>
@@ -328,7 +330,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, string message, StringComparison comparisonType)
         {
-            StartsWith(value, substring, message, comparisonType);
+            StartsWith(value, substring, message, comparisonType, Empty);
         }
 
         /// <summary>
@@ -408,7 +410,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, StringComparison comparisonType)
         {
-            EndsWith(value, substring, string.Empty, comparisonType);
+            EndsWith(value, substring, string.Empty, comparisonType, Empty);
         }
 
         /// <summary>
@@ -489,7 +491,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, string message, StringComparison comparisonType)
         {
-            EndsWith(value, substring, message, comparisonType);
+            EndsWith(value, substring, message, comparisonType, Empty);
         }
 
         /// <summary>

--- a/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
@@ -63,7 +63,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring)
         {
-            Contains(value, substring, string.Empty, null);
+            Contains(value, substring, string.Empty, StringComparison.Ordinal, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string contains the specified substring
+        /// and throws an exception if the substring does not occur within the
+        /// test string.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to contain <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to occur within <paramref name="value"/>.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="substring"/> is not found in
+        /// <paramref name="value"/>.
+        /// </exception>
+        public static void Contains(string value, string substring, StringComparison comparisonType)
+        {
+            Contains(value, substring, string.Empty, comparisonType, null);
         }
 
         /// <summary>
@@ -88,7 +111,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring, string message)
         {
-            Contains(value, substring, message, null);
+            Contains(value, substring, message, StringComparison.Ordinal, null);
         }
 
         /// <summary>
@@ -107,16 +130,16 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// is not in <paramref name="value"/>. The message is shown in
         /// test results.
         /// </param>
-        /// <param name="parameters">
-        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
         /// </param>
         /// <exception cref="AssertFailedException">
         /// Thrown if <paramref name="substring"/> is not found in
         /// <paramref name="value"/>.
         /// </exception>
-        public static void Contains(string value, string substring, string message, params object[] parameters)
+        public static void Contains(string value, string substring, string message, StringComparison comparisonType)
         {
-            Contains(value, substring, message, StringComparison.Ordinal, parameters);
+            Contains(value, substring, message, comparisonType, null);
         }
 
         /// <summary>
@@ -173,7 +196,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring)
         {
-            StartsWith(value, substring, string.Empty, null);
+            StartsWith(value, substring, string.Empty, StringComparison.Ordinal, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string begins with the specified substring
+        /// and throws an exception if the test string does not start with the
+        /// substring.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to begin with <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to be a prefix of <paramref name="value"/>.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="value"/> does not begin with
+        /// <paramref name="substring"/>.
+        /// </exception>
+        public static void StartsWith(string value, string substring, StringComparison comparisonType)
+        {
+            StartsWith(value, substring, string.Empty, comparisonType, null);
         }
 
         /// <summary>
@@ -198,7 +244,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, string message)
         {
-            StartsWith(value, substring, message, null);
+            StartsWith(value, substring, message, StringComparison.Ordinal, null);
         }
 
         /// <summary>
@@ -227,6 +273,34 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         public static void StartsWith(string value, string substring, string message, params object[] parameters)
         {
             StartsWith(value, substring, message, StringComparison.Ordinal, parameters);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string begins with the specified substring
+        /// and throws an exception if the test string does not start with the
+        /// substring.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to begin with <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to be a prefix of <paramref name="value"/>.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="value"/>
+        /// does not begin with <paramref name="substring"/>. The message is
+        /// shown in test results.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="value"/> does not begin with
+        /// <paramref name="substring"/>.
+        /// </exception>
+        public static void StartsWith(string value, string substring, string message, StringComparison comparisonType)
+        {
+            StartsWith(value, substring, message, comparisonType, null);
         }
 
         /// <summary>
@@ -283,7 +357,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring)
         {
-            EndsWith(value, substring, string.Empty, null);
+            EndsWith(value, substring, string.Empty, StringComparison.Ordinal, null);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string ends with the specified substring
+        /// and throws an exception if the test string does not end with the
+        /// substring.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to end with <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to be a suffix of <paramref name="value"/>.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="value"/> does not end with
+        /// <paramref name="substring"/>.
+        /// </exception>
+        public static void EndsWith(string value, string substring, StringComparison comparisonType)
+        {
+            EndsWith(value, substring, string.Empty, comparisonType, null);
         }
 
         /// <summary>
@@ -308,7 +405,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, string message)
         {
-            EndsWith(value, substring, message, null);
+            EndsWith(value, substring, message, StringComparison.Ordinal, null);
         }
 
         /// <summary>
@@ -337,6 +434,34 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         public static void EndsWith(string value, string substring, string message, params object[] parameters)
         {
             EndsWith(value, substring, message, StringComparison.Ordinal, parameters);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string ends with the specified substring
+        /// and throws an exception if the test string does not end with the
+        /// substring.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to end with <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to be a suffix of <paramref name="value"/>.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="value"/>
+        /// does not end with <paramref name="substring"/>. The message is
+        /// shown in test results.
+        /// </param>
+        /// <param name="comparisonType">
+        /// The comparison method to compare strings <paramref name="comparisonType"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="value"/> does not end with
+        /// <paramref name="substring"/>.
+        /// </exception>
+        public static void EndsWith(string value, string substring, string message, StringComparison comparisonType)
+        {
+            EndsWith(value, substring, message, comparisonType, null);
         }
 
         /// <summary>

--- a/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring)
         {
-            Contains(value, substring, string.Empty, StringComparison.Ordinal, null);
+            Contains(value, substring, string.Empty, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring, StringComparison comparisonType)
         {
-            Contains(value, substring, string.Empty, comparisonType, null);
+            Contains(value, substring, string.Empty, comparisonType);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring, string message)
         {
-            Contains(value, substring, message, StringComparison.Ordinal, null);
+            Contains(value, substring, message, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -139,7 +139,35 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Contains(string value, string substring, string message, StringComparison comparisonType)
         {
-            Contains(value, substring, message, comparisonType, null);
+            Contains(value, substring, message, comparisonType);
+        }
+
+        /// <summary>
+        /// Tests whether the specified string contains the specified substring
+        /// and throws an exception if the substring does not occur within the
+        /// test string.
+        /// </summary>
+        /// <param name="value">
+        /// The string that is expected to contain <paramref name="substring"/>.
+        /// </param>
+        /// <param name="substring">
+        /// The string expected to occur within <paramref name="value"/>.
+        /// </param>
+        /// <param name="message">
+        /// The message to include in the exception when <paramref name="substring"/>
+        /// is not in <paramref name="value"/>. The message is shown in
+        /// test results.
+        /// </param>
+        /// <param name="parameters">
+        /// An array of parameters to use when formatting <paramref name="message"/>.
+        /// </param>
+        /// <exception cref="AssertFailedException">
+        /// Thrown if <paramref name="substring"/> is not found in
+        /// <paramref name="value"/>.
+        /// </exception>
+        public static void Contains(string value, string substring, string message, params object[] parameters)
+        {
+            Contains(value, substring, message, StringComparison.Ordinal, parameters);
         }
 
         /// <summary>
@@ -196,7 +224,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring)
         {
-            StartsWith(value, substring, string.Empty, StringComparison.Ordinal, null);
+            StartsWith(value, substring, string.Empty, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -219,7 +247,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, StringComparison comparisonType)
         {
-            StartsWith(value, substring, string.Empty, comparisonType, null);
+            StartsWith(value, substring, string.Empty, comparisonType);
         }
 
         /// <summary>
@@ -244,7 +272,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, string message)
         {
-            StartsWith(value, substring, message, StringComparison.Ordinal, null);
+            StartsWith(value, substring, message, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -300,7 +328,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void StartsWith(string value, string substring, string message, StringComparison comparisonType)
         {
-            StartsWith(value, substring, message, comparisonType, null);
+            StartsWith(value, substring, message, comparisonType);
         }
 
         /// <summary>
@@ -357,7 +385,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring)
         {
-            EndsWith(value, substring, string.Empty, StringComparison.Ordinal, null);
+            EndsWith(value, substring, string.Empty, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -380,7 +408,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, StringComparison comparisonType)
         {
-            EndsWith(value, substring, string.Empty, comparisonType, null);
+            EndsWith(value, substring, string.Empty, comparisonType);
         }
 
         /// <summary>
@@ -405,7 +433,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, string message)
         {
-            EndsWith(value, substring, message, StringComparison.Ordinal, null);
+            EndsWith(value, substring, message, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -461,7 +489,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void EndsWith(string value, string substring, string message, StringComparison comparisonType)
         {
-            EndsWith(value, substring, message, comparisonType, null);
+            EndsWith(value, substring, message, comparisonType);
         }
 
         /// <summary>
@@ -522,7 +550,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Matches(string value, Regex pattern)
         {
-            Matches(value, pattern, string.Empty, null);
+            Matches(value, pattern, string.Empty);
         }
 
         /// <summary>
@@ -547,7 +575,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void Matches(string value, Regex pattern, string message)
         {
-            Matches(value, pattern, message, null);
+            Matches(value, pattern, message);
         }
 
         /// <summary>
@@ -601,7 +629,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void DoesNotMatch(string value, Regex pattern)
         {
-            DoesNotMatch(value, pattern, string.Empty, null);
+            DoesNotMatch(value, pattern, string.Empty);
         }
 
         /// <summary>
@@ -625,7 +653,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// </exception>
         public static void DoesNotMatch(string value, Regex pattern, string message)
         {
-            DoesNotMatch(value, pattern, message, null);
+            DoesNotMatch(value, pattern, message);
         }
 
         /// <summary>

--- a/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/StringAssert.cs
@@ -503,7 +503,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
 
         #endregion Substrings
 
-        #region Regular Expresssions
+        #region Regular Expressions
 
         /// <summary>
         /// Tests whether the specified string matches a regular expression and
@@ -662,6 +662,6 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             }
         }
 
-        #endregion Regular Expresssions
+        #endregion Regular Expressions
     }
 }

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/StringAssertTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/StringAssertTests.cs
@@ -6,8 +6,12 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.Assertions
     extern alias FrameworkV1;
     extern alias FrameworkV2;
 
+    using System;
+
+    using MSTestAdapter.TestUtilities;
     using Assert = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
     using TestClass = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute;
+    using TestFrameworkV1 = FrameworkV1.Microsoft.VisualStudio.TestTools.UnitTesting;
     using TestFrameworkV2 = FrameworkV2.Microsoft.VisualStudio.TestTools.UnitTesting;
     using TestMethod = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute;
 
@@ -24,6 +28,63 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.Assertions
         public void ThatShouldCacheStringAssertInstance()
         {
             Assert.AreEqual(TestFrameworkV2.StringAssert.That, TestFrameworkV2.StringAssert.That);
+        }
+
+        [TestMethod]
+        public void StringAssertContains()
+        {
+            string actual = "The quick brown fox jumps over the lazy dog.";
+            string notInString = "I'm not in the string above";
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.Contains(actual, notInString));
+            Assert.IsNotNull(ex);
+            TestFrameworkV1.StringAssert.Contains(ex.Message, "StringAssert.Contains failed");
+        }
+
+        [TestMethod]
+        public void StringAssertStartsWith()
+        {
+            string actual = "The quick brown fox jumps over the lazy dog.";
+            string notInString = "I'm not in the string above";
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.StartsWith(actual, notInString));
+            Assert.IsNotNull(ex);
+            TestFrameworkV1.StringAssert.Contains(ex.Message, "StringAssert.StartsWith failed");
+        }
+
+        [TestMethod]
+        public void StringAssertEndsWith()
+        {
+            string actual = "The quick brown fox jumps over the lazy dog.";
+            string notInString = "I'm not in the string above";
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.EndsWith(actual, notInString));
+            Assert.IsNotNull(ex);
+            TestFrameworkV1.StringAssert.Contains(ex.Message, "StringAssert.EndsWith failed");
+        }
+
+        [TestMethod]
+        public void StringAssertContainsIgnoreCase()
+        {
+            string actual = "The quick brown fox jumps over the lazy dog.";
+            string inString = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG.";
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.Contains(actual, inString, StringComparison.OrdinalIgnoreCase));
+            Assert.IsNull(ex);
+        }
+
+        [TestMethod]
+        public void StringAssertStartsWithIgnoreCase()
+        {
+            string actual = "The quick brown fox jumps over the lazy dog.";
+            string inString = "THE QUICK";
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.StartsWith(actual, inString, StringComparison.OrdinalIgnoreCase));
+            Assert.IsNull(ex);
+        }
+
+        [TestMethod]
+        public void StringAssertEndsWithIgnoreCase()
+        {
+            string actual = "The quick brown fox jumps over the lazy dog.";
+            string inString = "LAZY DOG.";
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.EndsWith(actual, inString, StringComparison.OrdinalIgnoreCase));
+            Assert.IsNull(ex);
         }
     }
 }


### PR DESCRIPTION
Description:

Added StringComparison to StringAssert Contains, EndsWith & StartsWith
Added tests to test functionality
Added API comment on StringComparison Enum
Updated APIs to default to StringComparison.Ordinal 

Probably needs API documentation updates if this gets merged.

Resolves #154