### PR TITLE
Upgraded winui to 0.8.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <!-- UWP and WinUI dependencies -->
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>5.3.0</MicrosoftNETCoreUniversalWindowsPlatformVersion>
-    <MicrosoftProjectReunionVersion>0.5.0</MicrosoftProjectReunionVersion>
+    <MicrosoftProjectReunionVersion>0.8.0</MicrosoftProjectReunionVersion>
     <!-- / UWP and WinUI dependencies -->
     <MoqVersion>4.8.3</MoqVersion>
     <CastleCoreVersion>4.3.0</CastleCoreVersion>

--- a/src/TestFramework/Extension.WinUI/UITestMethodAttribute.cs
+++ b/src/TestFramework/Extension.WinUI/UITestMethodAttribute.cs
@@ -12,10 +12,10 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer
     public class UITestMethodAttribute : TestMethodAttribute
     {
         /// <summary>
-        /// Gets or sets the <see cref="Microsoft.System.DispatcherQueue"/> that should be used to invoke the UITestMethodAttribute.
+        /// Gets or sets the <see cref="Microsoft.UI.Dispatching.DispatcherQueue"/> that should be used to invoke the UITestMethodAttribute.
         /// If none is provided, it will try to use the Microsoft.UI.Xaml.Window.Current.DispatcherQueue, which only works on UWP.
         /// </summary>
-        public static Microsoft.System.DispatcherQueue DispatcherQueue { get; set; }
+        public static Microsoft.UI.Dispatching.DispatcherQueue DispatcherQueue { get; set; }
 
         /// <summary>
         /// Executes the test method on the UI Thread.
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer
             {
                 var taskCompletionSource = new global::System.Threading.Tasks.TaskCompletionSource<object>();
 
-                if (!dispatcher.TryEnqueue(System.DispatcherQueuePriority.Normal, () =>
+                if (!dispatcher.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
                     {
                         try
                         {


### PR DESCRIPTION
The dispatcher has moved to a new namespace.
Without this change I can't really move to 0.8.0, since I can't verify test runs.