### PR TITLE
Add example for simple framework without VSTest bridge

### DIFF
--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework.sln
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34623.280
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnsureTestFramework", "EnsureTestFramework\EnsureTestFramework.csproj", "{E49270B4-CA6D-4D16-8852-9F90C93DB8E2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AF895EC8-0042-46F0-A11D-33DC1519784B}"
+	ProjectSection(SolutionItems) = preProject
+		MyTestProject = MyTestProject
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyTestProject", "MyTestProject\MyTestProject.csproj", "{9DF48339-27D8-44E9-9846-2E4082CF6733}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E49270B4-CA6D-4D16-8852-9F90C93DB8E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E49270B4-CA6D-4D16-8852-9F90C93DB8E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E49270B4-CA6D-4D16-8852-9F90C93DB8E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E49270B4-CA6D-4D16-8852-9F90C93DB8E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DF48339-27D8-44E9-9846-2E4082CF6733}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DF48339-27D8-44E9-9846-2E4082CF6733}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DF48339-27D8-44E9-9846-2E4082CF6733}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DF48339-27D8-44E9-9846-2E4082CF6733}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {857B6B98-1388-442D-8E96-D3458E60861B}
+	EndGlobalSection
+EndGlobal

--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFramework.cs
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFramework.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Requests;
+
+namespace Contoso.EnsureTestFramework;
+
+internal sealed class EnsureTestFramework : ITestFramework, IDataProducer
+{
+    private readonly IExtension _extension;
+
+    public EnsureTestFramework(IExtension extension, ITestFrameworkCapabilities _, IServiceProvider __)
+    {
+        _extension = extension;
+    }
+
+    public string Uid => _extension.Uid;
+
+    public string Version => _extension.Version;
+
+    public string DisplayName => _extension.DisplayName;
+
+    public string Description => _extension.Description;
+
+    public Type[] DataTypesProduced { get; } =
+        new Type[1] { typeof(TestNodeUpdateMessage) };
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+    {
+        // Cleanup, e.g. close all child processes if you started any.
+        CloseTestSessionResult result = new()
+        {
+            IsSuccess = true,
+            // Here you can report any errors that happened but don't belong to a test, e.g. you failed to clean up.
+            ErrorMessage = null,
+        };
+
+        return Task.FromResult(result);
+    }
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+    {
+        CreateTestSessionResult result = new()
+        {
+            IsSuccess = true,
+            // Here you can report any errors that happened but don't belong to a test, e.g. you failed start up.
+            ErrorMessage = null,
+        };
+
+        return Task.FromResult(result);
+    }
+
+    public Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        IRequest request = context.Request;
+        switch (request)
+        {
+            case DiscoverTestExecutionRequest:
+                {
+                    var testNode = new TestNode
+                    {
+                        DisplayName = "My test method",
+                        Uid = new TestNodeUid("A stable, unique id that identifies my test method, such as assemblyname.classname.methodname.parameters."),
+                        Properties = new PropertyBag(DiscoveredTestNodeStateProperty.CachedInstance),
+                    };
+
+                    // Report back the update, including optional parent of this test node.
+                    var discovered = new TestNodeUpdateMessage(context.Request.Session.SessionUid, testNode, parentTestNodeUid: null);
+
+                    // By implementing this interface, we tell the message bus what data we will produce.
+                    IDataProducer testUpdateReporter = this;
+                    context.MessageBus.PublishAsync(testUpdateReporter, discovered);
+                    break;
+                }
+            case RunTestExecutionRequest:
+                {
+                    var failedProperty = new FailedTestNodeStateProperty(new InvalidOperationException("Assertion failed."));
+                    var testNode = new TestNode
+                    {
+                        DisplayName = "My test method",
+                        Uid = new TestNodeUid("A stable, unique id that identifies my test method, such as assemblyname.classname.methodname.parameters."),
+                        Properties = new PropertyBag(
+                            failedProperty,
+                            new TimingProperty(new TimingInfo(DateTime.UtcNow.Subtract(TimeSpan.FromMilliseconds(100)), DateTime.UtcNow, TimeSpan.FromMilliseconds(100)))
+                        ),
+                    };
+                    var executed = new TestNodeUpdateMessage(context.Request.Session.SessionUid, testNode, parentTestNodeUid: null);
+
+                    // By implementing this interface, we tell the message bus what data we will produce.
+                    IDataProducer testUpdateReporter = this;
+                    context.MessageBus.PublishAsync(testUpdateReporter, executed);
+                    break;
+                }
+            default:
+                throw new NotSupportedException();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> IsEnabledAsync()
+    {
+        return Task.FromResult(true);
+    }
+}

--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFramework.cs
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFramework.cs
@@ -109,7 +109,6 @@ internal sealed class EnsureTestFramework : ITestFramework, IDataProducer
             context.Complete();
         }
 
-        return;
     }
 
     public Task<bool> IsEnabledAsync()

--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFramework.csproj
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFramework.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="1.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFrameworkCapabilities.cs
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFrameworkCapabilities.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+
+namespace Contoso.EnsureTestFramework;
+
+internal sealed class EnsureTestFrameworkCapabilities : ITestFrameworkCapabilities
+{
+    public IReadOnlyCollection<ITestFrameworkCapability> Capabilities => Array.Empty<ITestFrameworkCapability>();
+}

--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFrameworkExtension.cs
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/EnsureTestFrameworkExtension.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+using Microsoft.Testing.Platform.Extensions;
+
+namespace Contoso.EnsureTestFramework;
+
+internal sealed class EnsureTestFrameworkExtension : IExtension
+{
+    public string Uid => nameof(EnsureTestFrameworkExtension);
+
+    public string DisplayName => "Contoso.Ensure";
+
+    public string Version => "1.0.0";
+
+    public string Description => "An example of a non-bridged test framework.";
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+}

--- a/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/TestApplicationBuilderExtensions.cs
+++ b/samples/mstest-runner/EnsureTestFramework/EnsureTestFramework/TestApplicationBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+namespace Contoso.EnsureTestFramework;
+
+public static class TestApplicationBuilderExtensions
+{
+    public static void AddEnsureTestFramework(this ITestApplicationBuilder testApplicationBuilder)
+    {
+        EnsureTestFrameworkExtension extension = new();
+        testApplicationBuilder.RegisterTestFramework(GetCapabilities, GetFramework);
+    }
+
+    private static ITestFrameworkCapabilities GetCapabilities(IServiceProvider provider)
+    {
+        return new EnsureTestFrameworkCapabilities();
+    }
+
+    private static ITestFramework GetFramework(ITestFrameworkCapabilities capabilities, IServiceProvider provider)
+    {
+        EnsureTestFrameworkExtension extension = new();
+        return new EnsureTestFramework(extension, capabilities, provider);
+    }
+}

--- a/samples/mstest-runner/EnsureTestFramework/MyTestProject/MyTestProject.csproj
+++ b/samples/mstest-runner/EnsureTestFramework/MyTestProject/MyTestProject.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EnsureTestFramework\EnsureTestFramework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/mstest-runner/EnsureTestFramework/MyTestProject/Program.cs
+++ b/samples/mstest-runner/EnsureTestFramework/MyTestProject/Program.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Contoso.EnsureTestFramework;
+
+using Microsoft.Testing.Platform.Builder;
+
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var builder = await TestApplication.CreateBuilderAsync(args);
+        builder.AddEnsureTestFramework();
+        var app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+


### PR DESCRIPTION
Add example for simple test framework called Contoso.EnsureTestFramework, that does the bare minimum to wire together the infrastructure needed. 
