### PR TITLE
Improve assembly versions and available metadata

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -236,6 +236,8 @@ function Invoke-MSBuild([string]$solution, $buildTarget = $Target, $hasVsixExten
                 "-p:BuildVersion=$TFB_BuildVersion",
                 "-p:BranchName=`"$TPB_BRANCH`"",
                 "-p:CommitHash=$TPB_COMMIT",
+                "-p:MajorMinorPatch=$TFB_FrameworkVersion",
+                "-p:VersionSuffix=$TFB_VersionSuffix",
                 "-restore:$restore",
                 "`"$solutionPath`"",
                 "-bl:`"$binLog`"",

--- a/scripts/build/TestFx.props
+++ b/scripts/build/TestFx.props
@@ -11,7 +11,6 @@
   <PropertyGroup>
     <BranchName Condition=" '$(BranchName)' == '' ">BRANCHNAME</BranchName>
     <CommitHash Condition=" '$(CommitHash)' == '' ">COMMITHASH</CommitHash>
-    <CommitId>$(CommitHash.SubString(0, 8))</CommitId>
   </PropertyGroup>
 
   <Import Project="$(RepoRoot)eng\Versions.props" />

--- a/scripts/build/TestFx.targets
+++ b/scripts/build/TestFx.targets
@@ -35,20 +35,21 @@
   <!-- Generate AssemblyInfo.cs -->
   <PropertyGroup>
     <TFBuildNumber Condition=" '$(TFBuildNumber)' == '' ">0.1</TFBuildNumber>
-    <MajorVersion>14.0</MajorVersion>
+    <LegacyMajorVersion>14</LegacyMajorVersion>
+    <LegacyMinorVersion>0</LegacyMinorVersion>
     <GeneratedAssemblyInfoFile Condition="'$(GeneratedAssemblyInfoFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo.cs</GeneratedAssemblyInfoFile>
     <Company>Microsoft Corporation</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <AssemblyVersion>$(MajorVersion).0.0</AssemblyVersion>
-    <BuildVersion Condition=" '$(BuildVersion)' == '' ">$(MajorVersion).$(TFBuildNumber)</BuildVersion>
+    <AssemblyVersion>$(LegacyMajorVersion).$(LegacyMinorVersion).0.0</AssemblyVersion>
+    <BuildVersion Condition=" '$(BuildVersion)' == '' ">$(LegacyMajorVersion).$(LegacyMinorVersion).$(TFBuildNumber)</BuildVersion>
     <FileVersion Condition=" '$(FileVersion)' == '' ">$(BuildVersion)</FileVersion>
-    <InformationalVersion>$(BuildVersion)+$(CommitId)</InformationalVersion>
+    <InformationalVersion>$(MajorMinorPatch)-$(VersionSuffix).Branch.$(BranchName).Sha.$(CommitHash)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Not including branch name assemblies for now. -->
-    <!-- <AssemblyMetadata Include="Branch" Value="$(BranchName)" /> -->
+    <AssemblyMetadata Include="Branch" Value="$(BranchName)" />
     <AssemblyMetadata Include="Commit" Value="$(CommitHash)" />
+    <AssemblyMetadata Include="RepositoryUrl" Value="https://github.com/microsoft/testfx" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(GenerateAssemblyInfo)' == 'false' ">

--- a/scripts/build/TestFx.targets
+++ b/scripts/build/TestFx.targets
@@ -39,7 +39,7 @@
     <LegacyMajorVersion>14</LegacyMajorVersion>
     <LegacyMinorVersion>0</LegacyMinorVersion>
     <MajorMinorPatch Condition=" '$(MajorMinorPatch)' == '' ">255.255.255</MajorMinorPatch>
-    <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">dev</MajorMinorPatch>
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">dev</VersionSuffix>
     <GeneratedAssemblyInfoFile Condition="'$(GeneratedAssemblyInfoFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo.cs</GeneratedAssemblyInfoFile>
     <Company>Microsoft Corporation</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/scripts/build/TestFx.targets
+++ b/scripts/build/TestFx.targets
@@ -34,9 +34,12 @@
   -->
   <!-- Generate AssemblyInfo.cs -->
   <PropertyGroup>
+    <!-- We want to define defaults for some variables to ensure that they can still be used when building from VS -->
     <TFBuildNumber Condition=" '$(TFBuildNumber)' == '' ">0.1</TFBuildNumber>
     <LegacyMajorVersion>14</LegacyMajorVersion>
     <LegacyMinorVersion>0</LegacyMinorVersion>
+    <MajorMinorPatch Condition=" '$(MajorMinorPatch)' == '' ">255.255.255</MajorMinorPatch>
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">dev</MajorMinorPatch>
     <GeneratedAssemblyInfoFile Condition="'$(GeneratedAssemblyInfoFile)' ==''">$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo.cs</GeneratedAssemblyInfoFile>
     <Company>Microsoft Corporation</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
Fixes #1051 

Example when running locally:
![image](https://user-images.githubusercontent.com/11340282/188913447-8f26c4ce-04ab-4f7d-b230-510c5bba5069.png)

Obviously, version number will be the correct ones when coming from CI.