### PR TITLE
Add TreatDiscoveryWarningsAsErrors setting

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/UnitTestDiscoverer.cs
@@ -60,6 +60,8 @@ internal class UnitTestDiscoverer
     {
         var testElements = _assemblyEnumeratorWrapper.GetTests(source, discoveryContext?.RunSettings, out var warnings);
 
+        var treatDiscoveryWarningsAsErrors = MSTestSettings.CurrentSettings.TreatDiscoveryWarningsAsErrors;
+
         // log the warnings
         foreach (var warning in warnings)
         {
@@ -68,7 +70,7 @@ internal class UnitTestDiscoverer
                 source,
                 warning);
             var message = string.Format(CultureInfo.CurrentCulture, Resource.DiscoveryWarning, source, warning);
-            logger.SendMessage(TestMessageLevel.Warning, message);
+            logger.SendMessage(treatDiscoveryWarningsAsErrors ? TestMessageLevel.Error : TestMessageLevel.Warning, message);
         }
 
         // No tests found => nothing to do

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -53,6 +53,7 @@ public class MSTestSettings
         CaptureDebugTraces = true;
         MapInconclusiveToFailed = false;
         MapNotRunnableToFailed = true;
+        TreatDiscoveryWarningsAsErrors = false;
         EnableBaseClassTestMethodsFromOtherAssemblies = true;
         ForcedLegacyMode = false;
         TestSettingsFile = null;
@@ -108,6 +109,11 @@ public class MSTestSettings
     public bool MapNotRunnableToFailed { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether a not test discovery warnings should be treated as errors.
+    /// </summary>
+    public bool TreatDiscoveryWarningsAsErrors { get; private set; }
+
+    /// <summary>
     /// Gets a value indicating whether to enable discovery of test methods from base classes in a different assembly from the inheriting test class.
     /// </summary>
     public bool EnableBaseClassTestMethodsFromOtherAssemblies { get; private set; }
@@ -161,6 +167,7 @@ public class MSTestSettings
         CurrentSettings.TestSettingsFile = settings.TestSettingsFile;
         CurrentSettings.MapInconclusiveToFailed = settings.MapInconclusiveToFailed;
         CurrentSettings.MapNotRunnableToFailed = settings.MapNotRunnableToFailed;
+        CurrentSettings.TreatDiscoveryWarningsAsErrors = settings.TreatDiscoveryWarningsAsErrors;
         CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies = settings.EnableBaseClassTestMethodsFromOtherAssemblies;
         CurrentSettings.ClassCleanupLifecycle = settings.ClassCleanupLifecycle;
         CurrentSettings.ParallelizationWorkers = settings.ParallelizationWorkers;
@@ -289,6 +296,7 @@ public class MSTestSettings
         //     <CaptureTraceOutput>true</CaptureTraceOutput>
         //     <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
         //     <MapNotRunnableToFailed>false</MapNotRunnableToFailed>
+        //     <TreatDiscoveryWarningsAsErrors>false</TreatDiscoveryWarningsAsErrors>
         //     <EnableBaseClassTestMethodsFromOtherAssemblies>false</EnableBaseClassTestMethodsFromOtherAssemblies>
         //     <TestTimeout>5000</TestTimeout>
         //     <TreatClassAndAssemblyCleanupWarningsAsErrors>false</TreatClassAndAssemblyCleanupWarningsAsErrors>
@@ -385,6 +393,16 @@ public class MSTestSettings
                             if (bool.TryParse(reader.ReadInnerXml(), out result))
                             {
                                 settings.MapNotRunnableToFailed = result;
+                            }
+
+                            break;
+                        }
+
+                    case "TREATDISCOVERYWARNINGSASERRORS":
+                        {
+                            if (bool.TryParse(reader.ReadInnerXml(), out result))
+                            {
+                                settings.TreatDiscoveryWarningsAsErrors = result;
                             }
 
                             break;

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -109,7 +109,7 @@ public class MSTestSettings
     public bool MapNotRunnableToFailed { get; private set; }
 
     /// <summary>
-    /// Gets a value indicating whether a not test discovery warnings should be treated as errors.
+    /// Gets a value indicating whether or not test discovery warnings should be treated as errors.
     /// </summary>
     public bool TreatDiscoveryWarningsAsErrors { get; private set; }
 

--- a/src/Adapter/MSTest.TestAdapter/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/PublicAPI/PublicAPI.Shipped.txt
@@ -85,6 +85,7 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.Paralleliz
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TestSettingsFile.get -> string?
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TestTimeout.get -> int
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TreatClassAndAssemblyCleanupWarningsAsErrors.get -> bool
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TreatDiscoveryWarningsAsErrors.get -> bool
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod.AssemblyName.get -> string!
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod.DeclaringAssemblyName.get -> string?

--- a/src/Adapter/MSTest.TestAdapter/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/PublicAPI/PublicAPI.Shipped.txt
@@ -85,7 +85,6 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.Paralleliz
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TestSettingsFile.get -> string?
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TestTimeout.get -> int
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TreatClassAndAssemblyCleanupWarningsAsErrors.get -> bool
-Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TreatDiscoveryWarningsAsErrors.get -> bool
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod.AssemblyName.get -> string!
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod.DeclaringAssemblyName.get -> string?

--- a/src/Adapter/MSTest.TestAdapter/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.TreatDiscoveryWarningsAsErrors.get -> bool

--- a/test/UnitTests/MSTestAdapter.UnitTests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Discovery/UnitTestDiscovererTests.cs
@@ -94,6 +94,33 @@ public class UnitTestDiscovererTests : TestContainer
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Once);
     }
 
