### PR TITLE
Update CI testResultsFormat to vstest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,7 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
+      testResultsFormat: 'vstest'
       enablePublishBuildAssets: false
       enablePublishUsingPipelines: true
       enableTelemetry: true


### PR DESCRIPTION
Allows to avoid the un-needed `xUnit` step.