### PR TITLE
Add .NET Latest data source

### DIFF
--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TargetFrameworks.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TargetFrameworks.cs
@@ -18,6 +18,8 @@ public static class TargetFrameworks
 
     public static TestArgumentsEntry<string> NetCurrent { get; } = Net[0];
 
+    public static TestArgumentsEntry<string>[] NetLatest { get; } = new[] { Net[0] };
+
     public static TestArgumentsEntry<string>[] NetFramework { get; } = new TestArgumentsEntry<string>[] { new("net462", "net462") };
 
     public static TestArgumentsEntry<string>[] All { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)


### PR DESCRIPTION
Add .NET latest data source that can be used to decorate a test (unlike NetCurrent).