### PR TITLE
Add `ToString` to `IData` objects

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Logging/ServerLogMessage.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/ServerLogMessage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Resources;
 
@@ -15,4 +17,14 @@ internal sealed class ServerLogMessage(LogLevel level, string message) : IData
     public LogLevel Level { get; } = level;
 
     public string Message { get; } = message;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Server log message:");
+        builder.Append("Level: ").AppendLine(Level.ToString());
+        builder.Append("Message: ").AppendLine(Message);
+
+        return builder.ToString();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
@@ -125,36 +125,8 @@ internal class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDisposable
         StringBuilder messageBuilder = new();
         messageBuilder.AppendLine(
             CultureInfo.InvariantCulture,
-            $"The producer '{dataProducer.DisplayName}' (ID: {dataProducer.Uid}) pushed data '{data.GetType().FullName}'");
-        messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Display name: {data.DisplayName}");
-        messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Description: {data.Description}");
-
-        switch (data)
-        {
-            case TestNodeUpdateMessage message:
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Session UID: {message.SessionUid}");
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Parent Node UID: {message.ParentTestNodeUid}");
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Node: {message.TestNode}");
-                break;
-
-            case FileArtifact message:
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  File path: {message.FileInfo.FullName}");
-                break;
-
-            case TestNodeFileArtifact message:
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  File path: {message.FileInfo.FullName}");
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Session UID: {message.SessionUid}");
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Node UID: {message.Node.Uid}");
-                break;
-
-            case SessionFileArtifact message:
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  File path: {message.FileInfo.FullName}");
-                messageBuilder.AppendLine(CultureInfo.InvariantCulture, $"  Session UID: {message.SessionUid}");
-                break;
-
-            default:
-                break;
-        }
+            $"The producer '{dataProducer.DisplayName}' (ID: {dataProducer.Uid}) pushed data:");
+        messageBuilder.AppendLine(data.ToString());
 
         await _logger.LogTraceAsync(messageBuilder.ToString());
     }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/ChannelConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/ChannelConsumerDataProcessor.cs
@@ -11,7 +11,7 @@ using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.Messages;
 
