### PR TITLE
Ensure exit in case of timeout/cancellation

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -688,7 +688,8 @@ public class TestMethodInfo : ITestMethod
         object classInstance = null;
         try
         {
-            classInstance = await Task.Run(() => Parent.Constructor.Invoke(null), cancellationToken).WithCancellation(cancellationToken);
+            classInstance = await Task.Run(() => Parent.Constructor.Invoke(null), cancellationToken)
+                .WithCancellation(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -120,6 +120,7 @@ public class TestMethodInfo : ITestMethod
             {
                 result = IsTimeoutSet
                     ? ExecuteInternalWithTimeout(arguments)
+                    // TODO: Break public API and flow up async/await call. In the meantime, let's use blocking call.
                     : ExecuteInternal(arguments, CancellationToken.None, CancellationToken.None).GetAwaiter().GetResult();
             }
             finally
@@ -785,6 +786,7 @@ public class TestMethodInfo : ITestMethod
         {
             try
             {
+                // TODO: Rewrite ThreadOperations to accept async/await pattern. In the meantime, we have to use blocking call.
                 result = ExecuteInternal(arguments, testRunCancellationToken, cleanupTokenSource.Token).GetAwaiter().GetResult();
             }
             catch (Exception ex)

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -478,7 +478,8 @@ public class TestMethodInfo : ITestMethod
                 // Current TestClass -> Parent -> Grandparent
                 if (testCleanupMethod is not null)
                 {
-                    await testCleanupMethod.InvokeAsTask(classInstance, cancellationToken, null).WithCancellation(cancellationToken);
+                    await testCleanupMethod.InvokeAsTask(classInstance, cancellationToken, null)
+                        .WithCancellation(cancellationToken);
                 }
 
                 var baseTestCleanupQueue = new Queue<MethodInfo>(Parent.BaseTestCleanupMethodsQueue);
@@ -487,7 +488,8 @@ public class TestMethodInfo : ITestMethod
                     testCleanupMethod = baseTestCleanupQueue.Dequeue();
                     if (testCleanupMethod is not null)
                     {
-                        await testCleanupMethod.InvokeAsTask(classInstance, cancellationToken, null).WithCancellation(cancellationToken);
+                        await testCleanupMethod.InvokeAsTask(classInstance, cancellationToken, null)
+                            .WithCancellation(cancellationToken);
                     }
                 }
             }
@@ -495,7 +497,8 @@ public class TestMethodInfo : ITestMethod
             {
                 if (classInstance is IDisposable disposable)
                 {
-                    await Task.Run(disposable.Dispose, cancellationToken).WithCancellation(cancellationToken);
+                    await Task.Run(disposable.Dispose, cancellationToken)
+                        .WithCancellation(cancellationToken);
                 }
             }
         }

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -735,7 +735,7 @@ public class TestMethodInfo : ITestMethod
     [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Requirement is to handle all kinds of user exceptions and message appropriately.")]
     private TestResult ExecuteInternalWithTimeout(object[] arguments)
     {
-        Debug.Assert(IsTimeoutSet, "TimeoutContext should be set");
+        Debug.Assert(IsTimeoutSet, "Timeout should be set");
 
         TestResult result = null;
         Exception failure = null;

--- a/src/Adapter/MSTest.TestAdapter/Helpers/TaskHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/TaskHelper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+internal static class TaskHelper
+{
+    // See https://devblogs.microsoft.com/pfxteam/how-do-i-cancel-non-cancelable-async-operations/
+    public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
+        {
+            if (task != await Task.WhenAny(task, tcs.Task))
+                throw new OperationCanceledException(cancellationToken);
+        }
+
+        return await task;
+    }
+
+    public static async Task WithCancellation(this Task task, CancellationToken cancellationToken)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        using (cancellationToken.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
+        {
+            if (task != await Task.WhenAny(task, tcs.Task))
+                throw new OperationCanceledException(cancellationToken);
+        }
+
+        await task;
+    }
+}

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethodOptions.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethodOptions.cs
@@ -14,7 +14,7 @@ internal class TestMethodOptions
     /// <summary>
     /// Gets or sets the timeout specified for a test method.
     /// </summary>
-    internal int Timeout { get; set; }
+    internal TimeoutAttribute TimeoutContext { get; set; }
 
     /// <summary>
     /// Gets or sets the ExpectedException attribute adorned on a test method.

--- a/src/Adapter/MSTest.TestAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.TestAdapter/Resources/Resource.Designer.cs
@@ -504,6 +504,15 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to UTA055: {0}.{1} has invalid CleanupTimeout property on Timeout attribute. The timeout must be a valid integer value and cannot be less than 0..
+        /// </summary>
+        internal static string UTA_ErrorInvalidCleanupTimeout {
+            get {
+                return ResourceManager.GetString("UTA_ErrorInvalidCleanupTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to UTA031: class {0} does not have valid TestContext property. TestContext must be of type TestContext, must be non-static, public and must not be read-only. For example: public TestContext TestContext..
         /// </summary>
         internal static string UTA_ErrorInValidTestContextSignature {

--- a/src/Adapter/MSTest.TestAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.TestAdapter/Resources/Resource.resx
@@ -384,4 +384,7 @@ Error: {1}</value>
     <comment>{0}: Zero based index if an element inside of an array,
 {1}: Test name</comment>
   </data>
+  <data name="UTA_ErrorInvalidCleanupTimeout" xml:space="preserve">
+    <value>UTA055: {0}.{1} has invalid CleanupTimeout property on Timeout attribute. The timeout must be a valid integer value and cannot be less than 0.</value>
+  </data>
 </root>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -100,7 +100,8 @@ public class TestContextImplementation : UTF.TestContext, ITestContext
         // Cannot get this type in constructor directly, because all signatures for all platforms need to be the same.
         _threadSafeStringWriter = (ThreadSafeStringWriter)stringWriter;
         _properties = new Dictionary<string, object>(properties);
-        CancellationTokenSource = new CancellationTokenSource();
+        CancellationTokenSource = new();
+        CleanupCancellationTokenSource = new();
         InitializeProperties();
 
 #if !WINDOWS_UWP

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -24,9 +24,23 @@ public abstract class TestContext
     public abstract IDictionary Properties { get; }
 
     /// <summary>
-    /// Gets or sets the cancellation token source. This token source is canceled when test times out. Also when explicitly canceled the test will be aborted
+    /// Gets or sets the cancellation token source.
+    /// This token source is canceled when test times out. Also when explicitly canceled the test will be aborted.
     /// </summary>
+    /// <remarks>
+    /// Cancelling the token source for a test not marked with <see cref="TimeoutAttribute"/> will result in a no-op.
+    /// </remarks>
     public virtual CancellationTokenSource CancellationTokenSource { get; protected set; }
+
+    /// <summary>
+    /// Gets or sets the test cleanup cancellation token source. This token source is canceled when test cleanup times out (after that a test timed out).
+    /// Also when explicitly canceled the test cleanup will be aborted.
+    /// </summary>
+    /// <remarks>
+    /// Cancelling the token source for a test not marked with <see cref="TimeoutAttribute"/> or when <see cref="CancellationTokenSource"/>
+    /// is not canceled will result in a no-op.
+    /// </remarks>
+    public virtual CancellationTokenSource CleanupCancellationTokenSource { get; protected set; }
 
 #if NETFRAMEWORK
     /// <summary>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -19,9 +19,15 @@ public sealed class TimeoutAttribute : Attribute
     /// <param name="timeout">
     /// The timeout in milliseconds.
     /// </param>
-    public TimeoutAttribute(int timeout)
+    /// <param name="cleanupTimeout">
+    /// The cleanup timeout in milliseconds.
+    /// This represents the time allowed for the cleanup (TestCleanup, Dispose) to complete when the test times out.
+    /// The default value is infinite, meaning that all cleanup will be called and left infinite time to process.
+    /// </param>
+    public TimeoutAttribute(int timeout, int cleanupTimeout = int.MaxValue)
     {
         Timeout = timeout;
+        CleanupTimeout = cleanupTimeout;
     }
 
     /// <summary>
@@ -31,8 +37,8 @@ public sealed class TimeoutAttribute : Attribute
     /// The timeout
     /// </param>
     public TimeoutAttribute(TestTimeout timeout)
+        : this((int)timeout)
     {
-        Timeout = (int)timeout;
     }
 
     #endregion
@@ -43,6 +49,12 @@ public sealed class TimeoutAttribute : Attribute
     /// Gets the timeout in milliseconds.
     /// </summary>
     public int Timeout { get; }
+
+    /// <summary>
+    /// Gets the cleanup timeout in milliseconds.
+    /// This represents the time allowed for the cleanup (TestCleanup, Dispose) to complete when the test times out.
+    /// </summary>
+    public int CleanupTimeout { get; }
 
     #endregion
 }

--- a/test/E2ETests/Automation.CLI/CLITestBase.e2e.cs
+++ b/test/E2ETests/Automation.CLI/CLITestBase.e2e.cs
@@ -18,7 +18,7 @@ public partial class CLITestBase : TestContainer
 {
     private static VsTestConsoleWrapper s_vsTestConsoleWrapper;
     private DiscoveryEventsHandler _discoveryEventsHandler;
-    private RunEventsHandler _runEventsHandler;
+    protected RunEventsHandler _runEventsHandler;
 
     public CLITestBase()
     {

--- a/test/E2ETests/Smoke.E2E.Tests/TimeoutTests.cs
+++ b/test/E2ETests/Smoke.E2E.Tests/TimeoutTests.cs
@@ -5,6 +5,7 @@ namespace MSTestAdapter.Smoke.E2ETests;
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using Microsoft.MSTestV2.CLIAutomation;
 
@@ -22,11 +23,21 @@ public class TimeoutTests : CLITestBase
         ValidateTimeoutTests("netcoreapp3.1");
     }
 
+    public void ValidateTestRunLifecycle_net462()
+    {
+        ValidateTestRunLifecycle("net462");
+    }
+
+    public void ValidateTestRunLifecycle_netcoreapp31()
+    {
+        ValidateTestRunLifecycle("netcoreapp3.1");
+    }
+
     private void ValidateTimeoutTests(string targetFramework)
     {
-        InvokeVsTestForExecution(new string[] { targetFramework + "\\" + TimeoutTestAssembly }, testCaseFilter: "TimeoutTest|RegularTest");
+        InvokeVsTestForExecution(new string[] { targetFramework + "\\" + TimeoutTestAssembly }, testCaseFilter: "TimeoutTestClass");
 
-        ValidateFailedTestsCount(targetFramework == "net462" ? 5 : 4);
+        ValidateFailedTestsCount(targetFramework == "net462" ? 7 : 6);
 
         var failedTests = new List<string>
         {
@@ -46,5 +57,60 @@ public class TimeoutTests : CLITestBase
         // We should find the <TargetFramework>/TimeoutTestOutput.txt file, as it's our way to validate
         // that when the timeout expires it cancels the test context token.
         Verify(File.Exists(GetAssetFullPath(targetFramework + "\\" + "TimeoutTestOutput.txt")));
+    }
+
+    private void ValidateTestRunLifecycle(string targetFramework)
+    {
+        InvokeVsTestForExecution(new[] { targetFramework + "\\" + TimeoutTestAssembly }, testCaseFilter: "TestRunLifecycle");
+        Verify(_runEventsHandler.FailedTests.Count == 5);
+
+        var caseWithWaitInCtor = _runEventsHandler.FailedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("TestRunLifecycle_SyncWaitInCtor"));
+        Verify(caseWithWaitInCtor.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed);
+        Verify(caseWithWaitInCtor.Messages.Single().Text.Contains(
+            """
+            Ctor was called
+            """));
+
+        var caseWithWaitInTestInitialize = _runEventsHandler.FailedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("TestRunLifecycle_SyncWaitInTestInitialize"));
+        Verify(caseWithWaitInTestInitialize.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed);
+        Verify(caseWithWaitInTestInitialize.Messages.Single().Text.Contains(
+            """
+            Ctor was called
+            TestInitialize was called
+            TestCleanup was called
+            Dispose was called
+            """));
+
+        var caseWithWaitInTestMethod = _runEventsHandler.FailedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("TestRunLifecycle_SyncWaitInTestMethod"));
+        Verify(caseWithWaitInTestMethod.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed);
+        Verify(caseWithWaitInTestMethod.Messages.Single().Text.Contains(
+            """
+            Ctor was called
+            TestInitialize was called
+            TestMethod was called
+            TestCleanup was called
+            Dispose was called
+            """));
+
+        var caseWithWaitInTestCleanup = _runEventsHandler.FailedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("TestRunLifecycle_SyncWaitInTestCleanup"));
+        Verify(caseWithWaitInTestCleanup.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed);
+        Verify(caseWithWaitInTestCleanup.Messages.Single().Text.Contains(
+            """
+            Ctor was called
+            TestInitialize was called
+            TestMethod was called
+            TestCleanup was called
+            """));
+
+        var caseWithWaitInDispose = _runEventsHandler.FailedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("TestRunLifecycle_SyncWaitInDispose"));
+        Verify(caseWithWaitInDispose.Outcome == Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Failed);
+        Verify(caseWithWaitInDispose.Messages.Single().Text.Contains(
+            """
+            Ctor was called
+            TestInitialize was called
+            TestMethod was called
+            TestCleanup was called
+            Dispose was called
+            """));
     }
 }

