### PR TITLE
BugFix: WorkItemAttribute not extracted 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+// comment to trigger CI
 ### Microsoft Test Framework "MSTest V2"
 Welcome to the "MSTest V2" repository, the evolution of the Microsoft Test Framework and Adapter. "MSTest V2" is currently in use in a variety of scenarios including:
  - in the relevant in-box unit test project templates (Visual Studio 2017 Preview 4 onwards)
@@ -39,3 +40,4 @@ Please see [issue tracking](https://github.com/Microsoft/testfx-docs/blob/master
 
 ### Roadmap
 For information on shipped and upcoming features/enhancements please refer to our [Releases](https://github.com/Microsoft/testfx-docs/blob/master/docs/releases.md) and [Quarterly Checkin reports](https://github.com/Microsoft/testfx-docs/tree/master/Quarterly%20Checkins).
+

--- a/README.md
+++ b/README.md
@@ -39,4 +39,3 @@ Please see [issue tracking](https://github.com/Microsoft/testfx-docs/blob/master
 
 ### Roadmap
 For information on shipped and upcoming features/enhancements please refer to our [Releases](https://github.com/Microsoft/testfx-docs/blob/master/docs/releases.md) and [Quarterly Checkin reports](https://github.com/Microsoft/testfx-docs/tree/master/Quarterly%20Checkins).
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-// comment to trigger CI
 ### Microsoft Test Framework "MSTest V2"
 Welcome to the "MSTest V2" repository, the evolution of the Microsoft Test Framework and Adapter. "MSTest V2" is currently in use in a variety of scenarios including:
  - in the relevant in-box unit test project templates (Visual Studio 2017 Preview 4 onwards)

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/TypeEnumerator.cs
@@ -192,8 +192,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                 testElement.Description = descriptionAttribute.Description;
             }
 
-            var workItemAttributeArray = this.reflectHelper.GetCustomAttributes(method, typeof(WorkItemAttribute)).Cast<WorkItemAttribute>();
-            testElement.WorkItemIds = workItemAttributeArray.Select(x => x.Id.ToString()).ToArray();
+            var workItemAttributes = this.reflectHelper.GetCustomAttributes(method, typeof(WorkItemAttribute)).Cast<WorkItemAttribute>();
+            testElement.WorkItemIds = workItemAttributes.Select(x => x.Id.ToString()).ToArray();
 
             // Get Deployment items if any.
             testElement.DeploymentItems = PlatformServiceProvider.Instance.TestDeployment.GetDeploymentItems(

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/TypeEnumerator.cs
@@ -192,11 +192,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                 testElement.Description = descriptionAttribute.Description;
             }
 
-            var workItemAttributeArray = this.reflectHelper.GetCustomAttributes(method, typeof(WorkItemAttribute)) as WorkItemAttribute[];
-            if (workItemAttributeArray != null)
-            {
-                testElement.WorkItemIds = workItemAttributeArray.Select(x => x.Id.ToString()).ToArray();
-            }
+            var workItemAttributeArray = this.reflectHelper.GetCustomAttributes(method, typeof(WorkItemAttribute)).Cast<WorkItemAttribute>();
+            testElement.WorkItemIds = workItemAttributeArray.Select(x => x.Id.ToString()).ToArray();
 
             // Get Deployment items if any.
             testElement.DeploymentItems = PlatformServiceProvider.Instance.TestDeployment.GetDeploymentItems(

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/TypeEnumerator.cs
@@ -192,8 +192,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
                 testElement.Description = descriptionAttribute.Description;
             }
 
-            var workItemAttributes = this.reflectHelper.GetCustomAttributes(method, typeof(WorkItemAttribute)).Cast<WorkItemAttribute>();
-            testElement.WorkItemIds = workItemAttributes.Select(x => x.Id.ToString()).ToArray();
+            var workItemAttributes = this.reflectHelper.GetCustomAttributes(method, typeof(WorkItemAttribute)).Cast<WorkItemAttribute>().ToArray();
+            if (workItemAttributes.Any())
+            {
+                testElement.WorkItemIds = workItemAttributes.Select(x => x.Id.ToString()).ToArray();
+            }
 
             // Get Deployment items if any.
             testElement.DeploymentItems = PlatformServiceProvider.Instance.TestDeployment.GetDeploymentItems(

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/TypeEnumeratorTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/TypeEnumeratorTests.cs
@@ -440,7 +440,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
             this.SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
             TypeEnumerator typeEnumerator = this.GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
             var methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType");
-            this.mockReflectHelper.Setup(rh => rh.GetCustomAttributes(methodInfo, typeof(UTF.WorkItemAttribute))).Returns(new UTF.WorkItemAttribute[] { new UTF.WorkItemAttribute(123), new UTF.WorkItemAttribute(345) });
+            this.mockReflectHelper.Setup(rh => rh.GetCustomAttributes(methodInfo, typeof(UTF.WorkItemAttribute))).Returns(new Attribute[] { new UTF.WorkItemAttribute(123), new UTF.WorkItemAttribute(345) });
 
             var testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, this.warnings);
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/TypeEnumeratorTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/TypeEnumeratorTests.cs
@@ -448,6 +448,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
         }
 
         [TestMethod]
+        public void GetTestFromMethodShouldSetWorkItemIdsToNullIfNotAny()
+        {
+            this.SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+            TypeEnumerator typeEnumerator = this.GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
+            var methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType");
+            this.mockReflectHelper.Setup(rh => rh.GetCustomAttributes(methodInfo, typeof(UTF.WorkItemAttribute))).Returns(new Attribute[0]);
+
+            var testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, this.warnings);
+
+            Assert.IsNull(testElement.WorkItemIds);
+        }
+
+        [TestMethod]
         public void GetTestFromMethodShouldSetCssIteration()
         {
             this.SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);


### PR DESCRIPTION
The `TypeEnumerator` class returned an `Attribute[]`, which cannot be casted to an `WorkItemAttribute[]`. Even though the method signature specified an `Attribute[]`, the mock was set up to return a `WorkItemAttribute[]` array, which causes the test to pass but the `as` conversion to fail at runtime.