### PR TITLE
Fix TestContext nullabilities

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/PublicAPI.Shipped.txt
@@ -129,7 +129,7 @@ Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TraceListener
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TraceListenerWrapper.TraceListenerWrapper(System.IO.TextWriter! textWriter) -> void
 override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.AddResultFile(string? fileName) -> void
 override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.CurrentTestOutcome.get -> Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome
-override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.Properties.get -> System.Collections.IDictionary?
+override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.Properties.get -> System.Collections.IDictionary!
 override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.Write(string! format, params object?[]! args) -> void
 override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.Write(string? message) -> void
 override Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteLine(string! format, params object?[]! args) -> void

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -102,7 +102,6 @@ public class TestContextImplementation : UTF.TestContext, ITestContext
         // Cannot get this type in constructor directly, because all signatures for all platforms need to be the same.
         _threadSafeStringWriter = (ThreadSafeStringWriter)stringWriter;
         _properties = new Dictionary<string, object?>(properties);
-        CancellationTokenSource = new CancellationTokenSource();
         InitializeProperties();
 
 #if !WINDOWS_UWP
@@ -130,7 +129,7 @@ public class TestContextImplementation : UTF.TestContext, ITestContext
 #endif
 
     /// <inheritdoc/>
-    public override IDictionary? Properties => _properties as IDictionary;
+    public override IDictionary Properties => (IDictionary)_properties;
 
 #if !WINDOWS_UWP && !WIN_UI && !PORTABLE
     /// <inheritdoc/>

--- a/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Shipped.txt
@@ -1,13 +1,13 @@
 ﻿#nullable enable
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.AddResultFile(string? fileName) -> void
-abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Properties.get -> System.Collections.IDictionary?
+abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Properties.get -> System.Collections.IDictionary!
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Write(string! format, params object?[]! args) -> void
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Write(string! message) -> void
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.WriteLine(string! format, params object?[]! args) -> void
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.WriteLine(string! message) -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.TestContext
 Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestContext() -> void
-virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CancellationTokenSource.get -> System.Threading.CancellationTokenSource?
+virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CancellationTokenSource.get -> System.Threading.CancellationTokenSource!
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CancellationTokenSource.set -> void
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CurrentTestOutcome.get -> Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.FullyQualifiedTestClassName.get -> string?

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if NETFRAMEWORK
 using System.Data;
 using System.Data.Common;
+#endif
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
@@ -20,12 +22,12 @@ public abstract class TestContext
     /// <summary>
     /// Gets test properties for a test.
     /// </summary>
-    public abstract IDictionary? Properties { get; }
+    public abstract IDictionary Properties { get; }
 
     /// <summary>
     /// Gets or sets the cancellation token source. This token source is canceled when test times out. Also when explicitly canceled the test will be aborted.
     /// </summary>
-    public virtual CancellationTokenSource? CancellationTokenSource { get; protected set; }
+    public virtual CancellationTokenSource CancellationTokenSource { get; protected set; } = new();
 
 #if NETFRAMEWORK
     /// <summary>


### PR DESCRIPTION
Fixes #1376

Also, enforces the non-nullability of the `TestContext`.