### PR TITLE
Add parent domain assembly resolver for netfx

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHost.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHost.cs
@@ -106,15 +106,11 @@ public class TestSourceHost : ITestSourceHost
             EqtTrace.Info("DesktopTestSourceHost.SetupHost(): Creating assembly resolver with resolution paths {0}.", string.Join(",", resolutionPaths.ToArray()));
         }
 
-        // Case when DisableAppDomain setting is present in runsettings and no child-appdomain needs to be created
-        if (_isAppDomainCreationDisabled)
-        {
-            _parentDomainAssemblyResolver = new AssemblyResolver(resolutionPaths);
-            AddSearchDirectoriesSpecifiedInRunSettingsToAssemblyResolver(_parentDomainAssemblyResolver, Path.GetDirectoryName(_sourceFileName));
-        }
+        _parentDomainAssemblyResolver = new AssemblyResolver(resolutionPaths);
+        AddSearchDirectoriesSpecifiedInRunSettingsToAssemblyResolver(_parentDomainAssemblyResolver, Path.GetDirectoryName(_sourceFileName));
 
-        // Create child-appdomain and set assembly resolver on it
-        else
+        // Case when DisableAppDomain setting is present in runsettings and no child-appdomain needs to be created
+        if (!_isAppDomainCreationDisabled)
         {
             // Setup app-domain
             var appDomainSetup = new AppDomainSetup();


### PR DESCRIPTION
Fixes #1437 

Something changed in the way the extensions dll is being resolved. It's not clear if that's the change of infra, the merging of projects, the bump of target frameworks (as happened on TP) or something else. This seems to be the best fix but I will ask for a full vendor testing round to ensure this won't break non-automated tests.