--- a/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInCtor.cs
+++ b/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInCtor.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TimeoutTestProject;
+[TestClass]
+public sealed class TestRunLifecycle_SyncWaitInCtor : IDisposable
+{
+    private static TestContext s_testContext;
+
+    public TestContext TestContext { get; set; }
+
+    public TestRunLifecycle_SyncWaitInCtor()
+    {
+        s_testContext.WriteLine("Ctor was called");
+        Thread.Sleep(100_000);
+        TestContext.WriteLine("Ctor end was reached");
+    }
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+        s_testContext = testContext;
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        TestContext.WriteLine("TestInitialize was called");
+    }
+
+    [TestMethod]
+    [Timeout(500)]
+    public void TestMethod()
+    {
+        TestContext.WriteLine("TestMethod was called");
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        TestContext.WriteLine("TestCleanup was called");
+    }
+
+    public void Dispose()
+    {
+        TestContext.WriteLine("Dispose was called");
+    }
+}

--- a/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInDispose.cs
+++ b/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInDispose.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TimeoutTestProject;
+[TestClass]
+public sealed class TestRunLifecycle_SyncWaitInDispose : IDisposable
+{
+    private static TestContext s_testContext;
+
+    public TestContext TestContext { get; set; }
+
+    public TestRunLifecycle_SyncWaitInDispose()
+    {
+        s_testContext.WriteLine("Ctor was called");
+    }
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+        s_testContext = testContext;
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        TestContext.WriteLine("TestInitialize was called");
+    }
+
+    [TestMethod]
+    [Timeout(500, cleanupTimeout: 500)]
+    public void TestMethod()
+    {
+        TestContext.WriteLine("TestMethod was called");
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        TestContext.WriteLine("TestCleanup was called");
+    }
+
+    public void Dispose()
+    {
+        TestContext.WriteLine("Dispose was called");
+        Thread.Sleep(100_000);
+        TestContext.WriteLine("Dispose end was reached");
+    }
+}

