### PR TITLE
Shorten server pipe name

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -273,7 +273,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
                     PlatformResources.CouldNotFindDirectoryErrorMessage,
 #endif
                     directoryId))
-                : Path.Combine(directoryId, ".pipe"), true);
+                : Path.Combine(directoryId, ".p"), true);
     }
 
     public void Dispose()


### PR DESCRIPTION
contributes to https://github.com/microsoft/testfx/issues/2297

this plus update in the retry extension should shorten the above use case to 84:

`"/var/folders/jd/70dmjhl15_94kvft_dz552ph0000gq/T/6c71eeb55820467f8cf1bc78248b762d/.p"`