### PR TITLE
Fix vulnerability CVE-2017-0247

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,7 +31,7 @@
     <SystemCollectionsImmutableVersion>1.6.0</SystemCollectionsImmutableVersion>
     <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
     <!-- UWP and WinUI dependencies -->
-    <MicrosoftNETCoreUniversalWindowsPlatformVersion>5.3.0</MicrosoftNETCoreUniversalWindowsPlatformVersion>
+    <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.12</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <MicrosoftProjectReunionVersion>0.8.0</MicrosoftProjectReunionVersion>
     <!-- / UWP and WinUI dependencies -->
     <MoqVersion>4.8.3</MoqVersion>


### PR DESCRIPTION
Fixing [this](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/111969/alert/4311839?typeId=537149).
Changing parameter shows version of `Microsoft.NETCore.UniversalWindowsPlatform` package which contains vulnerable dll.