### PR TITLE
Fix output E2E tests

### DIFF
--- a/test/E2ETests/DiscoveryAndExecutionTests/DiscoverInternalsTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/DiscoverInternalsTests.cs
@@ -18,7 +18,7 @@ public class DiscoverInternalsTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath);
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.AtLeastTestsDiscovered(
@@ -50,7 +50,7 @@ public class DiscoverInternalsTests : CLITestBase
 
         var targetTestCases = testCases.Where(t => t.DisplayName == "DynamicDataTestMethod (DiscoverInternalsProject.SerializableInternalType)");
 
-        var testResults = RunTests(assemblyPath, targetTestCases);
+        var testResults = RunTests(targetTestCases);
 
         // Assert
         VerifyE2E.TestsPassed(

--- a/test/E2ETests/DiscoveryAndExecutionTests/FSharpTestProjectTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/FSharpTestProjectTests.cs
@@ -17,7 +17,7 @@ public class FSharpTestProjectTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath);
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(testResults, "Test method passing with a . in it");

--- a/test/E2ETests/DiscoveryAndExecutionTests/OutputTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/OutputTests.cs
@@ -37,7 +37,7 @@ public class OutputTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath).Where(tc => tc.FullyQualifiedName.Contains(className)).ToList();
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         testCases.Should().HaveCount(3);

--- a/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DataExtensibilityTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DataExtensibilityTests.cs
@@ -23,7 +23,7 @@ public class DataExtensibilityTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "CustomTestDataSourceTestMethod1");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.ContainsTestsPassed(testResults, "CustomTestDataSourceTestMethod1 (1,2,3)", "CustomTestDataSourceTestMethod1 (4,5,6)");
@@ -36,7 +36,7 @@ public class DataExtensibilityTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FxExtensibilityTestProject.AssertExTest");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.ContainsTestsPassed(testResults, "BasicAssertExtensionTest", "ChainedAssertExtensionTest");
@@ -50,7 +50,7 @@ public class DataExtensibilityTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "(Name~CustomTestMethod1)|(Name~CustomTestClass1)");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.ContainsTestsPassed(
@@ -77,7 +77,7 @@ public class DataExtensibilityTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "Name~CustomTestMethod2");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(

--- a/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DataRowTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DataRowTests.cs
@@ -17,7 +17,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "TestCategory~DataRowSimple");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -36,7 +36,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DerivedClass&TestCategory~DataRowSimple");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -52,7 +52,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "TestCategory~DataRowSomeOptional");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -69,7 +69,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "TestCategory~DataRowParamsArgument");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -87,7 +87,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_Regular&TestCategory~DataRowOptionalInvalidArguments");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -104,7 +104,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_Regular.DataRowTestDouble");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -120,7 +120,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_DerivedClass.DataRowTestMixed");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -135,7 +135,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_DerivedClass.DataRowEnums");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -153,7 +153,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_DerivedClass.DataRowNonSerializable");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsDiscovered(
@@ -174,7 +174,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_Enums");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -249,7 +249,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_NonSerializablePaths");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(
@@ -267,7 +267,7 @@ public class DataRowTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowTests_Regular");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.TestsPassed(

--- a/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DataSourceTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DataSourceTests.cs
@@ -18,7 +18,7 @@ public class DataSourceTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "CsvTestMethod");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.ContainsTestsPassed(

--- a/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DynamicDataTests.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/Parameterized tests/DynamicDataTests.cs
@@ -15,7 +15,7 @@ public class DynamicDataTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath);
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.ContainsTestsPassed(
@@ -58,7 +58,7 @@ public class DynamicDataTests : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "TestCategory~DynamicDataWithCategory");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.ContainsTestsPassed(

--- a/test/E2ETests/DiscoveryAndExecutionTests/TestId.DefaultStrategy.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/TestId.DefaultStrategy.cs
@@ -20,7 +20,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -41,7 +41,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowStringTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -63,7 +63,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -84,7 +84,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -104,7 +104,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -126,7 +126,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -147,7 +147,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -167,7 +167,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);

--- a/test/E2ETests/DiscoveryAndExecutionTests/TestId.DisplayNameStrategy.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/TestId.DisplayNameStrategy.cs
@@ -20,7 +20,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -41,7 +41,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowStringTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -64,7 +64,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -85,7 +85,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -105,7 +105,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -127,7 +127,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -148,7 +148,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -168,7 +168,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);

