### PR TITLE
Add experimental `MSBuild` sdk project

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -162,8 +162,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSTest.Internal.TestFx.Docu
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestingPlatformRunner", "TestingPlatformRunner", "{A9F9C49E-3CDA-4207-AA53-CC80AF1798FE}"
 	ProjectSection(SolutionItems) = preProject
-		eng\TestingPlatformRunner\TestingPlatformRunner.targets = eng\TestingPlatformRunner\TestingPlatformRunner.targets
 		eng\TestingPlatformRunner\TestingPlatform.Runner.targets = eng\TestingPlatformRunner\TestingPlatform.Runner.targets
+		eng\TestingPlatformRunner\TestingPlatformRunner.targets = eng\TestingPlatformRunner\TestingPlatformRunner.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1 - Runner", "1 - Runner", "{6AEE1440-FDF0-4729-8196-B24D0E333550}"
@@ -171,6 +171,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Testing.Platform", "src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj", "{48FAB979-8DA5-492E-8B3F-5DBBE82F659A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Testing.Platform.UnitTests", "test\UnitTests\Microsoft.Testing.Platform.UnitTests\Microsoft.Testing.Platform.UnitTests.csproj", "{0F1BB08E-BB6C-43E0-A7DF-1D6A03DA5DC7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSTest.Sdk", "src\Package\MSTest.Sdk\MSTest.Sdk.csproj", "{10930CFD-EDF9-4486-B0A3-49230B5A6798}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -354,6 +356,10 @@ Global
 		{0F1BB08E-BB6C-43E0-A7DF-1D6A03DA5DC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F1BB08E-BB6C-43E0-A7DF-1D6A03DA5DC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F1BB08E-BB6C-43E0-A7DF-1D6A03DA5DC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10930CFD-EDF9-4486-B0A3-49230B5A6798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10930CFD-EDF9-4486-B0A3-49230B5A6798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10930CFD-EDF9-4486-B0A3-49230B5A6798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10930CFD-EDF9-4486-B0A3-49230B5A6798}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -417,6 +423,7 @@ Global
 		{6AEE1440-FDF0-4729-8196-B24D0E333550} = {FF8B1B72-55A1-4FFE-809E-7B79323ED8D0}
 		{48FAB979-8DA5-492E-8B3F-5DBBE82F659A} = {6AEE1440-FDF0-4729-8196-B24D0E333550}
 		{0F1BB08E-BB6C-43E0-A7DF-1D6A03DA5DC7} = {BB874DF1-44FE-415A-B634-A6B829107890}
+		{10930CFD-EDF9-4486-B0A3-49230B5A6798} = {E374A3A6-C364-4890-B315-D60F5C682B6E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31E0F4D5-975A-41CC-933E-545B2201FAF9}

--- a/src/Package/MSTest.Sdk/MSTest.Sdk.csproj
+++ b/src/Package/MSTest.Sdk/MSTest.Sdk.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <IsShippingPackage>false</IsShippingPackage>
+    <PackageId>MSTest.Sdk</PackageId>
+    <NuspecFile>MSTest.Sdk.nuspec</NuspecFile>
+    <NuspecBasePath>$(OutputPath)</NuspecBasePath>
+    <PackageTags>MSTest TestFramework TestAdapter VisualStudio Unittest MSTestV2 Microsoft</PackageTags>
+    <PackageDescription>
+      MSTest is Microsoft supported Test Framework.
+
+      This package contains the MSTest MSBuild project SDK.
+    </PackageDescription>
+    <!-- Nothing in lib but that's expected -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="Sdk\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/Package/MSTest.Sdk/MSTest.Sdk.nuspec
+++ b/src/Package/MSTest.Sdk/MSTest.Sdk.nuspec
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0"?>
+<package >
+  <metadata>
+    $CommonMetadataElements$
+  </metadata>
+  <files>
+    $CommonFileElements$
+    <file src="netstandard2.0\Sdk\**" target="Sdk" />
+  </files>
+</package>

--- a/src/Package/MSTest.Sdk/Sdk/Sdk.props
+++ b/src/Package/MSTest.Sdk/Sdk/Sdk.props
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  <!-- Implicit top import -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  
+  <PropertyGroup>
+    <UseMSTestRunner>true</UseMSTestRunner>
+    <TestingPlatformDonetTestSupport>false</TestingPlatformDonetTestSupport>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23580-01" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.23601.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.23601.5" />
+    <PackageReference Include="Microsoft.Testing.Platform.Extensions.VSTestBridge" Version="1.0.0-alpha.23601.2" />
+  </ItemGroup>
+</Project>

--- a/src/Package/MSTest.Sdk/Sdk/Sdk.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Sdk.targets
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="_SetupEntryPoint" BeforeTargets="GenerateProgramFile" Condition=" '$(UseMSTestRunner)' == 'false' " >
+    <PropertyGroup>
+      <!-- Disable testing platform entry point generation -->
+      <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    </PropertyGroup>
+    <!--
+          We need to re-enable the VSTest sdk program.* generation by it's by default disabled when we reference Microsoft.Testing.Platform.MSBuild.
+          We cannot use the GenerateProgramFile property as Microsoft.NET.Test.Sdk.targets it's an 'InitialTargets' and we cannot plug any target before it.
+    -->
+    <CallTarget Targets="_GenerateProgramFileTakenFromVSTest" />
+  </Target>
+
+  <!--
+    ============================================================
+    GenerateProgramFile taken from Microsoft.NET.Test.Sdk.targets 
+    Generates Program file which contains the Main entry point
+    ============================================================
+  -->
+  <Target Name="_GenerateProgramFileTakenFromVSTest" >
+
+    <ItemGroup Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'">
+      <RemoveExistingMicrosoftNETTestSdkProgram Include="@(Compile)" Condition="'%(FileName)' == 'Microsoft.NET.Test.Sdk.Program'" />
+      <Compile Remove="@(RemoveExistingMicrosoftNETTestSdkProgram)" />
+      <Compile Include="$(GeneratedProgramFile)"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Language)' == 'F#'">
+      <ProgramCompiles Include="@(Compile)" Condition="'%(Identity)' == 'Program.fs'" />
+      <CompileAfter Include="$(GeneratedProgramFile)" Condition="@(ProgramCompiles-&gt;Count()) == 0" />
+    </ItemGroup>
+
+    <Warning Condition="@(ProgramCompiles-&gt;Count()) != 0" Text="A 'Program.fs' file can be automatically generated for F# .NET Core test projects. To fix this warning, either delete the file from the project, or set the &lt;GenerateProgramFile&gt; property to 'false'." />
+
+  </Target>
+
+  <!-- Implicit bottom import -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>


### PR DESCRIPTION
This PR is adding the first version of the MSBuild sdk for MSTest, it could be interesting mainly for:

* add or remove dependencies without the needs to ask to the user to do it, we know that's not easy to flow new features that needs new dependency to the users, they've to read the documentation but it's hard to reach everyone.
* we can provide simple msbuild props knob to disable/enable features.
* we can have better "testing coverage" because we can always test "our" configurations and guarantee that everything is good, having less "moving parts", users will add dependencies only for their business code.
* it's battle tested and used by other well known .NET platform to simplify the "default usage" https://learn.microsoft.com/en-us/dotnet/core/project-sdk/overview#available-sdks

The outcome will be a project file like:
```xml
<Project Sdk="MSTest.Sdk/3.2.0-dev">
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
    <!--<UseMSTestRunner>false</UseMSTestRunner>-->
    <!--<TestingPlatformDonetTestSupport>true</TestingPlatformDonetTestSupport>-->
  </PropertyGroup>
</Project>
```

The sample above is using the version inside the `Sdk` attribute self but it can be done "globally" using the `global.json` too like described here https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-use-project-sdk