### PR TITLE
Add copy of pipeline for migration

### DIFF
--- a/azure-pipelines-nonofficial.yml
+++ b/azure-pipelines-nonofficial.yml
@@ -1,0 +1,205 @@
+# Branches that trigger a build on commit
+trigger:
+  branches:
+    include:
+    - main
+    - rel/*
+    - dev/3.3.X
+    exclude:
+    - rel/2.*
+    - rel/3.0.*
+
+# Branch(es) that trigger(s) build(s) on PR
+pr:
+  branches:
+    include:
+    - main
+    - rel/*
+  paths:
+    exclude:
+      - .github/*
+      - .devcontainer/*
+      - docs/*
+      - .markdownlint.json
+      - .markdownlintignore
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - README.md
+      - SECURITY.md
+      - src/**/*.xlf
+
+parameters:
+- name: isRTM
+  displayName: "Produce RTM version?"
+  type: boolean
+  default: False
+# This option should be used with caution. This is useful for unblocking circular deps issue with testanywhere
+- name: SkipTests
+  displayName: "Skip tests"
+  type: boolean
+  default: False
+
+variables:
+  # Cannot use key:value syntax in root defined variables
+  - name: _TeamName
+    value: MSTest
+  - name: Codeql.Enabled
+    value: true
+  - name: _RunAsInternal
+    value: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
+  - name: _RunAsPublic
+    value: ${{ eq(variables._RunAsInternal, False) }}
+  # Set default value for variables of PR and Public builds
+  - name: _SignType
+    value: test
+  - name: _SignArgs
+    value: ''
+  - name: _Sign
+    value: False
+  - name: _InternalBuildArgs
+    value: ' '
+  - name: _ReleaseVersionKind
+    value: ''
+
+  - ${{ if eq(parameters.isRTM, True) }}:
+    - name: _ReleaseVersionKind
+      value: release
+
+  # Produce real signed binaries for Internal builds
+  - ${{ if eq(variables._RunAsInternal, True) }}:
+    - group: DotNet-Symbol-Server-Pats
+    - name: _SignType
+      value: real
+    - name: _SignArgs
+      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
+    - name: _Sign
+      value: True
+    - name: _InternalBuildArgs
+      value: /p:DotNetSignType=$(_SignType)
+        /p:TeamName=$(_TeamName)
+        /p:DotNetFinalVersionKind=$(_ReleaseVersionKind)
+        /p:DotNetPublishUsingPipelines=true
+        /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+        /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+        /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+
+stages:
+
+- stage: build
+  displayName: Build
+  jobs:
+
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      testResultsFormat: 'vstest'
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: true
+      enableTelemetry: true
+      jobs:
+      - job: Windows
+        timeoutInMinutes: 90
+        pool:
+          ${{ if eq(variables._RunAsPublic, True) }}:
+            name: NetCore-Public
+            demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          ${{ if eq(variables._RunAsInternal, True) }}:
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals windows.vs2022preview.amd64
+        strategy:
+          matrix:
+            Release:
+              _BuildConfig: Release
+            ${{ if eq(variables._RunAsPublic, True) }}:
+              Debug:
+                _BuildConfig: Debug
+        steps:
+        - task: PowerShell@2
+          displayName: 'Install Windows SDK'
+          inputs:
+            targetType: filePath
+            filePath: './eng/install-windows-sdk.ps1'
+            failOnStderr: true
+            showWarnings: true
+
+        - script: eng\common\CIBuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            $(_InternalBuildArgs)
+            /p:Test=false
+          name: Build
+          displayName: Build
+
+        - ${{ if eq(parameters.SkipTests, False) }}:
+          # -ci is allowing to import some environment variables and some required configurations
+          - script: Test.cmd
+              -configuration $(_BuildConfig)
+              -ci
+            name: Test
+            displayName: Test
+
+          # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
+          # through the console or trx
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish Test Results folders'
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+              ArtifactName: TestResults
+            condition: failed()
+
+        - ${{ if eq(variables._RunAsInternal, True) }}:
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate to test-tools feed'
+
+          - task: NuGetCommand@2
+            displayName: 'Publish NuGet packages to test-tools feed'
+            inputs:
+              command: push
+              # Do not push symbol packages nor Microsoft.Testing.Platform package
+              packagesToPush: 'artifacts/packages/$(_BuildConfig)/**/*.nupkg;!artifacts/packages/$(_BuildConfig)/**/*.symbols.nupkg;!artifacts/packages/$(_BuildConfig)/NonShipping/Microsoft.Testing.Platform.*.nupkg'
+              publishVstsFeed: 'public/test-tools'
+
+      - job: Linux
+        timeoutInMinutes: 90
+        pool:
+          ${{ if eq(variables._RunAsPublic, True) }}:
+            name: NetCore-Public
+            demands: ImageOverride -equals build.ubuntu.2004.amd64.open
+          ${{ if eq(variables._RunAsInternal, True) }}:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.ubuntu.2004.amd64
+        strategy:
+          matrix:
+            Release:
+              _BuildConfig: Release
+            ${{ if eq(variables._RunAsPublic, True) }}:
+              Debug:
+                _BuildConfig: Debug
+        steps:
+        - script: eng/common/cibuild.sh
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            /p:Test=false
+            /p:NonWindowsBuild=true
+          displayName: Build
+
+        - ${{ if eq(parameters.SkipTests, False) }}:
+          # -ci is allowing to import some environment variables and some required configurations
+          - script: |
+              chmod +x ./test.sh
+              ./test.sh --configuration $(_BuildConfig) --ci --test --integrationTest
+            name: Test
+            displayName: Tests
+
+  - ${{ if eq(variables._RunAsInternal, True) }}:
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        GitHubOrg: microsoft
+        MirrorRepo: testfx
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-TESTFX'
+
+- ${{ if eq(variables._RunAsInternal, True) }}:
+  - template: eng\common\templates\post-build\post-build.yml


### PR DESCRIPTION
Copy of the pipeline, so we can reconfigure the PR builds to use this. Will cleanup the non-official stuff in later prs.