### PR TITLE
Fixed TypesToLoadAttribute compatibility

### DIFF
--- a/scripts/build/TestFx.Versions.targets
+++ b/scripts/build/TestFx.Versions.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
   <PropertyGroup>
-    <TestPlatformVersion Condition=" '$(TestPlatformVersion)' == '' ">16.9.0-preview-20201123-04</TestPlatformVersion>
+    <TestPlatformVersion Condition=" '$(TestPlatformVersion)' == '' ">16.9.0-preview-20201214-05</TestPlatformVersion>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
 </Project>

--- a/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
+++ b/src/Adapter/MSTest.CoreAdapter/MSTest.CoreAdapter.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ObjectModel\AdapterSettingsException.cs" />
     <Compile Include="ObjectModel\TestAssemblySettings.cs" />
     <Compile Include="ObjectModel\TestFailedException.cs" />
+    <Compile Include="Properties\TypesToLoadAttribute.cs" />
     <Compile Include="TestMethodFilter.cs" />
     <Compile Include="Execution\TestMethodRunner.cs" />
     <Compile Include="Execution\TypeCache.cs" />

--- a/src/Adapter/MSTest.CoreAdapter/Properties/AssemblyInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Properties/AssemblyInfo.cs
@@ -18,7 +18,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
-[assembly: TypesToLoad(typeof(MSTestDiscoverer), typeof(MSTestExecutor))]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/src/Adapter/MSTest.CoreAdapter/Properties/TypesToLoadAttribute.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Properties/TypesToLoadAttribute.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+
+[assembly: TypesToLoad(typeof(MSTestDiscoverer), typeof(MSTestExecutor))]
+
+namespace Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities
+{
+    /// <summary>
+    /// Custom Attribute to specify the exact types which should be loaded from assembly
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = false)]
+    internal sealed class TypesToLoadAttribute : Attribute
+    {
+        public TypesToLoadAttribute(params Type[] types)
+        {
+            this.Types = types;
+        }
+
+        public Type[] Types { get; }
+    }
+}

--- a/src/Adapter/PlatformServices.Desktop/packages.config
+++ b/src/Adapter/PlatformServices.Desktop/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net451" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net45" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net45" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net45" />

--- a/src/Adapter/PlatformServices.Interface/packages.config
+++ b/src/Adapter/PlatformServices.Interface/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="portable45-net45+win8+wp8+wpa81" />

--- a/src/Adapter/PlatformServices.Portable/packages.config
+++ b/src/Adapter/PlatformServices.Portable/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" developmentDependency="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="portable45-net45+win8+wp8+wpa81" />

--- a/test/ComponentTests/PlatformServices.Desktop.Component.Tests/packages.config
+++ b/test/ComponentTests/PlatformServices.Desktop.Component.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net451" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net451" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net451" />
   <package id="Moq" version="4.8.2" targetFramework="net451" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net451" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net451" developmentDependency="true" />

--- a/test/E2ETests/Automation.CLI/CLITestBase.cs
+++ b/test/E2ETests/Automation.CLI/CLITestBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.MSTestV2.CLIAutomation
         private const string PackagesFolder = "packages";
 
         // This value is automatically updated by "build.ps1" script.
-        private const string TestPlatformCLIPackage = @"Microsoft.TestPlatform.16.9.0-preview-20201123-04";
+        private const string TestPlatformCLIPackage = @"Microsoft.TestPlatform.16.9.0-preview-20201214-05";
         private const string VstestConsoleRelativePath = @"tools\net451\Common7\IDE\Extensions\TestPlatform\vstest.console.exe";
 
         private static VsTestConsoleWrapper vsTestConsoleWrapper;

--- a/test/E2ETests/Automation.CLI/packages.config
+++ b/test/E2ETests/Automation.CLI/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.TestPlatform" version="16.9.0-preview-20201123-04" targetFramework="net46" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net46" />
-  <package id="Microsoft.TestPlatform.TranslationLayer" version="16.9.0-preview-20201123-04" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform" version="16.9.0-preview-20201214-05" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net46" />
+  <package id="Microsoft.TestPlatform.TranslationLayer" version="16.9.0-preview-20201214-05" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net46" developmentDependency="true" />

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/packages.config
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net452" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net452" />
   <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />

--- a/test/UnitTests/PlatformServices.Desktop.Unit.Tests/packages.config
+++ b/test/UnitTests/PlatformServices.Desktop.Unit.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net451" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net451" />
   <package id="Moq" version="4.5.21" targetFramework="net451" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net451" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net451" developmentDependency="true" />

--- a/test/UnitTests/PlatformServices.Portable.Unit.Tests/packages.config
+++ b/test/UnitTests/PlatformServices.Portable.Unit.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="3.3.3" targetFramework="net452" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net452" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net452" />
   <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />

--- a/test/UnitTests/PlatformServices.Universal.Unit.Tests/packages.config
+++ b/test/UnitTests/PlatformServices.Universal.Unit.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
-  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201123-04" targetFramework="net452" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="16.9.0-preview-20201214-05" targetFramework="net452" />
   <package id="Moq" version="4.7.8" targetFramework="net452" />
   <package id="NuGet.Frameworks" version="5.0.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
TestFx updated to implement changes in https://github.com/microsoft/vstest/pull/2674; this should fix the compatibility issue introduced in https://github.com/microsoft/vstest/pull/2537 and https://github.com/microsoft/testfx/pull/739.