### PR TITLE
Don't stop

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
@@ -253,7 +253,6 @@ internal class TestMethodRunner
 
                 if (dataRows == null)
                 {
-                    watch.Stop();
                     var inconclusiveResult = new TestResult
                     {
                         Outcome = UTF.UnitTestOutcome.Inconclusive,
@@ -282,7 +281,6 @@ internal class TestMethodRunner
             }
             catch (Exception ex)
             {
-                watch.Stop();
                 var failedResult = new TestResult
                 {
                     Outcome = UTF.UnitTestOutcome.Error,


### PR DESCRIPTION
Avoid unlikely bug where test is marked as inconclusive but then fails, and the duration is captured from the first stop of the stopwatch that happened in the inconclusive branch.

There is no issue to link to, I just noticed this when digging in code.