### PR TITLE
Added an EnumDataSourceAttribute

### DIFF
--- a/src/TestFramework/MSTest.Core/Attributes/EnumDataSourceAttribute.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/EnumDataSourceAttribute.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Attribute to define dynamic data for a test method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class EnumDataSourceAttribute : Attribute, ITestDataSource
+    {
+        private readonly Type enumDataSource;
+        private readonly object[] exclusions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumDataSourceAttribute"/> class.
+        /// </summary>
+        /// <param name="enumDataSource">
+        /// The type of the <see cref="Enum"/> to iterate for the test.
+        /// </param>
+        public EnumDataSourceAttribute(Type enumDataSource)
+            : this(enumDataSource, new object[0])
+        {
+            // Need to have this constructor explicitely to fix a CLS compliant error.
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumDataSourceAttribute"/> class.
+        /// </summary>
+        /// <param name="enumDataSource">
+        /// The type of the <see cref="Enum"/> to iterate for the test.
+        /// </param>
+        /// <param name="exclusions">
+        /// Values to exclude during the iteration.
+        /// </param>
+        public EnumDataSourceAttribute(Type enumDataSource, params object[] exclusions)
+        {
+            this.enumDataSource = enumDataSource ??
+                                  throw new ArgumentNullException(nameof(enumDataSource), "The enum to iterate is not specified.");
+
+            this.exclusions = exclusions;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<object[]> GetData(MethodInfo methodInfo)
+        {
+            if (!this.enumDataSource.GetTypeInfo().IsEnum)
+            {
+                throw new InvalidCastException("The requested type is not an enum.");
+            }
+
+            foreach (var value in Enum.GetValues(this.enumDataSource))
+            {
+                if (!this.exclusions.Contains(value))
+                {
+                    yield return new[] { value };
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public string GetDisplayName(MethodInfo methodInfo, object[] data)
+        {
+            return data == null ? null : $"{methodInfo.Name} ({string.Join(", ", data)})";
+        }
+    }
+}

--- a/src/TestFramework/MSTest.Core/MSTest.Core.csproj
+++ b/src/TestFramework/MSTest.Core/MSTest.Core.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="Attributes\DoNotParallelizeAttribute.cs" />
     <Compile Include="Attributes\DynamicDataAttribute.cs" />
+    <Compile Include="Attributes\EnumDataSourceAttribute.cs" />
     <Compile Include="Attributes\ParallelizeAttribute.cs" />
     <Compile Include="Attributes\ExecutionScope.cs" />
     <Compile Include="Interfaces\ITestDataSource.cs" />

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Attributes/EnumDataSourceAttributeTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Attributes/EnumDataSourceAttributeTests.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.Attributes
+{
+    extern alias FrameworkV1;
+    extern alias FrameworkV2;
+
+    using System;
+    using System.Linq;
+    using System.Reflection;
+
+    using FrameworkV2::Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using MSTestAdapter.TestUtilities;
+
+    using TestFrameworkV1 = FrameworkV1::Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestFrameworkV1.TestClass]
+    public class EnumDataSourceAttributeTests
+    {
+        private MethodInfo methodInfo;
+
+        [TestFrameworkV1.TestInitialize]
+        public void Initialize()
+        {
+            this.methodInfo = this.GetType().GetTypeInfo().GetDeclaredMethod(nameof(this.TestMethod1));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void ConstructorShouldThrowArgumentNullIfEnumDataSourceIsNull()
+        {
+            EnumDataSourceAttribute attribute;
+
+            Action action = () =>
+            {
+                attribute = new EnumDataSourceAttribute(null);
+            };
+
+            ActionUtility.ActionShouldThrowExceptionOfType(action, typeof(ArgumentNullException));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void ConstructorShouldNotThrowIfEnumDataSourceIsNotNull()
+        {
+            EnumDataSourceAttribute attribute;
+
+            Action action = () =>
+            {
+                attribute = new EnumDataSourceAttribute(typeof(Value));
+            };
+            action();
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void ConstructorShouldThrowArgumentNullIfEnumDataSourceIsNullAndExclusionsPassed()
+        {
+            EnumDataSourceAttribute attribute;
+
+            Action action = () =>
+            {
+                attribute = new EnumDataSourceAttribute(null, new object());
+            };
+
+            ActionUtility.ActionShouldThrowExceptionOfType(action, typeof(ArgumentNullException));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void ConstructorShouldNotThrowIfEnumDataSourceIsNotNullAndExclusionsPassed()
+        {
+            EnumDataSourceAttribute attribute;
+
+            Action action = () =>
+            {
+                attribute = new EnumDataSourceAttribute(typeof(Value), new object());
+            };
+            action();
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void GetDataShouldThrowInvalidCastIfEnumDataSourceIsNotAnEnum()
+        {
+            Action action = () =>
+            {
+                var attribute = new EnumDataSourceAttribute(typeof(int));
+                attribute.GetData(this.methodInfo).ToList();
+            };
+
+            ActionUtility.ActionShouldThrowExceptionOfType(action, typeof(InvalidCastException));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void GetDataShouldReturnsAllValuesOfEnumIfNoExclusionsIsSpecified()
+        {
+            var attribute = new EnumDataSourceAttribute(typeof(Value));
+
+            var results = attribute.GetData(this.methodInfo).ToList();
+
+            var values = results.Select(r => r.First()).ToList();
+            Assert.AreEqual(4, values.Count);
+            Assert.IsTrue(values.Contains(Value.First));
+            Assert.IsTrue(values.Contains(Value.Second));
+            Assert.IsTrue(values.Contains(Value.Third));
+            Assert.IsTrue(values.Contains(Value.Fourth));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void GetDataShouldReturnsAllValuesOfEnumExceptExclusionIfOneExclusionSpecified()
+        {
+            var attribute = new EnumDataSourceAttribute(typeof(Value), Value.Second);
+
+            var results = attribute.GetData(this.methodInfo).ToList();
+
+            var values = results.Select(r => r.First()).ToList();
+            Assert.AreEqual(3, values.Count);
+            Assert.IsTrue(values.Contains(Value.First));
+            Assert.IsTrue(values.Contains(Value.Third));
+            Assert.IsTrue(values.Contains(Value.Fourth));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void GetDataShouldReturnsAllValuesOfEnumExceptExclusionsIfTwoExclusionSpecified()
+        {
+            var attribute = new EnumDataSourceAttribute(typeof(Value), Value.Second, Value.Third);
+
+            var results = attribute.GetData(this.methodInfo).ToList();
+
+            var values = results.Select(r => r.First()).ToList();
+            Assert.AreEqual(2, values.Count);
+            Assert.IsTrue(values.Contains(Value.First));
+            Assert.IsTrue(values.Contains(Value.Fourth));
+        }
+
+        [TestFrameworkV1.TestMethod]
+        public void GetDisplayNameShouldReturnDisplayNameWithEnumValue()
+        {
+            var attribute = new EnumDataSourceAttribute(typeof(Value));
+
+            var result = attribute.GetDisplayName(this.methodInfo, new object[] { Value.First });
+
+            Assert.AreEqual($"{nameof(this.TestMethod1)} ({Value.First.ToString()})", result);
+        }
+
+        /// <summary>
+        /// The test method 1.
+        /// </summary>
+        [FrameworkV2::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute]
+        [EnumDataSource(typeof(Value))]
+        public void TestMethod1()
+        {
+        }
+
+        private enum Value
+        {
+            First,
+            Second,
+            Third,
+            Fourth
+        }
+    }
+}

--- a/test/UnitTests/MSTest.Core.Unit.Tests/MSTest.Core.Unit.Tests.csproj
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/MSTest.Core.Unit.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Attributes\ExpectedExceptionAttributeTests.cs" />
     <Compile Include="Attributes\ExpectedExceptionBaseAttributeTests.cs" />
     <Compile Include="Attributes\DynamicDataAttributeTests.cs" />
+    <Compile Include="Attributes\EnumDataSourceAttributeTests.cs" />
     <Compile Include="GenericParameterHelperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Sometimes, in our automated tests, it's possible we want to execute a given test for all values of an `enum`, or for all values except one or two. However, there are no easy and scalable way to do so.

For example, let's consider an arbitraty enum : 
``` csharp
private enum Value
{
    First,
    Second,
    Third,
    Fourth
}
```

We can use the `DataRow` attribute, but we have to keep it in sync everytime we add a new value to the `enum`. And, it is not always explicit that we want to exclude a particuliar valu, especially for larger `enum`s (imagine you have 50 values and 49 `DataRow`, it's not easy to see which value isn't there):
``` csharp
[DataTestMethod]
[DataRow(Value.First)]
[DataRow(Value.Second)]
[DataRow(Value.Fourth)]
public void MyMethodShouldReturnTrueIfValueIsNotThirdValue(Value value)
{
    ...
}
```

The same result can also be done with `DynamicData`, which can already be more explicit and be kept in sync with new values:
``` csharp
[DataTestMethod]
[DynamicData(nameof(AllValuesExceptThird),  DynamicDataSourceType.Method)]
public void MyMethodShouldReturnTrueIfValueIsNotThirdValue(Value value)
{
    ...
}

private static IEnumerable<object[]>  AllValuesExceptThird()
{
    var allValuesExceptThird = ((Value[])Enum.GetValues(typeof(Value))).Where(x => x != Value.Third);
    foreach (var value in allValuesExceptThird)
    {
        yield return new object[] { value};
    }
}
``` 

The problem with this approach is that it's not really scalable. If I want to exclude all `Value`s except `Value.First` in another test, I have to create a new method. And if I want all `Value`s except `Value.First` and `Value.Third`, I have to create yet a third method. It's going to take quite some place at the bottom of my test class, and doesn't really contribute to anything in the class.

Following this reflection, I came up with an `EnumDataSource`. With only 1 line, we can iterate on all values in an `enum`, or exclude some values:

``` csharp
[DataTestMethod]
[EnumDataSource(typeof(Value))]
public void MyMethodShouldReturnTrueForAllValues(Value value)
{
   ...
}

[DataTestMethod]
[EnumDataSource(typeof(Value), exclusions: Value.Third)]
public void MyMethodShouldReturnTrueIfValueIsNotThirdValue(Value value)
{
    ...
}
```

Contraty to `DataRow`, it's really explicit which values are excluded, and contrary to `DynamicData`, I don't have to create a new method each time I want a test to exclude a new value. No matter the size of the `enum`, it's always going to be a single line, that tells us what's going on in the test.