### PR TITLE
Handle possible null ref in error handler

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -717,11 +717,27 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             }
             catch (Exception ex)
             {
+                if (ex == null)
+                {
+                    // It seems that ex can be null in some rare cases when initialization fails in native code.
+                    // Get our own exception with a stack trace to satisfy GetStackTraceInformation.
+                    try
+                    {
+                        throw new InvalidOperationException(Resource.UTA_UserCodeThrewNullValueException);
+                    }
+                    catch (Exception exception)
+                    {
+                        ex = exception;
+                    }
+                }
+
                 // In most cases, exception will be TargetInvocationException with real exception wrapped
-                // in the InnerException; or user code throws an exception
+                // in the InnerException; or user code throws an exception.
+                // It also seems that in rare cases the ex can be null.
                 var actualException = ex.InnerException ?? ex;
                 var exceptionMessage = StackTraceHelper.GetExceptionMessage(actualException);
                 var stackTraceInfo = StackTraceHelper.GetStackTraceInformation(actualException);
+
                 var errorMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     Resource.UTA_InstanceCreationError,
@@ -733,6 +749,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             }
 
             return classInstance;
+        }
+
+        private Exception NullReferenceException()
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs
@@ -751,11 +751,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             return classInstance;
         }
 
-        private Exception NullReferenceException()
-        {
-            throw new NotImplementedException();
-        }
-
         /// <summary>
         /// Execute test with a timeout
         /// </summary>

--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodRunner.cs
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                                     {
                                         testResults = new[]
                                         {
-                                            new UTF.TestResult() { TestFailureException = new Exception(string.Format(CultureInfo.CurrentCulture, Resource.UTA_ExecuteThrewException, ex.Message), ex) }
+                                            new UTF.TestResult() { TestFailureException = new Exception(string.Format(CultureInfo.CurrentCulture, Resource.UTA_ExecuteThrewException, ex?.Message, ex?.StackTrace), ex) }
                                         };
                                     }
 
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                                 {
                                     testResults = new[]
                                     {
-                                        new UTF.TestResult() { TestFailureException = new Exception(string.Format(CultureInfo.CurrentCulture, Resource.UTA_ExecuteThrewException, ex.Message), ex) }
+                                        new UTF.TestResult() { TestFailureException = new Exception(string.Format(CultureInfo.CurrentCulture, Resource.UTA_ExecuteThrewException, ex?.Message, ex?.StackTrace), ex) }
                                     };
                                 }
 
@@ -346,7 +346,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         }
                         catch (Exception ex)
                         {
-                            results.Add(new UTF.TestResult() { TestFailureException = new Exception(string.Format(CultureInfo.CurrentCulture, Resource.UTA_ExecuteThrewException, ex.Message), ex) });
+                            results.Add(new UTF.TestResult() { TestFailureException = new Exception(string.Format(CultureInfo.CurrentCulture, Resource.UTA_ExecuteThrewException, ex?.Message, ex?.StackTrace), ex) });
                         }
                     }
                 }

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -495,7 +495,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exception thrown while executing test. If using extension of TestMethodAttribute then please contact vendor. Error message: {0}.
+        ///   Looks up a localized string similar to Exception thrown while executing test. If using extension of TestMethodAttribute then please contact vendor. Error message: {0}, Stack trace: {1}.
         /// </summary>
         internal static string UTA_ExecuteThrewException {
             get {
@@ -637,6 +637,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         internal static string UTA_TypeLoadError {
             get {
                 return ResourceManager.GetString("UTA_TypeLoadError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The called code threw an exception that was caught, but the exception value was null.
+        /// </summary>
+        internal static string UTA_UserCodeThrewNullValueException {
+            get {
+                return ResourceManager.GetString("UTA_UserCodeThrewNullValueException", resourceCulture);
             }
         }
         

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
@@ -209,7 +209,7 @@ Error: {1}</value>
     <value>Class Initialization method {0}.{1} threw exception. {2}: {3}.</value>
   </data>
   <data name="UTA_ExecuteThrewException" xml:space="preserve">
-    <value>Exception thrown while executing test. If using extension of TestMethodAttribute then please contact vendor. Error message: {0}</value>
+    <value>Exception thrown while executing test. If using extension of TestMethodAttribute then please contact vendor. Error message: {0}, Stack trace: {1}</value>
   </data>
   <data name="UTA_NoTestResult" xml:space="preserve">
     <value>Error in executing test. No result returned by extension. If using extension of TestMethodAttribute then please contact vendor.</value>
@@ -319,5 +319,8 @@ Error: {1}</value>
   </data>
   <data name="Execution_Test_Cancelled" xml:space="preserve">
     <value>Test '{0}' execution has been aborted.</value>
+  </data>
+  <data name="UTA_UserCodeThrewNullValueException" xml:space="preserve">
+    <value>The called code threw an exception that was caught, but the exception value was null</value>
   </data>
 </root>


### PR DESCRIPTION
I have a dump that throws access violation exception in native code and the test run fails with: 

`An exception occurred while invoking executor 'executor://mstestadapter/v2': Object reference not set to an instance of an object.`

I looked through the code and the only way I can get this result is when ex would be null in the handler. Otherwise it fails with different error, either from the asserts in the `StackTraceHelper` methods or in upstream error handlers. 


