### PR TITLE
Fix null ref bug when base class cleanup fails

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestClassInfo.cs
@@ -345,9 +345,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
             if (this.IsClassInitializeExecuted || this.ClassInitializeMethod is null)
             {
+                MethodInfo classCleanupMethod = null;
+
                 try
                 {
-                    var classCleanupMethod = this.ClassCleanupMethod;
+                    classCleanupMethod = this.ClassCleanupMethod;
                     classCleanupMethod?.InvokeAsSynchronousTask(null);
                     var baseClassCleanupQueue = new Queue<MethodInfo>(this.BaseClassCleanupMethodsStack);
                     while (baseClassCleanupQueue.Count > 0)
@@ -378,8 +380,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                     return string.Format(
                         CultureInfo.CurrentCulture,
                         Resource.UTA_ClassCleanupMethodWasUnsuccesful,
-                        this.ClassType.Name,
-                        this.ClassCleanupMethod.Name,
+                        classCleanupMethod.DeclaringType.Name,
+                        classCleanupMethod.Name,
                         errorMessage,
                         StackTraceHelper.GetStackTraceInformation(realException)?.ErrorStackTrace);
                 }

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestClassInfoTests.cs
@@ -545,6 +545,20 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethod]
+        public void RunBaseClassCleanupWithNoDerivedClassCleanupShouldReturnExceptionDetailsOfNonAssertExceptions()
+        {
+            DummyBaseTestClass.ClassCleanupMethodBody = () => { throw new ArgumentException("Argument Exception"); };
+
+            this.testClassInfo.ClassCleanupMethod = null;
+            this.testClassInfo.BaseClassInitAndCleanupMethods.Enqueue(
+                Tuple.Create((MethodInfo)null, typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod")));
+            this.testClassInfo.BaseClassCleanupMethodsStack.Push(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod"));
+            StringAssert.StartsWith(
+                this.testClassInfo.RunClassCleanup(),
+                "Class Cleanup method DummyBaseTestClass.CleanupClassMethod failed. Error Message: System.ArgumentException: Argument Exception. Stack Trace:     at Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TestClassInfoTests.<>c.<RunBaseClassCleanupWithNoDerivedClassCleanupShouldReturnExceptionDetailsOfNonAssertExceptions>");
+        }
+
+        [TestMethod]
         public void RunBaseClassCleanupEvenIfThereIsNoDerivedClassCleanup()
         {
             var classcleanupCallCount = 0;


### PR DESCRIPTION
If the executing test has no test class cleanup method but a base class does and it fails, we hit a null ref exception because we try to use the method name of the executing test class cleanup but there isn't one. 