### PR TITLE
Static init of StackTraceHelper.typesToBeExcluded

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Execution/StackTraceHelper.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Execution/StackTraceHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         /// <summary>
         /// Type that need to be excluded.
         /// </summary>
-        private static List<string> typesToBeExcluded;
+        private static List<string> typesToBeExcluded = new List<string>() { typeof(Microsoft.VisualStudio.TestTools.UnitTesting.Assert).Namespace, typeof(MSTestExecutor).Namespace };
 
         /// <summary>
         /// Gets the types whose methods should be ignored in the reported call stacks.
@@ -30,13 +30,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution
         {
             get
             {
-                if (typesToBeExcluded == null)
-                {
-                    typesToBeExcluded = new List<string>();
-                    typesToBeExcluded.Add(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.Assert).Namespace);
-                    typesToBeExcluded.Add(typeof(MSTestExecutor).Namespace);
-                }
-
                 return typesToBeExcluded;
             }
         }


### PR DESCRIPTION
Address thread-safety issue https://github.com/microsoft/testfx/issues/1053 by initializing the static field StackTraceHelper.typesToBeExcluded statically instead of on demand.