### PR TITLE
Find TP package version using Versions.props

### DIFF
--- a/scripts/common.lib.ps1
+++ b/scripts/common.lib.ps1
@@ -239,8 +239,6 @@ function Sync-PackageVersions {
   (Get-ChildItem "$PSScriptRoot\..\src\*packages.config", "$PSScriptRoot\..\test\*packages.config" -Recurse) | ForEach-Object {
     Replace-InFile -File $_ -RegEx $packageRegex -ReplaceWith ('<package id="Microsoft.TestPlatform$1" version="{0}"' -f $TestPlatformVersion)
   }
-
-  Replace-InFile -File "$PSScriptRoot\..\test\E2ETests\Automation.CLI\CLITestBase.common.cs" -RegEx $sourceRegex -ReplaceWith ('$1Microsoft.TestPlatform\{0}";' -f $TestPlatformVersion)
 }
 
 function Install-DotNetCli {

--- a/test/E2ETests/Automation.CLI/CLITestBase.common.cs
+++ b/test/E2ETests/Automation.CLI/CLITestBase.common.cs
@@ -15,10 +15,30 @@ public partial class CLITestBase
     private const string TestAssetsFolder = "TestAssets";
     private const string ArtifactsFolder = "artifacts";
     private const string PackagesFolder = "packages";
+    private const string EngineeringFolder = "eng";
 
     // This value is automatically updated by "build.ps1" script.
-    private const string TestPlatformCLIPackage = @"Microsoft.TestPlatform\17.4.0-preview-20220901-01";
+    private const string TestPlatformCLIPackageName = "Microsoft.TestPlatform";
     private const string VstestConsoleRelativePath = @"tools\net462\Common7\IDE\Extensions\TestPlatform\vstest.console.exe";
+
+    protected XmlDocument ReadVersionProps()
+    {
+        var versionPropsFilePath = Path.Combine(Environment.CurrentDirectory, GetRelativeRepositoryRootPath(), EngineeringFolder, "Versions.props");
+        using var fileStream = File.OpenRead(versionPropsFilePath);
+        using var xmlTextReader = new XmlTextReader(fileStream) { Namespaces = false };
+        var versionPropsXml = new XmlDocument();
+        versionPropsXml.Load(xmlTextReader);
+
+        return versionPropsXml;
+    }
+
+    protected string GetTestPlatformVersion()
+    {
+        var versionPropsXml = ReadVersionProps();
+        var testSdkVersion = versionPropsXml.DocumentElement.SelectSingleNode($"PropertyGroup/MicrosoftNETTestSdkVersion");
+
+        return testSdkVersion.InnerText;
+    }
 
     /// <summary>
     /// Gets the relative path of repository root from start-up directory.

--- a/test/E2ETests/Automation.CLI/CLITestBase.e2e.cs
+++ b/test/E2ETests/Automation.CLI/CLITestBase.e2e.cs
@@ -67,7 +67,7 @@ public partial class CLITestBase
     public string GetConsoleRunnerPath()
     {
         var packagesFolder = Path.Combine(Environment.CurrentDirectory, GetRelativeRepositoryRootPath(), PackagesFolder);
-        var vstestConsolePath = Path.Combine(packagesFolder, TestPlatformCLIPackage, VstestConsoleRelativePath);
+        var vstestConsolePath = Path.Combine(packagesFolder, TestPlatformCLIPackageName, GetTestPlatformVersion(), VstestConsoleRelativePath);
 
         Assert.IsTrue(File.Exists(vstestConsolePath), "GetConsoleRunnerPath: Path not found: {0}", vstestConsolePath);
 


### PR DESCRIPTION
Stop relying on build script to update a constant defined in E2E test and instead reads the version from the Versions.props file.