### PR TITLE
Make BeginTimer and EndTimer methods obsolete

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -183,12 +183,14 @@ public class TestContextImplementation : TestContext, ITestContext
 
 #if NETFRAMEWORK
     /// <inheritdoc/>
+    [Obsolete("This method is only available for .NET framework and only throws NotSupportedException. It will be removed in a future update.")]
     public override void BeginTimer(string timerName)
     {
         throw new NotSupportedException();
     }
 
     /// <inheritdoc/>
+    [Obsolete("This method is only available for .NET framework and only throws NotSupportedException. It will be removed in a future update.")]
     public override void EndTimer(string timerName)
     {
         throw new NotSupportedException();

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -165,12 +165,14 @@ public abstract class TestContext
     /// Begins a timer with the specified name.
     /// </summary>
     /// <param name="timerName"> Name of the timer.</param>
+    [Obsolete("This method is only available for .NET framework and only throws NotSupportedException. It will be removed in a future update.")]
     public abstract void BeginTimer(string timerName);
 
     /// <summary>
     /// Ends a timer with the specified name.
     /// </summary>
     /// <param name="timerName"> Name of the timer.</param>
+    [Obsolete("This method is only available for .NET framework and only throws NotSupportedException. It will be removed in a future update.")]
     public abstract void EndTimer(string timerName);
 #endif
 


### PR DESCRIPTION
These API are .NET framework only and have never been implemented so there is no good reason to keep it part of the API.

Relates to #504 