### PR TITLE
Change NuGet package to use `None` ItemGroup to copy files to output directory

### DIFF
--- a/src/Adapter/Build/Desktop/MSTest.TestAdapter.props
+++ b/src/Adapter/Build/Desktop/MSTest.TestAdapter.props
@@ -1,20 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
-	<Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
+    </TestAdapterContent>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Including `@(TestAdapterContent)` in the `None` ItemGroup to get the `CopyToOutputDirectory`
+         behavior be default, package consumers can opt-out of this behavior
+         by removing `@(TestAdapterContent)` from the `None` ItemGroup
+         i.e. `<None Remove="@(TestAdapterContent)" />` -->
+    <None Include="@(TestAdapterContent)" />
   </ItemGroup>
 </Project>

--- a/src/Adapter/Build/NetCore/MSTest.TestAdapter.props
+++ b/src/Adapter/Build/NetCore/MSTest.TestAdapter.props
@@ -1,20 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
-	<Content Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
+    </TestAdapterContent>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Including `@(TestAdapterContent)` in the `None` ItemGroup to get the `CopyToOutputDirectory`
+         behavior be default, package consumers can opt-out of this behavior
+         by removing `@(TestAdapterContent)` from the `None` ItemGroup
+         i.e. `<None Remove="@(TestAdapterContent)" />` -->
+    <None Include="@(TestAdapterContent)" />
   </ItemGroup>
 </Project>

--- a/src/Adapter/Build/Universal/MSTest.TestAdapter.props
+++ b/src/Adapter/Build/Universal/MSTest.TestAdapter.props
@@ -1,20 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
-	<Content Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
       <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
-    </Content>
+    </TestAdapterContent>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Including `@(TestAdapterContent)` in the `None` ItemGroup to get the `CopyToOutputDirectory`
+         behavior be default, package consumers can opt-out of this behavior
+         by removing `@(TestAdapterContent)` from the `None` ItemGroup
+         i.e. `<None Remove="@(TestAdapterContent)" />` -->
+    <None Include="@(TestAdapterContent)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Without this change, files from this nuget package will be included
automatically when the consuming project is packing.

Example error when packing a project:
> C:\Program Files\dotnet\sdk\3.1.200\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(198,5):
warning NU5100: The assembly 'content\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll' is
not inside the 'lib' folder and hence it won't be added as a reference
when the package is installed into a project. Move it into the 'lib'
folder if it needs to be referenced.

Additionally, add the contents to an ItemGroup so they can be seperated later if needed.