### PR TITLE
Fix issue causing null ref when test class has no namespace

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -205,6 +205,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OutputTestProject", "test\E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestFramework.ForTestingMSTest", "test\TestFramework.ForTestingMSTest\TestFramework.ForTestingMSTest.csproj", "{0685FBC3-C3A9-43A9-B15C-15BAA39705FE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HierarchyProject", "test\E2ETests\TestAssets\HierarchyProject\HierarchyProject.csproj", "{94A4DAA8-9645-4161-91F6-11EB1AD70EFC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -213,7 +215,6 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{98BA6D2C-1F3D-4636-8E1D-D4932B7A253D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{98BA6D2C-1F3D-4636-8E1D-D4932B7A253D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{98BA6D2C-1F3D-4636-8E1D-D4932B7A253D}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{98BA6D2C-1F3D-4636-8E1D-D4932B7A253D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98BA6D2C-1F3D-4636-8E1D-D4932B7A253D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BBC99A6B-4490-49DD-9C12-AF2C1E95576E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -360,6 +361,10 @@ Global
 		{0685FBC3-C3A9-43A9-B15C-15BAA39705FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0685FBC3-C3A9-43A9-B15C-15BAA39705FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0685FBC3-C3A9-43A9-B15C-15BAA39705FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94A4DAA8-9645-4161-91F6-11EB1AD70EFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94A4DAA8-9645-4161-91F6-11EB1AD70EFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94A4DAA8-9645-4161-91F6-11EB1AD70EFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94A4DAA8-9645-4161-91F6-11EB1AD70EFC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -421,6 +426,7 @@ Global
 		{44A504D9-A0D6-427D-BFB2-DB144A74F0D5} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 		{66608D86-416A-49AF-A937-C47F7E4586AE} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 		{0685FBC3-C3A9-43A9-B15C-15BAA39705FE} = {33D3029D-E653-4929-BB31-C714178C4BEE}
+		{94A4DAA8-9645-4161-91F6-11EB1AD70EFC} = {D53BD452-F69F-4FB3-8B98-386EDA28A4C8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31E0F4D5-975A-41CC-933E-545B2201FAF9}

--- a/test/E2ETests/DiscoveryAndExecutionTests/NoNamespaceTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/NoNamespaceTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.MSTestV2.Smoke.DiscoveryAndExecutionTests;
+
+using Microsoft.MSTestV2.CLIAutomation;
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+public class NoNamespaceTests : CLITestBase
+{
+    private const string TestAssembly = "HierarchyProject.dll";
+
+    public void TestsAreDiscoveredWithExpectedHierarchy()
+    {
+        // Arrange & Act
+        var testCases = DiscoverTests(GetAssetFullPath(TestAssembly));
+
+        // Assert
+        Verify(testCases.Count == 2);
+
+        VerifyHierarchy(testCases[0], null, "ClassWithNoNamespace", "MyMethodUnderTest");
+        VerifyHierarchy(testCases[1], "SomeNamespace.WithMultipleLevels", "ClassWithNamespace", "MyMethodUnderTest");
+    }
+
+    private static void VerifyHierarchy(TestCase testCase, string expectedNamespace, string expectedClassName, string expectedMethodName)
+    {
+        var hierarchy = testCase.GetPropertyValue(TestCaseExtensions.HierarchyProperty) as string[];
+        Verify(hierarchy?.Length == 4);
+        // This level is always null.
+        Verify(hierarchy[0] == null);
+        Verify(hierarchy[1] == expectedNamespace);
+        Verify(hierarchy[2] == expectedClassName);
+        Verify(hierarchy[3] == expectedMethodName);
+    }
+}

--- a/test/E2ETests/TestAssets/HierarchyProject/ClassWithNamespace.cs
+++ b/test/E2ETests/TestAssets/HierarchyProject/ClassWithNamespace.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SomeNamespace.WithMultipleLevels;
+[TestClass]
+public class ClassWithNamespace
+{
+    [TestMethod]
+    public void MyMethodUnderTest() { }
+}

--- a/test/E2ETests/TestAssets/HierarchyProject/ClassWithNoNamespace.cs
+++ b/test/E2ETests/TestAssets/HierarchyProject/ClassWithNoNamespace.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class ClassWithNoNamespace
+{
+    [TestMethod]
+    public void MyMethodUnderTest() { }
+}

--- a/test/E2ETests/TestAssets/HierarchyProject/HierarchyProject.csproj
+++ b/test/E2ETests/TestAssets/HierarchyProject/HierarchyProject.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(RepoRoot)artifacts\TestAssets\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\TestFramework\Extension\Extension.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\TestFramework\MSTest.Core\MSTest.Core.csproj" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
Actual fix lays on Test Platform side as we are simply using an API they provide. We still want to add some tests as safetynet against regression.

Fixes #889