### PR TITLE
Prevent format exceptions when parameters array is empty

### DIFF
--- a/src/TestFramework/MSTest.Core/Assertions/Assert.cs
+++ b/src/TestFramework/MSTest.Core/Assertions/Assert.cs
@@ -2374,7 +2374,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             string finalMessage = string.Empty;
             if (!string.IsNullOrEmpty(message))
             {
-                if (parameters == null)
+                if (parameters == null || parameters.Length == 0)
                 {
                     finalMessage = ReplaceNulls(message);
                 }
@@ -2763,7 +2763,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting
             string finalMessage = string.Empty;
             if (!string.IsNullOrEmpty(message))
             {
-                if (parameters == null)
+                if (parameters == null || parameters.Length == 0)
                 {
                     finalMessage = ReplaceNulls(message);
                 }

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/AssertTests.cs
@@ -608,5 +608,29 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests
         }
 
         #endregion
+
+        #region HandleFail tests
+        [TestMethod] // See https://github.com/dotnet/sdk/issues/25373
+        public void HandleFailDoesNotFailWithFormatExceptionOnEmptyParameters()
+        {
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.HandleFail("name", "{"));
+
+            Assert.IsNotNull(ex);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertFailedException), ex.GetType());
+            StringAssert.Contains(ex.Message, "name failed. {");
+        }
+        #endregion
+
+        #region Inconclusive tests
+        [TestMethod] // See https://github.com/dotnet/sdk/issues/25373
+        public void InconclusiveDoesNotFailWithFormatExceptionOnEmptyParameters()
+        {
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.Assert.Inconclusive("{"));
+
+            Assert.IsNotNull(ex);
+            Assert.AreEqual(typeof(TestFrameworkV2.AssertInconclusiveException), ex.GetType());
+            StringAssert.Contains(ex.Message, "Assert.Inconclusive failed. {");
+        }
+        #endregion
     }
 }

--- a/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/StringAssertTests.cs
+++ b/test/UnitTests/MSTest.Core.Unit.Tests/Assertions/StringAssertTests.cs
@@ -97,5 +97,13 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.Assertions
             var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.EndsWith(actual, inString, StringComparison.OrdinalIgnoreCase));
             Assert.IsNull(ex);
         }
+
+        [TestMethod] // See https://github.com/dotnet/sdk/issues/25373
+        public void StringAssertContainsDoesNotThrowFormatException()
+        {
+            var ex = ActionUtility.PerformActionAndReturnException(() => TestFrameworkV2.StringAssert.Contains(":-{", "x"));
+            Assert.IsNotNull(ex);
+            TestFrameworkV1.StringAssert.Contains(ex.Message, "StringAssert.Contains failed");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/25373