### PR TITLE
Remove the `Microsoft.Testing.Extensions.Telemetry` from the package

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.Linux.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.Linux.nuspec
@@ -5,27 +5,22 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
     </dependencies>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -5,33 +5,27 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net462">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="uap10.0" />
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
-        <dependency id="Microsoft.Testing.Extensions.Telemetry" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
       </group>
     </dependencies>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Program.cs
@@ -11,6 +11,9 @@ using Microsoft.Testing.Platform.Extensions.TestHost;
 
 using MSTest.Acceptance.IntegrationTests;
 
+// Opt-out telemetry
+Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+
 CommandLine.MaxOutstandingCommands = Environment.ProcessorCount;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Program.cs
@@ -10,6 +10,9 @@ using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 
+// Opt-out telemetry
+Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+
 CommandLine.MaxOutstandingCommands = Environment.ProcessorCount;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
@@ -13,6 +13,9 @@ using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Services;
 using Microsoft.Testing.TestInfrastructure;
 
+// Opt-out telemetry
+Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+
 // DebuggerUtility.AttachVSToCurrentProcess();
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
 builder.TestHost.AddTestApplicationLifecycleCallbacks(sp => new GlobalTasks(sp.GetCommandLineOptions()));


### PR DESCRIPTION
Remove the `Microsoft.Testing.Extensions.Telemetry` from the package it will come from the VSBridge
