### PR TITLE
Fixes #799 by testing logged messages against "null or whitespace" instead of "null or empty"

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/TestExecutionManager.cs
@@ -469,17 +469,17 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         {
             Debug.Assert(testExecutionRecorder != null, "Logger should not be null");
 
-            if (!string.IsNullOrEmpty(result.StandardOut))
+            if (!string.IsNullOrWhiteSpace(result.StandardOut))
             {
                 testExecutionRecorder.SendMessage(TestMessageLevel.Informational, result.StandardOut);
             }
 
-            if (!string.IsNullOrEmpty(result.DebugTrace))
+            if (!string.IsNullOrWhiteSpace(result.DebugTrace))
             {
                 testExecutionRecorder.SendMessage(TestMessageLevel.Informational, result.DebugTrace);
             }
 
-            if (!string.IsNullOrEmpty(result.StandardError))
+            if (!string.IsNullOrWhiteSpace(result.StandardError))
             {
                 testExecutionRecorder.SendMessage(
                     MSTestSettings.CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors ? TestMessageLevel.Error : TestMessageLevel.Warning,
@@ -490,9 +490,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
             {
                 foreach (string warning in result.Warnings)
                 {
-                    testExecutionRecorder.SendMessage(
-                        MSTestSettings.CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors ? TestMessageLevel.Error : TestMessageLevel.Warning,
-                        warning);
+                    if (!string.IsNullOrWhiteSpace(warning))
+                    {
+                        testExecutionRecorder.SendMessage(
+                            MSTestSettings.CurrentSettings.TreatClassAndAssemblyCleanupWarningsAsErrors ? TestMessageLevel.Error : TestMessageLevel.Warning,
+                            warning);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The initial issue reported in #799 was related to test suites failing to execute completely in Visual Studio because sometimes, the cleanup phase was throwing with messages like this:

```
An exception occurred while invoking executor 'executor://mstestadapter/v2': The parameter cannot be null or empty.
Parameter name: message
Stack trace:
   at Microsoft.VisualStudio.TestPlatform.Common.Logging.TestSessionMessageLogger.SendMessage(TestMessageLevel testMessageLevel, String message)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.LogCleanupResult(ITestExecutionRecorder testExecutionRecorder, RunCleanupResult result)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.RunCleanup(ITestExecutionRecorder testExecutionRecorder, UnitTestRunner testRunner)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.ExecuteTestsInSource(IEnumerable`1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle, String source, Boolean isDeploymentDone)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.ExecuteTests(IEnumerable`1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle, Boolean isDeploymentDone)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestExecutionManager.RunTests(IEnumerable`1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle, TestRunCancellationToken runCancellationToken)
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestExecutor.RunTests(IEnumerable`1 tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
   at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.RunTestsWithTests.InvokeExecutor(LazyExtension`2 executor, Tuple`2 executorUri, RunContext runContext, IFrameworkHandle frameworkHandle)
   at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.BaseRunTests.<>c__DisplayClass48_0.<RunTestInternalWithExecutors>b__0()
   at Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformThread.<>c__DisplayClass0_0.<Run>b__0()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformThread.Run(Action action, PlatformApartmentState apartmentState, Boolean waitForCompletion)
   at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.BaseRunTests.TryToRunInSTAThread(Action action, Boolean waitForCompletion)
   at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Execution.BaseRunTests.RunTestInternalWithExecutors(IEnumerable`1 executorUriExtensionMap, Int64 totalTests)
```

By examining both the code in testfx and what the `Microsoft.VisualStudio.TestPlatform.Common.Logging.TestSessionMessageLogger.SendMessage` is really doing, it appears the message passed to `SendMessage` must be neither null nor empty, but more than that, it must not be all withespaces.

Hence this fix: in `TestExecutionManager.LogCleanupResult`, I simply:
* Replaced all guards in the form `string.IsNullOrEmpty` by `string.IsNullOrWhiteSpace`
* Added a (potentially) missing test inside the loop over warnings.

I manually tested this fix against my own code, but I'll need help (poke @Haplois) if I were to add test cases in testfx itself.