-[DebuggerDisplay("DataConsumer = {DataConsumer.Uid}")]
+[DebuggerDisplay("DataConsumer = {DataConsumer.Value}")]
 internal class AsyncConsumerDataProcessor : IDisposable
 {
     private readonly ITask _task;

--- a/src/Platform/Microsoft.Testing.Platform/Messages/DataWithSessionUid.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/DataWithSessionUid.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 using Microsoft.Testing.Platform.TestHost;
 
 namespace Microsoft.Testing.Platform.Extensions.Messages;
@@ -9,4 +11,22 @@ public abstract class DataWithSessionUid(string displayName, string? description
     : PropertyBagData(displayName, description)
 {
     public SessionUid SessionUid { get; } = sessionUid;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Generic session data:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.Append("Session UID: ").AppendLine(SessionUid.Value);
+        builder.AppendLine("Properties: [");
+        foreach (IProperty property in Properties)
+        {
+            builder.AppendLine(property.ToString());
+        }
+
+        builder.AppendLine("]");
+
+        return builder.ToString();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/FileArtifacts.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/FileArtifacts.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 using Microsoft.Testing.Platform.TestHost;
 
 namespace Microsoft.Testing.Platform.Extensions.Messages;
@@ -9,16 +11,73 @@ public class FileArtifact(FileInfo fileInfo, string displayName, string? descrip
     : PropertyBagData(displayName, description)
 {
     public FileInfo FileInfo { get; } = fileInfo;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Test node file artifact:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.Append("File path: ").AppendLine(FileInfo.FullName);
+        builder.AppendLine("Properties: [");
+        foreach (IProperty property in Properties)
+        {
+            builder.AppendLine(property.ToString());
+        }
+
+        builder.AppendLine("]");
+
+        return builder.ToString();
+    }
 }
 
 public class SessionFileArtifact(SessionUid sessionUid, FileInfo fileInfo, string displayName, string? description = null)
     : DataWithSessionUid(displayName, description, sessionUid)
 {
     public FileInfo FileInfo { get; } = fileInfo;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Session file artifact:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.AppendLine("Properties: [");
+        foreach (IProperty property in Properties)
+        {
+            builder.AppendLine(property.ToString());
+        }
+
+        builder.AppendLine("]");
+        builder.Append("Session UID: ").AppendLine(SessionUid.Value);
+        builder.Append("File path: ").AppendLine(FileInfo.FullName);
+
+        return builder.ToString();
+    }
 }
 
-public class TestNodeFileArtifact(SessionUid sessionUid, TestNode node, FileInfo fileInfo, string displayName, string? description = null)
+public class TestNodeFileArtifact(SessionUid sessionUid, TestNode testNode, FileInfo fileInfo, string displayName, string? description = null)
     : SessionFileArtifact(sessionUid, fileInfo, displayName, description)
 {
-    public TestNode Node { get; } = node;
+    public TestNode TestNode { get; } = testNode;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Session test node file artifact:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.AppendLine("Properties: [");
+        foreach (IProperty property in Properties)
+        {
+            builder.AppendLine(property.ToString());
+        }
+
+        builder.AppendLine("]");
+        builder.Append("Session UID: ").AppendLine(SessionUid.Value);
+        builder.Append("File path: ").AppendLine(FileInfo.FullName);
+        builder.AppendLine("Test node: ").AppendLine("{").AppendLine(TestNode.ToString()).AppendLine("}");
+
+        return builder.ToString();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/ListTestsMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/ListTestsMessageBus.cs
@@ -12,7 +12,7 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Platform.Messages;
 
-internal class ListTestsMessageBus(
+internal sealed class ListTestsMessageBus(
     ITestFramework testFrameworkAdapter,
     ITestApplicationCancellationTokenSource testApplicationCancellationTokenSource,
     ILoggerFactory loggerFactory,

--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBagData.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBagData.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Microsoft.Testing.Platform.Extensions.Messages;
 
 public abstract class PropertyBagData(string displayName, string? description) : IData
@@ -10,4 +12,21 @@ public abstract class PropertyBagData(string displayName, string? description) :
     public string DisplayName { get; } = displayName;
 
     public string? Description { get; } = description;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Generic data:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.AppendLine("Properties: [");
+        foreach (IProperty property in Properties)
+        {
+            builder.AppendLine(property.ToString());
+        }
+
+        builder.AppendLine("]");
+
+        return builder.ToString();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNode.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNode.cs
@@ -16,7 +16,7 @@ public class TestNode
     public override string ToString()
     {
         StringBuilder sb = new();
-        sb.Append("Uid: ");
+        sb.Append("Value: ");
         sb.AppendLine(Uid.ToString());
         sb.Append("DisplayName: ");
         sb.AppendLine(DisplayName);

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUpdateMessage.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUpdateMessage.cs
@@ -21,6 +21,12 @@ public sealed class TestNodeUpdateMessage(SessionUid sessionUid, TestNode testNo
         builder.Append("Display name: ").AppendLine(DisplayName);
         builder.Append("Description: ").AppendLine(Description);
         builder.Append("Session UID: ").AppendLine(SessionUid.Value);
+        foreach (IProperty property in Properties)
+        {
+            builder.AppendLine(property.ToString());
+        }
+
+        builder.AppendLine("]");
         builder.Append("Parent test node UID: ").AppendLine(ParentTestNodeUid?.Value ?? "null");
         builder.AppendLine("Test node: ").AppendLine("{").AppendLine(TestNode.ToString()).AppendLine("}");
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUpdateMessage.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUpdateMessage.cs
@@ -1,14 +1,29 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 using Microsoft.Testing.Platform.TestHost;
 
 namespace Microsoft.Testing.Platform.Extensions.Messages;
 
 public sealed class TestNodeUpdateMessage(SessionUid sessionUid, TestNode testNode, TestNodeUid? parentTestNodeUid = null)
-    : DataWithSessionUid(nameof(TestNodeUpdateMessage), "This data is used to report a TestNode state change.", sessionUid)
+    : DataWithSessionUid("TestNode update", "This data is used to report a TestNode state change.", sessionUid)
 {
     public TestNode TestNode { get; } = testNode;
 
     public TestNodeUid? ParentTestNodeUid { get; } = parentTestNodeUid;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Test node update:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.Append("Session UID: ").AppendLine(SessionUid.Value);
+        builder.Append("Parent test node UID: ").AppendLine(ParentTestNodeUid?.Value ?? "null");
+        builder.AppendLine("Test node: ").AppendLine("{").AppendLine(TestNode.ToString()).AppendLine("}");
+
+        return builder.ToString();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
+
 namespace Microsoft.Testing.Platform.Extensions.Messages;
 
 internal readonly struct TestRequestExecutionTimeInfo(TimingInfo timingInfo) : IData
@@ -10,4 +12,15 @@ internal readonly struct TestRequestExecutionTimeInfo(TimingInfo timingInfo) : I
     public readonly string? Description => "Information about the test execution times.";
 
     public TimingInfo TimingInfo { get; } = timingInfo;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        builder.AppendLine("Test node update:");
+        builder.Append("Display name: ").AppendLine(DisplayName);
+        builder.Append("Description: ").AppendLine(Description);
+        builder.AppendLine(TimingInfo.ToString());
+
+        return builder.ToString();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/ConsoleDisplayService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/ConsoleDisplayService.cs
@@ -273,7 +273,7 @@ internal class ConsoleOutputDevice : IPlatformOutputDevice,
             artifacts.AppendLine(CultureInfo.InvariantCulture, $"{(_firstCallTo_OnSessionStartingAsync ? "Out of process" : "In process")} file artifacts produced:");
             foreach (TestNodeFileArtifact testNodeFileArtifact in _sessionFilesArtifact.OfType<TestNodeFileArtifact>())
             {
-                artifacts.AppendLine(CultureInfo.InvariantCulture, $"- For test {testNodeFileArtifact.Node.DisplayName}: {testNodeFileArtifact.FileInfo.FullName}");
+                artifacts.AppendLine(CultureInfo.InvariantCulture, $"- For test {testNodeFileArtifact.TestNode.DisplayName}: {testNodeFileArtifact.FileInfo.FullName}");
             }
 
             foreach (SessionFileArtifact sessionFileArtifact in _sessionFilesArtifact.Except(_sessionFilesArtifact.OfType<TestNodeFileArtifact>()))

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -189,8 +189,8 @@ Microsoft.Testing.Platform.Extensions.Messages.TestNode.TestNode() -> void
 Microsoft.Testing.Platform.Extensions.Messages.TestNode.Uid.get -> Microsoft.Testing.Platform.Extensions.Messages.TestNodeUid!
 Microsoft.Testing.Platform.Extensions.Messages.TestNode.Uid.init -> void
 Microsoft.Testing.Platform.Extensions.Messages.TestNodeFileArtifact
-Microsoft.Testing.Platform.Extensions.Messages.TestNodeFileArtifact.Node.get -> Microsoft.Testing.Platform.Extensions.Messages.TestNode!
-Microsoft.Testing.Platform.Extensions.Messages.TestNodeFileArtifact.TestNodeFileArtifact(Microsoft.Testing.Platform.TestHost.SessionUid sessionUid, Microsoft.Testing.Platform.Extensions.Messages.TestNode! node, System.IO.FileInfo! fileInfo, string! displayName, string? description = null) -> void
+Microsoft.Testing.Platform.Extensions.Messages.TestNodeFileArtifact.TestNode.get -> Microsoft.Testing.Platform.Extensions.Messages.TestNode!
+Microsoft.Testing.Platform.Extensions.Messages.TestNodeFileArtifact.TestNodeFileArtifact(Microsoft.Testing.Platform.TestHost.SessionUid sessionUid, Microsoft.Testing.Platform.Extensions.Messages.TestNode! testNode, System.IO.FileInfo! fileInfo, string! displayName, string? description = null) -> void
 Microsoft.Testing.Platform.Extensions.Messages.TestNodeStateProperty
 Microsoft.Testing.Platform.Extensions.Messages.TestNodeStateProperty.Explanation.get -> string?
 Microsoft.Testing.Platform.Extensions.Messages.TestNodeStateProperty.Explanation.init -> void
@@ -362,8 +362,8 @@ Microsoft.Testing.Platform.TestHost.ITestHostManager.AddTestSessionLifetimeHandl
 Microsoft.Testing.Platform.TestHost.ITestHostManager.AddTestSessionLifetimeHandle<T>(Microsoft.Testing.Platform.Extensions.CompositeExtensionFactory<T!>! compositeServiceFactory) -> void
 Microsoft.Testing.Platform.TestHost.SessionUid
 Microsoft.Testing.Platform.TestHost.SessionUid.SessionUid() -> void
-Microsoft.Testing.Platform.TestHost.SessionUid.SessionUid(string! uid) -> void
-Microsoft.Testing.Platform.TestHost.SessionUid.Uid.get -> string!
+Microsoft.Testing.Platform.TestHost.SessionUid.SessionUid(string! value) -> void
+Microsoft.Testing.Platform.TestHost.SessionUid.Value.get -> string!
 Microsoft.Testing.Platform.TestHost.TestSessionContext
 Microsoft.Testing.Platform.TestHost.TestSessionContext.Client.get -> Microsoft.Testing.Platform.TestHost.ClientInfo!
 Microsoft.Testing.Platform.TestHost.TestSessionContext.SessionUid.get -> Microsoft.Testing.Platform.TestHost.SessionUid
@@ -377,10 +377,16 @@ override Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity.Equals(
 override Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity.GetHashCode() -> int
 override Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.Equals(object? obj) -> bool
 override Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.GetHashCode() -> int
+override Microsoft.Testing.Platform.Extensions.Messages.DataWithSessionUid.ToString() -> string!
+override Microsoft.Testing.Platform.Extensions.Messages.FileArtifact.ToString() -> string!
+override Microsoft.Testing.Platform.Extensions.Messages.PropertyBagData.ToString() -> string!
+override Microsoft.Testing.Platform.Extensions.Messages.SessionFileArtifact.ToString() -> string!
 override Microsoft.Testing.Platform.Extensions.Messages.TestNode.ToString() -> string!
+override Microsoft.Testing.Platform.Extensions.Messages.TestNodeFileArtifact.ToString() -> string!
 override Microsoft.Testing.Platform.Extensions.Messages.TestNodeUid.Equals(object? obj) -> bool
 override Microsoft.Testing.Platform.Extensions.Messages.TestNodeUid.GetHashCode() -> int
 override Microsoft.Testing.Platform.Extensions.Messages.TestNodeUid.ToString() -> string!
+override Microsoft.Testing.Platform.Extensions.Messages.TestNodeUpdateMessage.ToString() -> string!
 override Microsoft.Testing.Platform.TestHost.SessionUid.ToString() -> string!
 static Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(string![]! args, Microsoft.Testing.Platform.Builder.TestApplicationOptions? testApplicationOptions = null) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!>!
 static Microsoft.Testing.Platform.Builder.TestApplication.CreateServerModeBuilderAsync(string![]! args, Microsoft.Testing.Platform.Builder.TestApplicationOptions? testApplicationOptions = null) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!>!

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestHostTestFrameworkInvoker.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestHostTestFrameworkInvoker.cs
@@ -38,7 +38,7 @@ internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : 
     {
         ILogger<TestHostTestFrameworkInvoker> logger = ServiceProvider.GetLoggerFactory().CreateLogger<TestHostTestFrameworkInvoker>();
 
-        await logger.LogInformationAsync($"TestFrameworkAdapter Uid: '{testFrameworkAdapter.Uid}' Version: '{testFrameworkAdapter.Version}' DisplayName: '{testFrameworkAdapter.DisplayName}' Description: '{testFrameworkAdapter.Description}'");
+        await logger.LogInformationAsync($"TestFrameworkAdapter Value: '{testFrameworkAdapter.Uid}' Version: '{testFrameworkAdapter.Version}' DisplayName: '{testFrameworkAdapter.DisplayName}' Description: '{testFrameworkAdapter.Description}'");
 
         foreach (ICapability capability in ServiceProvider.GetTestFrameworkCapabilities().Capabilities)
         {

--- a/src/Platform/Microsoft.Testing.Platform/Telemetry/ExtensionInformationCollector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Telemetry/ExtensionInformationCollector.cs
@@ -48,7 +48,7 @@ internal static class ExtensionInformationCollector
         foreach (ExtensionInformation extension in extensionsInformation)
         {
             writer.WriteStartObject();
-            writer.WriteString("Uid", extension.Id);
+            writer.WriteString("Value", extension.Id);
             writer.WriteString("Version", extension.Version);
             writer.WriteBoolean("Enabled", extension.Enabled);
             writer.WriteEndObject();
@@ -64,7 +64,7 @@ internal static class ExtensionInformationCollector
         {
             JsonObject jsonObject = new()
             {
-                { "Uid", extension.Id },
+                { "Value", extension.Id },
                 { "Version", extension.Version },
                 { "Enabled", extension.Enabled },
             };

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/SessionUid.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/SessionUid.cs
@@ -3,9 +3,9 @@
 
 namespace Microsoft.Testing.Platform.TestHost;
 
-public readonly struct SessionUid(string uid)
+public readonly struct SessionUid(string value)
 {
-    public string Uid { get; } = uid;
+    public string Value { get; } = value;
 
-    public override string ToString() => Uid;
+    public override string ToString() => Value;
 }


### PR DESCRIPTION
When analyzing some logs we realized that we forgot to add some `ToString` and so some info were missing or were not enitrely usable.