### PR TITLE
Remove unused build step

### DIFF
--- a/scripts/Build.ps1
+++ b/scripts/Build.ps1
@@ -16,7 +16,7 @@ Param(
   [Alias("av")]
   [Parameter(ParameterSetName = 'MultipleVersions')]
   [string] $AdapterVersion = "99.99.99",
-  
+
   [Alias("v")]
   [Parameter(ParameterSetName = 'OneVersion')]
   [string] $Version,
@@ -145,25 +145,6 @@ function Print-Help {
 
   Write-Host -object ""
   Exit 0
-}
-
-function Install-WindowsSDK {
-  Push-Location
-  $temp = [System.IO.Path]::GetTempFileName();
-  Remove-Item $temp
-  New-Item $temp -Type Directory | Out-Null
-  Set-Location $temp
-
-  try {
-    Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=838916 -OutFile sdksetup.exe -UseBasicParsing
-    Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/ceip off", "/features OptionId.WindowsSoftwareDevelopmentKit" -PassThru
-  }
-  finally {
-    Pop-Location
-
-    Remove-Item $temp -Force -Recurse | Out-Null
-  }
-
 }
 
 #
@@ -346,10 +327,6 @@ Print-Help
 
 if (ShouldRunStep @("UpdateTPVersion")) {
   Sync-PackageVersions
-}
-
-if (ShouldRunStep @("Install-WindowsSDK")) {
-  Install-WindowsSDK
 }
 
 if (ShouldRunStep @("UpdateTPVersion", "Restore")) {


### PR DESCRIPTION
This step can no longer be run and downloaded SDK is outdated. Besides, an external script already exists for the same action (and it up-to-date).