### PR TITLE
DataSerializationHelper.SerializerSettings.SerializeReadOnlyTypes=true

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Helpers/DataSerializationHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/DataSerializationHelper.cs
@@ -13,6 +13,7 @@ internal static class DataSerializationHelper
     private static readonly ConcurrentDictionary<string, DataContractJsonSerializer> SerializerCache = new();
     private static readonly DataContractJsonSerializerSettings SerializerSettings = new()
     {
+        SerializeReadOnlyTypes = true,
         UseSimpleDictionaryFormat = true,
         EmitTypeInformation = System.Runtime.Serialization.EmitTypeInformation.Always,
         DateTimeFormat = new System.Runtime.Serialization.DateTimeFormat("O", System.Globalization.CultureInfo.InvariantCulture),

--- a/test/UnitTests/MSTestAdapter.UnitTests/Helpers/DataSerializationHelperTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Helpers/DataSerializationHelperTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.Serialization;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 
@@ -59,5 +60,34 @@ public class DataSerializationHelperTests : TestContainer
         Verify(actual[0].GetType() == typeof(DateTime));
         Verify(actual[0].Equals(source));
         Verify(((DateTime)actual[0]).Kind.Equals(source.Kind));
+    }
+
+    public void DataSerializerShouldRoundTripReadOnlyData()
+    {
+        var source = new ReadOnlyDataWrapper { ReadOnlyData = new ReadOnlyDataType(42) };
+
+        var actual = DataSerializationHelper.Deserialize(
+            DataSerializationHelper.Serialize(new object[] { source }));
+
+        Verify(actual.Length == 1);
+        Verify(actual[0].GetType() == typeof(ReadOnlyDataWrapper));
+        Verify(((ReadOnlyDataWrapper)actual[0]).ReadOnlyData.Equals(source));
+    }
+
+    public class ReadOnlyDataWrapper
+    {
+        public ReadOnlyDataType ReadOnlyData { get; set; }
+    }
+
+    [DataContract]
+    public readonly struct ReadOnlyDataType
+    {
+        public ReadOnlyDataType(int a)
+        {
+            A = a;
+        }
+
+        [DataMember]
+        public int A { get; }
     }
 }


### PR DESCRIPTION
+ test case

Allows using read-only types (e.g. readonly struct with ctor) in dynamic data with the benefit of seeing individual test cases in the explorer.

#1535 