### PR TITLE
Added WinUI TestAdapter.

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -191,11 +191,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NetCore", "NetCore", "{D11C
 		src\Adapter\Build\NetCore\MSTest.TestAdapter.props = src\Adapter\Build\NetCore\MSTest.TestAdapter.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlatformServices.WinUI", "src\Adapter\PlatformServices.WinUI\PlatformServices.WinUI.csproj", "{F4E2876F-6E42-4DCF-B629-041A9DF7C579}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WinUI", "WinUI", "{35D010CC-CDF2-4115-BCFB-E2E3D21C1055}"
+	ProjectSection(SolutionItems) = preProject
+		src\Adapter\Build\WinUI\MSTest.TestAdapter.props = src\Adapter\Build\WinUI\MSTest.TestAdapter.props
+		src\Adapter\Build\WinUI\MSTest.TestAdapter.targets = src\Adapter\Build\WinUI\MSTest.TestAdapter.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Adapter\PlatformServices.Shared\PlatformServices.Shared.projitems*{2177c273-ae07-43b3-b87a-443e47a23c5a}*SharedItemsImports = 13
-		src\TestFramework\Extension.Shared\Extension.Shared.projitems*{272ca5e1-8e81-4825-9e47-86cce02f700d}*SharedItemsImports = 13
 		src\TestFramework\Extension.Shared\Extension.Shared.projitems*{23b9d9a2-4aee-47e6-97b5-060df21539fb}*SharedItemsImports = 5
+		src\TestFramework\Extension.Shared\Extension.Shared.projitems*{272ca5e1-8e81-4825-9e47-86cce02f700d}*SharedItemsImports = 13
 		src\TestFramework\Extension.Shared\Extension.Shared.projitems*{df131865-84ee-4540-8112-e88acebdea09}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1197,6 +1205,30 @@ Global
 		{23B9D9A2-4AEE-47E6-97B5-060DF21539FB}.Release|x64.Build.0 = Release|Any CPU
 		{23B9D9A2-4AEE-47E6-97B5-060DF21539FB}.Release|x86.ActiveCfg = Release|Any CPU
 		{23B9D9A2-4AEE-47E6-97B5-060DF21539FB}.Release|x86.Build.0 = Release|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|ARM.ActiveCfg = Debug|ARM
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|ARM.Build.0 = Debug|ARM
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|x64.ActiveCfg = Debug|x64
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|x64.Build.0 = Debug|x64
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|x86.ActiveCfg = Debug|x86
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Code Analysis Debug|x86.Build.0 = Debug|x86
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|ARM.ActiveCfg = Debug|ARM
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|ARM.Build.0 = Debug|ARM
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|x64.ActiveCfg = Debug|x64
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|x64.Build.0 = Debug|x64
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|x86.ActiveCfg = Debug|x86
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Debug|x86.Build.0 = Debug|x86
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|ARM.ActiveCfg = Release|ARM
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|ARM.Build.0 = Release|ARM
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|x64.ActiveCfg = Release|x64
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|x64.Build.0 = Release|x64
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|x86.ActiveCfg = Release|x86
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1263,6 +1295,8 @@ Global
 		{E5E58613-82FC-44CD-B75F-4F1C7ED52D0D} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 		{23B9D9A2-4AEE-47E6-97B5-060DF21539FB} = {E48AC786-E150-4F41-9A16-32F02E4493D8}
 		{D11C6664-1C4E-48F0-AA92-7F5BADC6F82C} = {CA01DAF5-8D9D-496E-9AD3-94BB7FBB2D34}
+		{F4E2876F-6E42-4DCF-B629-041A9DF7C579} = {24088844-2107-4DB2-8F3F-CBCA94FC4B28}
+		{35D010CC-CDF2-4115-BCFB-E2E3D21C1055} = {CA01DAF5-8D9D-496E-9AD3-94BB7FBB2D34}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31E0F4D5-975A-41CC-933E-545B2201FAF9}

