### PR TITLE
Fix support of winui for net6+

### DIFF
--- a/src/Adapter/Build/NetWithWinUI/MSTest.TestAdapter.targets
+++ b/src/Adapter/Build/NetWithWinUI/MSTest.TestAdapter.targets
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(UseWinUI)' == 'true' ">
-    <__TestAdapterPlatformServicesRoot>$(MSBuildThisFileDirectory)winui/</__TestAdapterPlatformServicesRoot>
+    <__TestAdapterPlatformServicesRoot>$(MSBuildThisFileDirectory)../net6.0/winui/</__TestAdapterPlatformServicesRoot>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UseWinUI)' != 'true' ">
     <__TestAdapterPlatformServicesRoot>$(MSBuildThisFileDirectory)</__TestAdapterPlatformServicesRoot>

--- a/src/Adapter/Build/NetWithWinUI/MSTest.TestFramework.targets
+++ b/src/Adapter/Build/NetWithWinUI/MSTest.TestFramework.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition=" '$(UseWinUI)' == 'true' ">
-      <_TestFrameworkExtensionsRoot>$(MSBuildThisFileDirectory)winui/</_TestFrameworkExtensionsRoot>
+      <_TestFrameworkExtensionsRoot>$(MSBuildThisFileDirectory)../net6.0/winui/</_TestFrameworkExtensionsRoot>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UseWinUI)' != 'true' ">
       <_TestFrameworkExtensionsRoot>$(MSBuildThisFileDirectory)</_TestFrameworkExtensionsRoot>


### PR DESCRIPTION
When introducing net8.0 and net9.0, we broke the referencing of the specifically built dll. Instead of referencing the same dll multiple times, I have decided to update the target to copy the net6 one.

I will investigate separately the complexity and benefit of multi-targeting the netX-windowsY entries.

Fixes #2188 

@abdes you should be able to modify the locally extracted NuGet package to apply the same change if you want to do some manual double checking. It works for me on the project shared in the linked issue.