### PR TITLE
Fixed serialization issues with ITestDataSource.

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
     using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
@@ -375,18 +376,14 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
 
                 var startTime = DateTimeOffset.Now;
 
-                PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo(
-                    "Executing test {0}",
-                    unitTestElement.TestMethod.Name);
+                PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Executing test {0}", unitTestElement.TestMethod.Name);
 
                 // Run single test passing test context properties to it.
                 var tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
                 var testContextProperties = this.GetTestContextProperties(tcmProperties, sourceLevelParameters);
                 var unitTestResult = testRunner.RunSingleTest(unitTestElement.TestMethod, testContextProperties);
 
-                PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo(
-                    "Executed test {0}",
-                    unitTestElement.TestMethod.Name);
+                PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Executed test {0}", unitTestElement.TestMethod.Name);
 
                 var endTime = DateTimeOffset.Now;
 

--- a/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/UnitTestRunner.cs
@@ -94,7 +94,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
                         return new UnitTestResult[] { new UnitTestResult(UnitTestOutcome.NotRunnable, testMethodInfo.NotRunnableReason) };
                     }
 
-                    return new TestMethodRunner(testMethodInfo, testMethod, testContext, MSTestSettings.CurrentSettings.CaptureDebugTraces).Execute();
+                    var testMethodRunner = new TestMethodRunner(testMethodInfo, testMethod, testContext, MSTestSettings.CurrentSettings.CaptureDebugTraces);
+                    return testMethodRunner.Execute();
                 }
             }
             catch (TypeInspectionException ex)

--- a/src/Adapter/MSTest.CoreAdapter/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Extensions/TestCaseExtensions.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions
                 var data = testCase.GetPropertyValue<string[]>(Constants.TestDynamicDataProperty, null);
 
                 testMethod.DataType = dataType;
-                testMethod.Data = Helpers.DataSerializationHelper.Deserialize(data);
+                testMethod.SerializedData = data;
             }
 
             testMethod.DisplayName = testCase.DisplayName;

