### PR TITLE
Make `RootDeploymentDirectory` name unique

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtility.cs
@@ -3,7 +3,7 @@
 
 #if !WINDOWS_UWP
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD || NETCOREAPP3_1
 using System.Diagnostics;
 #endif
 using System.Globalization;
@@ -66,7 +66,11 @@ internal class DeploymentUtility : DeploymentUtilityBase
     /// <returns>Root deployment directory.</returns>
     public override string GetRootDeploymentDirectory(string baseDirectory)
     {
-        string dateTimeSuffix = DateTime.Now.ToString("yyyyMMddTHHmmss", DateTimeFormatInfo.InvariantInfo);
+#if NETFRAMEWORK || NETSTANDARD || NETCOREAPP3_1
+        string dateTimeSuffix = $"{DateTime.Now.ToString("yyyyMMddTHHmmss", DateTimeFormatInfo.InvariantInfo)}_{Process.GetCurrentProcess().Id}";
+#else
+        string dateTimeSuffix = $"{DateTime.Now.ToString("yyyyMMddTHHmmss", DateTimeFormatInfo.InvariantInfo)}_{Environment.ProcessId}";
+#endif
         string directoryName = string.Format(CultureInfo.InvariantCulture, Resource.TestRunName, DeploymentFolderPrefix,
 #if NETFRAMEWORK
             Environment.UserName,


### PR DESCRIPTION
Append pid to make the deploy directory unique during parallel test run.


Fixes https://github.com/microsoft/testfx/issues/2219

