### PR TITLE
Fix setup of MSBuild Reference item entry

### DIFF
--- a/src/Adapter/Build/Common/MSTest.TestAdapter.targets
+++ b/src/Adapter/Build/Common/MSTest.TestAdapter.targets
@@ -31,7 +31,7 @@
       (i.e. `<None Remove="@(TestAdapterContent)" />`)
       -->
     <None Include="@(TestAdapterContent)" />
-    <Reference Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" Condition=" '$(EnableMSTestRunner)' == 'true' " />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter" HintPath="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" Condition=" '$(EnableMSTestRunner)' == 'true' " />
   </ItemGroup>
 
   <Target Name="GetMSTestV2CultureHierarchy">

--- a/src/Adapter/Build/NetWithWinUI/MSTest.TestAdapter.targets
+++ b/src/Adapter/Build/NetWithWinUI/MSTest.TestAdapter.targets
@@ -38,7 +38,7 @@
       (i.e. `<None Remove="@(TestAdapterContent)" />`)
       -->
     <None Include="@(TestAdapterContent)" />
-    <Reference Include="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" Condition=" '$(EnableMSTestRunner)' == 'true' " />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter" HintPath="$(MSBuildThisFileDirectory)Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" Condition=" '$(EnableMSTestRunner)' == 'true' " />
   </ItemGroup>
 
   <Target Name="GetMSTestV2CultureHierarchy">


### PR DESCRIPTION
`Include` should be the name of the dll without the .dll suffix and `HintPath` should be the full path.

Relates to #2173