### PR TITLE
Allow IEnumerable of tuple for DynamicData source

### DIFF
--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.Designer.cs
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.Designer.cs
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;..
+        ///   Looks up a localized string similar to Property or method {0} on {1} return type is not assignable to &apos;IEnumerable&lt;object[]&gt;&apos; (nor &apos;IEnumerable&lt;ITuple&gt;&apos; for .NET Core)..
         /// </summary>
         internal static string DynamicDataIEnumerableNull {
             get {

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -263,7 +263,7 @@ Stack Trace: {4}</value>
     <value>UITestMethodAttribute.DispatcherQueue should not be null. To use UITestMethodAttribute within a WinUI Desktop App, remember to set the static UITestMethodAttribute.DispatcherQueue during the test initialization.</value>
   </data>
   <data name="DynamicDataIEnumerableNull" xml:space="preserve">
-    <value>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</value>
+    <value>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</value>
   </data>
   <data name="DynamicDataValueNull" xml:space="preserve">
     <value>Value returned by property or method {0} shouldn't be null.</value>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -243,9 +243,9 @@ Trasování zásobníku: {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">Vlastnost nebo metoda {0} v {1} nevrací IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">Vlastnost nebo metoda {0} v {1} nevrací IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -243,9 +243,9 @@ Stapelüberwachung: {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">Eigenschaft oder Methode "{0}" in "{1}" gibt IEnumerable&lt;object[]&gt; nicht zurück.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">Eigenschaft oder Methode "{0}" in "{1}" gibt IEnumerable&lt;object[]&gt; nicht zurück.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -243,9 +243,9 @@ Seguimiento de la pila: {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">La propiedad o el método {0} en {1} no devuelve IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">La propiedad o el método {0} en {1} no devuelve IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -243,9 +243,9 @@ Trace de la pile : {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">La propriété ou la méthode {0} sur {1} ne retourne pas IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">La propriété ou la méthode {0} sur {1} ne retourne pas IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -243,9 +243,9 @@ Analisi dello stack: {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">La proprietà o il metodo {0} su {1} non restituisce IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">La proprietà o il metodo {0} su {1} non restituisce IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -243,9 +243,9 @@ Stack Trace: {4}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">{1} 上のプロパティまたはメソッド {0} は IEnumerable&lt;object[]&gt; を返しません。</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">{1} 上のプロパティまたはメソッド {0} は IEnumerable&lt;object[]&gt; を返しません。</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -243,9 +243,9 @@ Stack Trace: {4}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">{1}의 속성 또는 메서드 {0}이(가) IEnumerable&lt;object[]&gt;를 반환하지 않습니다.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">{1}의 속성 또는 메서드 {0}이(가) IEnumerable&lt;object[]&gt;를 반환하지 않습니다.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -243,9 +243,9 @@ Komunikat o wyjątku: {3}
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">Właściwość lub metoda {0} w elemencie {1} nie zwraca obiektu IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">Właściwość lub metoda {0} w elemencie {1} nie zwraca obiektu IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -243,9 +243,9 @@ Rastreamento de Pilha: {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">A propriedade ou o método {0} em {1} não retorna IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">A propriedade ou o método {0} em {1} não retorna IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -243,9 +243,9 @@ Stack Trace: {4}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">Свойство или метод {0} объекта {1} не возвращает IEnumerable&lt;object[]&gt;.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">Свойство или метод {0} объекта {1} не возвращает IEnumerable&lt;object[]&gt;.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -243,9 +243,9 @@ Yığın İzleme: {4}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">{1} üzerindeki {0} özelliği veya metodu IEnumerable&lt;object[]&gt; döndürmez.</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">{1} üzerindeki {0} özelliği veya metodu IEnumerable&lt;object[]&gt; döndürmez.</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -243,9 +243,9 @@ Stack Trace: {4}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">{1} 上的属性或方法 {0} 不返回 IEnumerable&lt;object[]&gt;。</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">{1} 上的属性或方法 {0} 不返回 IEnumerable&lt;object[]&gt;。</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -243,9 +243,9 @@ Stack Trace: {4}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="DynamicDataIEnumerableNull">
-        <source>Property or method {0} on {1} does not return IEnumerable&lt;object[]&gt;.</source>
-        <target state="translated">{1} 上的屬性或方法 {0} 並未傳回 IEnumerable&lt;object[]&gt;。</target>
-        <note></note>
+        <source>Property or method {0} on {1} return type is not assignable to 'IEnumerable&lt;object[]&gt;' (nor 'IEnumerable&lt;ITuple&gt;' for .NET Core).</source>
+        <target state="needs-review-translation">{1} 上的屬性或方法 {0} 並未傳回 IEnumerable&lt;object[]&gt;。</target>
+        <note />
       </trans-unit>
       <trans-unit id="DynamicDataValueNull">
         <source>Value returned by property or method {0} shouldn't be null.</source>

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/DynamicDataAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/DynamicDataAttributeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -256,6 +257,75 @@ public class DynamicDataAttributeTests : TestContainer
         displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, data2);
         Verify(displayName == "TestMethod1 (value1,,value2)");
     }
+
+#if NETCOREAPP
+    public void DynamicDataSource_WithTuple_Works()
+    {
+        var testMethodInfo = new TestClassTupleData().GetType().GetTypeInfo().GetDeclaredMethod(nameof(TestClassTupleData.DynamicDataTestWithTuple));
+        var dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.DataWithTuple), typeof(TestClassTupleData), DynamicDataSourceType.Property);
+        var data = dynamicDataAttribute.GetData(testMethodInfo);
+
+        dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.GetDataWithTuple), typeof(TestClassTupleData), DynamicDataSourceType.Method);
+        data = dynamicDataAttribute.GetData(testMethodInfo);
+    }
+
+    public void DynamicDataSource_WithValueTuple_Works()
+    {
+        var testMethodInfo = new TestClassTupleData().GetType().GetTypeInfo().GetDeclaredMethod(nameof(TestClassTupleData.DynamicDataTestWithTuple));
+        var dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.DataWithValueTuple), typeof(TestClassTupleData), DynamicDataSourceType.Property);
+        var data = dynamicDataAttribute.GetData(testMethodInfo);
+
+        dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.GetDataWithValueTuple), typeof(TestClassTupleData), DynamicDataSourceType.Method);
+        data = dynamicDataAttribute.GetData(testMethodInfo);
+    }
+
+    public void DynamicDataSource_WithValueTupleWithTupleSyntax_Works()
+    {
+        var testMethodInfo = new TestClassTupleData().GetType().GetTypeInfo().GetDeclaredMethod(nameof(TestClassTupleData.DynamicDataTestWithTuple));
+        var dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.DataWithValueTupleWithTupleSyntax), typeof(TestClassTupleData), DynamicDataSourceType.Property);
+        var data = dynamicDataAttribute.GetData(testMethodInfo);
+
+        dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.GetDataWithValueTupleWithTupleSyntax), typeof(TestClassTupleData), DynamicDataSourceType.Method);
+        data = dynamicDataAttribute.GetData(testMethodInfo);
+    }
+#else
+    public void DynamicDataSource_WithTuple_Throws()
+    {
+        var testMethodInfo = new TestClassTupleData().GetType().GetTypeInfo().GetDeclaredMethod(nameof(TestClassTupleData.DynamicDataTestWithTuple));
+        var dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.DataWithTuple), typeof(TestClassTupleData), DynamicDataSourceType.Property);
+
+        var ex = VerifyThrows(() => dynamicDataAttribute.GetData(testMethodInfo));
+        Verify(ex is ArgumentNullException);
+
+        dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.GetDataWithTuple), typeof(TestClassTupleData), DynamicDataSourceType.Method);
+        ex = VerifyThrows(() => dynamicDataAttribute.GetData(testMethodInfo));
+        Verify(ex is ArgumentNullException);
+    }
+
+    public void DynamicDataSource_WithValueTuple_Throws()
+    {
+        var testMethodInfo = new TestClassTupleData().GetType().GetTypeInfo().GetDeclaredMethod(nameof(TestClassTupleData.DynamicDataTestWithTuple));
+        var dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.DataWithValueTuple), typeof(TestClassTupleData), DynamicDataSourceType.Property);
+        var ex = VerifyThrows(() => dynamicDataAttribute.GetData(testMethodInfo));
+        Verify(ex is ArgumentNullException);
+
+        dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.GetDataWithValueTuple), typeof(TestClassTupleData), DynamicDataSourceType.Method);
+        ex = VerifyThrows(() => dynamicDataAttribute.GetData(testMethodInfo));
+        Verify(ex is ArgumentNullException);
+    }
+
+    public void DynamicDataSource_WithValueTupleWithTupleSyntax_Throws()
+    {
+        var testMethodInfo = new TestClassTupleData().GetType().GetTypeInfo().GetDeclaredMethod(nameof(TestClassTupleData.DynamicDataTestWithTuple));
+        var dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.DataWithValueTupleWithTupleSyntax), typeof(TestClassTupleData), DynamicDataSourceType.Property);
+        var ex = VerifyThrows(() => dynamicDataAttribute.GetData(testMethodInfo));
+        Verify(ex is ArgumentNullException);
+
+        dynamicDataAttribute = new DynamicDataAttribute(nameof(TestClassTupleData.GetDataWithValueTupleWithTupleSyntax), typeof(TestClassTupleData), DynamicDataSourceType.Method);
+        ex = VerifyThrows(() => dynamicDataAttribute.GetData(testMethodInfo));
+        Verify(ex is ArgumentNullException);
+    }
+#endif
 }
 
 /// <summary>