--- a/src/Adapter/Build/WinUI/MSTest.TestAdapter.props
+++ b/src/Adapter/Build/WinUI/MSTest.TestAdapter.props
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll">
+      <Link>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)..\_common\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll">
+      <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll">
+      <Link>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </TestAdapterContent>
+    <TestAdapterContent Include="$(MSBuildThisFileDirectory)\Microsoft.TestPlatform.AdapterUtilities.dll">
+      <Link>Microsoft.TestPlatform.AdapterUtilities.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </TestAdapterContent>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Including `@(TestAdapterContent)` in the `None` ItemGroup to get the `CopyToOutputDirectory`
+         behavior be default, package consumers can opt-out of this behavior
+         by removing `@(TestAdapterContent)` from the `None` ItemGroup
+         i.e. `<None Remove="@(TestAdapterContent)" />` -->
+    <None Include="@(TestAdapterContent)" />
+  </ItemGroup>
+</Project>

--- a/src/Adapter/Build/WinUI/MSTest.TestAdapter.targets
+++ b/src/Adapter/Build/WinUI/MSTest.TestAdapter.targets
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <EnableMSTestV2CopyResources Condition="$(EnableMSTestV2CopyResources) == ''">true</EnableMSTestV2CopyResources>
+  </PropertyGroup>
+
+  <Target Name="GetMSTestV2CultureHierarchy">
+    <!-- Only traversing 5 levels in the culture hierarchy. This is the maximum lenght for all cultures and should be sufficient to get to a culture name that maps to a resource folder we package. 
+    The root culture name for all cultures is invariant whose name is ''(empty) and the parent for invariant culture is invariant itself.(https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.parent(v=vs.110).aspx.) 
+    So the below code should not break build in any case. -->
+    <ItemGroup>
+      <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Name)" />
+      <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Name)"/>
+      <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Name)"  Condition="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Name) != ''"/>
+      <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Name)"  Condition="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Name) != ''"/>
+      <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Parent.Name)"  Condition="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Parent.Name) != ''"/>
+    </ItemGroup>
+  </Target> 
+
+  <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
+  <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild" Condition="$(EnableMSTestV2CopyResources) == 'true'" DependsOnTargets="GetMSTestV2CultureHierarchy">
+  
+    <PropertyGroup>
+      <CurrentUICultureHierarchy>%(CurrentUICultureHierarchy.Identity)</CurrentUICultureHierarchy>
+    </PropertyGroup>
+  
+    <ItemGroup>
+      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_common\*.dll" />
+    </ItemGroup>
+	
+	<ItemGroup>
+      <Content Include="@(MSTestV2Files->'%(RootDir)%(Directory)$(CurrentUICultureHierarchy)\%(FileName).resources.dll')" 
+               Condition="Exists('%(RootDir)%(Directory)$(CurrentUICultureHierarchy)\%(FileName).resources.dll')">
+         <Link>$(CurrentUICultureHierarchy)\%(FileName).resources.dll</Link>
+         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+         <BaseAssemblyFullPath>%(FullPath)</BaseAssemblyFullPath>
+         <Visible>False</Visible>
+      </Content>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Adapter/PlatformServices.Shared/netstandard1.0/ns10RecursiveDirectoryPath.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.0/ns10RecursiveDirectoryPath.cs
@@ -54,6 +54,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
         /// The <see cref="object"/>.
         /// </returns>
         [SecurityCritical]
+#if NET5_0
+        [Obsolete]
+#endif
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/Adapter/PlatformServices.Shared/netstandard1.3/Services/ns13TestDeployment.cs
+++ b/src/Adapter/PlatformServices.Shared/netstandard1.3/Services/ns13TestDeployment.cs
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
             }
 
             // Object model currently does not have support for SuspendCodeCoverage. We can remove this once support is added
