### PR TITLE
MSTEST0001: Set default severity to Info

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,7 +5,7 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-MSTEST0001 | Performance | Warning | UseParallelizeAttributeAnalyzer, [Documentation](https://github.com/microsoft/testfx/blob/main/docs/analyzers/MSTEST0001.md)
+MSTEST0001 | Performance | Info | UseParallelizeAttributeAnalyzer, [Documentation](https://github.com/microsoft/testfx/blob/main/docs/analyzers/MSTEST0001.md)
 MSTEST0002 | Usage | Warning | TestClassShouldBeValidAnalyzer, [Documentation](https://github.com/microsoft/testfx/blob/main/docs/analyzers/MSTEST0002.md)
 MSTEST0003 | Usage | Warning | TestMethodShouldBeValidAnalyzer, [Documentation](https://github.com/microsoft/testfx/blob/main/docs/analyzers/MSTEST0003.md)
 MSTEST0004 | Design | Disabled | PublicTypeShouldBeTestClassAnalyzer, [Documentation](https://github.com/microsoft/testfx/blob/main/docs/analyzers/MSTEST0004.md)

--- a/src/Analyzers/MSTest.Analyzers/UseParallelizeAttributeAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseParallelizeAttributeAnalyzer.cs
@@ -24,7 +24,7 @@ public sealed class UseParallelizeAttributeAnalyzer : DiagnosticAnalyzer
         MessageFormat,
         Description,
         Category.Performance,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         isEnabledByDefault: true,
         isReportedAtCompilationEnd: true);
 


### PR DESCRIPTION
Follow-up from internal dogfood, when team have many test projects, having this rule as warning by default leads to headache and doesn't well align with us trying to follow semantic versioning. So we decided to downgrade the rule default severity to `Info` and we will bump it back to `Warning` as part of v4.