### PR TITLE
Automatic `MSTestExtension` versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,6 @@ project.fragment.lock.json
 # ===========================
 /src/Package/MSTest.Sdk/Sdk/Sdk.props
 /src/Package/MSTest.Sdk/Sdk/Runner/Runner.targets
-/src/Adapter/MSTest.TestAdapter/Versions.cs
 
 # Playground project (use force add if a change is really worth it)
 /samples/Playground/

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ project.fragment.lock.json
 # ===========================
 /src/Package/MSTest.Sdk/Sdk/Sdk.props
 /src/Package/MSTest.Sdk/Sdk/Runner/Runner.targets
+/src/Adapter/MSTest.TestAdapter/Versions.cs
 
 # Playground project (use force add if a change is really worth it)
 /samples/Playground/

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -88,4 +88,29 @@
   <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" Condition=" '$(OS)' == 'Windows_NT' " />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(OS)' != 'Windows_NT' " />
 
+
+  <!-- Version templating -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Versions.cs.template" />
+  </ItemGroup>
+  <Target Name="GenerateTemplates" AfterTargets="PrepareForBuild">
+    <PropertyGroup>
+      <_TemplateProperties>MSTestVersion=$(Version)</_TemplateProperties>
+    </PropertyGroup>
+
+    <!--
+      List all templates that use ${} template, that will be replaced by the properties defined below.
+      This will happen on every build. When adding a new file, also add the destination fileto .gitignore.
+      -->
+    <ItemGroup>
+      <_TemplateCsproj Include="$(MSBuildProjectDirectory)/Versions.cs.template" Destination="$(MSBuildProjectDirectory)/Versions.cs" />
+    </ItemGroup>
+
+    <GenerateFileFromTemplate TemplateFile="%(_TemplateCsproj.Identity)" OutputPath="%(_TemplateCsproj.Destination)" Properties="$(_TemplateProperties)">
+      <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
+    </GenerateFileFromTemplate>
+  </Target>
 </Project>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -95,6 +95,10 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Versions.cs.template" />
+    <Compile Update="Versions.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
   </ItemGroup>
   <Target Name="GenerateTemplates" AfterTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestExtension.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestExtension.cs
@@ -12,7 +12,7 @@ internal sealed class MSTestExtension : IExtension
 
     public string DisplayName => "MSTest";
 
-    public string Version => "3.3.0"; // TODO: Decide whether to read from assembly or use hardcoded string.
+    public string Version => RepositoryVersion.Version;
 
     public string Description => "MSTest Framework for Microsoft Testing Platform";
 

--- a/src/Adapter/MSTest.TestAdapter/Versions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Versions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Repository version, created at build time.
+/// </summary>
+internal static class RepositoryVersion
+{
+    public const string Version = "3.3.0-dev";
+}

--- a/src/Adapter/MSTest.TestAdapter/Versions.cs.template
+++ b/src/Adapter/MSTest.TestAdapter/Versions.cs.template
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Repository version, created at build time.
+/// </summary>
+internal static class RepositoryVersion
+{
+    public const string Version = "${MSTestVersion}";
+}


### PR DESCRIPTION
@Evangelink I had to add the source file because Compile items cannot be added if we don't update the project for "manual" Includes and I don't like the idea to miss some defaults. We can decide to do it...but.

So what will happen is that on CI we will mutate the file before the build directly there for now. We do similar for the SDK the only difference is that the file is "excluded" in the .gitignore.

Another solution can be add a resource...but it's less performant. 

If version is not changed the task won't touch the file so in local we won't see any difference.