--- a/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInTestCleanup.cs
+++ b/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInTestCleanup.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TimeoutTestProject;
+[TestClass]
+public sealed class TestRunLifecycle_SyncWaitInTestCleanup : IDisposable
+{
+    private static TestContext s_testContext;
+
+    public TestContext TestContext { get; set; }
+
+    public TestRunLifecycle_SyncWaitInTestCleanup()
+    {
+        s_testContext.WriteLine("Ctor was called");
+    }
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+        s_testContext = testContext;
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        TestContext.WriteLine("TestInitialize was called");
+    }
+
+    [TestMethod]
+    [Timeout(500, cleanupTimeout: 500)]
+    public void TestMethod()
+    {
+        TestContext.WriteLine("TestMethod was called");
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        TestContext.WriteLine("TestCleanup was called");
+        Thread.Sleep(100_000);
+        TestContext.WriteLine("TestCleanup end was reached");
+    }
+
+    public void Dispose()
+    {
+        TestContext.WriteLine("Dispose was called");
+    }
+}

--- a/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInTestInitialize.cs
+++ b/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInTestInitialize.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TimeoutTestProject;
+[TestClass]
+public sealed class TestRunLifecycle_SyncWaitInTestInitialize : IDisposable
+{
+    private static TestContext s_testContext;
+
+    public TestContext TestContext { get; set; }
+
+    public TestRunLifecycle_SyncWaitInTestInitialize()
+    {
+        s_testContext.WriteLine("Ctor was called");
+    }
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+        s_testContext = testContext;
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        TestContext.WriteLine("TestInitialize was called");
+
+        Thread.Sleep(100_000);
+        TestContext.WriteLine("TestInitialize end was reached");
+    }
+
+    [TestMethod]
+    [Timeout(500)]
+    public void TestMethod()
+    {
+        TestContext.WriteLine("TestMethod was called");
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        TestContext.WriteLine("TestCleanup was called");
+    }
+
+    public void Dispose()
+    {
+        TestContext.WriteLine("Dispose was called");
+    }
+}

