### PR TITLE
Fix Logger.LogMessage to not call string.Format when no arguments are…

### DIFF
--- a/src/TestFramework/TestFramework/Logger.cs
+++ b/src/TestFramework/TestFramework/Logger.cs
@@ -43,7 +43,14 @@ public class Logger
             throw new ArgumentNullException(nameof(format));
         }
 
-        string message = string.Format(CultureInfo.InvariantCulture, format, args);
+        if (args is null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        string message = args.Length == 0
+            ? format
+            : string.Format(CultureInfo.InvariantCulture, format, args);
 
         // Making sure all event handlers are called in sync on same thread.
         foreach (var invoker in OnLogMessage.GetInvocationList())

--- a/test/UnitTests/TestFramework.UnitTests/LoggerTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/LoggerTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+
+using TestFramework.ForTestingMSTest;
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
+public sealed class LoggerTests : TestContainer
+{
+    public void LogMessageWhenFormatIsNullShouldThrow()
+    {
+        Logger.OnLogMessage += message => { };
+        var ex = VerifyThrows(() => Logger.LogMessage(null!, "arg1"));
+        Verify(ex is ArgumentNullException && ex.Message.Contains("format"));
+    }
+
+    public void LogMessageWhenArgsIsNullShouldThrow()
+    {
+        Logger.OnLogMessage += message => { };
+        var ex = VerifyThrows(() => Logger.LogMessage("foo", null!));
+        Verify(ex is ArgumentNullException && ex.Message.Contains("args"));
+    }
+
+    public void LogMessageWhenFormatIsSimpleMessageAndNoArgsShouldCallEvent()
+    {
+        string? calledWith = null;
+        Logger.OnLogMessage += message =>
+        {
+            calledWith = message;
+        };
+        Logger.LogMessage("message");
+        Verify(calledWith == "message");
+    }
+
+    public void LogMessageWhenFormatIsFormateMessageWithArgsShouldCallEvent()
+    {
+        string? calledWith = null;
+        Logger.OnLogMessage += message =>
+        {
+            calledWith = message;
+        };
+        Logger.LogMessage("message {0}", 1);
+        Verify(calledWith == "message 1");
+    }
+
+    public void LogMessageWhenFormatContainsCurlyBrace()
+    {
+        string? calledWith = null;
+        Logger.OnLogMessage += message =>
+        {
+            calledWith = message;
+        };
+        Logger.LogMessage("{ A");
+        Verify(calledWith == "{ A");
+    }
+}


### PR DESCRIPTION
… provided

Fixes #1687 