### PR TITLE
Fix for incorrect Microsoft.TestPlatform.AdapterUtilities.dll for net45 target (#980)

### DIFF
--- a/src/Package/MSTest.TestAdapter.Enu.nuspec
+++ b/src/Package/MSTest.TestAdapter.Enu.nuspec
@@ -77,7 +77,7 @@
     <!-- net45 -->
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.props" />
     <file src="Build\Desktop\MSTest.TestAdapter.targets" target="build\net45\MSTest.TestAdapter.targets" />
-    <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net45\" />
+    <file src="Microsoft.TestPlatform.AdapterUtilities\net45\" target="build\net45\" />
 
     <!-- Icon -->
     <file src="Icon.png" target="" />

--- a/src/Package/MSTest.TestAdapter.nuspec
+++ b/src/Package/MSTest.TestAdapter.nuspec
@@ -77,7 +77,7 @@
     <!-- net45 -->
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.props" />
     <file src="Build\Desktop\MSTest.TestAdapter.targets" target="build\net45\MSTest.TestAdapter.targets" />
-    <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net45\" />
+    <file src="Microsoft.TestPlatform.AdapterUtilities\net45\" target="build\net45\" />
 
     <!-- Localization -->
     <file src="MSTest.CoreAdapter\**\*.resources.dll" target="\build\_common\" />

--- a/src/Package/MSTest.TestAdapter.symbols.nuspec
+++ b/src/Package/MSTest.TestAdapter.symbols.nuspec
@@ -76,7 +76,7 @@
     <!-- net45 -->
     <file src="Build\Desktop\MSTest.TestAdapter.props" target="build\net45\MSTest.TestAdapter.symbols.props" />
     <file src="Build\Desktop\MSTest.TestAdapter.targets" target="build\net45\MSTest.TestAdapter.symbols.targets" />
-    <file src="Microsoft.TestPlatform.AdapterUtilities\netstandard2.0\" target="build\net45\" />
+    <file src="Microsoft.TestPlatform.AdapterUtilities\net45\" target="build\net45\" />
 
     <!-- Symbols -->
     <file src="MSTest.CoreAdapter\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.pdb" target="build\_common\" />


### PR DESCRIPTION
Fix for incorrect Microsoft.TestPlatform.AdapterUtilities.dll for net45 target (#980)