### PR TITLE
Resolve dependencies from GAC

### DIFF
--- a/src/Adapter/PlatformServices.Desktop/Utilities/DesktopAssemblyUtility.cs
+++ b/src/Adapter/PlatformServices.Desktop/Utilities/DesktopAssemblyUtility.cs
@@ -190,7 +190,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
             EqtTrace.InfoIf(EqtTrace.IsInfoEnabled, "AssemblyDependencyFinder.GetDependentAssemblies: start.");
 
             AppDomainSetup setupInfo = new AppDomainSetup();
-            setupInfo.ApplicationBase = Path.GetDirectoryName(Path.GetFullPath(assemblyPath));
+            var dllDirectory = Path.GetDirectoryName(Path.GetFullPath(assemblyPath));
+            setupInfo.ApplicationBase = dllDirectory;
 
             Debug.Assert(string.IsNullOrEmpty(configFile) || File.Exists(configFile), "Config file is specified but does not exist: {0}", configFile);
 
@@ -227,7 +228,18 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
 
                     EqtTrace.InfoIf(EqtTrace.IsInfoEnabled, "AssemblyDependencyFinder.GetDependentAssemblies: loaded the worker.");
 
-                    return worker.GetFullPathToDependentAssemblies(assemblyPath, out warnings);
+                    var allDependencies = worker.GetFullPathToDependentAssemblies(assemblyPath, out warnings);
+                    var dependenciesFromDllDirectory = new List<string>();
+                    var dllDirectoryUppercase = dllDirectory.ToUpperInvariant();
+                    foreach (var dependency in allDependencies)
+                    {
+                        if (dependency.ToUpperInvariant().Contains(dllDirectoryUppercase))
+                        {
+                            dependenciesFromDllDirectory.Add(dependency);
+                        }
+                    }
+
+                    return dependenciesFromDllDirectory.ToArray();
                 }
             }
             finally

--- a/src/Adapter/PlatformServices.Desktop/Utilities/DesktopDeploymentUtility.cs
+++ b/src/Adapter/PlatformServices.Desktop/Utilities/DesktopDeploymentUtility.cs
@@ -219,6 +219,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
             Debug.Assert(deploymentItems != null, "deploymentItems should not be null.");
             Debug.Assert(Path.IsPathRooted(testSource), "path should be rooted.");
 
+            var sw = Stopwatch.StartNew();
+
             // Note: if this is not an assembly we simply return empty array, also:
             //       we do recursive search and report missing.
             string[] references = this.AssemblyUtility.GetFullPathToDependentAssemblies(testSource, configFile, out var warningList);
@@ -230,6 +232,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
             if (EqtTrace.IsInfoEnabled)
             {
                 EqtTrace.Info("DeploymentManager: Source:{0} has following references", testSource);
+                EqtTrace.Info("DeploymentManager: Resolving dependencies took {0} ms", sw.ElapsedMilliseconds);
             }
 
             foreach (string reference in references)


### PR DESCRIPTION
Cherry-picked from #950

> When there are dependencies that the project installs, but they would only resolve via a reference that is located in GAC (e.g. System.ValueTuple via netstandard) then the deployment into Out folder would ignore it.
> 
> If user then installs a version that is newer than what is in GAC it will get into their assembly redirects, but won't get copied into Out folder, resulting into TypeLoad exception for tests with DeploymentItem attribute.
> 
> This change fixes the resolver to look through all the dependencies including GAC dependencies and then copy over only the ones that are found in the bin folder, because ultimately Out should be just a subset (or the same) as the contents in bin folder.
> 
> Looking through GAC assemblies does not seem to add significant overhead the whole resolve is under 300ms so hopefully we don't need an option to configure enabling this.
> 
> (The new log messages won't go into diag log, because it probably is not correctly initialized in the new appdomain that loads the dll, but they will be written to Debug Trace and can be observed by DebugView++ or DebugView.)

