### PR TITLE
Forward logs to EqtTrace

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.CoreAdapter/MSTestExecutor.cs
@@ -44,6 +44,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
 
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor.RunTests: Running tests from testcases.");
+
             ValidateArg.NotNull(frameworkHandle, "frameworkHandle");
             ValidateArg.NotNullOrEmpty(tests, "tests");
 
@@ -76,6 +78,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter
 
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
+            PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor.RunTests: Running tests from sources.");
             ValidateArg.NotNull(frameworkHandle, "frameworkHandle");
             ValidateArg.NotNullOrEmpty(sources, "sources");
 

--- a/src/Adapter/PlatformServices.Desktop/Services/DesktopAdapterTraceLogger.cs
+++ b/src/Adapter/PlatformServices.Desktop/Services/DesktopAdapterTraceLogger.cs
@@ -20,7 +20,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// <param name="args"> The args. </param>
         public void LogError(string format, params object[] args)
         {
-            EqtTrace.ErrorIf(EqtTrace.IsErrorEnabled, format, args);
+            if (EqtTrace.IsErrorEnabled)
+            {
+                EqtTrace.Error(this.PrependAdapterName(format, args));
+            }
         }
 
         /// <summary>
@@ -30,7 +33,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// <param name="args"> The args. </param>
         public void LogWarning(string format, params object[] args)
         {
-            EqtTrace.WarningIf(EqtTrace.IsWarningEnabled, format, args);
+            if (EqtTrace.IsWarningEnabled)
+            {
+                EqtTrace.Warning(this.PrependAdapterName(format, args));
+            }
         }
 
         /// <summary>
@@ -40,7 +46,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// <param name="args"> The args. </param>
         public void LogInfo(string format, params object[] args)
         {
-            EqtTrace.InfoIf(EqtTrace.IsInfoEnabled, format, args);
+            if (EqtTrace.IsInfoEnabled)
+            {
+                EqtTrace.Info(this.PrependAdapterName(format, args));
+            }
+        }
+
+        private string PrependAdapterName(string format, params object[] args)
+        {
+            return string.Format($"MSTest - {string.Format(format, args)}");
         }
     }
 

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TraceLogger.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/Services/ns10TraceLogger.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
 {
     using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 #pragma warning disable SA1649 // SA1649FileNameMustMatchTypeName
 
@@ -17,10 +18,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// </summary>
         /// <param name="format"> The format. </param>
         /// <param name="args"> The args. </param>
-        /// <exception cref="System.NotImplementedException"> This is currently not implemented. </exception>
         public void LogError(string format, params object[] args)
         {
-            // Do Nothing.
+            if (EqtTrace.IsErrorEnabled)
+            {
+                EqtTrace.Error(this.PrependAdapterName(format, args));
+            }
         }
 
         /// <summary>
@@ -28,10 +31,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// </summary>
         /// <param name="format"> The format. </param>
         /// <param name="args"> The args. </param>
-        /// <exception cref="System.NotImplementedException"> This is currently not implemented. </exception>
         public void LogWarning(string format, params object[] args)
         {
-            // Do Nothing.
+            if (EqtTrace.IsWarningEnabled)
+            {
+                EqtTrace.Warning(this.PrependAdapterName(format, args));
+            }
         }
 
         /// <summary>
@@ -39,10 +44,17 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// </summary>
         /// <param name="format"> The format. </param>
         /// <param name="args"> The args. </param>
-        /// <exception cref="System.NotImplementedException"> This is currently not implemented. </exception>
         public void LogInfo(string format, params object[] args)
         {
-            // Do Nothing.
+            if (EqtTrace.IsInfoEnabled)
+            {
+                EqtTrace.Info(this.PrependAdapterName(format, args));
+            }
+        }
+
+        private string PrependAdapterName(string format, params object[] args)
+        {
+            return string.Format($"MSTest - {string.Format(format, args)}");
         }
     }
 


### PR DESCRIPTION
When running on .NET Core forward logs to EqtTrace to be written into diag log when it is enabled.