--- a/test/E2ETests/DiscoveryAndExecutionTests/TestId.FullyQualifiedStrategy.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/TestId.FullyQualifiedStrategy.cs
@@ -20,7 +20,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -41,7 +41,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowStringTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -63,7 +63,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -84,7 +84,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -104,7 +104,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -126,7 +126,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -147,7 +147,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -167,7 +167,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);

--- a/test/E2ETests/DiscoveryAndExecutionTests/TestId.LegacyStrategy.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/TestId.LegacyStrategy.cs
@@ -20,7 +20,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -41,7 +41,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DataRowStringTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -63,7 +63,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -84,7 +84,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -104,7 +104,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~DynamicDataGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -126,7 +126,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceArraysTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -147,7 +147,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceTuplesTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);
@@ -167,7 +167,7 @@ public partial class TestId : CLITestBase
 
         // Act
         var testCases = DiscoverTests(assemblyPath, "FullyQualifiedName~TestDataSourceGenericCollectionsTests");
-        var testResults = RunTests(assemblyPath, testCases);
+        var testResults = RunTests(testCases);
 
         // Assert
         VerifyE2E.FailedTestCount(testResults, 0);

--- a/test/E2ETests/DiscoveryAndExecutionTests/Utilities/CLITestBase.discovery.cs
+++ b/test/E2ETests/DiscoveryAndExecutionTests/Utilities/CLITestBase.discovery.cs
@@ -35,9 +35,8 @@ public partial class CLITestBase : TestContainer
         return sink.DiscoveredTests;
     }
 
-    internal ReadOnlyCollection<TestResult> RunTests(string source, IEnumerable<TestCase> testCases)
+    internal ReadOnlyCollection<TestResult> RunTests(IEnumerable<TestCase> testCases)
     {
-        var settings = GetSettings(true);
         var testExecutionManager = new TestExecutionManager();
         var frameworkHandle = new InternalFrameworkHandle();
 
@@ -46,38 +45,6 @@ public partial class CLITestBase : TestContainer
     }
 
     #region Helper classes