--- a/src/Adapter/MSTest.CoreAdapter/Helpers/DataSerializationHelper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Helpers/DataSerializationHelper.cs
@@ -3,12 +3,23 @@
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers
 {
+    using System;
+    using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
+    using System.Reflection;
     using System.Runtime.Serialization.Json;
     using System.Text;
 
     internal static class DataSerializationHelper
     {
+        private static readonly Dictionary<Type, DataContractJsonSerializer> SerializerCache = new Dictionary<Type, DataContractJsonSerializer>();
+        private static readonly DataContractJsonSerializerSettings SerializerSettings = new DataContractJsonSerializerSettings()
+        {
+            UseSimpleDictionaryFormat = true,
+            EmitTypeInformation = System.Runtime.Serialization.EmitTypeInformation.Always
+        };
+
         /// <summary>
         /// Serializes the date in such a way that won't throw exceptions during deserialization in Test Platform.
         /// The result can be deserialized using <see cref="Deserialize(string[])"/> method.
@@ -22,23 +33,33 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers
                 return null;
             }
 
-            var serializer = GetSerializer();
-            var serializedData = new string[data.Length];
+            var serializedData = new string[data.Length * 2];
 
             for (int i = 0; i < data.Length; i++)
             {
+                var typeIndex = i * 2;
+                var dataIndex = typeIndex + 1;
+
                 if (data[i] == null)
                 {
-                    serializedData[i] = null;
+                    serializedData[typeIndex] = null;
+                    serializedData[dataIndex] = null;
                     continue;
                 }
+
+                var type = data[i].GetType();
+                var typeName = type.FullName;
+
+                serializedData[typeIndex] = typeName;
+
+                var serializer = GetSerializer(type);
 
                 using (var memoryStream = new MemoryStream())
                 {
                     serializer.WriteObject(memoryStream, data[i]);
                     var serializerData = memoryStream.ToArray();
 
-                    serializedData[i] = Encoding.UTF8.GetString(serializerData, 0, serializerData.Length);
+                    serializedData[dataIndex] = Encoding.UTF8.GetString(serializerData, 0, serializerData.Length);
                 }
             }
 
@@ -49,26 +70,33 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers
         /// Deserialzes the data serialzed by <see cref="Serialize(object[])" /> method.
         /// </summary>
         /// <param name="serializedData">Serialized data array to deserialize.</param>
+        /// <param name="assemblies">Assemblies that serialized types defined in.</param>
         /// <returns>Deserialized array.</returns>
-        public static object[] Deserialize(string[] serializedData)
+        public static object[] Deserialize(string[] serializedData, params Assembly[] assemblies)
         {
-            if (serializedData == null)
+            if (serializedData == null || serializedData.Length % 2 != 0)
             {
                 return null;
             }
 
-            var serializer = GetSerializer();
-            var data = new object[serializedData.Length];
+            var length = serializedData.Length / 2;
+            var data = new object[length];
 
-            for (int i = 0; i < serializedData.Length; i++)
+            for (int i = 0; i < length; i++)
             {
+                var typeIndex = i * 2;
+                var dataIndex = typeIndex + 1;
+
                 if (serializedData[i] == null)
                 {
                     data[i] = null;
                     continue;
                 }
 
-                var serialzedDataBytes = Encoding.UTF8.GetBytes(serializedData[i]);
+                var typeName = serializedData[typeIndex];
+                var serializer = GetSerializer(typeName, assemblies);
+
+                var serialzedDataBytes = Encoding.UTF8.GetBytes(serializedData[dataIndex]);
                 using (var memoryStream = new MemoryStream(serialzedDataBytes))
                 {
                     data[i] = serializer.ReadObject(memoryStream);
@@ -78,17 +106,43 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers
             return data;
         }
 
-        private static DataContractJsonSerializer GetSerializer()
+        private static DataContractJsonSerializer GetSerializer(string typeName, Assembly[] assemblies)
         {
-            var settings = new DataContractJsonSerializerSettings()
+            var serializer = SerializerCache.SingleOrDefault(i => i.Key.FullName == typeName);
+            if (serializer.Value != null)
             {
-                UseSimpleDictionaryFormat = true,
-                EmitTypeInformation = System.Runtime.Serialization.EmitTypeInformation.Always
-            };
+                return serializer.Value;
+            }
 
-            var serializer = new DataContractJsonSerializer(typeof(object), settings);
+            var type = Type.GetType(typeName);
+            if (type != null)
+            {
+                return GetSerializer(type);
+            }
 
-            return serializer;
+            if (assemblies != null)
+            {
+                foreach (var assembly in assemblies)
+                {
+                    type = assembly.GetType(typeName);
+                    if (type != null)
+                    {
+                        return GetSerializer(type);
+                    }
+                }
+            }
+
+            return GetSerializer(typeof(object));
+        }
+
+        private static DataContractJsonSerializer GetSerializer(Type type)
+        {
+            if (SerializerCache.ContainsKey(type))
+            {
+                return SerializerCache[type];
+            }
+
+            return SerializerCache[type] = new DataContractJsonSerializer(type, SerializerSettings);
         }
     }
 }

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/TestMethod.cs
@@ -144,9 +144,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
         internal DynamicDataType DataType { get; set; }
 
         /// <summary>
-        /// Gets or sets indices of dynamic data
+        /// Gets or sets the serialized data
         /// </summary>
-        internal object[] Data { get; set; }
+        internal string[] SerializedData { get; set; }
 
         /// <summary>
         /// Gets or sets the test group set during discovery

--- a/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.CoreAdapter/ObjectModel/UnitTestElement.cs
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel
             // Store resolved data if any
             if (this.TestMethod.DataType != DynamicDataType.None)
             {
-                var data = Helpers.DataSerializationHelper.Serialize(this.TestMethod.Data);
+                var data = this.TestMethod.SerializedData;
 
                 testCase.SetPropertyValue(TestAdapter.Constants.TestDynamicDataTypeProperty, (int)this.TestMethod.DataType);
                 testCase.SetPropertyValue(TestAdapter.Constants.TestDynamicDataProperty, data);

--- a/src/Adapter/PlatformServices.Desktop/AssemblyResolver.cs
+++ b/src/Adapter/PlatformServices.Desktop/AssemblyResolver.cs
@@ -526,10 +526,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices
                                 {
                                     if (EqtTrace.IsInfoEnabled)
                                     {
-                                        EqtTrace.Info(
-                                            "AssemblyResolver: {0}: Failed to load assembly. Reason:{1} ",
-                                            assemblyNameToLoad,
-                                            ex);
+                                        EqtTrace.Info("AssemblyResolver: {0}: Failed to load assembly. Reason: {1}", assemblyNameToLoad, ex);
                                     }
                                 });
                 }

--- a/test/E2ETests/Automation.CLI/CLITestBase.common.cs
+++ b/test/E2ETests/Automation.CLI/CLITestBase.common.cs
@@ -5,10 +5,8 @@ namespace Microsoft.MSTestV2.CLIAutomation
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.Xml;
 
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     public partial class CLITestBase
@@ -29,6 +27,12 @@ namespace Microsoft.MSTestV2.CLIAutomation
         protected virtual string GetRelativeRepositoryRootPath() => E2ETestsRelativePath;
 
         /// <summary>
