### PR TITLE
Ensure proper usage of Guard helpers

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -78,7 +78,7 @@ public sealed class TestApplication : ITestApplication
 
         // Create the UnhandledExceptionHandler that will be set inside the TestHostBuilder.
         LazyInitializer.EnsureInitialized(ref s_unhandledExceptionHandler, () => new UnhandledExceptionHandler(systemEnvironment, new SystemConsole(), parseResult.IsOptionSet(PlatformCommandLineProvider.TestHostControllerPIDOptionKey)));
-        ArgumentGuard.IsNotNull(s_unhandledExceptionHandler);
+        ApplicationStateGuard.Ensure(s_unhandledExceptionHandler is not null);
 
         // First task is to setup the logger if enabled and we take the info from the command line or env vars.
         ApplicationLoggingState loggingState = CreateFileLoggerIfDiagnosticIsEnabled(parseResult, testApplicationModuleInfo, systemClock, systemEnvironment, new SystemTask(), new SystemConsole());

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
@@ -163,7 +163,7 @@ internal sealed class CommandLineHandler(string[] args, CommandLineParseResult p
 
     private async Task<ValidationResult> ValidateOptionsArgumentsAsync()
     {
-        ArgumentGuard.IsNotNull(_parseResult);
+        ApplicationStateGuard.Ensure(_parseResult is not null);
 
         StringBuilder? stringBuilder = null;
         foreach (OptionRecord optionRecord in _parseResult.Options)
@@ -189,7 +189,7 @@ internal sealed class CommandLineHandler(string[] args, CommandLineParseResult p
     {
         error = null;
 
-        ArgumentGuard.IsNotNull(_parseResult);
+        ApplicationStateGuard.Ensure(_parseResult is not null);
 
         StringBuilder? stringBuilder = null;
         foreach (OptionRecord optionRecord in _parseResult.Options)
@@ -214,7 +214,7 @@ internal sealed class CommandLineHandler(string[] args, CommandLineParseResult p
     {
         error = null;
 
-        ArgumentGuard.IsNotNull(_parseResult);
+        ApplicationStateGuard.Ensure(_parseResult is not null);
 
         StringBuilder stringBuilder = new();
         foreach (IGrouping<string, OptionRecord> groupedOptions in _parseResult.Options.GroupBy(x => x.Option))

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/CompositeExtensionsFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/CompositeExtensionsFactory.cs
@@ -25,13 +25,13 @@ TestHost: IDataConsumer, ITestApplicationLifetime
 
     public CompositeExtensionFactory(Func<IServiceProvider, TExtension> factory)
     {
-        ArgumentGuard.IsNotNull(factory, nameof(factory));
+        ArgumentGuard.IsNotNull(factory);
         _factoryWithServiceProvider = factory;
     }
 
     public CompositeExtensionFactory(Func<TExtension> factory)
     {
-        ArgumentGuard.IsNotNull(factory, nameof(factory));
+        ArgumentGuard.IsNotNull(factory);
         _factory = factory;
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcessHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcessHandler.cs
@@ -16,7 +16,7 @@ internal sealed class SystemProcessHandler : IProcessHandler
     public IProcess? Start(ProcessStartInfo startInfo)
     {
         var process = Process.Start(startInfo);
-        ArgumentGuard.IsNotNull(process);
+        ApplicationStateGuard.Ensure(process is not null);
         process.EnableRaisingEvents = true;
         return process is null ? null : (IProcess)new SystemProcess(process);
     }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -67,7 +67,7 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
         DateTimeOffset createBuilderStart)
     {
         // ============= SETUP COMMON SERVICE USED IN ALL MODES ===============//
-        ArgumentGuard.IsNotNull(TestFramework);
+        ApplicationStateGuard.Ensure(TestFramework is not null);
 
         var systemClock = new SystemClock();
         DateTimeOffset buildBuilderStart = systemClock.UtcNow;
@@ -330,7 +330,7 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
         // Setup the test host working folder.
         // Out of the test host controller extension the current working directory is the test host working directory.
         string? currentWorkingDirectory = configuration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory];
-        ArgumentGuard.IsNotNull(currentWorkingDirectory);
+        ApplicationStateGuard.Ensure(currentWorkingDirectory is not null);
         configuration.SetTestHostWorkingDirectory(currentWorkingDirectory);
 
         // If we're under test controllers and currently we're inside the started test host we connect to the out of process

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -62,7 +62,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
         int maxNumberOfServerInstances,
         CancellationToken cancellationToken)
     {
-        ArgumentGuard.Ensure(pipeNameDescription != null, nameof(pipeNameDescription), "Pipe name cannot be null");
+        ArgumentGuard.IsNotNull(pipeNameDescription);
         _namedPipeServerStream = new((PipeName = pipeNameDescription).Name, PipeDirection.InOut, maxNumberOfServerInstances);
         _callback = callback;
         _environment = environment;

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryExtensions.cs
@@ -9,7 +9,7 @@ public static class LoggerFactoryExtensions
 {
     public static ILogger<TCategoryName> CreateLogger<TCategoryName>(this ILoggerFactory factory)
     {
-        ArgumentGuard.IsNotNull(factory, nameof(factory));
+        ArgumentGuard.IsNotNull(factory);
         return new Logger<TCategoryName>(factory);
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
@@ -29,7 +29,7 @@ public sealed partial class PropertyBag
 
     public PropertyBag(params IProperty[] properties)
     {
-        ArgumentGuard.IsNotNull(properties, nameof(properties));
+        ArgumentGuard.IsNotNull(properties);
 
         if (properties.Length == 0)
         {
@@ -68,7 +68,7 @@ public sealed partial class PropertyBag
 
     public PropertyBag(IEnumerable<IProperty> properties)
     {
-        ArgumentGuard.IsNotNull(properties, nameof(properties));
+        ArgumentGuard.IsNotNull(properties);
 
         if (!properties.Any())
         {
@@ -111,7 +111,7 @@ public sealed partial class PropertyBag
 
     public void Add(IProperty property)
     {
-        ArgumentGuard.IsNotNull(property, nameof(property));
+        ArgumentGuard.IsNotNull(property);
 
         // Optimized access to the TestNodeStateProperty, it's one of the most used property.
         if (property is TestNodeStateProperty testNodeStateProperty)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceManager.cs
@@ -15,7 +15,7 @@ internal sealed class PlatformOutputDeviceManager : IPlatformOutputDeviceManager
 
     public void SetPlatformOutputDevice(Func<IServiceProvider, IPlatformOutputDevice> platformOutputDeviceFactory)
     {
-        ArgumentGuard.IsNotNull(platformOutputDeviceFactory, nameof(platformOutputDeviceFactory));
+        ArgumentGuard.IsNotNull(platformOutputDeviceFactory);
         _platformOutputDeviceFactory = platformOutputDeviceFactory;
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Requests/ConsoleTestExecutionRequestFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/ConsoleTestExecutionRequestFactory.cs
@@ -21,7 +21,7 @@ internal sealed class ConsoleTestExecutionRequestFactory(ICommandLineOptions com
             throw new InvalidOperationException(PlatformResources.CannotCreateTestExecutionFilterErrorMessage);
         }
 
-        ArgumentGuard.IsNotNull(testExecutionFilter);
+        ApplicationStateGuard.Ensure(testExecutionFilter is not null);
 
         TestExecutionRequest testExecutionRequest = _commandLineService.IsOptionSet(PlatformCommandLineProvider.DiscoverTestsOptionKey)
             ? new DiscoverTestExecutionRequest(session, testExecutionFilter)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/SerializerUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/SerializerUtilities.cs
@@ -592,11 +592,11 @@ internal static class SerializerUtilities
                     {
                         if (properties.TryGetValue("location.file", out object? location_file))
                         {
-                            ArgumentGuard.IsNotNull(location_file);
+                            ApplicationStateGuard.Ensure(location_file is not null);
                             if (properties.TryGetValue("location.line-start", out object? location_lineStart) && properties.TryGetValue("location.line-end", out object? location_lineEnd))
                             {
-                                ArgumentGuard.IsNotNull(location_lineStart);
-                                ArgumentGuard.IsNotNull(location_lineEnd);
+                                ApplicationStateGuard.Ensure(location_lineStart is not null);
+                                ApplicationStateGuard.Ensure(location_lineEnd is not null);
                                 var testFileLocationProperty = new TestFileLocationProperty(
                                     (string)location_file,
                                     new LinePositionSpan(new LinePosition((int)location_lineStart, 0), new LinePosition((int)location_lineEnd, 0)));

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
@@ -70,7 +70,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
         // the need to rewrite binary files. If we don't move files are locked by ourself.
         var aggregatedConfiguration = (AggregatedConfiguration)serviceProvider.GetConfiguration();
         string? currentWorkingDirectory = aggregatedConfiguration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory];
-        ArgumentGuard.IsNotNull(currentWorkingDirectory);
+        ApplicationStateGuard.Ensure(currentWorkingDirectory is not null);
         aggregatedConfiguration.SetTestHostWorkingDirectory(currentWorkingDirectory);
 
         List<(ITestHostEnvironmentVariableProvider TestHostEnvironmentVariableProvider, int RegistrationOrder)> environmentVariableProviders = [];

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrcherstrator/TestHostOrchestratorManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrcherstrator/TestHostOrchestratorManager.cs
@@ -15,7 +15,7 @@ internal class TestHostOrchestratorManager : ITestHostOrchestratorManager
 
     public void AddTestHostOrchestrator(Func<IServiceProvider, ITestHostOrchestrator> factory)
     {
-        ArgumentGuard.IsNotNull(factory, nameof(factory));
+        ArgumentGuard.IsNotNull(factory);
         _factories ??= [];
         _factories.Add(factory);
     }


### PR DESCRIPTION
`ArgumentGuard` is made to check only arguments, for internal state, we should use `ApplicationStateGuard` instead.