### PR TITLE
Add support to treat class/assembly warnings as errors

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -430,12 +430,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Executed cleanup methods.");
             if (cleanupResult != null)
             {
-                IList<string> warnings = cleanupResult.Warnings;
-
                 // Do not attach the standard output and error messages to any test result. It is not
                 // guaranteed that a test method of same class would have run last. We will end up
                 // adding stdout to test method of another class.
-                this.LogWarnings(testExecutionRecorder, warnings);
+                this.LogCleanupResult(testExecutionRecorder, cleanupResult);
             }
         }
 
@@ -469,20 +467,36 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// Log the parameter warnings on the parameter logger
         /// </summary>
         /// <param name="testExecutionRecorder">Handle to record test start/end/results/messages.</param>
-        /// <param name="warnings">Any warnings during run operation.</param>
-        private void LogWarnings(ITestExecutionRecorder testExecutionRecorder, IEnumerable<string> warnings)
+        /// <param name="result">Result of the run operation.</param>
+        private void LogCleanupResult(ITestExecutionRecorder testExecutionRecorder, RunCleanupResult result)
         {
-            if (warnings == null)
-            {
-                return;
-            }
-
             Debug.Assert(testExecutionRecorder != null, "Logger should not be null");
 
-            // log the warnings
-            foreach (string warning in warnings)
+            if (!string.IsNullOrEmpty(result.StandardOut))
             {
-                testExecutionRecorder.SendMessage(TestMessageLevel.Warning, warning);
+                testExecutionRecorder.SendMessage(TestMessageLevel.Informational, result.StandardOut);
+            }
+
+            if (!string.IsNullOrEmpty(result.DebugTrace))
+            {
+                testExecutionRecorder.SendMessage(TestMessageLevel.Informational, result.DebugTrace);
+            }
+
+            if (!string.IsNullOrEmpty(result.StandardError))
+            {
+                testExecutionRecorder.SendMessage(
+                    MSTestSettings.CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors ? TestMessageLevel.Error : TestMessageLevel.Warning,
+                    result.StandardError);
+            }
+
+            if (result.Warnings != null)
+            {
+                foreach (string warning in result.Warnings)
+                {
+                    testExecutionRecorder.SendMessage(
+                        MSTestSettings.CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors ? TestMessageLevel.Error : TestMessageLevel.Warning,
+                        warning);
+                }
             }
         }
     }

--- a/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.CoreAdapter/MSTestSettings.cs
@@ -57,6 +57,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             this.TestSettingsFile = null;
             this.DisableParallelization = false;
             this.TestTimeout = 0;
+            this.TreatClassAndAssemblyCleanupWarningsAsErrors = false;
         }
 
         /// <summary>
@@ -156,6 +157,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
         public int TestTimeout { get; private set; }
 
         /// <summary>
+        /// Gets a value indicating whether failures in class cleanups should be treated as errors.
+        /// </summary>
+        public bool TreatClassAndAssemblyCleanupWarningsAsErrors { get; private set; }
+
+        /// <summary>
         /// Populate settings based on existing settings object.
         /// </summary>
         /// <param name="settings">The existing settings object.</param>
@@ -171,6 +177,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             CurrentSettings.ParallelizationScope = settings.ParallelizationScope;
             CurrentSettings.DisableParallelization = settings.DisableParallelization;
             CurrentSettings.TestTimeout = settings.TestTimeout;
+            CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors = settings.TreatClassAndAssemblyCleanupWarningsAsErrors;
         }
 
         /// <summary>
@@ -290,6 +297,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
             //     <MapNotRunnableToFailed>false</MapNotRunnableToFailed>
             //     <EnableBaseClassTestMethodsFromOtherAssemblies>false</EnableBaseClassTestMethodsFromOtherAssemblies>
             //     <TestTimeout>5000</TestTimeout>
+            //     <TreatClassAndAssemblyCleanupWarningsAsErrors>false</TreatClassAndAssemblyCleanupWarningsAsErrors>
             //     <Parallelize>
             //        <Workers>4</Workers>
             //        <Scope>TestClass</Scope>
@@ -393,6 +401,16 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
                                 if (int.TryParse(reader.ReadInnerXml(), out int testTimeout) && testTimeout > 0)
                                 {
                                     settings.TestTimeout = testTimeout;
+                                }
+
+                                break;
+                            }
+
+                        case "TREATCLASSANDASSEMBLYCLEANUPWARNINGSASERRORS":
+                            {
+                                if (bool.TryParse(reader.ReadInnerXml(), out result))
+                                {
+                                    settings.TreatClassAndAssemblyCleanupWarningsAsErrors = result;
                                 }
 
                                 break;

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Execution/TestExecutionManagerTests.cs
@@ -194,7 +194,29 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
         }
 
         [TestMethodV1]
