### PR TITLE
[rel/3.2] Fix analyzers doc link

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Shipped.md
@@ -4,9 +4,9 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-MSTEST0001 | Performance | Info | UseParallelizeAttributeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-MSTEST0001)
-MSTEST0002 | Usage | Warning | TestClassShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-MSTEST0002)
-MSTEST0003 | Usage | Warning | TestMethodShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-MSTEST0003)
-MSTEST0004 | Design | Disabled | PublicTypeShouldBeTestClassAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-MSTEST0004)
-MSTEST0005 | Usage | Warning | TestContextShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-MSTEST0005)
-MSTEST0006 | Design | Info | AvoidExpectedExceptionAttributeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-MSTEST0006)
+MSTEST0001 | Performance | Info | UseParallelizeAttributeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0001)
+MSTEST0002 | Usage | Warning | TestClassShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0002)
+MSTEST0003 | Usage | Warning | TestMethodShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0003)
+MSTEST0004 | Design | Disabled | PublicTypeShouldBeTestClassAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0004)
+MSTEST0005 | Usage | Warning | TestContextShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0005)
+MSTEST0006 | Design | Info | AvoidExpectedExceptionAttributeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0006)

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticDescriptorHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticDescriptorHelper.cs
@@ -20,7 +20,7 @@ internal static class DiagnosticDescriptorHelper
         bool isReportedAtCompilationEnd = false,
         params string[] customTags)
         => new(id, title, messageFormat, category.ToString(), defaultSeverity, isEnabledByDefault, description,
-            $"https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-analyzers-{id}",
+            $"https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/{id.ToLowerInvariant()}",
             CreateCustomTags(isReportedAtCompilationEnd, customTags));
 
     public static DiagnosticDescriptor WithMessage(this DiagnosticDescriptor diagnosticDescriptor, LocalizableResourceString messageFormat)


### PR DESCRIPTION
The learn doc link was shorten and updated to simplifying lookup and improve SEO. This fix follows the new format.