### PR TITLE
Use custom runner that calls vstest runner

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,4 +70,9 @@
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 
+  <!-- Test config -->
+  <PropertyGroup>
+    <TestRunnerName>MSTestRunner</TestRunnerName>
+  </PropertyGroup>
+
 </Project>

--- a/eng/MSTestRunner/MSTestRunner.targets
+++ b/eng/MSTestRunner/MSTestRunner.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.arcade.sdk\$(ArcadeSdkVersion)\tools\VSTest.targets" />
+</Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,9 +4,6 @@
     <VersionPrefix>3.2.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
-  <PropertyGroup Label="Arcade settings">
-    <UseVSTestRunner>true</UseVSTestRunner>
-  </PropertyGroup>
   <PropertyGroup Label="MSTest dependencies">
     <!-- Test Platform, .NET Test SDK and Object Model  -->
     <MicrosoftNETTestSdkVersion>17.6.0</MicrosoftNETTestSdkVersion>


### PR DESCRIPTION
This trick allows me to shortcircuit arcade that would force having one of the predefined test framwork when we want to use our local custom test framework to test MSTest.