--- a/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInTestMethod.cs
+++ b/test/E2ETests/TestAssets/TimeoutTestProject/TestRunLifecycle_SyncWaitInTestMethod.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TimeoutTestProject;
+[TestClass]
+public sealed class TestRunLifecycle_SyncWaitInTestMethod : IDisposable
+{
+    private static TestContext s_testContext;
+
+    public TestContext TestContext { get; set; }
+
+    public TestRunLifecycle_SyncWaitInTestMethod()
+    {
+        s_testContext.WriteLine("Ctor was called");
+    }
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+        s_testContext = testContext;
+    }
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        TestContext.WriteLine("TestInitialize was called");
+    }
+
+    [TestMethod]
+    [Timeout(500)]
+    public void TestMethod()
+    {
+        TestContext.WriteLine("TestMethod was called");
+        Thread.Sleep(100_000);
+        TestContext.WriteLine("TestMethod end was reached");
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        TestContext.WriteLine("TestCleanup was called");
+    }
+
+    public void Dispose()
+    {
+        TestContext.WriteLine("Dispose was called");
+    }
+}

--- a/test/E2ETests/TestAssets/TimeoutTestProject/TimeoutTestClass.cs
+++ b/test/E2ETests/TestAssets/TimeoutTestProject/TimeoutTestClass.cs
@@ -13,6 +13,9 @@ namespace TimeoutTestProject;
 [TestClass]
 public class TimeoutTestClass
 {
+    private bool _waitInCleanup = false;
+    private bool _cancelInCleanup = false;
+
     public TestContext TestContext { get; set; }
 
     [TestMethod]
@@ -54,6 +57,36 @@ public class TimeoutTestClass
     public void TimeoutTest_WhenTimeoutReached_ForcesTestAbort()
     {
         Thread.Sleep(100_000);
+    }
+
+    [TestMethod]
+    [Timeout(50, cleanupTimeout: 100)]
+    public void TimeoutTest_WaitInCleanup()
+    {
+        _waitInCleanup = true;
+    }
+
+    [TestMethod]
+    [Timeout(50)]
+    public void TimeoutTest_CancelInCleanup()
+    {
+        _cancelInCleanup = true;
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        if (_waitInCleanup)
+        {
+            Thread.Sleep(100_000);
+            Assert.Fail("Should not have been called.");
+        }
+
+        if (_cancelInCleanup)
+        {
+            TestContext.CleanupCancellationTokenSource.Cancel();
+            Assert.Fail("Should not have been called.");
+        }
     }
 
     private void ExecuteLong()

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodInfoTests.cs
@@ -73,7 +73,7 @@ public class TestMethodInfoTests : TestContainer
         _expectedException = new UTF.ExpectedExceptionAttribute(typeof(DivideByZeroException));
         _testMethodOptions = new TestMethodOptions()
         {
-            Timeout = 3600 * 1000,
+            TimeoutContext = new(3600 * 1000),
             Executor = _testMethodAttribute,
             ExpectedException = null,
             TestContext = _testContextImplementation
@@ -946,7 +946,7 @@ public class TestMethodInfoTests : TestContainer
     public void HandleMethodExceptionShouldInvokeVerifyOfCustomExpectedException()
     {
         CustomExpectedExceptionAttribute customExpectedException = new(typeof(DivideByZeroException), "Attempted to divide by zero");
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = customExpectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -962,7 +962,7 @@ public class TestMethodInfoTests : TestContainer
     public void HandleMethodExceptionShouldSetOutcomeAsFailedIfVerifyOfExpectedExceptionThrows()
     {
         CustomExpectedExceptionAttribute customExpectedException = new(typeof(DivideByZeroException), "Custom Exception");
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = customExpectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -978,7 +978,7 @@ public class TestMethodInfoTests : TestContainer
     public void HandleMethodExceptionShouldSetOutcomeAsInconclusveIfVerifyOfExpectedExceptionThrowsAssertInconclusiveException()
     {
         CustomExpectedExceptionAttribute customExpectedException = new(typeof(DivideByZeroException), "Custom Exception");
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = customExpectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -995,7 +995,7 @@ public class TestMethodInfoTests : TestContainer
     public void HandleMethodExceptionShouldInvokeVerifyOfDerivedCustomExpectedException()
     {
         DerivedCustomExpectedExceptionAttribute derivedCustomExpectedException = new(typeof(DivideByZeroException), "Attempted to divide by zero");
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = derivedCustomExpectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1014,7 +1014,7 @@ public class TestMethodInfoTests : TestContainer
         {
             AllowDerivedTypes = true
         };
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = expectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1032,7 +1032,7 @@ public class TestMethodInfoTests : TestContainer
         {
             AllowDerivedTypes = true
         };
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = expectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1053,7 +1053,7 @@ public class TestMethodInfoTests : TestContainer
         {
             AllowDerivedTypes = true
         };
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = expectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1073,7 +1073,7 @@ public class TestMethodInfoTests : TestContainer
         {
             AllowDerivedTypes = true
         };
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = expectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1090,7 +1090,7 @@ public class TestMethodInfoTests : TestContainer
     public void VerifyShouldThrowIfThrownExceptionIsNotSameAsExpectedException()
     {
         UTF.ExpectedExceptionAttribute expectedException = new(typeof(Exception));
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = expectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1108,7 +1108,7 @@ public class TestMethodInfoTests : TestContainer
     public void VerifyShouldRethrowIfThrownExceptionIsAssertExceptionWhichIsNotSameAsExpectedException()
     {
         UTF.ExpectedExceptionAttribute expectedException = new(typeof(Exception));
-        _testMethodOptions.Timeout = 0;
+        _testMethodOptions.TimeoutContext = new(0);
         _testMethodOptions.ExpectedException = expectedException;
         var method = new TestMethodInfo(
             _methodInfo,
@@ -1168,7 +1168,7 @@ public class TestMethodInfoTests : TestContainer
 
             testablePlatformServiceProvider.MockThreadOperations.Setup(
              to => to.Execute(It.IsAny<Action>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
-            _testMethodOptions.Timeout = 1;
+            _testMethodOptions.TimeoutContext = new(1);
             var method = new TestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions);
 
             var result = method.Invoke(null);
@@ -1196,7 +1196,7 @@ public class TestMethodInfoTests : TestContainer
 
             testablePlatformServiceProvider.MockThreadOperations.Setup(
              to => to.Execute(It.IsAny<Action>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(false);
-            _testMethodOptions.Timeout = 1;
+            _testMethodOptions.TimeoutContext = new(1);
 
             var method = new TestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions);
             var result = method.Invoke(null);
@@ -1227,7 +1227,7 @@ public class TestMethodInfoTests : TestContainer
                  }
              });
 
-            _testMethodOptions.Timeout = 100000;
+            _testMethodOptions.TimeoutContext = new(100000);
             _testContextImplementation.CancellationTokenSource.CancelAfter(100);
             var method = new TestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions);
             var result = method.Invoke(null);

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodRunnerTests.cs
@@ -70,7 +70,7 @@ public class TestMethodRunnerTests : TestContainer
 
         _globaltestMethodOptions = new TestMethodOptions()
         {
-            Timeout = 3600 * 1000,
+            TimeoutContext = new(3600 * 1000),
             Executor = _testMethodAttribute,
             TestContext = _testContextImplementation,
             ExpectedException = null
@@ -84,7 +84,7 @@ public class TestMethodRunnerTests : TestContainer
 
         _testMethodOptions = new TestMethodOptions()
         {
-            Timeout = 200,
+            TimeoutContext = new(200),
             Executor = _testMethodAttribute,
             TestContext = _testContextImplementation,
             ExpectedException = null
@@ -252,7 +252,7 @@ public class TestMethodRunnerTests : TestContainer
 
         var localTestMethodOptions = new TestMethodOptions
         {
-            Timeout = 200,
+            TimeoutContext = new(200),
             Executor = testMethodAttributeMock.Object,
             TestContext = _testContextImplementation,
             ExpectedException = null

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TypeCacheTests.cs
@@ -885,7 +885,7 @@ public class TypeCacheTests : TestContainer
                 false);
 
         Verify(methodInfo == testMethodInfo.TestMethod);
-        Verify(0 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(0 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
         Verify(_typeCache.ClassInfoCache.ToArray()[0] == testMethodInfo.Parent);
         Verify(testMethodInfo.TestMethodOptions.Executor is not null);
     }
@@ -905,7 +905,7 @@ public class TypeCacheTests : TestContainer
                 false);
 
         Verify(methodInfo == testMethodInfo.TestMethod);
-        Verify(10 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(10 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
         Verify(_typeCache.ClassInfoCache.ToArray()[0] == testMethodInfo.Parent);
         Verify(testMethodInfo.TestMethodOptions.Executor is not null);
     }
@@ -931,7 +931,7 @@ public class TypeCacheTests : TestContainer
 
         var expectedMessage =
             string.Format(
-                "UTA054: {0}.{1} has invalid Timeout attribute. The timeout must be a valid integer value and cannot be less than 0.",
+                "UTA054: {0}.{1} has invalid TimeoutContext attribute. The timeout must be a valid integer value and cannot be less than 0.",
                 testMethod.FullClassName,
                 testMethod.Name);
 
@@ -958,7 +958,7 @@ public class TypeCacheTests : TestContainer
                 new TestContextImplementation(testMethod, new ThreadSafeStringWriter(null, "test"), new Dictionary<string, object>()),
                 false);
 
-        Verify(4000 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(4000 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
     }
 
     public void GetTestMethodInfoWhenTimeoutAttributeSetShouldReturnTimeoutBasedOnAtrributeEvenIfGlobalTimeoutSet()
@@ -984,7 +984,7 @@ public class TypeCacheTests : TestContainer
                 new TestContextImplementation(testMethod, new ThreadSafeStringWriter(null, "test"), new Dictionary<string, object>()),
                 false);
 
-        Verify(10 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(10 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
     }
 
     public void GetTestMethodInfoForInvalidGLobalTimeoutShouldReturnTestMethodInfoWithTimeoutZero()
@@ -1007,7 +1007,7 @@ public class TypeCacheTests : TestContainer
                 new TestContextImplementation(testMethod, new ThreadSafeStringWriter(null, "test"), new Dictionary<string, object>()),
                 false);
 
-        Verify(0 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(0 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
     }
 
     public void GetTestMethodInfoShouldReturnTestMethodInfoForMethodsAdornedWithADerivedTestMethodAttribute()
@@ -1022,7 +1022,7 @@ public class TypeCacheTests : TestContainer
                 false);
 
         Verify(methodInfo == testMethodInfo.TestMethod);
-        Verify(0 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(0 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
         Verify(_typeCache.ClassInfoCache.ToArray()[0] == testMethodInfo.Parent);
         Verify(testMethodInfo.TestMethodOptions.Executor is not null);
         Verify(testMethodInfo.TestMethodOptions.Executor is DerivedTestMethodAttribute);
@@ -1137,7 +1137,7 @@ public class TypeCacheTests : TestContainer
                 false);
 
         Verify(methodInfo == testMethodInfo.TestMethod);
-        Verify(0 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(0 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
         Verify(_typeCache.ClassInfoCache.ToArray()[0] == testMethodInfo.Parent);
         Verify(testMethodInfo.TestMethodOptions.Executor is not null);
     }
@@ -1154,7 +1154,7 @@ public class TypeCacheTests : TestContainer
                 false);
 
         Verify(methodInfo == testMethodInfo.TestMethod);
-        Verify(0 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(0 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
         Verify(_typeCache.ClassInfoCache.ToArray()[0] == testMethodInfo.Parent);
         Verify(testMethodInfo.TestMethodOptions.Executor is not null);
     }
@@ -1177,7 +1177,7 @@ public class TypeCacheTests : TestContainer
         // The two MethodInfo instances will have different ReflectedType properties,
         // so cannot be compared directly. Use MethodHandle to verify it's the same.
         Verify(methodInfo.MethodHandle == testMethodInfo.TestMethod.MethodHandle);
-        Verify(0 == testMethodInfo.TestMethodOptions.Timeout);
+        Verify(0 == testMethodInfo.TestMethodOptions.TimeoutContext.Timeout);
         Verify(_typeCache.ClassInfoCache.ToArray()[0] == testMethodInfo.Parent);
         Verify(testMethodInfo.TestMethodOptions.Executor is not null);
     }

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/MethodInfoExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/MethodInfoExtensionsTests.cs
@@ -243,28 +243,6 @@ public class MethodInfoExtensionsTests : TestContainer
 
     #endregion
 
-    #region HasCorrectTimeout tests
-
-    public void HasCorrectTimeoutShouldReturnFalseForMethodsWithoutTimeoutAttribute()
-    {
-        var methodInfo = typeof(DummyTestClass).GetMethod("PublicMethod");
-        Verify(!methodInfo.HasCorrectTimeout());
-    }
-
-    public void HasCorrectTimeoutShouldReturnFalseForMethodsWithInvalidTimeoutAttribute()
-    {
-        var methodInfo = typeof(DummyTestClass).GetMethod("PublicMethodWithInvalidTimeout");
-        Verify(!methodInfo.HasCorrectTimeout());
-    }
-
-    public void HasCorrectTimeoutShouldReturnTrueForMethodsWithTimeoutAttribute()
-    {
-        var methodInfo = typeof(DummyTestClass).GetMethod("PublicMethodWithTimeout");
-        Verify(methodInfo.HasCorrectTimeout());
-    }
-
-    #endregion
-
     #region IsVoidOrTaskReturnType tests
 
     public void IsVoidOrTaskReturnTypeShouldReturnTrueForVoidMethods()


### PR DESCRIPTION
Ensure sync and async calls to constructor, test initialize, test method, test cleanup and dispose awaiting can be cancelled to respect timeout/cancellation feature.

Ensure test cleanup and dispose are correctly called even in case of timeout/cancellation during test initialize or test method.

Also introduces a new property onto the TimeoutAttribute to control the time given to the cleanup in case of a timeout/cancellation of the test run.

Fixes #522

PS: There are more refactoring I would like to introduce (e.g., reducing number of try/catch) but I wanted to keep this change as minimal as possible. Once this is merged, I will work on refactoring, simplification and cleanup of this class.