### PR TITLE
Housekeeping for named pipe infrastructure sharing

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Logging/ILogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/ILogger.cs
@@ -3,7 +3,11 @@
 
 namespace Microsoft.Testing.Platform.Logging;
 
+#if INTERNALIZE_LOGGING
+internal interface ILogger
+#else
 public interface ILogger
+#endif
 {
     Task LogAsync<TState>(LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
 
@@ -12,6 +16,10 @@ public interface ILogger
     bool IsEnabled(LogLevel logLevel);
 }
 
+#if INTERNALIZE_LOGGING
+internal interface ILogger<out TCategoryName> : ILogger
+#else
 public interface ILogger<out TCategoryName> : ILogger
+#endif
 {
 }

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LogLevel.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LogLevel.cs
@@ -3,7 +3,11 @@
 
 namespace Microsoft.Testing.Platform.Logging;
 
+#if INTERNALIZE_LOGGING
+internal enum LogLevel
+#else
 public enum LogLevel
+#endif
 {
     /// <summary>
     /// Logs that contain the most detailed messages.

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggingExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggingExtensions.cs
@@ -3,7 +3,11 @@
 
 namespace Microsoft.Testing.Platform.Logging;
 
+#if INTERNALIZE_LOGGING
+internal static class LoggingExtensions
+#else
 public static class LoggingExtensions
+#endif
 {
     internal static readonly Func<string, Exception?, string> Formatter =
         (state, exception) =>


### PR DESCRIPTION
We will share named pipe infra to a different project and we don't want to expose contracts from there. 
At the moment all IPC is internal and it's using logging that's exposed, this update will let us to internalize the type definitions to avoid to expose the interface in the other projects.