### PR TITLE
Switching to use a LICENSE expression instead of a file

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -240,10 +240,6 @@ function Create-NugetPackages {
 
   Copy-Item -Path "$($env:TF_PACKAGES_DIR)\microsoft.testplatform.adapterutilities\$TestPlatformVersion\lib" -Destination "$($stagingDir)\Microsoft.TestPlatform.AdapterUtilities" -Recurse -Force
 
-  # Copy over LICENSE file to staging directory
-  $licenseFilePath = Join-Path $env:TF_ROOT_DIR "LICENSE"
-  Copy-Item $licenseFilePath $stagingDir -Force
-
   # Call nuget pack on these components.
   $nugetExe = Locate-Nuget
 

--- a/src/Package/MSTest.Internal.TestFx.Documentation.nuspec
+++ b/src/Package/MSTest.Internal.TestFx.Documentation.nuspec
@@ -10,7 +10,8 @@
     <summary>This is a private nuget package that contains the xml documentation files for MSTest V2 Framework.</summary>
     <description>This is a private nuget package that contains the xml documentation files for MSTest V2 Framework.</description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -23,10 +24,6 @@
     <file src="Extension.Desktop\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="contentFiles\any\any\Extensions\Desktop" />
     <file src="Extension.UWP\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="contentFiles\any\any\Extensions\UWP" />
     <file src="Extension.WinUI\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="contentFiles\any\any\Extensions\WinUI" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestAdapter.Enu.nuspec
+++ b/src/Package/MSTest.TestAdapter.Enu.nuspec
@@ -17,7 +17,8 @@
       - ASP.NET Core 1.0+ (Visual Studio 2017)
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -77,10 +78,6 @@
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.props" />
     <file src="Build\Desktop\MSTest.TestAdapter.targets" target="build\net45\MSTest.TestAdapter.targets" />
     <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net45\" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestAdapter.nuspec
+++ b/src/Package/MSTest.TestAdapter.nuspec
@@ -17,7 +17,8 @@
       - ASP.NET Core 1.0+ (Visual Studio 2017)
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -82,10 +83,6 @@
     <file src="MSTest.CoreAdapter\**\*.resources.dll" target="\build\_common\" />
     <file src="PlatformServices.Desktop\**\*.resources.dll" target="\build\_common\" />
     <file src="MSTest.Core\**\*.resources.dll" target="build\_common\" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestAdapter.symbols.nuspec
+++ b/src/Package/MSTest.TestAdapter.symbols.nuspec
@@ -17,7 +17,8 @@
       - ASP.NET Core 1.0+ (Visual Studio 2017)
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -102,10 +103,6 @@
     <file src="MSTest.CoreAdapter\**\*.resources.dll" target="\build\_common\" />
     <file src="PlatformServices.Desktop\**\*.resources.dll" target="\build\_common\" />
     <file src="MSTest.Core\**\*.resources.dll" target="build\_common\" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestFramework.enu.nuspec
+++ b/src/Package/MSTest.TestFramework.enu.nuspec
@@ -20,7 +20,8 @@
       To discover and execute tests install MSTest.TestAdapter.
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -63,10 +64,6 @@
     <file src="MSTest.Core\Microsoft.VisualStudio.TestPlatform.TestFramework.xml" target="lib\net5.0-windows10.0.18362.0" />
     <file src="Extension.WinUI\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="lib\net5.0-windows10.0.18362.0" />
     <file src="Extension.WinUI\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="lib\net5.0-windows10.0.18362.0" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestFramework.nuspec
+++ b/src/Package/MSTest.TestFramework.nuspec
@@ -20,7 +20,8 @@
       To discover and execute tests install MSTest.TestAdapter.
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -71,10 +72,6 @@
     <file src="Extension.WinUI\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="lib\net5.0-windows10.0.18362.0\" />
     <file src="MSTest.Core\**\Microsoft.VisualStudio.TestPlatform.TestFramework.xml" target="lib\net5.0-windows10.0.18362.0\" />
     <file src="Extension.WinUI\**\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="lib\net5.0-windows10.0.18362.0\" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestFramework.symbols.nuspec
+++ b/src/Package/MSTest.TestFramework.symbols.nuspec
@@ -19,7 +19,8 @@
       To discover and execute tests install MSTest.TestAdapter.
     </description>
     <projectUrl>https://github.com/microsoft/testfx</projectUrl>
-    <license type="file">LICENSE</license>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <icon>Icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
@@ -81,10 +82,6 @@
 
     <!-- Source code -->
     <file src="$srcroot$\**\*.cs" target="src" />
-
-    <!-- LICENSE -->
-    <!-- Workaround for https://github.com/NuGet/Home/issues/7601 -->
-    <file src="LICENS*" target="" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />


### PR DESCRIPTION
 - Replaced LICENSE files in NuGet packages with a license expression, and added a licenseUrl.
 - Fixes #804 