### PR TITLE
Load specific types from adapter

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -185,10 +185,13 @@ function Run-Test([string[]] $testContainers, [string[]] $netCoreTestContainers)
 
 function Get-VSTestPath
 {
-	$vsInstallPath = Locate-VsInstallPath
-	$vstestPath = Join-Path -path $vsInstallPath "Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
+    $versionsFile = "$PSScriptRoot\build\TestFx.Versions.targets"
+    $TestPlatformVersion = (([XML](Get-Content $versionsFile)).Project.PropertyGroup.TestPlatformVersion).InnerText
+
+	$vsInstallPath = "$PSScriptRoot\..\packages\Microsoft.TestPlatform.$TestPlatformVersion\"
+	$vstestPath = Join-Path -path $vsInstallPath "tools\net451\Common7\IDE\Extensions\TestPlatform\vstest.console.exe"
 	return Resolve-Path -path $vstestPath
 }
-	
+
 Print-Help
 Invoke-Test

--- a/src/Adapter/MSTest.CoreAdapter/Properties/AssemblyInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -16,6 +18,7 @@ using System.Resources;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
+[assembly: TypesToLoad(typeof(MSTestDiscoverer), typeof(MSTestExecutor))]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/Services/DesktopTestSourceHostTests.cs
@@ -37,8 +37,15 @@ namespace MSTestAdapter.PlatformServices.Desktop.UnitTests
             List<string> result = sut.GetResolutionPaths("DummyAssembly.dll", isPortableMode: false);
 
             // Assert
-            Assert.IsTrue(result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
-            Assert.IsTrue(result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
+            if (!string.IsNullOrWhiteSpace(VSInstallationUtilities.PathToPublicAssemblies))
+            {
+                Assert.IsTrue(result.Contains(VSInstallationUtilities.PathToPublicAssemblies));
+            }
+
+            if (!string.IsNullOrWhiteSpace(VSInstallationUtilities.PathToPrivateAssemblies))
+            {
+                Assert.IsTrue(result.Contains(VSInstallationUtilities.PathToPrivateAssemblies));
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Added functionality to MSTestAdapter from Test Platform, where we load only necessary types from assemblies.