### PR TITLE
[UITestMethod] should invoke test method with null

### DIFF
--- a/src/TestFramework/Extension.UWP/UITestMethodAttribute.cs
+++ b/src/TestFramework/Extension.UWP/UITestMethodAttribute.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer
                 Windows.UI.Core.CoreDispatcherPriority.Normal,
                 () =>
                 {
-                    result = testMethod.Invoke(new object[] { });
+                    result = testMethod.Invoke(null);
                 }).AsTask().GetAwaiter().GetResult();
 
             return new TestResult[] { result };

--- a/src/TestFramework/Extension.WinUI/UITestMethodAttribute.cs
+++ b/src/TestFramework/Extension.WinUI/UITestMethodAttribute.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer
             {
                 try
                 {
-                    result = testMethod.Invoke(Array.Empty<object>());
+                    result = testMethod.Invoke(null);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
# What

Changed the argument of `ITestMethod` invocation call in `UITestMethod` from an empty array to null.

# Why

`DataRowAttribute` and other data driven testing [depends on the argument being null](https://github.com/microsoft/testfx/blob/aad795f4321d640caa4ed0db846d374d10b0362e/src/Adapter/MSTest.CoreAdapter/Execution/TestMethodInfo.cs#L113-L116) to inject the parameters from data source or data row. Sending an empty array into `ITestMethod.Invoke` breaks this mechanism. 

_There is no existing test for these two attributes, thus not tests are updated._