### PR TITLE
Fixed test run executable files.

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -146,7 +146,7 @@ function Install-WindowsSDK {
 
   try {
     Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=838916 -OutFile sdksetup.exe -UseBasicParsing
-    Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit"  -Wait -PassThru
+    Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit" -PassThru
   }
   finally {
     Pop-Location
@@ -169,6 +169,7 @@ function Perform-Restore {
     return;
   }
 
+  $msbuild = Locate-MSBuildPath
   $nuget = Locate-NuGet
   $nugetConfig = Locate-NuGetConfig
   $toolset = ".\scripts\Toolset\tools.proj"
@@ -178,8 +179,8 @@ function Perform-Restore {
   }
 
   Write-Log "Starting toolset restore..."
-  Write-Verbose "$nuget restore -verbosity normal -nonInteractive -configFile $nugetConfig $toolset"
-  & $nuget restore -verbosity normal -nonInteractive -configFile $nugetConfig $toolset
+  Write-Verbose "$nuget restore -verbosity normal -nonInteractive -configFile $nugetConfig -msbuildpath $msbuild $toolset"
+  & $nuget restore -verbosity normal -nonInteractive -configFile $nugetConfig -msbuildpath $msbuild $toolset
 
   if ($lastExitCode -ne 0) {
     throw "The restore failed with an exit code of '$lastExitCode'."

--- a/scripts/common.lib.ps1
+++ b/scripts/common.lib.ps1
@@ -131,6 +131,13 @@ function Locate-VsWhere {
   $packagesPath = Locate-PackagesPath 
 
   $vswhere = Join-Path -path $packagesPath -childPath "vswhere\$vswhereVersion\tools\vswhere.exe"
+  if(-not (Test-Path $vswhere)) {
+    $nuget = Locate-NuGet
+    $nugetConfig = Locate-NuGetConfig
+
+    Write-Verbose "$nuget install vswhere -version $vswhereVersion -OutputDirectory $packagesPath -ConfigFile $nugetConfig -ExcludeVersion"
+    & $nuget install vswhere -version $vswhereVersion -OutputDirectory $packagesPath -ConfigFile $nugetConfig -ExcludeVersion | Out-Null
+  }
 
   Write-Verbose "vswhere location is : $vswhere"
   return $vswhere

--- a/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Discovery/AssemblyEnumerator.cs
@@ -86,22 +86,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery
             var warningMessages = new List<string>();
             var tests = new List<UnitTestElement>();
 
-            Assembly assembly;
-            if (assemblyFileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                // We only want to load the source assembly in reflection only context in UWP scenarios where it is always an exe.
-                // For normal test assemblies continue loading it in the default context since:
-                // 1. There isn't much benefit in terms of Performance loading the assembly in a Reflection Only context during discovery.
-                // 2. Loading it in Reflection only context entails a bunch of custom logic to identify custom attributes which is over-kill for normal desktop users.
-                assembly = PlatformServiceProvider.Instance.FileOperations.LoadAssembly(assemblyFileName, isReflectionOnly: true);
-            }
-            else
-            {
-                assembly = PlatformServiceProvider.Instance.FileOperations.LoadAssembly(assemblyFileName, isReflectionOnly: false);
-            }
+            var assembly = PlatformServiceProvider.Instance.FileOperations.LoadAssembly(assemblyFileName, isReflectionOnly: false);
 
             var types = this.GetTypes(assembly, assemblyFileName, warningMessages);
-
             var discoverInternals = assembly.GetCustomAttribute<UTF.DiscoverInternalsAttribute>() != null;
             var testDataSourceDiscovery = assembly.GetCustomAttribute<UTF.TestDataSourceDiscoveryAttribute>()?.DiscoveryOption ?? UTF.TestDataSourceDiscoveryOption.DuringDiscovery;
 

--- a/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorTests.cs
+++ b/test/UnitTests/MSTest.CoreAdapter.Unit.Tests/Discovery/AssemblyEnumeratorTests.cs
@@ -284,26 +284,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery
         }
 
         [TestMethodV1]
-        public void EnumerateAssemblyShouldLoadExeContainersInReflectionOnlyContext()
-        {
-            var mockAssembly = CreateMockTestableAssembly();
-            var testableAssemblyEnumerator = new TestableAssemblyEnumerator();
-            var unitTestElement = new UnitTestElement(new TestMethod("DummyMethod", "DummyClass", "DummyAssembly", false));
-
-            // Setup mocks
-            mockAssembly.Setup(a => a.DefinedTypes)
-                .Returns(new List<TypeInfo>() { typeof(DummyTestClass).GetTypeInfo() });
-            this.testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly.exe", true))
-                .Returns(mockAssembly.Object);
-            testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out this.warnings))
-                .Returns(new Collection<UnitTestElement> { unitTestElement });
-
-            var testElements = testableAssemblyEnumerator.EnumerateAssembly("DummyAssembly.exe", out this.warnings);
-
-            CollectionAssert.AreEqual(new Collection<UnitTestElement> { unitTestElement }, testElements.ToList());
-        }
-
-        [TestMethodV1]
         public void EnumerateAssemblyShouldReturnMoreThanOneTestElementForAType()
         {
             var mockAssembly = CreateMockTestableAssembly();


### PR DESCRIPTION
Reflection only loading for executable files was preventing us to discover and run tests because of different attribute reading mechanism. Now loading assemblies entirely, regardless of type.

 - Fixes #1019