+    public void DiscoverTestsInSourceShouldSendBackHandleTreatAsError()
+    {
+        // Setup mocks.
+        _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.GetFullFilePath(Source))
+            .Returns(Source);
+        _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.DoesFileExist(Source))
+            .Returns(false);
+
+        string settingsXml =
+        @"<?xml version=""1.0"" encoding=""utf-8""?>
+                <RunSettings>
+                    <MSTestV2>
+                        <TreatDiscoveryWarningsAsErrors>True</TreatDiscoveryWarningsAsErrors>
+                    </MSTestV2>
+                </RunSettings>";
+
+        _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(settingsXml);
+
+        // Act
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object);
+
+        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object);
+
+        // Assert.
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Once);
+    }
+
     public void DiscoverTestsInSourceShouldSendBackTestCasesDiscovered()
     {
         // Setup mocks.

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestSettingsTests.cs
@@ -260,6 +260,33 @@ public class MSTestSettingsTests : TestContainer
         Verify(adapterSettings.TreatClassAndAssemblyCleanupWarningsAsErrors);
     }
 
+    public void TreatDiscoveryWarningsAsErrorsShouldBeFalseByDefault()
+    {
+        string runSettingxml =
+            @"<RunSettings>
+                    <MSTestV2>
+                    </MSTestV2>
+                  </RunSettings>";
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+        Verify(!adapterSettings.TreatDiscoveryWarningsAsErrors);
+    }
+
+    public void TreatDiscoveryWarningsAsErrorsShouldBeConsumedFromRunSettingsWhenSpecified()
+    {
+        string runSettingxml =
+            @"<RunSettings>
+                    <MSTestV2>
+                        <TreatDiscoveryWarningsAsErrors>True</TreatDiscoveryWarningsAsErrors>
+                    </MSTestV2>
+                  </RunSettings>";
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingxml, MSTestSettings.SettingsNameAlias);
+
+        Verify(adapterSettings.TreatDiscoveryWarningsAsErrors);
+    }
+
     public void ParallelizationSettingsShouldNotBeSetByDefault()
     {
         string runSettingxml =
@@ -873,6 +900,7 @@ public class MSTestSettingsTests : TestContainer
         Verify(!adapterSettings.MapInconclusiveToFailed);
         Verify(adapterSettings.MapNotRunnableToFailed);
         Verify(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+        Verify(!adapterSettings.TreatDiscoveryWarningsAsErrors);
     }
 
     public void PopulateSettingsShouldInitializeDefaultSettingsWhenRunSettingsIsNull()
@@ -884,6 +912,7 @@ public class MSTestSettingsTests : TestContainer
         Verify(!adapterSettings.MapInconclusiveToFailed);
         Verify(adapterSettings.MapNotRunnableToFailed);
         Verify(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+        Verify(!adapterSettings.TreatDiscoveryWarningsAsErrors);
     }
 
     public void PopulateSettingsShouldInitializeDefaultSettingsWhenRunSettingsXmlIsEmpty()
@@ -896,6 +925,7 @@ public class MSTestSettingsTests : TestContainer
         Verify(!adapterSettings.MapInconclusiveToFailed);
         Verify(adapterSettings.MapNotRunnableToFailed);
         Verify(adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies);
+        Verify(!adapterSettings.TreatDiscoveryWarningsAsErrors);
     }
 
     public void PopulateSettingsShouldInitializeSettingsToDefaultIfNotSpecified()


### PR DESCRIPTION
Addresses #1544 by adding a setting TreatDiscoveryWarningsAsErrors which will report discovery warnings as errors to loggers.