+        /// Gets the path of test assets folder
+        /// </summary>
+        /// <returns>Path to testassets folder</returns>
+        protected string GetAssetFolderPath() => Path.Combine(Environment.CurrentDirectory, this.GetRelativeRepositoryRootPath(), ArtifactsFolder, TestAssetsFolder);
+
+        /// <summary>
         /// Gets the full path to a test asset.
         /// </summary>
         /// <param name="assetName">Name of the asset with extension. E.g. <c>SimpleUnitTest.dll</c></param>
@@ -42,12 +46,7 @@ namespace Microsoft.MSTestV2.CLIAutomation
         /// </remarks>
         protected string GetAssetFullPath(string assetName)
         {
-            var assetPath = Path.Combine(
-                Environment.CurrentDirectory,
-                this.GetRelativeRepositoryRootPath(),
-                ArtifactsFolder,
-                TestAssetsFolder,
-                assetName);
+            var assetPath = Path.Combine(this.GetAssetFolderPath(), assetName);
 
             Assert.IsTrue(File.Exists(assetPath), "GetTestAsset: Path not found: {0}.", assetPath);
 

--- a/test/E2ETests/Automation.CLI/RunConfiguration.cs
+++ b/test/E2ETests/Automation.CLI/RunConfiguration.cs
@@ -16,11 +16,11 @@ namespace Microsoft.MSTestV2.CLIAutomation
         public string SettingsName { get; set; }
 
         /// <summary>
-        /// Gets or sets paths at which engine should look for test adapters
+        /// Gets the paths at which engine should look for test adapters
         /// </summary>
-        public string TestAdaptersPaths { get; set; }
+        public string[] TestAdaptersPaths { get; }
 
-        public RunConfiguration(string testAdapterPaths)
+        public RunConfiguration(params string[] testAdapterPaths)
         {
             this.SettingsName = Constants.RunConfigurationSettingsName;
             this.TestAdaptersPaths = testAdapterPaths;
@@ -35,9 +35,13 @@ namespace Microsoft.MSTestV2.CLIAutomation
             XmlDocument doc = new XmlDocument();
             XmlElement root = doc.CreateElement(this.SettingsName);
 
-            var testAdaptersPaths = doc.CreateElement("TestAdaptersPaths");
-            testAdaptersPaths.InnerXml = this.TestAdaptersPaths;
-            root.AppendChild(testAdaptersPaths);
+            foreach (var p in this.TestAdaptersPaths)
+            {
+                var testAdaptersPaths = doc.CreateElement("TestAdaptersPaths");
+                testAdaptersPaths.InnerText = p;
+
+                root.AppendChild(testAdaptersPaths);
+            }
 
             return root;
         }

--- a/test/E2ETests/DiscoveryAndExecutionTests/DataRowTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/DataRowTests.cs
@@ -26,18 +26,13 @@ namespace Microsoft.MSTestV2.Smoke.DiscoveryAndExecutionTests
             var testResults = RunTests(assemblyPath, testCases);
 
             // Assert
-            Assert.That.ContainsTestsPassed(testResults,
+            Assert.That.TestsPassed(testResults,
                 "DataRowTestMethod (BaseString1)",
                 "DataRowTestMethod (BaseString2)",
                 "DataRowTestMethod (BaseString3)",
                 "DataRowTestMethod (DerivedString1)",
                 "DataRowTestMethod (DerivedString2)"
             );
-
-            // 4 tests of BaseClass.DataRowTestMethod - 3 data row results and 1 parent result
-            // 3 tests of DerivedClass.DataRowTestMethod - 2 data row results and 1 parent result
-            // Total 7 tests - Making sure that DerivedClass doesn't run BaseClass tests
-            Assert.That.PassedTestCount(testResults, 7 - 2);
         }
 
         [TestMethod]
@@ -51,13 +46,10 @@ namespace Microsoft.MSTestV2.Smoke.DiscoveryAndExecutionTests
             var testResults = RunTests(assemblyPath, testCases);
 
             // Assert
-            Assert.That.ContainsTestsPassed(testResults,
+            Assert.That.TestsPassed(testResults,
                 "DataRowTestMethod (DerivedString1)",
                 "DataRowTestMethod (DerivedString2)"
             );
-
-            // 3 tests of DerivedClass.DataRowTestMethod - 2 datarow result and 1 parent result
-            Assert.That.PassedTestCount(testResults, 3 - 1);
         }
 
         [TestMethod]
@@ -71,14 +63,11 @@ namespace Microsoft.MSTestV2.Smoke.DiscoveryAndExecutionTests
             var testResults = RunTests(assemblyPath, testCases);
 
             // Assert
-            Assert.That.ContainsTestsPassed(testResults,
+            Assert.That.TestsPassed(testResults,
                 "DataRowTestMethodWithSomeOptionalParameters (123)",
                 "DataRowTestMethodWithSomeOptionalParameters (123,DerivedOptionalString1)",
                 "DataRowTestMethodWithSomeOptionalParameters (123,DerivedOptionalString2,DerivedOptionalString3)"
             );
-
-            // 4 tests of DerivedClass.DataRowTestMethodWithSomeOptionalParameters - 3 datarow result and 1 parent result
-            Assert.That.PassedTestCount(testResults, 4 - 1);
         }
 
         [TestMethod]
@@ -92,15 +81,12 @@ namespace Microsoft.MSTestV2.Smoke.DiscoveryAndExecutionTests
             var testResults = RunTests(assemblyPath, testCases);
 
             // Assert
-            Assert.That.ContainsTestsPassed(testResults,
+            Assert.That.TestsPassed(testResults,
                 "DataRowTestMethodWithParamsParameters (2)",
                 "DataRowTestMethodWithParamsParameters (2,DerivedSingleParamsArg)",
                 "DataRowTestMethodWithParamsParameters (2,DerivedParamsArg1,DerivedParamsArg2)",
                 "DataRowTestMethodWithParamsParameters (2,DerivedParamsArg1,DerivedParamsArg2,DerivedParamsArg3)"
             );
-
-            // 5 tests of DerivedClass.DataRowTestMethodWithParamsParameters - 4 datarow result and 1 parent result
-            Assert.That.PassedTestCount(testResults, 5 - 1);
         }
 
         [TestMethod]
@@ -114,14 +100,85 @@ namespace Microsoft.MSTestV2.Smoke.DiscoveryAndExecutionTests
             var testResults = RunTests(assemblyPath, testCases);
 
             // Assert
-            Assert.That.ContainsTestsPassed(testResults,
+            Assert.That.TestsPassed(testResults,
                 "DataRowTestMethodFailsWithInvalidArguments ()",
                 "DataRowTestMethodFailsWithInvalidArguments (2)",
                 "DataRowTestMethodFailsWithInvalidArguments (2,DerivedRequiredArgument,DerivedOptionalArgument,DerivedExtraArgument)"
             );
+        }
 
-            // 4 tests of DerivedClass.DataRowTestMethodFailsWithInvalidArguments - 3 datarow result and 1 parent result
-            Assert.That.PassedTestCount(testResults, 4 - 1);
+        [TestMethod]
+        public void DataRowsShouldSerializeDoublesProperly()
+        {
+            // Arrange
+            var assemblyPath = Path.IsPathRooted(TestAssembly) ? TestAssembly : this.GetAssetFullPath(TestAssembly);
+
+            // Act
+            var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTestDouble");
+            var testResults = RunTests(assemblyPath, testCases);
+
+            // Assert
+            Assert.That.TestsPassed(testResults,
+                "DataRowTestDouble (10.01,20.01)",
+                "DataRowTestDouble (10.02,20.02)"
+            );
+        }
+
+        [TestMethod]
+        public void DataRowsShouldSerializeMixedTypesProperly()
+        {
+            // Arrange
+            var assemblyPath = Path.IsPathRooted(TestAssembly) ? TestAssembly : this.GetAssetFullPath(TestAssembly);
+
+            // Act
+            var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTestMixed");
+            var testResults = RunTests(assemblyPath, testCases);
+
+            // Assert
+            Assert.That.TestsPassed(testResults,
+                "DataRowTestMixed (10,10,10,10,10,10,10,10)"
+            );
+        }
+
+        [TestMethod]
+        public void DataRowsShouldSerializeEnumsProperly()
+        {
+            // Arrange
+            var assemblyPath = Path.IsPathRooted(TestAssembly) ? TestAssembly : this.GetAssetFullPath(TestAssembly);
+
+            // Act
+            var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowEnums");
+            var testResults = RunTests(assemblyPath, testCases);
+
+            // Assert
+            Assert.That.TestsPassed(testResults,
+                "DataRowEnums ()",
+                "DataRowEnums (Alfa)",
+                "DataRowEnums (Beta)",
+                "DataRowEnums (Gamma)"
+            );
+        }
+
+        [TestMethod]
+        public void DataRowsShouldHandleNonSerializableValues()
+        {
+            // Arrange
+            var assemblyPath = Path.IsPathRooted(TestAssembly) ? TestAssembly : this.GetAssetFullPath(TestAssembly);
+
+            // Act
+            var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowNonSerializable");
+            var testResults = RunTests(assemblyPath, testCases);
+
+            // Assert
+            Assert.That.TestsDiscovered(testCases,
+                "DataRowNonSerializable"
+            );
+
+            Assert.That.TestsPassed(testResults,
+                "DataRowNonSerializable (System.String)",
+                "DataRowNonSerializable (System.Int32)",
+                "DataRowNonSerializable (DataRowTestProject.DerivedClass)"
+            );
         }
     }
 }

