### PR TITLE
TestResults folder names are now cross platform compatible, as per #678

### DIFF
--- a/src/Adapter/PlatformServices.Desktop.Legacy/Utilities/DesktopDeploymentUtility.cs
+++ b/src/Adapter/PlatformServices.Desktop.Legacy/Utilities/DesktopDeploymentUtility.cs
@@ -57,8 +57,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
         /// <returns>Root deployment directory.</returns>
         public override string GetRootDeploymentDirectory(string baseDirectory)
         {
-            string dateTimeSufix = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", DateTimeFormatInfo.InvariantInfo);
-            string directoryName = string.Format(CultureInfo.CurrentCulture, Resource.TestRunName, DeploymentFolderPrefix, Environment.UserName, dateTimeSufix);
+            string dateTimeSufix = DateTime.Now.ToString("yyyyMMddTHHmmss", DateTimeFormatInfo.InvariantInfo);
+            string directoryName = string.Format(CultureInfo.InvariantCulture, Resource.TestRunName, DeploymentFolderPrefix, Environment.UserName, dateTimeSufix);
             directoryName = this.FileUtility.ReplaceInvalidFileNameCharacters(directoryName);
 
             return this.FileUtility.GetNextIterationDirectoryName(baseDirectory, directoryName);

--- a/src/Adapter/PlatformServices.Desktop/Utilities/DesktopDeploymentUtility.cs
+++ b/src/Adapter/PlatformServices.Desktop/Utilities/DesktopDeploymentUtility.cs
@@ -57,8 +57,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
         /// <returns>Root deployment directory.</returns>
         public override string GetRootDeploymentDirectory(string baseDirectory)
         {
-            string dateTimeSufix = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", DateTimeFormatInfo.InvariantInfo);
-            string directoryName = string.Format(CultureInfo.CurrentCulture, Resource.TestRunName, DeploymentFolderPrefix, Environment.UserName, dateTimeSufix);
+            string dateTimeSufix = DateTime.Now.ToString("yyyyMMddTHHmmss", DateTimeFormatInfo.InvariantInfo);
+            string directoryName = string.Format(CultureInfo.InvariantCulture, Resource.TestRunName, DeploymentFolderPrefix, Environment.UserName, dateTimeSufix);
             directoryName = this.FileUtility.ReplaceInvalidFileNameCharacters(directoryName);
 
             return this.FileUtility.GetNextIterationDirectoryName(baseDirectory, directoryName);

--- a/src/Adapter/PlatformServices.NetCore/Utilities/NetCoreDeploymentUtility.cs
+++ b/src/Adapter/PlatformServices.NetCore/Utilities/NetCoreDeploymentUtility.cs
@@ -39,8 +39,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Uti
         /// <returns>Root deployment directory.</returns>
         public override string GetRootDeploymentDirectory(string baseDirectory)
         {
-            string dateTimeSufix = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", DateTimeFormatInfo.InvariantInfo);
-            string directoryName = string.Format(CultureInfo.CurrentCulture, Resource.TestRunName, DeploymentFolderPrefix, Environment.GetEnvironmentVariable("USERNAME") ?? Environment.GetEnvironmentVariable("USER"), dateTimeSufix);
+            string dateTimeSufix = DateTime.Now.ToString("yyyyMMddTHHmmss", DateTimeFormatInfo.InvariantInfo);
+            string directoryName = string.Format(CultureInfo.InvariantCulture, Resource.TestRunName, DeploymentFolderPrefix, Environment.GetEnvironmentVariable("USERNAME") ?? Environment.GetEnvironmentVariable("USER"), dateTimeSufix);
             directoryName = this.FileUtility.ReplaceInvalidFileNameCharacters(directoryName);
 
             return this.FileUtility.GetNextIterationDirectoryName(baseDirectory, directoryName);


### PR DESCRIPTION
I ran into the issue in #678 today, so we wanted to contribute a fix for it. I'm happy to revise if I've not followed the contributor guidelines.

- Fixes #678 