### PR TITLE
Ensure test ID strategy is saved as property

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
@@ -230,6 +230,8 @@ internal class UnitTestElement
 
     private void SetTestCaseId(TestCase testCase, string testFullName)
     {
+        testCase.SetPropertyValue(Constants.TestIdGenerationStrategyProperty, (int)TestMethod.TestIdGenerationStrategy);
+
         switch (TestMethod.TestIdGenerationStrategy)
         {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/test/E2ETests/DiscoveryAndExecutionTests/TestId.LegacyStrategy.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/TestId.LegacyStrategy.cs
@@ -26,6 +26,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "DataRowArraysTests (0,System.Int32[])",
             "DataRowArraysTests (0,System.Int32[])",
             "DataRowArraysTests (0,System.Int32[])");
@@ -47,6 +48,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "DataRowStringTests ()",
             "DataRowStringTests ()",
             "DataRowStringTests ( )",
@@ -69,6 +71,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "DynamicDataArraysTests (0,System.Int32[])",
             "DynamicDataArraysTests (0,System.Int32[])",
             "DynamicDataArraysTests (0,System.Int32[])");
@@ -90,6 +93,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "DynamicDataTuplesTests ((1, text, True))",
             "DynamicDataTuplesTests ((1, text, False))");
 
@@ -110,6 +114,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])",
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])",
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])",
@@ -132,6 +137,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "Custom name",
             "Custom name",
             "Custom name");
@@ -153,6 +159,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "Custom name",
             "Custom name");
 
@@ -173,6 +180,7 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
+            null, // For legacy, there is an extra test result, being the parent and it has no display name
             "Custom name",
             "Custom name",
             "Custom name",

--- a/test/UnitTests/MSTestAdapter.UnitTests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/ObjectModel/UnitTestElementTests.cs
@@ -194,6 +194,7 @@ public class UnitTestElementTests : TestContainer
             var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, TestIdGenerationStrategy.Legacy) { DataType = dataType }).ToTestCase();
             var expectedTestCase = new TestCase(testCase.FullyQualifiedName, testCase.ExecutorUri, testCase.Source);
             Verify(expectedTestCase.Id == testCase.Id);
+            Verify(testCase.GetPropertyValue(Constants.TestIdGenerationStrategyProperty).Equals((int)TestIdGenerationStrategy.Legacy));
         }
     }
 
@@ -212,6 +213,8 @@ public class UnitTestElementTests : TestContainer
             {
                 Verify(expectedTestCase.Id != testCase.Id);
             }
+
+            Verify(testCase.GetPropertyValue(Constants.TestIdGenerationStrategyProperty).Equals((int)TestIdGenerationStrategy.DisplayName));
         }
     }
 
@@ -222,6 +225,7 @@ public class UnitTestElementTests : TestContainer
             var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, TestIdGenerationStrategy.FullyQualified) { DataType = dataType }).ToTestCase();
             var expectedTestCase = new TestCase(testCase.FullyQualifiedName, testCase.ExecutorUri, testCase.Source);
             Verify(expectedTestCase.Id != testCase.Id);
+            Verify(testCase.GetPropertyValue(Constants.TestIdGenerationStrategyProperty).Equals((int)TestIdGenerationStrategy.FullyQualified));
         }
     }
 


### PR DESCRIPTION
In addition to the fix on Test Platform side, I have realized that we don't store the ID strategy property so we always restore it as the new strategy which is causing some issue for inner results (in case of Legacy strategy).

Relates to #1149