### PR TITLE
Add a console logger sample for the runner

### DIFF
--- a/samples/mstest-runner/CustomReportExtension/CustomReportExtension.sln
+++ b/samples/mstest-runner/CustomReportExtension/CustomReportExtension.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34530.316
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomReportExtension", "CustomReportExtension\CustomReportExtension.csproj", "{CA6AD41B-B89A-4C7C-8724-7703FF5650DF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA6AD41B-B89A-4C7C-8724-7703FF5650DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA6AD41B-B89A-4C7C-8724-7703FF5650DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA6AD41B-B89A-4C7C-8724-7703FF5650DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA6AD41B-B89A-4C7C-8724-7703FF5650DF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6B917A32-D4B0-46BD-BA01-01631383E577}
+	EndGlobalSection
+EndGlobal

--- a/samples/mstest-runner/CustomReportExtension/CustomReportExtension/CustomReportExtension.csproj
+++ b/samples/mstest-runner/CustomReportExtension/CustomReportExtension/CustomReportExtension.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+
+    <!-- For simplicity, we will create the program.cs manually -->
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/samples/mstest-runner/CustomReportExtension/CustomReportExtension/Program.cs
+++ b/samples/mstest-runner/CustomReportExtension/CustomReportExtension/Program.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Extensions;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+
+// Register MSTest as the test framework to use.
+builder.AddMSTest(() => new[] { typeof(Program).Assembly });
+
+// This is a convenience helper that simplifies the process of creating a composite extension (a type that implements multiple extension points).
+// Thanks to that, you can implement multiple extension points in a single class and you don't have to handle communication/synchronization between them.
+CompositeExtensionFactory<TestResultConsoleLogger> testUpdateConsoleReporter =
+    new(serviceProvider => new TestResultConsoleLogger());
+
+// Register the extension as a data consumer and test session lifetime handler.
+builder.TestHost.AddDataConsumer(testUpdateConsoleReporter);
+builder.TestHost.AddTestSessionLifetimeHandle(testUpdateConsoleReporter);
+
+ITestApplication app = await builder.BuildAsync();
+
+return await app.RunAsync();

--- a/samples/mstest-runner/CustomReportExtension/CustomReportExtension/TestResultConsoleLogger.cs
+++ b/samples/mstest-runner/CustomReportExtension/CustomReportExtension/TestResultConsoleLogger.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.TestHost;
+
+internal sealed class TestResultConsoleLogger :
+    // This is the extension point to subscribe to data messages published to the platform.
+    // The type should then be registered as a data consumer in the test host.
+    IDataConsumer,
+    // This is the extension point to subscribe to test session lifetime events.
+    // The type should then be registered as a test session lifetime handler in the test host.
+    ITestSessionLifetimeHandler
+{
+    public string Uid => nameof(TestResultConsoleLogger);
+
+    public string Version => "1.0.0";
+
+    public string DisplayName => "Test results console logger";
+
+    public string Description => "Displays to the console the results of tests execution";
+
+    public Type[] DataTypesConsumed { get; } = new[]
+    {
+        // Subscribe to test node update messages.
+        typeof(TestNodeUpdateMessage)
+    };
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        var testNodeUpdate = (TestNodeUpdateMessage)value;
+        string? resultMessage = testNodeUpdate.TestNode.Properties.Single<TestNodeStateProperty>() switch
+        {
+            PassedTestNodeStateProperty => "passed",
+            FailedTestNodeStateProperty => "failed",
+            SkippedTestNodeStateProperty => "was skipped",
+            ErrorTestNodeStateProperty => "errored",
+            TimeoutTestNodeStateProperty => "timed out",
+            CancelledTestNodeStateProperty => "was cancelled",
+            _ => null,
+        };
+
+        if (resultMessage is not null)
+        {
+            PrintMessage($"{testNodeUpdate.TestNode.DisplayName} {resultMessage}");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task OnTestSessionFinishingAsync(SessionUid sessionUid, CancellationToken cancellationToken)
+    {
+        PrintMessage($"Closing test session '{sessionUid.Value}'");
+        return Task.CompletedTask;
+    }
+
+    public Task OnTestSessionStartingAsync(SessionUid sessionUid, CancellationToken cancellationToken)
+    {
+        PrintMessage($"Starting test session '{sessionUid.Value}'");
+        return Task.CompletedTask;
+    }
+
+    private static void PrintMessage(string message)
+    {
+        try
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            // The console service is not yet public as it needs to be finalized so for now we can use Console.WriteLine.
+            Console.WriteLine(message);
+        }
+        finally
+        {
+            Console.ResetColor();
+        }
+    }
+}

--- a/samples/mstest-runner/CustomReportExtension/CustomReportExtension/UnitTest1.cs
+++ b/samples/mstest-runner/CustomReportExtension/CustomReportExtension/UnitTest1.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace CustomReportExtension;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void PassedTestMethod()
+    {
+    }
+
+    [TestMethod]
+    public void FailedTestMethod()
+    {
+        Assert.Fail();
+    }
+}


### PR DESCRIPTION
Contributes to #2242

Provides a sample of extending the platform to provide a custom report generator through some simple (naive) console logger.