### PR TITLE
Add comment on 'OnTestHostProcessStartedAsync' design

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -227,7 +227,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
                     throw ApplicationStateGuard.Unreachable();
                 }
 
-                // We don't block the host during the 'OnTestHostProcessStartedAsync' by-design, if lifetimeHandler extensions needs
+                // We don't block the host during the 'OnTestHostProcessStartedAsync' by-design, if 'ITestHostProcessLifetimeHandler' extensions needs
                 // to block the execution of the test host should add an in-process extension like an 'ITestApplicationLifecycleCallbacks' and
                 // wait for a connection/signal to return.
                 var testHostProcessInformation = new TestHostProcessInformation(_testHostPID.Value);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -227,6 +227,9 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
                     throw ApplicationStateGuard.Unreachable();
                 }
 
+                // We don't block the host during the 'OnTestHostProcessStartedAsync' by-design, if lifetimeHandler extensions needs
+                // to block the execution of the test host should add an in-process extension like an 'ITestApplicationLifecycleCallbacks' and
+                // wait for a connection/signal to return.
                 var testHostProcessInformation = new TestHostProcessInformation(_testHostPID.Value);
                 foreach (ITestHostProcessLifetimeHandler lifetimeHandler in _testHostsInformation.LifetimeHandlers)
                 {


### PR DESCRIPTION
We don't block by-design for performance reason, it's up to the extension decide how to do it.

cc: @Evangelink 