### PR TITLE
Fixed documentation for the TestMethodAttribute

### DIFF
--- a/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/VSTestAttributes.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// Initializes a new instance of the <see cref="TestMethodAttribute"/> class.
         /// </summary>
         /// <param name="displayName">
-        /// Message specifies reason for ignoring.
+        /// Display Name for the Test Window
         /// </param>
         public TestMethodAttribute(string displayName)
         {


### PR DESCRIPTION
This PR fixes a wrong XML documentation comment for the `displayName` parameter on the `TestMethodAttribute` constructor.