### PR TITLE
Remove DataRowAttribute argument count limitation

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -152,7 +152,17 @@ internal static class MethodInfoExtensions
             throw new TestFailedException(ObjectModel.UnitTestOutcome.Error, Resource.UTA_TestMethodExpectedParameters);
         }
 
-        var task = methodInfo.Invoke(classInstance, parameters) as Task;
+        Task? task;
+        if (parameters is not null
+            && methodParameters?.Length == 1
+            && methodParameters[0].ParameterType == typeof(object[]))
+        {
+            task = methodInfo.Invoke(classInstance, new[] { parameters }) as Task;
+        }
+        else
+        {
+            task = methodInfo.Invoke(classInstance, parameters) as Task;
+        }
 
         // If methodInfo is an Async method, wait for returned task
         task?.GetAwaiter().GetResult();

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
@@ -19,275 +19,34 @@ public class DataRowAttribute : Attribute, ITestDataSource
     /// Initializes a new instance of the <see cref="DataRowAttribute"/> class.
     /// </summary>
     public DataRowAttribute()
-        => Data = Array.Empty<object>();
+        : this(Array.Empty<object>())
+    {
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataRowAttribute"/> class.
     /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    // Need to have this constructor explicitly to fix a CLS compliance error.
-    public DataRowAttribute(object? arg1)
-        => Data = new object?[] { arg1 };
+    /// <param name="stringArrayData"> The string array data. </param>
+    public DataRowAttribute(string?[]? stringArrayData)
+        : this(new object?[] { stringArrayData })
+    {
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
     /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2)
-        => Data = new object?[] { arg1, arg2 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3)
-        => Data = new object?[] { arg1, arg2, arg3 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4)
-        => Data = new object?[] { arg1, arg2, arg3, arg4 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5)
-        => Data = new object?[] { arg1, arg2, arg3, arg4, arg5 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6)
-        => Data = new object?[] { arg1, arg2, arg3, arg4, arg5, arg6 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7)
-        => Data = new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8)
-        => Data = new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9)
-        => Data = new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10)
-        => Data = new object?[] { arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    /// <param name="arg11"> The eleventh argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10, object? arg11)
-        => Data = new object?[]
+    /// <param name="data"> The data. </param>
+    public DataRowAttribute(params object?[]? data)
+    {
+        if (data == null)
         {
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
-        };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    /// <param name="arg11"> The eleventh argument. </param>
-    /// <param name="arg12"> The twelfth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12)
-        => Data = new object?[]
+            Data = new object?[] { null };
+        }
+        else
         {
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12,
-        };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    /// <param name="arg11"> The eleventh argument. </param>
-    /// <param name="arg12"> The twelfth argument. </param>
-    /// <param name="arg13"> The thirteen argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13)
-        => Data = new object?[]
-        {
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
-            arg12, arg13,
-        };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    /// <param name="arg11"> The eleventh argument. </param>
-    /// <param name="arg12"> The twelfth argument. </param>
-    /// <param name="arg13"> The thirteen argument. </param>
-    /// <param name="arg14"> The fourteenth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13,
-        object? arg14)
-        => Data = new object?[]
-        {
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
-            arg12, arg13, arg14,
-        };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    /// <param name="arg11"> The eleventh argument. </param>
-    /// <param name="arg12"> The twelfth argument. </param>
-    /// <param name="arg13"> The thirteen argument. </param>
-    /// <param name="arg14"> The fourteenth argument. </param>
-    /// <param name="arg15"> The fifteenth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13,
-        object? arg14, object? arg15)
-        => Data = new object?[]
-        {
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
-            arg12, arg13, arg14, arg15,
-        };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DataRowAttribute"/> class which takes in an array of arguments.
-    /// </summary>
-    /// <param name="arg1"> The first argument. </param>
-    /// <param name="arg2"> The second argument. </param>
-    /// <param name="arg3"> The third argument. </param>
-    /// <param name="arg4"> The fourth argument. </param>
-    /// <param name="arg5"> The fifth argument. </param>
-    /// <param name="arg6"> The sixth argument. </param>
-    /// <param name="arg7"> The seventh argument. </param>
-    /// <param name="arg8"> The eight argument. </param>
-    /// <param name="arg9"> The nineth argument. </param>
-    /// <param name="arg10"> The tenth argument. </param>
-    /// <param name="arg11"> The eleventh argument. </param>
-    /// <param name="arg12"> The twelfth argument. </param>
-    /// <param name="arg13"> The thirteen argument. </param>
-    /// <param name="arg14"> The fourteenth argument. </param>
-    /// <param name="arg15"> The fifteenth argument. </param>
-    /// <param name="arg16"> The sixteenth argument. </param>
-    public DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6,
-        object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13,
-        object? arg14, object? arg15, object? arg16)
-        => Data = new object?[]
-        {
-            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
-            arg12, arg13, arg14, arg15, arg16,
-        };
+            Data = data;
+        }
+    }
 
     /// <summary>
     /// Gets data for calling test method.
@@ -313,15 +72,21 @@ public class DataRowAttribute : Attribute, ITestDataSource
             return DisplayName;
         }
 
-        if (data != null)
+        if (data == null)
         {
-            // We want to force call to `data.AsEnumerable()` to ensure that objects are casted to strings (using ToString())
-            // so that null do appear as "null". If you remove the call, and do string.Join(",", new object[] { null, "a" }),
-            // you will get empty string while with the call you will get "null,a".
-            return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name,
-                string.Join(",", data.AsEnumerable()));
+            return null;
         }
 
-        return null;
+        var parameters = methodInfo.GetParameters();
+
+        // We want to force call to `data.AsEnumerable()` to ensure that objects are casted to strings (using ToString())
+        // so that null do appear as "null". If you remove the call, and do string.Join(",", new object[] { null, "a" }),
+        // you will get empty string while with the call you will get "null,a".
+        IEnumerable<object?> displayData = parameters.Length == 1 && parameters[0].ParameterType == typeof(object[])
+            ? new object[] { data.AsEnumerable() }
+            : data.AsEnumerable();
+
+        return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name,
+            string.Join(",", displayData));
     }
 }

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Shipped.txt
@@ -45,22 +45,6 @@ Microsoft.VisualStudio.TestTools.UnitTesting.DataAccessMethod.Sequential = 0 -> 
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.Data.get -> object?[]!
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute() -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10, object? arg11) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13, object? arg14) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13, object? arg14, object? arg15) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6, object? arg7, object? arg8, object? arg9, object? arg10, object? arg11, object? arg12, object? arg13, object? arg14, object? arg15, object? arg16) -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DisplayName.get -> string?
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DisplayName.set -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.GetData(System.Reflection.MethodInfo! methodInfo) -> System.Collections.Generic.IEnumerable<object?[]!>!

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(params object?[]? data) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(string?[]? stringArrayData) -> void


### PR DESCRIPTION
Rework DataRow to remove the limit on argument count while still allowing to pass arrays.

Fixes #1503 and [AB#1807559](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1807559)