### PR TITLE
Set correct diagnostic default and cut allocations

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -255,7 +255,7 @@ public sealed class TestApplication : ITestApplication
         CommandLineParseResult result, CurrentTestApplicationModuleInfo testApplicationModuleInfo, SystemClock clock,
         SystemEnvironment environment, SystemTask task, SystemConsole console)
     {
-        LogLevel logLevel = LogLevel.Trace;
+        LogLevel logLevel = LogLevel.None;
 
         if (result.HasError)
         {
@@ -277,6 +277,8 @@ public sealed class TestApplication : ITestApplication
         {
             return new(logLevel, result);
         }
+
+        logLevel = LogLevel.Trace;
 
         if (result.TryGetOptionArgumentList(PlatformCommandLineProvider.DiagnosticVerbosityOptionKey, out string[]? verbosity))
         {


### PR DESCRIPTION
Reduce allocations by ~39 per test

Before
![before](https://github.com/microsoft/testfx/assets/7894084/d1affbd8-efcf-436b-8ebb-9a41359dfedf)
After
<img width="1235" alt="after" src="https://github.com/microsoft/testfx/assets/7894084/0a9d4aee-6736-4502-9014-0fec3bcea368">
