### PR TITLE
Refactor available ctors for DataRowAttribute

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
@@ -37,7 +37,7 @@ public class DataRowAttribute : Attribute, ITestDataSource
     /// <summary>
     /// Gets data for calling test method.
     /// </summary>
-    public object[] Data { get; }
+    public object[] Data { get; private set; }
 
     /// <summary>
     /// Gets or sets display name in test results for customization.
@@ -57,10 +57,12 @@ public class DataRowAttribute : Attribute, ITestDataSource
         {
             return DisplayName;
         }
-
-        if (data != null)
+        else
         {
-            return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name, string.Join(",", data));
+            if (data != null)
+            {
+                return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name, string.Join(",", data.AsEnumerable()));
+            }
         }
 
         return null;

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -18,40 +17,27 @@ public class DataRowAttribute : Attribute, ITestDataSource
     /// <summary>
     /// Initializes a new instance of the <see cref="DataRowAttribute"/> class.
     /// </summary>
-    public DataRowAttribute()
-    {
-        Data = Array.Empty<object>();
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class.
-    /// </summary>
-    /// <param name="data1"> The data object. </param>
-    public DataRowAttribute(object data1)
+    /// <param name="data"> The data object. </param>
+    public DataRowAttribute(object data)
     {
         // Need to have this constructor explicitly to fix a CLS compliance error.
-        Data = new object[] { data1 };
+        Data = new object[] { data };
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
     /// </summary>
-    /// <param name="data1"> A data object. </param>
-    /// <param name="moreData"> More data. </param>
-    public DataRowAttribute(object data1, params object[] moreData)
+    /// <param name="data"> More data. </param>
+    public DataRowAttribute(params object[] data)
     {
         // This actually means that the user wants to pass in a 'null' value to the test method.
-        moreData ??= new object[] { null };
-
-        Data = new object[moreData.Length + 1];
-        Data[0] = data1;
-        Array.Copy(moreData, 0, Data, 1, moreData.Length);
+        Data = data ?? new object[] { null };
     }
 
     /// <summary>
     /// Gets data for calling test method.
     /// </summary>
-    public object[] Data { get; private set; }
+    public object[] Data { get; }
 
     /// <summary>
     /// Gets or sets display name in test results for customization.
@@ -71,12 +57,10 @@ public class DataRowAttribute : Attribute, ITestDataSource
         {
             return DisplayName;
         }
-        else
+
+        if (data != null)
         {
-            if (data != null)
-            {
-                return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name, string.Join(",", data.AsEnumerable()));
-            }
+            return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name, string.Join(",", data));
         }
 
         return null;

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Shipped.txt
@@ -43,9 +43,6 @@ Microsoft.VisualStudio.TestTools.UnitTesting.DataAccessMethod.Random = 1 -> Micr
 Microsoft.VisualStudio.TestTools.UnitTesting.DataAccessMethod.Sequential = 0 -> Microsoft.VisualStudio.TestTools.UnitTesting.DataAccessMethod
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.Data.get -> object[]
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute() -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object data1) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object data1, params object[] moreData) -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DisplayName.get -> string
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DisplayName.set -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.GetData(System.Reflection.MethodInfo methodInfo) -> System.Collections.Generic.IEnumerable<object[]>

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-﻿
+﻿Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object data) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(params object[] data) -> void


### PR DESCRIPTION
Fixes the issue #1180 that was preventing to have exactly 2 arrays as argument of DataRowAttribute ctor because the compiler was considering the second array as the params array and not as a first item of it.