### PR TITLE
Remove nullability option from cleanupBehavior parameter

### DIFF
--- a/src/TestFramework/MSTest.Core/Attributes/Lifecycle/Cleanup/ClassCleanupAttribute.cs
+++ b/src/TestFramework/MSTest.Core/Attributes/Lifecycle/Cleanup/ClassCleanupAttribute.cs
@@ -54,7 +54,23 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
         /// To capture output of class clean-up method in logs
         /// <paramref name="cleanupBehavior"/> must be set to <see cref="ClassCleanupBehavior.EndOfClass"/>.
         /// </param>
-        public ClassCleanupAttribute(InheritanceBehavior inheritanceBehavior, ClassCleanupBehavior? cleanupBehavior)
+        public ClassCleanupAttribute(InheritanceBehavior inheritanceBehavior, ClassCleanupBehavior cleanupBehavior)
+            : this(inheritanceBehavior, new ClassCleanupBehavior?(cleanupBehavior))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassCleanupAttribute"/> class.
+        /// </summary>
+        /// <param name="inheritanceBehavior">
+        /// Specifies the ClassCleanup Inheritance Behavior
+        /// </param>
+        /// <param name="cleanupBehavior">
+        /// Specifies the class clean-up behavior.
+        /// To capture output of class clean-up method in logs
+        /// <paramref name="cleanupBehavior"/> must be set to <see cref="ClassCleanupBehavior.EndOfClass"/>.
+        /// </param>
+        private ClassCleanupAttribute(InheritanceBehavior inheritanceBehavior, ClassCleanupBehavior? cleanupBehavior)
         {
             this.InheritanceBehavior = inheritanceBehavior;
             this.CleanupBehavior = cleanupBehavior;


### PR DESCRIPTION
Attribute enum parameters must be constant. The parameter "cleanupBehavior" can't be of type Nullable<ClassCleanupBehavior> as it is not possible to create a constant attribute parameter for it.