### PR TITLE
Fix issue #2121 DataTestMethodAttribute is missing a constructor

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/TypeEnumerator.cs
@@ -199,6 +199,13 @@ internal class TypeEnumerator
         var testMethodAttribute = _reflectHelper.GetCustomAttribute<TestMethodAttribute>(method);
         testElement.DisplayName = testMethodAttribute?.DisplayName ?? method.Name;
 
+        // OR get DisplayName from DataTestMethodAttribute
+        if (testMethodAttribute == null)
+        {
+            var dataTestMethodAttribute = _reflectHelper.GetCustomAttribute<DataTestMethodAttribute>(method);
+            testElement.DisplayName = dataTestMethodAttribute?.DisplayName ?? method.Name;
+        }
+
         return testElement;
     }
 }

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataTestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataTestMethodAttribute.cs
@@ -9,4 +9,21 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class DataTestMethodAttribute : TestMethodAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataTestMethodAttribute"/> class.
+    /// </summary>
+    public DataTestMethodAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataTestMethodAttribute"/> class.
+    /// </summary>
+    /// <param name="displayName">
+    /// Display name for the test.
+    /// </param>
+    public DataTestMethodAttribute(string? displayName)
+        : base(displayName)
+    {
+    }
 }

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
 Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute.DataRowAttribute(object? data) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute.DataTestMethodAttribute(string? displayName) -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome.NotFound = 9 -> Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.Logging.Logger.LogMessageHandler.Invoke(string! message) -> void

--- a/test/UnitTests/MSTestAdapter.UnitTests/Discovery/TypeEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Discovery/TypeEnumeratorTests.cs
@@ -517,7 +517,7 @@ public class TypeEnumeratorTests : TestContainer
         Verify(testElement.DisplayName == "MethodWithVoidReturnType");
     }
 
-    public void GetTestFromMethodShouldSetDisplayNameFromAttribute()
+    public void GetTestFromMethodShouldSetDisplayNameFromTestMethodAttribute()
     {
         SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
@@ -526,6 +526,22 @@ public class TypeEnumeratorTests : TestContainer
         // Setup mocks to behave like we have [TestMethod("Test method display name.")] attribute on the method
         _mockReflectHelper.Setup(
             rh => rh.GetCustomAttribute<TestMethodAttribute>(methodInfo)).Returns(new TestMethodAttribute("Test method display name."));
+
+        var testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+
+        Verify(testElement is not null);
+        Verify(testElement.DisplayName == "Test method display name.");
+    }
+
+    public void GetTestFromMethodShouldSetDisplayNameFromDataTestMethodAttribute()
+    {
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
+        var methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType));
+
+        // Setup mocks to behave like we have [TestMethod("Test method display name.")] attribute on the method
+        _mockReflectHelper.Setup(
+            rh => rh.GetCustomAttribute<DataTestMethodAttribute>(methodInfo)).Returns(new DataTestMethodAttribute("Test method display name."));
 
         var testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
 


### PR DESCRIPTION
A fix for issue #2121 DataTestMethodAttribute doesn't have a constructor to set display name 

I added the constructor and extended the TypeEnumerator logic to get the DisplayName for DataTestMethodAttribute (only if no regular TestMethodAttribute was found) 
Renamed an existing unit test for TestMethodAttribute  and added a new test for DataTestMethodAttribute that verifies that the DisplayName is set. 