-    private MSTestSettings GetSettings(bool captureDebugTraceValue)
-    {
-        string runSettingxml =
-             @"<RunSettings>
-                    <RunConfiguration>  
-                        <DisableAppDomain>True</DisableAppDomain>   
-                    </RunConfiguration>";
-
-        /*
-        var path = Path.GetDirectoryName(this.GetAssetFullPath(TestAssembly));
-
-        runSettingxml += @"
-                <MSTestV2>
-                    <AssemblyResolution>
-                        <Directory path = """ + path + @""" />
-                    </AssemblyResolution>
-                </MSTestV2>";
-        */
-
-        if (captureDebugTraceValue)
-        {
-            runSettingxml
-             += @"<MSTest>
-                        <CaptureTraceOutput>true</CaptureTraceOutput>
-                     </MSTest>";
-        }
-
-        runSettingxml += @"</RunSettings>";
-
-        return MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsName);
-    }
-
     private class InternalLogger : IMessageLogger
     {
         public void SendMessage(TestMessageLevel testMessageLevel, string message)

--- a/test/E2ETests/TestAssets/OutputTestProject/UnitTest1.cs
+++ b/test/E2ETests/TestAssets/OutputTestProject/UnitTest1.cs
@@ -35,13 +35,13 @@ public class UnitTest1
     [ClassCleanup()]
     public static void ClassCleanup()
     {
-        WriteLines($"UnitTest1 - ClassCleanup");
+        WriteLines("UnitTest1 - ClassCleanup");
     }
 
     [TestMethod]
     public void TestMethod1()
     {
-        WriteLines("UnitTest1 - TestMethod1");
+        WriteLines("UnitTest1 - TestMethod1 - Call 1");
         // This makes the outputs more likely to run into each other
         // when running in parallel.
         // It also makes the test longer, because we check in the test
@@ -49,29 +49,29 @@ public class UnitTest1
         // they actually run in parallel), and this gives us more leeway
         // on slower machines.
         Thread.Sleep(Rng.Next(20, 50));
-        WriteLines("UnitTest1 - TestMethod1");
+        WriteLines("UnitTest1 - TestMethod1 - Call 2");
         Thread.Sleep(Rng.Next(20, 50));
-        WriteLines("UnitTest1 - TestMethod1");
+        WriteLines("UnitTest1 - TestMethod1 - Call 3");
     }
 
     [TestMethod]
     public void TestMethod2()
     {
-        WriteLines("UnitTest1 - TestMethod2");
+        WriteLines("UnitTest1 - TestMethod2 - Call 1");
         Thread.Sleep(Rng.Next(20, 50));
-        WriteLines("UnitTest1 - TestMethod2");
+        WriteLines("UnitTest1 - TestMethod2 - Call 2");
         Thread.Sleep(Rng.Next(20, 50));
-        WriteLines("UnitTest1 - TestMethod2");
+        WriteLines("UnitTest1 - TestMethod2 - Call 3");
     }
 
     [TestMethod]
     public void TestMethod3()
     {
-        WriteLines("UnitTest1 - TestMethod3");
+        WriteLines("UnitTest1 - TestMethod3 - Call 1");
         Thread.Sleep(Rng.Next(20, 50));
-        WriteLines("UnitTest1 - TestMethod3");
+        WriteLines("UnitTest1 - TestMethod3 - Call 2");
         Thread.Sleep(Rng.Next(20, 50));
-        WriteLines("UnitTest1 - TestMethod3");
+        WriteLines("UnitTest1 - TestMethod3 - Call 3");
     }
 
     private static void WriteLines(string message)

--- a/test/E2ETests/TestAssets/OutputTestProject/UnitTest2.cs
+++ b/test/E2ETests/TestAssets/OutputTestProject/UnitTest2.cs
@@ -13,7 +13,7 @@ public class UnitTest2
 
     public TestContext TestContext { get; set; }
 
-    [ClassInitialize()]
+    [ClassInitialize]
     public static void ClassInitialize(TestContext _)
     {
         WriteLines("UnitTest2 - ClassInitialize");
@@ -32,16 +32,16 @@ public class UnitTest2
     }
 
 
-    [ClassCleanup()]
+    [ClassCleanup]
     public static void ClassCleanup()
     {
-        WriteLines($"UnitTest2 - ClassCleanup");
+        WriteLines("UnitTest2 - ClassCleanup");
     }
 
     [TestMethod]
     public async Task TestMethod1()
     {
-        WriteLines("UnitTest2 - TestMethod1");
+        WriteLines("UnitTest2 - TestMethod1 - Call 1");
         // This makes the outputs more likely to run into each other
         // when running in parallel.
         // It also makes the test longer, because we check in the test
@@ -49,29 +49,29 @@ public class UnitTest2
         // they actually run in parallel), and this gives us more leeway
         // on slower machines.
         await Task.Delay(Rng.Next(20, 50));
-        WriteLines("UnitTest2 - TestMethod1");
+        WriteLines("UnitTest2 - TestMethod1 - Call 2");
         await Task.Delay(Rng.Next(20, 50));
-        WriteLines("UnitTest2 - TestMethod1");
+        WriteLines("UnitTest2 - TestMethod1 - Call 3");
     }
 
     [TestMethod]
     public async Task TestMethod2()
     {
-        WriteLines("UnitTest2 - TestMethod2");
+        WriteLines("UnitTest2 - TestMethod2 - Call 1");
         await Task.Delay(Rng.Next(20, 50));
-        WriteLines("UnitTest2 - TestMethod2");
+        WriteLines("UnitTest2 - TestMethod2 - Call 2");
         await Task.Delay(Rng.Next(20, 50));
-        WriteLines("UnitTest2 - TestMethod2");
+        WriteLines("UnitTest2 - TestMethod2 - Call 3");
     }
 
     [TestMethod]
     public async Task TestMethod3()
     {
-        WriteLines("UnitTest2 - TestMethod3");
+        WriteLines("UnitTest2 - TestMethod3 - Call 1");
         await Task.Delay(Rng.Next(20, 50));
-        WriteLines("UnitTest2 - TestMethod3");
+        WriteLines("UnitTest2 - TestMethod3 - Call 2");
         await Task.Delay(Rng.Next(20, 50));
-        WriteLines("UnitTest2 - TestMethod3");
+        WriteLines("UnitTest2 - TestMethod3 - Call 3");
     }
 
     private static void WriteLines(string message)


### PR DESCRIPTION
CI is often failing on test `OutputIsNotMixedWhenAsyncTestsRunInParallel`, try to refactor the test to fix it.