-#if !NETSTANDARD1_5
+#if !NETSTANDARD1_5 && !NET5_0
             using (new SuspendCodeCoverage())
 #endif
             {

--- a/src/Adapter/PlatformServices.WinUI/Friends.cs
+++ b/src/Adapter/PlatformServices.WinUI/Friends.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Friend assemblies
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.WinUI.UnitTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293")]

--- a/src/Adapter/PlatformServices.WinUI/PlatformServices.WinUI.csproj
+++ b/src/Adapter/PlatformServices.WinUI/PlatformServices.WinUI.csproj
@@ -1,0 +1,102 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TestFxRoot Condition="$(TestFxRoot) == ''">..\..\..\</TestFxRoot>
+    <FrameworkIdentifier>NetCore</FrameworkIdentifier>
+  </PropertyGroup>
+  <Import Project="$(TestFxRoot)scripts\build\TestFx.Settings.targets" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</RootNamespace>
+    <AssemblyName>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</AssemblyName>
+    <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
+
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <UseSharedResources>true</UseSharedResources>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Constants.cs">
+      <Link>Constants.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10ReflectionOperations.cs">
+      <Link>Services\ns10ReflectionOperations.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10DiaSessionOperations.cs">
+      <Link>Services\ns10DiaSessionOperations.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10TestContextImplementation.cs">
+      <Link>Services\ns10TestContextImplementation.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10TestDataSource.cs">
+      <Link>Services\ns10TestDataSource.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Services\ns13TestDeployment.cs">
+      <Link>Services\ns13TestDeployment.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Utilities\ns13DeploymentItemUtility.cs" Link="Utilities\ns13DeploymentItemUtility.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Utilities\ns13DeploymentUtilityBase.cs" Link="Utilities\ns13DeploymentUtilityBase.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Utilities\ns13FileUtility.cs" Link="Utilities\ns13FileUtility.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Services\ns13MSTestAdapterSettings.cs" Link="Services\ns13MSTestAdapterSettings.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\ns13DeploymentItem.cs" Link="Deployment\ns13DeploymentItem.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Utilities\ns10Validate.cs" Link="Utilities\ns10Validate.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Extensions\ns13ExceptionExtensions.cs" Link="Extensions\ns13ExceptionExtensions.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10MSTestSettingsProvider.cs" Link="Services\ns10MSTestSettingsProvider.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\ns10RecursiveDirectoryPath.cs" Link="ns10RecursiveDirectoryPath.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10TestContextPropertyStrings.cs" Link="Services\ns10TestContextPropertyStrings.cs" />
+    <Compile Include="..\PlatformServices.NetCore\Utilities\NetCoreReflectionUtility.cs" Link="Utilities\NetCoreReflectionUtility.cs"/>
+    <Compile Include="..\PlatformServices.NetCore\Utilities\NetCoreDeploymentUtility.cs" Link="Utilities\NetCoreDeploymentUtility.cs"/>
+    <Compile Include="..\PlatformServices.NetCore\Deployment\NetCoreTestRunDirectories.cs" Link="Deployment\NetCoreTestRunDirectories.cs" />
+    <Compile Include="..\PlatformServices.NetCore\Utilities\NetCoreAssemblyUtility.cs" Link="Utilities\NetCoreAssemblyUtility.cs" />
+    <Compile Include="..\PlatformServices.NetCore\Services\NetCoreTestSourceHost.cs" Link="Services\NetCoreTestSourceHost.cs" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10ThreadOperations.cs">
+      <Link>Services\ns10ThreadOperations.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10TraceListener.cs">
+      <Link>Services\ns10TraceListener.cs</Link>
+    </Compile>
+    <Compile Include="..\PlatformServices.Shared\netstandard1.0\Services\ns10TraceListenerManager.cs">
+      <Link>Services\ns10TraceListenerManager.cs</Link>
+    </Compile>
+    <Compile Include="Friends.cs" />
+    <Compile Include="Services\WinUIAdapterTraceLogger.cs" />
+    <Compile Include="Services\WinUIFileOperations.cs" />
+    <Compile Include="Services\WinUITestSource.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Folder Include="Resources\" />
+    <Compile Include="..\PlatformServices.Shared\netstandard1.3\Resources\Resource.Designer.cs">
+      <Link>Resources\Resource.Designer.cs</Link>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resource.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\PlatformServices.Shared\netstandard1.3\Resources\Resource.resx">
+      <Link>Resources\Resource.resx</Link>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resource.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+      <CustomToolNamespace>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</CustomToolNamespace>
+    </EmbeddedResource>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(TestPlatformVersion)" />
+    <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\TestFramework\Extension.Core\Extension.Core.csproj" />
+    <ProjectReference Include="..\..\TestFramework\MSTest.Core\MSTest.Core.csproj" />
+    <ProjectReference Include="..\PlatformServices.Interface\PlatformServices.Interface.csproj" />
+    <ProjectReference Include="..\..\TestFramework\Extension.Core\Extension.Core.csproj" />
+    <ProjectReference Include="..\..\TestFramework\MSTest.Core\MSTest.Core.csproj" />
+  </ItemGroup>
+  
+  <Import Project="$(TestFxRoot)scripts\build\TestFx.targets" />
+</Project>

--- a/src/Adapter/PlatformServices.WinUI/Properties/AssemblyInfo.cs
+++ b/src/Adapter/PlatformServices.WinUI/Properties/AssemblyInfo.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+// This is set by GlobalAssemblyInfo which is auto-generated due to import of Microbuild.Settings.targets
+// [assembly: AssemblyVersion("1.0.0.0")]
+// [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]
+
+[assembly: TypeForwardedTo(typeof(SerializableAttribute))]
+[assembly: TypeForwardedTo(typeof(MarshalByRefObject))]

--- a/src/Adapter/PlatformServices.WinUI/Resources/README.txt
+++ b/src/Adapter/PlatformServices.WinUI/Resources/README.txt
@@ -1,0 +1,1 @@
+This file is kept to commit Resources directory as language specific resx files needs to be copied here.

--- a/src/Adapter/PlatformServices.WinUI/Services/WinUIAdapterTraceLogger.cs
+++ b/src/Adapter/PlatformServices.WinUI/Services/WinUIAdapterTraceLogger.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
+{
+    using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+#pragma warning disable SA1649 // SA1649FileNameMustMatchTypeName
+
+    /// <summary>
+    /// A service to log any trace messages from the adapter that would be shown in *.TpTrace files.
+    /// </summary>
+    public class AdapterTraceLogger : IAdapterTraceLogger
+    {
+        /// <summary>
+        /// Log an error in a given format.
+        /// </summary>
+        /// <param name="format"> The format. </param>
+        /// <param name="args"> The args. </param>
+        public void LogError(string format, params object[] args)
+        {
+            EqtTrace.ErrorIf(EqtTrace.IsErrorEnabled, format, args);
+        }
+
+        /// <summary>
+        /// Log a warning in a given format.
+        /// </summary>
+        /// <param name="format"> The format. </param>
+        /// <param name="args"> The args. </param>
+        public void LogWarning(string format, params object[] args)
+        {
+            EqtTrace.WarningIf(EqtTrace.IsWarningEnabled, format, args);
+        }
+
+        /// <summary>
+        /// Log an information message in a given format.
+        /// </summary>
+        /// <param name="format"> The format. </param>
+        /// <param name="args"> The args. </param>
+        public void LogInfo(string format, params object[] args)
+        {
+            EqtTrace.InfoIf(EqtTrace.IsInfoEnabled, format, args);
+        }
+    }
+
+#pragma warning restore SA1649 // SA1649FileNameMustMatchTypeName
+}

--- a/src/Adapter/PlatformServices.WinUI/Services/WinUIFileOperations.cs
+++ b/src/Adapter/PlatformServices.WinUI/Services/WinUIFileOperations.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
+{
+    using global::System;
+    using global::System.IO;
+    using global::System.Reflection;
+    using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+#pragma warning disable SA1649 // SA1649FileNameMustMatchTypeName
+
+    /// <summary>
+    /// The file operations.
+    /// </summary>
+    public class FileOperations : IFileOperations
+    {
+        /// <summary>
+        /// Loads an assembly.
+        /// </summary>
+        /// <param name="assemblyName"> The assembly name. </param>
+        /// <param name="isReflectionOnly">
+        /// Indicates whether this should be a reflection only load.
+        /// </param>
+        /// <returns> The <see cref="Assembly"/>. </returns>
+        public Assembly LoadAssembly(string assemblyName, bool isReflectionOnly)
+        {
+            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(assemblyName);
+            return Assembly.Load(new AssemblyName(fileNameWithoutExtension));
+        }
+
+        /// <summary>
+        /// Gets the path to the .DLL of the assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <returns>Path to the .DLL of the assembly.</returns>
+        public string GetAssemblyPath(Assembly assembly)
+        {
+            return assembly.Location;
+        }
+
+        /// <summary>
+        ///  Verifies if file exists in context.
+        /// </summary>
+        /// <param name="assemblyFileName"> The assembly file name. </param>
+        /// <returns> The <see cref="bool"/>. </returns>
+        public bool DoesFileExist(string assemblyFileName)
+        {
+            var fileExists = false;
+
+            try
+            {
+                var fileNameWithoutPath = Path.GetFileName(assemblyFileName);
+                var searchTask = Windows.ApplicationModel.Package.Current.InstalledLocation.GetFileAsync(fileNameWithoutPath).AsTask();
+                searchTask.Wait();
+                fileExists = searchTask.Result != null;
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
+
+            return fileExists;
+        }
+
+        /// <summary>
+        /// Creates a Navigation session for the source file.
+        /// This is used to get file path and line number information for its components.
+        /// </summary>
+        /// <param name="source"> The source file. </param>
+        /// <returns> A Navigation session instance for the current platform.
+        /// <see cref="INavigationSession"/>.
+        /// </returns>
+        public object CreateNavigationSession(string source)
+        {
+            return DiaSessionOperations.CreateNavigationSession(source);
+        }
+
+        /// <summary>
+        /// Get's the navigation data for a navigation session.
+        /// </summary>
+        /// <param name="navigationSession"> The navigation session. </param>
+        /// <param name="className"> The class name. </param>
+        /// <param name="methodName"> The method name. </param>
+        /// <param name="minLineNumber"> The min line number. </param>
+        /// <param name="fileName"> The file name. </param>
+        public void GetNavigationData(object navigationSession, string className, string methodName, out int minLineNumber, out string fileName)
+        {
+            DiaSessionOperations.GetNavigationData(navigationSession, className, methodName, out minLineNumber, out fileName);
+        }
+
+        /// <summary>
+        /// Dispose's the navigation session instance.
+        /// </summary>
+        /// <param name="navigationSession"> The navigation session. </param>
+        public void DisposeNavigationSession(object navigationSession)
+        {
+            DiaSessionOperations.DisposeNavigationSession(navigationSession);
+        }
+
+        /// <summary>
+        /// Gets the full file path of an assembly file.
+        /// </summary>
+        /// <param name="assemblyFileName"> The assembly file name. </param>
+        /// <returns> The full file path
+        /// <see cref="string"/>.
+        /// </returns>
+        public string GetFullFilePath(string assemblyFileName)
+        {
+            return (SafeInvoke<string>(() => Path.GetFullPath(assemblyFileName)) as string) ?? assemblyFileName;
+        }
+
+        private static object SafeInvoke<T>(Func<T> action, string messageFormatOnException = null)
+        {
+            try
+            {
+                return action.Invoke();
+            }
+            catch (Exception exception)
+            {
+                if (string.IsNullOrEmpty(messageFormatOnException))
+                {
+                    messageFormatOnException = "{0}";
+                }
+
+                EqtTrace.ErrorIf(EqtTrace.IsErrorEnabled, messageFormatOnException, exception.Message);
+            }
+
+            return null;
+        }
+    }
+
+#pragma warning restore SA1649 // SA1649FileNameMustMatchTypeName
+}

--- a/src/Adapter/PlatformServices.WinUI/Services/WinUITestSource.cs
+++ b/src/Adapter/PlatformServices.WinUI/Services/WinUITestSource.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
+{
+    using global::System;
+    using global::System.Collections.Generic;
+    using global::System.IO;
+    using global::System.Linq;
+    using global::System.Reflection;
+
+    using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+#pragma warning disable SA1649 // SA1649FileNameMustMatchTypeName
+
+    /// <summary>
+    /// This platform service is responsible for any data or operations to validate
+    /// the test sources provided to the adapter.
+    /// </summary>
+    public class TestSource : ITestSource
+    {
+        private const string SystemAssembliesPrefix = "system.";
+
+        private static IEnumerable<string> executableExtensions = new HashSet<string>()
+        {
+             Constants.ExeExtension
+        };
+
+        private static HashSet<string> systemAssemblies = new HashSet<string>(new string[]
+        {
+            "MICROSOFT.CSHARP.DLL",
+            "MICROSOFT.VISUALBASIC.DLL",
+            "CLRCOMPRESSION.DLL",
+        });
+
+        // Well known platform assemblies.
+        private static HashSet<string> platformAssemblies = new HashSet<string>(new string[]
+        {
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.TESTFRAMEWORK.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.TESTFRAMEWORK.EXTENSIONS.CORE.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.CORE.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.COMMON.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.TESTEXECUTOR.CORE.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.EXTENSIONS.MSAPPCONTAINERADAPTER.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.EXTENSIONS.MSPHONEADAPTER.DLL",
+            "MICROSOFT.VISUALSTUDIO.TESTPLATFORM.OBJECTMODEL.DLL",
+            "VSTEST_EXECUTIONENGINE_PLATFORMBRIDGE.DLL",
+            "VSTEST_EXECUTIONENGINE_PLATFORMBRIDGE.WINMD",
+            "VSTEST.EXECUTIONENGINE.WINDOWSPHONE.DLL",
+        });
+
+        /// <summary>
+        /// Gets the set of valid extensions for sources targeting this platform.
+        /// </summary>
+        public IEnumerable<string> ValidSourceExtensions => new List<string> { Constants.DllExtension, Constants.ExeExtension, Constants.AppxPackageExtension };
+
+        /// <summary>
+        /// Verifies if the assembly provided is referenced by the source.
+        /// </summary>
+        /// <param name="assemblyName"> The assembly name. </param>
+        /// <param name="source"> The source. </param>
+        /// <returns> True if the assembly is referenced. </returns>
+        public bool IsAssemblyReferenced(AssemblyName assemblyName, string source)
+        {
+            // This code will get hit when Discovery happens during Run Tests.
+            // Since Discovery during Discover Tests would have validated the presence of Unit Test Framework as reference,
+            // no need to do validation again.
+            // Simply return true.
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the set of sources (dll's/exe's) that contain tests. If a source is a package(appx), return the file(dll/exe) that contains tests from it.
+        /// </summary>
+        /// <param name="sources"> Sources given to the adapter.  </param>
+        /// <returns> Sources that contains tests. <see cref="IEnumerable{T}"/>. </returns>
+        public IEnumerable<string> GetTestSources(IEnumerable<string> sources)
+        {
+            string appxSource;
+            if ((appxSource = this.FindAppxSource(sources)) != null)
+            {
+                var appxSourceDirectory = Path.GetDirectoryName(appxSource);
+
+                List<string> newSources = new List<string>();
+
+                var fileSearchTask = Windows.ApplicationModel.Package.Current.InstalledLocation.GetFilesAsync().AsTask();
+                fileSearchTask.Wait();
+                foreach (var filePath in fileSearchTask.Result)
+                {
+                    var fileName = filePath.Name;
+                    var isExtSupported =
+                        executableExtensions.Any(ext => fileName.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
+
+                    if (isExtSupported && !fileName.StartsWith(SystemAssembliesPrefix, StringComparison.OrdinalIgnoreCase)
+                            && !platformAssemblies.Contains(fileName.ToUpperInvariant())
+                            && !systemAssemblies.Contains(fileName.ToUpperInvariant()))
+                    {
+                        // WinUI Desktop uses .net 5, which builds both a .dll and an .exe.
+                        // The manifest will provide the .exe, but the tests are inside the .dll, so we replace the name here.
+                        newSources.Add(Path.Combine(appxSourceDirectory, Path.ChangeExtension(fileName, Constants.DllExtension)));
+                    }
+                }
+
+                return newSources;
+            }
+
+            return sources;
+        }
+
+        /// <summary>
+        /// Checks if given list of sources contains any ".appx" source.
+        /// </summary>
+        /// <param name="sources">The list of sources.</param>
+        /// <returns>True if there is an appx source.</returns>
+        private string FindAppxSource(IEnumerable<string> sources)
+        {
+            foreach (string source in sources)
+            {
+                if (string.Compare(Path.GetExtension(source), Constants.AppxPackageExtension, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    return source;
+                }
+            }
+
+            return null;
+        }
+    }
+
+#pragma warning restore SA1649 // SA1649FileNameMustMatchTypeName
+}

--- a/src/Package/MSTest.TestAdapter.Enu.nuspec
+++ b/src/Package/MSTest.TestAdapter.Enu.nuspec
@@ -8,12 +8,13 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <description>
-      The adapter to discover and execute MSTest Framework based tests. 
+      The adapter to discover and execute MSTest Framework based tests.
 
-      Supported platforms: 
-      - .NET 4.5.0+ 
-      - .NET Core 1.0+ (Universal Windows Apps 10+) (Visual Studio 2017) 
-      - ASP.NET Core 1.0+ (Visual Studio 2017) 
+      Supported platforms:
+      - .NET 4.5.0+
+      - .NET Core 1.0+ (Universal Windows Apps 10+) (Visual Studio 2017)
+      - .NET 5.0 Windows.17763+ (WinUI Desktop Apps) (Visual Studio 2019)
+      - ASP.NET Core 1.0+ (Visual Studio 2017)
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
     <license type="file">LICENSE</license>
@@ -27,7 +28,7 @@
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Diagnostics.TextWriterTraceListener" version="4.3.0" />
       </group>
-      
+
       <group targetFramework="netstandard1.5">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Diagnostics.TextWriterTraceListener" version="4.3.0" />
@@ -37,7 +38,9 @@
 
       <group targetFramework="uap10.0" />
 
-      <group targetFramework="net5.0-windows10.0.18362" />
+      <group targetFramework="net5.0-windows10.0.18362">
+        <dependency id="System.Diagnostics.TextWriterTraceListener" version="4.3.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -62,6 +65,12 @@
     <file src="Build\Universal\MSTest.TestAdapter.targets" target="build\uap10.0\MSTest.TestAdapter.targets" />
     <file src="PlatformServices.Universal\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\uap10.0\" />
     <file src="Microsoft.TestPlatform.AdapterUtilities\uap10.0\" target="build\uap10.0\" />
+
+    <!-- net5.0-windows10.0.18362 -->
+    <file src="Build\WinUI\MSTest.TestAdapter.props" target="build\net5.0-windows10.0.18362.0\MSTest.TestAdapter.props" />
+    <file src="Build\WinUI\MSTest.TestAdapter.targets" target="build\net5.0-windows10.0.18362.0\MSTest.TestAdapter.targets" />
+    <file src="PlatformServices.WinUI\net5.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\net5.0-windows10.0.18362.0\" />
+    <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net5.0-windows10.0.18362.0\" />
 
     <!-- net45 -->
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.props" />

--- a/src/Package/MSTest.TestAdapter.nuspec
+++ b/src/Package/MSTest.TestAdapter.nuspec
@@ -13,6 +13,7 @@
       Supported platforms:
       - .NET 4.5.0+
       - .NET Core 1.0+ (Universal Windows Apps 10+) (Visual Studio 2017)
+      - .NET 5.0 Windows.17763+ (WinUI Desktop Apps) (Visual Studio 2019)
       - ASP.NET Core 1.0+ (Visual Studio 2017)
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
@@ -37,7 +38,9 @@
 
       <group targetFramework="uap10.0" />
 
-      <group targetFramework="net5.0-windows10.0.18362" />
+      <group targetFramework="net5.0-windows10.0.18362">
+        <dependency id="System.Diagnostics.TextWriterTraceListener" version="4.3.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -62,6 +65,12 @@
     <file src="Build\Universal\MSTest.TestAdapter.targets" target="build\uap10.0\MSTest.TestAdapter.targets" />
     <file src="PlatformServices.Universal\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\uap10.0\" />
     <file src="Microsoft.TestPlatform.AdapterUtilities\uap10.0\" target="build\uap10.0\" />
+
+    <!-- net5.0-windows10.0.18362.0 -->
+    <file src="Build\WinUI\MSTest.TestAdapter.props" target="build\net5.0-windows10.0.18362.0\MSTest.TestAdapter.props" />
+    <file src="Build\WinUI\MSTest.TestAdapter.targets" target="build\net5.0-windows10.0.18362.0\MSTest.TestAdapter.targets" />
+    <file src="PlatformServices.WinUI\net5.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\net5.0-windows10.0.18362.0\" />
+    <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net5.0-windows10.0.18362.0\" />
 
     <!-- net45 -->
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.props" />

--- a/src/Package/MSTest.TestAdapter.symbols.nuspec
+++ b/src/Package/MSTest.TestAdapter.symbols.nuspec
@@ -8,12 +8,13 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <description>
-      The adapter to discover and execute MSTest Framework based tests. 
+      The adapter to discover and execute MSTest Framework based tests.
 
-      Supported platforms: 
-      - .NET 4.5.0+ 
-      - .NET Core 1.0+ (Universal Windows Apps 10+) (Visual Studio 2017) 
-      - ASP.NET Core 1.0+ (Visual Studio 2017) 
+      Supported platforms:
+      - .NET 4.5.0+
+      - .NET Core 1.0+ (Universal Windows Apps 10+) (Visual Studio 2017)
+      - .NET 5.0 Windows.17763+ (WinUI Desktop Apps) (Visual Studio 2019)
+      - ASP.NET Core 1.0+ (Visual Studio 2017)
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
     <license type="file">LICENSE</license>
@@ -36,7 +37,9 @@
 
       <group targetFramework="uap10.0" />
 
-      <group targetFramework="net5.0-windows10.0.18362" />
+      <group targetFramework="net5.0-windows10.0.18362">
+        <dependency id="System.Diagnostics.TextWriterTraceListener" version="4.3.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -62,6 +65,12 @@
     <file src="PlatformServices.Universal\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\uap10.0\" />
     <file src="Microsoft.TestPlatform.AdapterUtilities\uap10.0\" target="build\uap10.0\" />
 
+    <!-- net5.0-windows10.0.18362.0 -->
+    <file src="Build\WinUI\MSTest.TestAdapter.props" target="build\net5.0-windows10.0.18362.0\MSTest.TestAdapter.symbols.props" />
+    <file src="Build\WinUI\MSTest.TestAdapter.targets" target="build\net5.0-windows10.0.18362.0\MSTest.TestAdapter.symbols.targets" />
+    <file src="PlatformServices.WinUI\net5.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\net5.0-windows10.0.18362.0\" />
+    <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net5.0-windows10.0.18362.0\" />
+
     <!-- net45 -->
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.symbols.props" />
     <file src="Build\Desktop\MSTest.TestAdapter.targets" target="build\net45\MSTest.TestAdapter.symbols.targets" />
@@ -78,6 +87,9 @@
 
     <!-- uap10.0 -->
     <file src="PlatformServices.Universal\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.pdb" target="build\uap10.0\" />
+
+    <!-- net5.0-windows10.0.18362.0 -->
+    <file src="PlatformServices.WinUI\net5.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.pdb" target="build\net5.0-windows10.0.18362.0\" />
 
     <!-- netstandard1.5 -->
     <file src="PlatformServices.Universal\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.pdb" target="build\netstandard1.5\" />

--- a/src/Package/MSTest.TestFramework.enu.nuspec
+++ b/src/Package/MSTest.TestFramework.enu.nuspec
@@ -14,9 +14,10 @@
       Supported platforms:
       - .NET 4.5.0+
       - .NET Core 1.0+ (Universal Windows Apps 10+)
+      - .NET 5.0 Windows.17763+ (WinUI Desktop Apps) (Visual Studio 2019)
       - ASP.NET Core 1.0+
 
-      To discover and execute tests install MSTest.TestAdapter. 
+      To discover and execute tests install MSTest.TestAdapter.
 
       To discover and execute tests for project.json based projects install dotnet-test-mstest.
     </description>

--- a/src/Package/MSTest.TestFramework.nuspec
+++ b/src/Package/MSTest.TestFramework.nuspec
@@ -14,6 +14,7 @@
       Supported platforms:
       - .NET 4.5.0+
       - .NET Core 1.0+ (Universal Windows Apps 10+, DNX Core 5+)
+      - .NET 5.0 Windows.17763+ (WinUI Desktop Apps) (Visual Studio 2019)
       - ASP.NET Core 1.0+
 
       To discover and execute tests install MSTest.TestAdapter.

--- a/src/Package/MSTest.TestFramework.symbols.nuspec
+++ b/src/Package/MSTest.TestFramework.symbols.nuspec
@@ -13,9 +13,10 @@
       Supported platforms:
       - .NET 4.5.0+
       - .NET Core 1.0+ (Universal Windows Apps 10+)
+      - .NET 5.0 Windows.17763+ (WinUI Desktop Apps) (Visual Studio 2019)
       - ASP.NET Core 1.0+
 
-      To discover and execute tests install MSTest.TestAdapter. 
+      To discover and execute tests install MSTest.TestAdapter.
 
       To discover and execute tests for project.json based projects install dotnet-test-mstest.
     </description>

--- a/src/TestFramework/Extension.WinUI/Extension.WinUI.csproj
+++ b/src/TestFramework/Extension.WinUI/Extension.WinUI.csproj
@@ -10,8 +10,8 @@
     
     <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
-    <SupportedOSPlatformVersion>10.0.18362.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
 
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>


### PR DESCRIPTION
This adds a new adapter TFM (net5.0-windows10.0.18362.0), which is used for WinUI projects.
Complemented by https://github.com/microsoft/vstest/pull/2849