@@ -519,4 +589,60 @@ public class DummyTestClass2
     /// </returns>
     public static string GetCustomDynamicDataDisplayName2(MethodInfo methodInfo, object[] data)
         => $"DynamicDataTestWithDisplayName {methodInfo.Name} with {data.Length} parameters";
+}
+
+[TestClass]
+public class TestClassTupleData
+{
+    public static IEnumerable<Tuple<int, string>> GetDataWithTuple()
+    {
+        yield return new(0, "0");
+        yield return new(1, "1");
+    }
+
+    public static IEnumerable<Tuple<int, string>> DataWithTuple
+    {
+        get
+        {
+            yield return new(0, "0");
+            yield return new(1, "1");
+        }
+    }
+
+    [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1141:Use tuple syntax", Justification = "We want to explicitly test this syntax")]
+    public static IEnumerable<ValueTuple<int, string>> GetDataWithValueTuple()
+    {
+        yield return new(0, "0");
+        yield return new(1, "1");
+    }
+
+    [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1141:Use tuple syntax", Justification = "We want to explicitly test this syntax")]
+    public static IEnumerable<ValueTuple<int, string>> DataWithValueTuple
+    {
+        get
+        {
+            yield return new(0, "0");
+            yield return new(1, "1");
+        }
+    }
+
+    public static IEnumerable<(int Integer, string AsString)> GetDataWithValueTupleWithTupleSyntax()
+    {
+        yield return (0, "0");
+        yield return (1, "1");
+    }
+
+    public static IEnumerable<(int Integer, string AsString)> DataWithValueTupleWithTupleSyntax
+    {
+        get
+        {
+            yield return (0, "0");
+            yield return (1, "1");
+        }
+    }
+
+    [DataTestMethod]
+    public void DynamicDataTestWithTuple(int value, string integerAsString)
+    {
+    }
 }


### PR DESCRIPTION
To avoid breaking public API, we decided to convert the tuple in `object[]` to preserve it. The current solution relies on `ITuple` which is only available in NET471+. Given we currently target net462 for full framework, that means that the feature will only be available for netcore. I'll weigh the benefit/cost ratio of adding net471 build
 in the package so this feature can be available more widely.

Fixes #1335 and fixes #1624