--- a/test/E2ETests/DiscoveryAndExecutionTests/Utilities/TestCaseFilterFactory.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/Utilities/TestCaseFilterFactory.cs
@@ -265,6 +265,8 @@ namespace DiscoveryAndExecutionTests.Utilities
 
         private static bool EqualsComparer(string[] values, string value)
         {
+            if (values == null) return false;
+
             foreach (var v in values)
             {
                 if (v.Equals(value, StringComparison.OrdinalIgnoreCase))
@@ -278,6 +280,8 @@ namespace DiscoveryAndExecutionTests.Utilities
 
         private static bool ContainsComparer(string[] values, string value)
         {
+            if (values == null) return false;
+
             foreach (var v in values)
             {
                 if (v.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0)

--- a/test/E2ETests/TestAssets/DataRowTestProject/DerivedClass.cs
+++ b/test/E2ETests/TestAssets/DataRowTestProject/DerivedClass.cs
@@ -3,6 +3,8 @@
 
 namespace DataRowTestProject
 {
+    using System;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -37,13 +39,13 @@ namespace DataRowTestProject
         {
             Assert.IsTrue(true);
         }
-        
+
         [TestCategory("DataRowParamsArgument")]
         [TestMethod]
         [DataRow(2)]
         [DataRow(2, "DerivedSingleParamsArg")]
         [DataRow(2, "DerivedParamsArg1", "DerivedParamsArg2")]
-        [DataRow(2, "DerivedParamsArg1", "DerivedParamsArg2","DerivedParamsArg3")]
+        [DataRow(2, "DerivedParamsArg1", "DerivedParamsArg2", "DerivedParamsArg3")]
         public void DataRowTestMethodWithParamsParameters(int i, params string[] args)
         {
             Assert.IsTrue(true);
@@ -58,6 +60,58 @@ namespace DataRowTestProject
         public void DataRowTestMethodFailsWithInvalidArguments(int i1, string requiredString, string s1 = null)
         {
             Assert.Fail();
+        }
+
+
+        [TestMethod]
+        [DataRow(10.01d, 20.01d)]
+        [DataRow(10.02d, 20.02d)]
+        public void DataRowTestDouble(double value1, double value2)
+        {
+            Assert.IsTrue(value1 > 10d);
+            Assert.IsTrue(value2 > 20d);
+        }
+
+        [TestMethod]
+        [DataRow((byte)10, 10, 10U, 10L, 10UL, 10F, 10D, "10")]
+        public void DataRowTestMixed(byte b, int i, uint u, long l, ulong ul, float f, double d, string s)
+        {
+            Assert.AreEqual<byte>(10, b);
+            Assert.AreEqual(10, i);
+            Assert.AreEqual(10U, u);
+            Assert.AreEqual(10L, l);
+            Assert.AreEqual(10UL, ul);
+            Assert.AreEqual(10F, f);
+            Assert.AreEqual(10D, d);
+            Assert.AreEqual("10", s);
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow(TestEnum.Alfa)]
+        [DataRow(TestEnum.Beta)]
+        [DataRow(TestEnum.Gamma)]
+        public void DataRowEnums(TestEnum? testEnum)
+        {
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        [DataRow(typeof(string))]
+        [DataRow(typeof(int))]
+        [DataRow(typeof(DerivedClass))]
+        public void DataRowNonSerializable(Type type)
+        {
+            Assert.IsTrue(true);
+        }
+
+        public enum TestEnum
+        {
+            Alfa,
+            Beta,
+            Gamma,
+            Delta,
+            Epsilon
         }
     }
 }


### PR DESCRIPTION
 - Fixed a bug causes that types of some `ITestDataSource` data were lost during their transfer between application domain boundaries.
 - Fixed a bug preventing test discovery when non-serializable values are provided with `ITestDataSource`.
 - Fixed #844