-        public void RunTestsShouldLogResultCleanupWarnings()
+        public void RunTestsShouldLogResultCleanupWarningsAsErrorsWhenTreatClassCleanupWarningsAsErrorsIsTrue()
+        {
+            this.runContext.MockRunSettings.Setup(rs => rs.SettingsXml).Returns(
+                                         @"<RunSettings> 
+                                              <MSTest>
+                                                 <TreatClassAndAssemblyCleanupWarningsAsErrors>true</TreatClassAndAssemblyCleanupWarningsAsErrors>
+                                              </MSTest>
+                                            </RunSettings>");
+            MSTestSettings.PopulateSettings(this.runContext);
+
+            var testCase = this.GetTestCase(typeof(DummyTestClassWithCleanupMethods), "TestMethod");
+            TestCase[] tests = new[] { testCase };
+
+            this.TestExecutionManager.RunTests(tests, this.runContext, this.frameworkHandle, new TestRunCancellationToken());
+
+            // Warnings should get logged.
+            Assert.AreEqual(1, this.frameworkHandle.MessageList.Count);
+            StringAssert.StartsWith(this.frameworkHandle.MessageList[0], "Error");
+            Assert.IsTrue(this.frameworkHandle.MessageList[0].Contains("ClassCleanupException"));
+        }
+
+        [TestMethodV1]
+        public void RunTestsShouldLogResultOutput()
         {
             var testCase = this.GetTestCase(typeof(DummyTestClassWithCleanupMethods), "TestMethod");
             TestCase[] tests = new[] { testCase };
@@ -203,6 +225,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
 
             // Warnings should get logged.
             Assert.AreEqual(1, this.frameworkHandle.MessageList.Count);
+            StringAssert.StartsWith(this.frameworkHandle.MessageList[0], "Warning");
             Assert.IsTrue(this.frameworkHandle.MessageList[0].Contains("ClassCleanupException"));
         }
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/MSTestSettingsTests.cs
@@ -254,6 +254,35 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
         }
 
         [TestMethod]
+        public void TreatClassCleanupWarningsAsErrorsShouldBeFalseByDefault()
+        {
+            string runSettingxml =
+                @"<RunSettings>
+                    <MSTestV2>
+                    </MSTestV2>
+                  </RunSettings>";
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+            Assert.IsFalse(adapterSettings.TreatClassAndAssemblyCleanupWarningsAsErrors);
+        }
+
+        [TestMethod]
+        public void TreatClassCleanupWarningsAsErrorsShouldBeConsumedFromRunSettingsWhenSpecified()
+        {
+            string runSettingxml =
+                @"<RunSettings>
+                    <MSTestV2>
+                        <TreatClassAndAssemblyCleanupWarningsAsErrors>True</TreatClassAndAssemblyCleanupWarningsAsErrors>
+                    </MSTestV2>
+                  </RunSettings>";
+
+            MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+            Assert.IsTrue(adapterSettings.TreatClassAndAssemblyCleanupWarningsAsErrors);
+        }
+
+        [TestMethod]
         public void ParallelizationSettingsShouldNotBeSetByDefault()
         {
             string runSettingxml =
@@ -864,6 +893,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
                    <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
                    <ForcedLegacyMode>true</ForcedLegacyMode>
                    <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
+                   <TreatClassAndAssemblyCleanupWarningsAsErrors>true</TreatClassAndAssemblyCleanupWarningsAsErrors>
                  </MSTest>
                </RunSettings>";
 
@@ -876,6 +906,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests
             Assert.IsTrue(MSTestSettings.CurrentSettings.MapNotRunnableToFailed);
             Assert.IsTrue(MSTestSettings.CurrentSettings.ForcedLegacyMode);
             Assert.IsTrue(MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+            Assert.IsTrue(MSTestSettings.CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors);
             Assert.IsFalse(string.IsNullOrEmpty(MSTestSettings.CurrentSettings.TestSettingsFile));
         }
 


### PR DESCRIPTION
Assembly/Class cleanup errors mostly go unnoticed today (they get logged as a warning which for most automated CI systems means nobody sees the warning since it doesn't fail the test run). Even if the warning was surfaced, any output from these cleanups are discarded so it's harder to debug the issue.

There are two parts to this change:
- Add a setting to treat assembly/class cleanup warnings as errors to cause the test run to fail
- Log stdout & stderr captured during cleanup to help in debugging.