### PR TITLE
Use System.Text.Json instead of Jsonite

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -491,26 +491,23 @@ internal sealed class Json
                 int id = json.OptionalPropertyBind<int>(jsonElement, JsonRpcStrings.Id);
 
                 object? @params = null;
-                if (method != JsonRpcMethods.Exit)
+                if (jsonElement.TryGetProperty(JsonRpcStrings.Params, out JsonElement value))
                 {
-                    if (jsonElement.TryGetProperty(JsonRpcStrings.Params, out JsonElement value))
+                    // Parse the specific methods
+                    @params = method switch
                     {
-                        // Parse the specific methods
-                        @params = method switch
-                        {
-                            JsonRpcMethods.Initialize => json.Bind<InitializeRequestArgs>(value),
-                            JsonRpcMethods.TestingDiscoverTests => json.Bind<DiscoverRequestArgs>(value),
-                            JsonRpcMethods.TestingRunTests => json.Bind<RunRequestArgs>(value),
-                            JsonRpcMethods.CancelRequest => json.Bind<CancelRequestArgs>(value),
-                            JsonRpcMethods.Exit => json.Bind<ExitRequestArgs>(value),
+                        JsonRpcMethods.Initialize => json.Bind<InitializeRequestArgs>(value),
+                        JsonRpcMethods.TestingDiscoverTests => json.Bind<DiscoverRequestArgs>(value),
+                        JsonRpcMethods.TestingRunTests => json.Bind<RunRequestArgs>(value),
+                        JsonRpcMethods.CancelRequest => json.Bind<CancelRequestArgs>(value),
+                        JsonRpcMethods.Exit => json.Bind<ExitRequestArgs>(value),
 
-                            // Note: Let the server report unknown RPC request back to the client.
-                            _ => null,
-                        };
-                    }
+                        // Note: Let the server report unknown RPC request back to the client.
+                        _ => null,
+                    };
                 }
 
-                return id is default(int)
+                return id is not default(int)
                     ? new RequestMessage(id, method, @params)
                     : new NotificationMessage(method, @params);
             }
@@ -527,8 +524,7 @@ internal sealed class Json
                 // Note: Because the result message does not contain the original method name,
                 //       it's not possible for us to do a typed deserialization.
                 //       The best option we've got is to return a generic property bag.
-                string idStr = json.Bind<string>(jsonElement, JsonRpcStrings.Id);
-                int id = int.TryParse(idStr, out int identity) ? identity : default;
+                int id = json.Bind<int>(jsonElement, JsonRpcStrings.Id);
 
                 var result = element.ValueKind == JsonValueKind.Null ? null :
                     json.Bind<IDictionary<string, object>>(jsonElement, JsonRpcStrings.Result);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -434,38 +434,38 @@ internal sealed class Json
 
         _deserializers[typeof(IDictionary<string, object?>)] = new JsonElementDeserializer<IDictionary<string, object?>>((json, jsonDocument) =>
         {
-            var dict = new Dictionary<string, object?>();
+            var items = new Dictionary<string, object?>();
             foreach (var kvp in jsonDocument.EnumerateObject())
             {
                 switch (kvp.Value.ValueKind)
                 {
                     case JsonValueKind.String:
-                        dict.Add(kvp.Name, kvp.Value.GetString());
+                        items.Add(kvp.Name, kvp.Value.GetString());
                         break;
                     case JsonValueKind.Number:
-                        dict.Add(kvp.Name, kvp.Value.GetInt32());
+                        items.Add(kvp.Name, kvp.Value.GetInt32());
                         break;
                     case JsonValueKind.True:
-                        dict.Add(kvp.Name, true);
+                        items.Add(kvp.Name, true);
                         break;
                     case JsonValueKind.False:
-                        dict.Add(kvp.Name, false);
+                        items.Add(kvp.Name, false);
                         break;
                     case JsonValueKind.Object:
-                        dict.Add(kvp.Name, json.Bind<IDictionary<string, object?>>(kvp.Value));
+                        items.Add(kvp.Name, json.Bind<IDictionary<string, object?>>(kvp.Value));
                         break;
                     case JsonValueKind.Array:
-                        dict.Add(kvp.Name, json.Bind<object[]>(kvp.Value));
+                        items.Add(kvp.Name, json.Bind<object[]>(kvp.Value));
                         break;
                     case JsonValueKind.Null:
-                        dict.Add(kvp.Name, null);
+                        items.Add(kvp.Name, null);
                         break;
                     default:
                         throw new InvalidOperationException($"key: {kvp.Name}, value: {kvp.Value}, type: {kvp.Value.ValueKind}");
                 }
             }
 
-            return dict;
+            return items;
         });
 
         _deserializers[typeof(ErrorMessage)] = new JsonElementDeserializer<ErrorMessage>(

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -752,42 +752,16 @@ internal sealed class Json
             }
         }
 
-        bool deserializerFound = _deserializers.TryGetValue(typeof(T), out JsonDeserializer? deserializer);
-
-        if (deserializerFound && deserializer is JsonElementDeserializer<T> objectDeserializer)
-        {
-            T obj = objectDeserializer.CreateObject(this, element);
-            return obj;
-        }
-
-        if (deserializerFound && deserializer is JsonCollectionDeserializer<T> collectionDeserializer)
-        {
-            T obj = collectionDeserializer.CreateObject(this, element);
-            return obj;
-        }
-
-        if (deserializerFound && deserializer is JsonElementDeserializer<object> baseObjectDeserializer)
-        {
-            var obj = (T)baseObjectDeserializer.CreateObject(this, element);
-            return obj;
-        }
-
-        if (deserializerFound && deserializer is JsonCollectionDeserializer<object> baseCollectionDeserializer)
-        {
-            var obj = (T)baseCollectionDeserializer.CreateObject(this, element);
-            return obj;
-        }
-
-        throw new InvalidOperationException($"Cannot find deserializer for {typeof(T)}.");
+        return Deserialize<T>(element);
     }
 
     internal T? OptionalBind<T>(JsonElement element, string? property = null)
     {
-        if (property != null && !element.TryGetProperty(property, out element))
-        {
-            return default;
-        }
+        return property != null && !element.TryGetProperty(property, out element) ? default : Deserialize<T>(element);
+    }
 
+    private T Deserialize<T>(JsonElement element)
+    {
         bool deserializerFound = _deserializers.TryGetValue(typeof(T), out JsonDeserializer? deserializer);
 
         if (deserializerFound && deserializer is JsonElementDeserializer<T> objectDeserializer)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -627,7 +627,6 @@ internal sealed class Json
                         locationFile,
                         new LinePositionSpan(new LinePosition(locationLineStart, 0), new LinePosition(locationLineEnd, 0)));
                     propertyBag.Add(testFileLocationProperty);
-
                 }
 
                 return new TestNode

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -623,23 +623,19 @@ internal sealed class Json
               int id = json.Bind<int>(jsonElement, JsonRpcStrings.Id);
               var error = jsonElement.GetProperty(JsonRpcStrings.Error);
 
-              var dataObj = json.OptionalPropertyBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
-              if (dataObj is not null)
-              {
-                  if (dataObj is Dictionary<string, object?> data && data.Count == 0)
-                  {
-                      dataObj = null!;
-                  }
-              }
-
               var code = json.Bind<int>(error, JsonRpcStrings.Code);
               var message = json.Bind<string>(error, JsonRpcStrings.Message);
+              var data = json.OptionalPropertyBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
+              if (data is not null && data.Count == 0)
+              {
+                  data = null;
+              }
 
               return new ErrorMessage(
                   Id: id,
                   ErrorCode: code,
                   Message: message ?? string.Empty,
-                  Data: dataObj);
+                  Data: data);
           });
 
         // Try to add serializers passed from outside

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Testing.Platform.ServerMode.Json;
 
 internal sealed class Json
 {
-    private const string RPCVersion = "2.0";
-
     private readonly Dictionary<Type, JsonDeserializer> _deserializers = [];
     private readonly Dictionary<Type, JsonSerializer> _serializers = [];
     private readonly ObjectPool<MemoryStream> _memoryStreamPool = new(() => new MemoryStream());
@@ -27,7 +25,7 @@ internal sealed class Json
          {
              var list = new (string, object?)[4]
              {
-                 (JsonRpcStrings.JsonRpc, RPCVersion),
+                 (JsonRpcStrings.JsonRpc, "2.0"),
                  (JsonRpcStrings.Id, request.Id),
                  (JsonRpcStrings.Method, request.Method),
                  (JsonRpcStrings.Params, request.Params),
@@ -40,7 +38,7 @@ internal sealed class Json
         {
             var list = new (string, object?)[3]
             {
-                 (JsonRpcStrings.JsonRpc, RPCVersion),
+                 (JsonRpcStrings.JsonRpc, "2.0"),
                  (JsonRpcStrings.Id, response.Id),
                  (JsonRpcStrings.Result, response.Result),
             };
@@ -52,7 +50,7 @@ internal sealed class Json
         {
             var list = new (string, object?)[3]
             {
-                 (JsonRpcStrings.JsonRpc, RPCVersion),
+                 (JsonRpcStrings.JsonRpc, "2.0"),
                  (JsonRpcStrings.Method, notification.Method),
                  (JsonRpcStrings.Params, notification.Params),
             };
@@ -71,7 +69,7 @@ internal sealed class Json
 
             var list = new (string, object?)[4]
             {
-                 (JsonRpcStrings.JsonRpc, RPCVersion),
+                 (JsonRpcStrings.JsonRpc, "2.0"),
                  (JsonRpcStrings.Code, error.ErrorCode),
                  (JsonRpcStrings.Id, error.Id),
                  (JsonRpcStrings.Error, errorMsg),
@@ -831,7 +829,7 @@ internal sealed class Json
         var rpcVersion = json.Bind<string>(jsonElement, JsonRpcStrings.JsonRpc);
 
         // Note: The test anywhere supports only JSON-RPC version 2.0
-        if (rpcVersion is null or not RPCVersion)
+        if (rpcVersion is null or not "2.0")
         {
             throw new MessageFormatException("jsonrpc field is not valid");
         }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Text;
 using System.Text.Json;
 
+using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.ServerMode.Json;
@@ -17,40 +18,395 @@ internal sealed class Json
 
     public Json(Dictionary<Type, JsonSerializer>? serializers = null, Dictionary<Type, JsonDeserializer>? deserializers = null)
     {
-        // At the moment we're sometime not using custom performant serialization because we need to support
-        // netstandard2.0 and to flat with jsonite we use a Dictionary<string, object?>
-        // We share the serialization logic inside SerializerUtilities.
-        _deserializers[typeof(JsoniteProperties)] = new JsonElementDeserializer<JsoniteProperties>(
-        (json, jsonDocument) =>
+        // Overriden default serializers for better performance using .NET runtime serialization Apis
+
+        // Serialize response types.
+        _serializers[typeof(RequestMessage)] = new JsonObjectSerializer<RequestMessage>(request =>
+         {
+             var list = new (string, object?)[4]
+             {
+                 (JsonRpcStrings.JsonRpc, "2.0"),
+                 (JsonRpcStrings.Id, request.Id),
+                 (JsonRpcStrings.Method, request.Method),
+                 (JsonRpcStrings.Params, request.Params),
+             };
+
+             return list;
+         });
+
+        _serializers[typeof(ResponseMessage)] = new JsonObjectSerializer<ResponseMessage>(response =>
         {
-            var obj = new JsoniteProperties();
-            foreach (JsonProperty property in jsonDocument.EnumerateObject())
+            var list = new (string, object?)[3]
             {
-                // !!!DANGER!!!
-                // This is a big boxing source, we have to implement custom json serialization for better performance.
-                // And avoid to land here if serialization is already implemented for the type.
-                object? value = DeserializeObject(json, property.Value);
-                obj.Add(property.Name, value!);
+                 (JsonRpcStrings.JsonRpc, "2.0"),
+                 (JsonRpcStrings.Id, response.Id),
+                 (JsonRpcStrings.Result, response.Result),
+            };
 
-                // !!!DANGER!!!
-            }
-
-            return obj.Count == 0 ? null! : obj;
-
-            static object? DeserializeObject(Json json, JsonElement value)
-                => value.ValueKind switch
-                {
-                    JsonValueKind.Object => json.Bind<JsoniteProperties>(value),
-                    JsonValueKind.Array => value.EnumerateArray().Select(element => DeserializeObject(json, element)).ToList(),
-                    JsonValueKind.String => value.GetString(),
-                    JsonValueKind.Number => value.GetInt32(),
-                    JsonValueKind.True => true,
-                    JsonValueKind.False => false,
-                    _ => null,
-                };
+            return list;
         });
 
-        // Overriden default serializers for better performance using .NET runtime serialization Apis
+        _serializers[typeof(NotificationMessage)] = new JsonObjectSerializer<NotificationMessage>(notification =>
+        {
+            var list = new (string, object?)[3]
+            {
+                 (JsonRpcStrings.JsonRpc, "2.0"),
+                 (JsonRpcStrings.Method, notification.Method),
+                 (JsonRpcStrings.Params, notification.Params),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(ErrorMessage)] = new JsonObjectSerializer<ErrorMessage>(error =>
+        {
+            object errorMsg = new Dictionary<string, object?>(3)
+            {
+                { JsonRpcStrings.Code, error.ErrorCode },
+                { JsonRpcStrings.Data, error.Data ?? new() },
+                { JsonRpcStrings.Message, error.Message },
+            };
+
+            var list = new (string, object?)[4]
+            {
+                 (JsonRpcStrings.JsonRpc, "2.0"),
+                 (JsonRpcStrings.Code, error.ErrorCode),
+                 (JsonRpcStrings.Id, error.Id),
+                 (JsonRpcStrings.Error, errorMsg),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(InitializeResponseArgs)] = new JsonObjectSerializer<InitializeResponseArgs>(response =>
+        {
+            var list = new (string, object?)[2]
+            {
+                (JsonRpcStrings.ServerInfo, response.ServerInfo),
+                (JsonRpcStrings.Capabilities, response.Capabilities),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(ServerInfo)] = new JsonObjectSerializer<ServerInfo>(info =>
+        {
+            var list = new (string, object?)[2]
+            {
+                (JsonRpcStrings.Name, info.Name),
+                (JsonRpcStrings.Version, info.Version),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(ServerCapabilities)] = new JsonObjectSerializer<ServerCapabilities>(capabilities =>
+        {
+            var list = new (string, object?)[1]
+            {
+                (JsonRpcStrings.Testing, capabilities.TestingCapabilities),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(ServerTestingCapabilities)] = new JsonObjectSerializer<ServerTestingCapabilities>(capabilities =>
+        {
+            var list = new (string, object?)[3]
+            {
+                (JsonRpcStrings.SupportsDiscovery, capabilities.SupportsDiscovery),
+                (JsonRpcStrings.MultiRequestSupport, capabilities.MultiRequestSupport),
+                (JsonRpcStrings.VSTestProviderSupport, capabilities.VSTestProviderSupport),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(Artifact)] = new JsonObjectSerializer<Artifact>(artifact =>
+        {
+            var list = new (string, object?)[5]
+            {
+                (JsonRpcStrings.Uri, artifact.Uri),
+                (JsonRpcStrings.Producer, artifact.Producer),
+                (JsonRpcStrings.Type, artifact.Type),
+                (JsonRpcStrings.DisplayName, artifact.DisplayName),
+                (JsonRpcStrings.Description, artifact.Description),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(DiscoverResponseArgs)] = new JsonObjectSerializer<DiscoverResponseArgs>(response =>
+        {
+            return Array.Empty<(string, object?)>();
+        });
+
+        _serializers[typeof(RunResponseArgs)] = new JsonObjectSerializer<RunResponseArgs>(response =>
+        {
+            var list = new (string, object?)[1]
+            {
+                (JsonRpcStrings.Attachments, response.Artifacts),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(TestNodeUpdateMessage)] = new JsonObjectSerializer<TestNodeUpdateMessage>(message =>
+        {
+            var list = new (string, object?)[2]
+            {
+                (JsonRpcStrings.Node, message.TestNode),
+                (JsonRpcStrings.Parent, message.ParentTestNodeUid?.Value),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(TestNodeStateChangedEventArgs)] = new JsonObjectSerializer<TestNodeStateChangedEventArgs>(message =>
+        {
+            var list = new (string, object?)[2]
+            {
+                (JsonRpcStrings.RunId, message.RunId),
+                (JsonRpcStrings.Changes, message.Changes),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(TestNode)] = new JsonObjectSerializer<TestNode>(message =>
+        {
+            List<(string Name, object? Value)> properties = new()
+            {
+                (JsonRpcStrings.Uid,  message.Uid.Value),
+                (JsonRpcStrings.DisplayName, message.DisplayName),
+            };
+
+            TestMetadataProperty[] metadataProperties = message.Properties.OfType<TestMetadataProperty>();
+            bool isNodeTypeAction = false;
+
+            if (metadataProperties.Length > 0)
+            {
+#if NETCOREAPP
+                properties.Add(("traits", metadataProperties.Select(x => new KeyValuePair<string, string>(x.Key, x.Value))));
+#else
+                var collection = new List<(string, object?)>(metadataProperties.Length);
+                foreach (TestMetadataProperty metadata in metadataProperties)
+                {
+                    collection.Add((metadata.Key, metadata.Value));
+
+                }
+
+                properties.Add(("traits", collection));
+#endif
+            }
+
+            foreach (IProperty property in message.Properties)
+            {
+                if (property is SerializableKeyValuePairStringProperty keyValuePairProperty)
+                {
+                    properties.Add((keyValuePairProperty.Key, keyValuePairProperty.Value));
+                    continue;
+                }
+
+                if (property is SerializableNamedArrayStringProperty namedArrayStringProperty)
+                {
+                    properties.Add((namedArrayStringProperty.Name, namedArrayStringProperty.Values));
+                    continue;
+                }
+
+                if (property is SerializableNamedKeyValuePairsStringProperty namedKvpStringProperty)
+                {
+#if NETCOREAPP
+                    properties.Add((namedKvpStringProperty.Name, namedKvpStringProperty.Pairs));
+#else
+                    var collection = new List<(string, object?)>(namedKvpStringProperty.Pairs.Length);
+                    foreach (KeyValuePair<string, string> item in namedKvpStringProperty.Pairs)
+                    {
+                        collection.Add((item.Key, item.Value));
+                    }
+
+                    properties.Add((namedKvpStringProperty.Name, collection));
+#endif
+                    continue;
+                }
+
+                if (property is TestFileLocationProperty fileLocationProperty)
+                {
+                    properties.Add(("location.file", fileLocationProperty.FilePath));
+                    properties.Add(("location.line-start", fileLocationProperty.LineSpan.Start.Line));
+                    properties.Add(("location.line-end", fileLocationProperty.LineSpan.End.Line));
+                    continue;
+                }
+
+                if (property is TestMethodIdentifierProperty testMethodIdentifierProperty)
+                {
+                    properties.Add(("location.namespace", testMethodIdentifierProperty.Namespace));
+                    properties.Add(("location.type", testMethodIdentifierProperty.TypeName));
+                    properties.Add(("location.method", testMethodIdentifierProperty.ParameterTypeFullNames.Length > 0
+                        ? $"{testMethodIdentifierProperty.MethodName}({string.Join(",", testMethodIdentifierProperty.ParameterTypeFullNames)})"
+                        : testMethodIdentifierProperty.MethodName));
+                    continue;
+                }
+
+                if (property is TestNodeStateProperty testNodeStateProperty)
+                {
+                    properties.Add(("node-type", "action"));
+                    isNodeTypeAction = true;
+                    switch (property)
+                    {
+                        case DiscoveredTestNodeStateProperty _:
+                            {
+                                properties.Add(("execution-state", "discovered"));
+                                break;
+                            }
+
+                        case InProgressTestNodeStateProperty _:
+                            {
+                                properties.Add(("execution-state", "in-progress"));
+                                break;
+                            }
+
+                        case PassedTestNodeStateProperty _:
+                            {
+                                properties.Add(("execution-state", "passed"));
+                                break;
+                            }
+
+                        case SkippedTestNodeStateProperty _:
+                            {
+                                properties.Add(("execution-state", "skipped"));
+                                break;
+                            }
+
+                        case FailedTestNodeStateProperty failedTestNodeStateProperty:
+                            {
+                                properties.Add(("execution-state", "failed"));
+                                properties.Add(("error.message", failedTestNodeStateProperty?.Explanation ?? failedTestNodeStateProperty?.Exception?.Message));
+                                if (failedTestNodeStateProperty?.Exception != null)
+                                {
+                                    Exception exception = failedTestNodeStateProperty.Exception;
+                                    properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
+                                    properties.Add(("assert.actual", exception.Data["assert.actual"] ?? string.Empty));
+                                    properties.Add(("assert.expected", exception.Data["assert.expected"] ?? string.Empty));
+                                }
+
+                                break;
+                            }
+
+                        case TimeoutTestNodeStateProperty timeoutTestNodeStateProperty:
+                            {
+                                properties.Add(("execution-state", "timed-out"));
+                                properties.Add(("error.message", timeoutTestNodeStateProperty?.Explanation ?? timeoutTestNodeStateProperty?.Exception?.Message));
+                                if (timeoutTestNodeStateProperty?.Exception != null)
+                                {
+                                    properties.Add(("error.stacktrace", timeoutTestNodeStateProperty?.Exception?.StackTrace ?? string.Empty));
+                                }
+
+                                break;
+                            }
+
+                        case ErrorTestNodeStateProperty errorTestNodeStateProperty:
+                            {
+                                properties.Add(("execution-state", "error"));
+                                properties.Add(("error.message", errorTestNodeStateProperty?.Explanation ?? errorTestNodeStateProperty?.Exception?.Message));
+                                if (errorTestNodeStateProperty?.Exception != null)
+                                {
+                                    properties.Add(("error.stacktrace", errorTestNodeStateProperty?.Exception?.StackTrace ?? string.Empty));
+                                }
+
+                                break;
+                            }
+
+                        case CancelledTestNodeStateProperty cancelledTestNodeStateProperty:
+                            {
+                                properties.Add(("execution-state", "cancelled"));
+                                properties.Add(("error.message", cancelledTestNodeStateProperty?.Explanation ?? cancelledTestNodeStateProperty?.Exception?.Message));
+                                if (cancelledTestNodeStateProperty?.Exception != null)
+                                {
+                                    properties.Add(("error.stacktrace", cancelledTestNodeStateProperty?.Exception?.StackTrace ?? string.Empty));
+                                }
+
+                                break;
+                            }
+
+                        default:
+                            throw new NotSupportedException($"Unsupported TestNodeStateProperty '{testNodeStateProperty.GetType()}'");
+                    }
+
+                    continue;
+                }
+
+                if (property is TimingProperty timingProperty)
+                {
+                    properties.Add(("time.start-utc", timingProperty.GlobalTiming.StartTime));
+                    properties.Add(("time.stop-utc", timingProperty.GlobalTiming.EndTime));
+                    properties.Add(("time.duration-ms", timingProperty.GlobalTiming.Duration.TotalMilliseconds));
+                    continue;
+                }
+            }
+
+            if (!isNodeTypeAction)
+            {
+                properties.Add(("node-type", "group"));
+            }
+
+            return properties.ToArray();
+        });
+
+        _serializers[typeof(LogEventArgs)] = new JsonObjectSerializer<LogEventArgs>(message =>
+        {
+            var list = new (string, object?)[2]
+            {
+                (JsonRpcStrings.Level, message.LogMessage.Level.ToString()),
+                (JsonRpcStrings.Message, message.LogMessage.Message),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(CancelRequestArgs)] = new JsonObjectSerializer<CancelRequestArgs>(request =>
+        {
+            var list = new (string, object?)[1]
+            {
+                (JsonRpcStrings.Id, request.CancelRequestId),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(TelemetryEventArgs)] = new JsonObjectSerializer<TelemetryEventArgs>(ev =>
+        {
+            var list = new (string, object?)[2]
+            {
+                (JsonRpcStrings.EventName, ev.EventName),
+                (JsonRpcStrings.Metrics, ev.Metrics),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(ProcessInfoArgs)] = new JsonObjectSerializer<ProcessInfoArgs>(info =>
+        {
+            var list = new (string, object?)[4]
+            {
+                (JsonRpcStrings.Program, info.Program),
+                (JsonRpcStrings.Args, info.Args),
+                (JsonRpcStrings.WorkingDirectory, info.WorkingDirectory),
+                (JsonRpcStrings.EnvironmentVariables, info.EnvironmentVariables),
+            };
+
+            return list;
+        });
+
+        _serializers[typeof(AttachDebuggerInfoArgs)] = new JsonObjectSerializer<AttachDebuggerInfoArgs>(info =>
+        {
+            var list = new (string, object?)[1]
+            {
+                (JsonRpcStrings.ProcessId, info.ProcessId),
+            };
+
+            return list;
+        });
 
         // Serializers
         _serializers[typeof(string)] = new JsonValueSerializer<string>((w, v) => w.WriteStringValue(v));
@@ -71,9 +427,153 @@ internal sealed class Json
 
         // Deserializers
         _deserializers[typeof(string)] = new JsonElementDeserializer<string>((json, jsonDocument) => jsonDocument.GetString()!);
+        _deserializers[typeof(bool)] = new JsonElementDeserializer<bool>((json, jsonDocument) => jsonDocument.GetBoolean());
         _deserializers[typeof(int)] = new JsonElementDeserializer<int>((json, jsonDocument) => jsonDocument.GetInt32());
         _deserializers[typeof(decimal)] = new JsonElementDeserializer<decimal>((json, jsonDocument) => jsonDocument.GetDecimal());
         _deserializers[typeof(DateTime)] = new JsonElementDeserializer<DateTime>((json, jsonDocument) => jsonDocument.GetDateTime());
+
+        _deserializers[typeof(IDictionary<string, object?>)] = new JsonElementDeserializer<IDictionary<string, object?>>((json, jsonDocument) =>
+        {
+            var dict = new Dictionary<string, object?>();
+            foreach (var kvp in jsonDocument.EnumerateObject())
+            {
+                switch (kvp.Value.ValueKind)
+                {
+                    case JsonValueKind.String:
+                        dict.Add(kvp.Name, kvp.Value.GetString());
+                        break;
+                    case JsonValueKind.Number:
+                        dict.Add(kvp.Name, kvp.Value.GetInt32());
+                        break;
+                    case JsonValueKind.True:
+                        dict.Add(kvp.Name, true);
+                        break;
+                    case JsonValueKind.False:
+                        dict.Add(kvp.Name, false);
+                        break;
+                    case JsonValueKind.Object:
+                        dict.Add(kvp.Name, json.Bind<IDictionary<string, object?>>(kvp.Value));
+                        break;
+                    case JsonValueKind.Array:
+                        dict.Add(kvp.Name, json.Bind<object[]>(kvp.Value));
+                        break;
+                    case JsonValueKind.Null:
+                        dict.Add(kvp.Name, null);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"key: {kvp.Name}, value: {kvp.Value}, type: {kvp.Value.ValueKind}");
+                }
+            }
+
+            return dict;
+        });
+
+        _deserializers[typeof(ErrorMessage)] = new JsonElementDeserializer<ErrorMessage>(
+          (json, jsonElement) =>
+          {
+
+              int id = json.Bind<int>(jsonElement, JsonRpcStrings.Id);
+              IDictionary<string, object?> errorObj = json.Bind<IDictionary<string, object?>>(jsonElement, JsonRpcStrings.Error);
+
+#if !NETCOREAPP
+              if (errorObj.TryGetValue(JsonRpcStrings.Data, out object? errorData))
+              {
+                  if (errorData is Dictionary<string, object?> error && error.Count == 0)
+                  {
+                      errorObj[JsonRpcStrings.Data] = null!;
+                  }
+              }
+#endif
+
+              if (!errorObj.TryGetValue(JsonRpcStrings.Code, out object? codeObj) ||
+                codeObj is not int code)
+              {
+                  throw new MessageFormatException("error.code field missing");
+              }
+
+              if (!errorObj.TryGetValue(JsonRpcStrings.Message, out object? errorMessageObj) ||
+                errorMessageObj is not string errorMessage)
+              {
+                  throw new MessageFormatException("error.message field is missing");
+              }
+
+              object? data = errorObj.TryGetValue(JsonRpcStrings.Data, out object? dataJson)
+                ? dataJson
+                : null;
+
+              return new ErrorMessage(
+                  Id: id,
+                  ErrorCode: code,
+                  Message: errorMessage ?? string.Empty,
+                  Data: null);
+          });
+
+        _deserializers[typeof(InitializeResponseArgs)] = new JsonElementDeserializer<InitializeResponseArgs>(
+          (json, jsonElement) =>
+          {
+              return new InitializeResponseArgs(
+                  ServerInfo: json.Bind<ServerInfo>(jsonElement, JsonRpcStrings.ServerInfo),
+                  Capabilities: json.Bind<ServerCapabilities>(jsonElement, JsonRpcStrings.Capabilities));
+          });
+
+        _deserializers[typeof(ServerInfo)] = new JsonElementDeserializer<ServerInfo>(
+          (json, jsonElement) =>
+          {
+              return new ServerInfo(
+                  Name: json.Bind<string>(jsonElement, JsonRpcStrings.Name),
+                  Version: json.Bind<string>(jsonElement, JsonRpcStrings.Version));
+          });
+
+        _deserializers[typeof(ServerCapabilities)] = new JsonElementDeserializer<ServerCapabilities>(
+          (json, jsonElement) =>
+          {
+              return new ServerCapabilities(
+                  TestingCapabilities: json.Bind<ServerTestingCapabilities>(jsonElement, JsonRpcStrings.Testing));
+          });
+
+        _deserializers[typeof(ServerTestingCapabilities)] = new JsonElementDeserializer<ServerTestingCapabilities>(
+          (json, jsonElement) =>
+          {
+              return new ServerTestingCapabilities(
+                        SupportsDiscovery: json.Bind<bool>(jsonElement, JsonRpcStrings.SupportsDiscovery),
+                        MultiRequestSupport: json.Bind<bool>(jsonElement, JsonRpcStrings.MultiRequestSupport),
+                        VSTestProviderSupport: json.Bind<bool>(jsonElement, JsonRpcStrings.VSTestProviderSupport));
+          });
+
+        _deserializers[typeof(TestNode)] = new JsonElementDeserializer<TestNode>(
+            (json, properties) =>
+            {
+                var propertyBag = new PropertyBag();
+                string uid = json.Bind<string>(properties, JsonRpcStrings.Uid) ?? string.Empty;
+                string displayName = json.Bind<string>(properties, JsonRpcStrings.DisplayName);
+
+                var locationFile = json.Bind<string>(properties, "location.file");
+                if (locationFile is not null)
+                {
+                    ApplicationStateGuard.Ensure(locationFile is not null);
+                    var locationLineStart = json.Bind<int>(properties, "location.line-start");
+                    var locationLineEnd = json.Bind<int>(properties, "location.line-end");
+
+                    var testFileLocationProperty = new TestFileLocationProperty(
+                        locationFile,
+                        new LinePositionSpan(new LinePosition(locationLineStart, 0), new LinePosition(locationLineEnd, 0)));
+                    propertyBag.Add(testFileLocationProperty);
+                }
+
+                return new TestNode
+                {
+                    Uid = new TestNodeUid(uid),
+                    DisplayName = displayName,
+                    Properties = propertyBag,
+                };
+            });
+
+        _deserializers[typeof(CancelRequestArgs)] = new JsonElementDeserializer<CancelRequestArgs>(
+          (json, jsonElement) =>
+          {
+              int id = json.Bind<int>(jsonElement, JsonRpcStrings.Id);
+              return new CancelRequestArgs(id);
+          });
 
         // Try to add serializers passed from outside
         if (serializers != null)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -489,12 +489,16 @@ internal sealed class Json
                 return error;
             }
 
-            if (jsonElement.TryGetProperty(JsonRpcStrings.Result, out JsonElement result))
+            if (jsonElement.TryGetProperty(JsonRpcStrings.Result, out JsonElement element))
             {
                 // Note: Because the result message does not contain the original method name,
                 //       it's not possible for us to do a typed deserialization.
                 //       The best option we've got is to return a generic property bag.
-                int id = json.Bind<int>(result, JsonRpcStrings.Id);
+                string idStr = json.Bind<string>(jsonElement, JsonRpcStrings.Id);
+                int id = int.TryParse(idStr, out int identity) ? identity : default;
+
+                var result = element.ValueKind == JsonValueKind.Null ? null :
+                    json.Bind<IDictionary<string, object>>(jsonElement, JsonRpcStrings.Result);
 
                 return new ResponseMessage(id, result);
             }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -641,9 +641,9 @@ internal sealed class Json
         _deserializers[typeof(CancelRequestArgs)] = new JsonElementDeserializer<CancelRequestArgs>(
           (json, jsonElement) =>
           {
-              string? id = json.OptionalPropertyBind<string>(jsonElement, JsonRpcStrings.Id);
+              int id = json.OptionalPropertyBind<int>(jsonElement, JsonRpcStrings.Id);
 
-              return int.TryParse(id, out int result) ? new CancelRequestArgs(result) : throw new MessageFormatException("id field should be a string or an int");
+              return id is default(int) ? throw new MessageFormatException("id field should be a string or an int") : new CancelRequestArgs(id);
           });
 
         _deserializers[typeof(ExitRequestArgs)] = new JsonElementDeserializer<ExitRequestArgs>(

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -20,7 +20,6 @@ internal sealed class Json
 
     public Json(Dictionary<Type, JsonSerializer>? serializers = null, Dictionary<Type, JsonDeserializer>? deserializers = null)
     {
-
         // Overridden default serializers for better performance using .NET runtime serialization APIs
 
         // Serialize response types.
@@ -264,7 +263,7 @@ internal sealed class Json
                             {
                                 properties.Add(("execution-state", "failed"));
                                 properties.Add(("error.message", failedTestNodeStateProperty?.Explanation ?? failedTestNodeStateProperty?.Exception?.Message));
-                                if (failedTestNodeStateProperty?.Exception != null)
+                                if (failedTestNodeStateProperty?.Exception is not null)
                                 {
                                     Exception exception = failedTestNodeStateProperty.Exception;
                                     properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
@@ -279,7 +278,7 @@ internal sealed class Json
                             {
                                 properties.Add(("execution-state", "timed-out"));
                                 properties.Add(("error.message", timeoutTestNodeStateProperty?.Explanation ?? timeoutTestNodeStateProperty?.Exception?.Message));
-                                if (timeoutTestNodeStateProperty?.Exception != null)
+                                if (timeoutTestNodeStateProperty?.Exception is not null)
                                 {
                                     properties.Add(("error.stacktrace", timeoutTestNodeStateProperty?.Exception?.StackTrace ?? string.Empty));
                                 }
@@ -291,7 +290,7 @@ internal sealed class Json
                             {
                                 properties.Add(("execution-state", "error"));
                                 properties.Add(("error.message", errorTestNodeStateProperty?.Explanation ?? errorTestNodeStateProperty?.Exception?.Message));
-                                if (errorTestNodeStateProperty?.Exception != null)
+                                if (errorTestNodeStateProperty?.Exception is not null)
                                 {
                                     properties.Add(("error.stacktrace", errorTestNodeStateProperty?.Exception?.StackTrace ?? string.Empty));
                                 }
@@ -303,7 +302,7 @@ internal sealed class Json
                             {
                                 properties.Add(("execution-state", "cancelled"));
                                 properties.Add(("error.message", cancelledTestNodeStateProperty?.Explanation ?? cancelledTestNodeStateProperty?.Exception?.Message));
-                                if (cancelledTestNodeStateProperty?.Exception != null)
+                                if (cancelledTestNodeStateProperty?.Exception is not null)
                                 {
                                     properties.Add(("error.stacktrace", cancelledTestNodeStateProperty?.Exception?.StackTrace ?? string.Empty));
                                 }
@@ -635,7 +634,7 @@ internal sealed class Json
           });
 
         // Try to add serializers passed from outside
-        if (serializers != null)
+        if (serializers is not null)
         {
             foreach (KeyValuePair<Type, JsonSerializer> serializer in serializers)
             {
@@ -650,7 +649,7 @@ internal sealed class Json
             }
         }
 
-        if (deserializers != null)
+        if (deserializers is not null)
         {
             foreach (KeyValuePair<Type, JsonDeserializer> deserializer in deserializers)
             {
@@ -776,7 +775,7 @@ internal sealed class Json
             {
                 writer.WriteStartObject();
                 (string Key, object? Value)[]? properties = objectConverter.Properties(obj);
-                if (properties != null)
+                if (properties is not null)
                 {
                     int count = 1;
                     foreach ((string property, object? value) in properties)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -18,7 +18,7 @@ internal sealed class Json
 
     public Json(Dictionary<Type, JsonSerializer>? serializers = null, Dictionary<Type, JsonDeserializer>? deserializers = null)
     {
-        // Overriden default serializers for better performance using .NET runtime serialization Apis
+        // Overridden default serializers for better performance using .NET runtime serialization APIs
 
         // Serialize response types.
         _serializers[typeof(RequestMessage)] = new JsonObjectSerializer<RequestMessage>(request =>
@@ -471,7 +471,6 @@ internal sealed class Json
         _deserializers[typeof(ErrorMessage)] = new JsonElementDeserializer<ErrorMessage>(
           (json, jsonElement) =>
           {
-
               int id = json.Bind<int>(jsonElement, JsonRpcStrings.Id);
               IDictionary<string, object?> errorObj = json.Bind<IDictionary<string, object?>>(jsonElement, JsonRpcStrings.Error);
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -485,10 +485,10 @@ internal sealed class Json
         {
             ValidateJsonRpcHeader(json, jsonElement);
 
-            string? method = json.OptionalPropertyBind<string>(jsonElement, JsonRpcStrings.Method);
+            string? method = json.OptionalBind<string>(jsonElement, JsonRpcStrings.Method);
             if (method is not null)
             {
-                int id = json.OptionalPropertyBind<int>(jsonElement, JsonRpcStrings.Id);
+                int id = json.OptionalBind<int>(jsonElement, JsonRpcStrings.Id);
 
                 object? @params = null;
                 if (jsonElement.TryGetProperty(JsonRpcStrings.Params, out JsonElement value))
@@ -525,7 +525,7 @@ internal sealed class Json
                 return new ResponseMessage(id, result);
             }
 
-            ErrorMessage? error = json.OptionalPropertyBind<ErrorMessage>(jsonElement);
+            ErrorMessage? error = json.OptionalBind<ErrorMessage>(jsonElement);
 
             return error is not null ? (RpcMessage)error : throw new MessageFormatException();
         });
@@ -592,8 +592,8 @@ internal sealed class Json
 
             return new DiscoverRequestArgs(
                 RunId: result,
-                TestNodes: json.OptionalPropertyBind<ICollection<TestNode>?>(jsonElement, JsonRpcStrings.Tests),
-                GraphFilter: json.OptionalPropertyBind<string>(jsonElement, JsonRpcStrings.Filter));
+                TestNodes: json.OptionalBind<ICollection<TestNode>?>(jsonElement, JsonRpcStrings.Tests),
+                GraphFilter: json.OptionalBind<string>(jsonElement, JsonRpcStrings.Filter));
         });
 
         _deserializers[typeof(RunRequestArgs)] = new JsonElementDeserializer<RunRequestArgs>((json, jsonElement) =>
@@ -603,8 +603,8 @@ internal sealed class Json
 
             return new RunRequestArgs(
                 RunId: result,
-                TestNodes: json.OptionalPropertyBind<ICollection<TestNode>?>(jsonElement, JsonRpcStrings.Tests),
-                GraphFilter: json.OptionalPropertyBind<string>(jsonElement, JsonRpcStrings.Filter));
+                TestNodes: json.OptionalBind<ICollection<TestNode>?>(jsonElement, JsonRpcStrings.Tests),
+                GraphFilter: json.OptionalBind<string>(jsonElement, JsonRpcStrings.Filter));
         });
 
         _deserializers[typeof(TestNode)] = new JsonElementDeserializer<TestNode>(
@@ -614,12 +614,12 @@ internal sealed class Json
                 string uid = json.Bind<string>(properties, JsonRpcStrings.Uid) ?? string.Empty;
                 string displayName = json.Bind<string>(properties, JsonRpcStrings.DisplayName);
 
-                var locationFile = json.OptionalPropertyBind<string>(properties, "location.file");
+                var locationFile = json.OptionalBind<string>(properties, "location.file");
                 if (locationFile is not null)
                 {
                     ApplicationStateGuard.Ensure(locationFile is not null);
-                    int locationLineStart = json.OptionalPropertyBind<int>(properties, "location.line-start");
-                    int locationLineEnd = json.OptionalPropertyBind<int>(properties, "location.line-end");
+                    int locationLineStart = json.OptionalBind<int>(properties, "location.line-start");
+                    int locationLineEnd = json.OptionalBind<int>(properties, "location.line-end");
 
                     ApplicationStateGuard.Ensure(locationLineStart is not default(int));
                     ApplicationStateGuard.Ensure(locationLineEnd is not default(int));
@@ -641,7 +641,7 @@ internal sealed class Json
         _deserializers[typeof(CancelRequestArgs)] = new JsonElementDeserializer<CancelRequestArgs>(
           (json, jsonElement) =>
           {
-              int id = json.OptionalPropertyBind<int>(jsonElement, JsonRpcStrings.Id);
+              int id = json.OptionalBind<int>(jsonElement, JsonRpcStrings.Id);
 
               return id is default(int) ? throw new MessageFormatException("id field should be a string or an int") : new CancelRequestArgs(id);
           });
@@ -659,7 +659,7 @@ internal sealed class Json
 
               var code = json.Bind<int>(error, JsonRpcStrings.Code);
               var message = json.Bind<string>(error, JsonRpcStrings.Message);
-              var data = json.OptionalPropertyBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
+              var data = json.OptionalBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
               if (data is not null && data.Count == 0)
               {
                   data = null;
@@ -781,7 +781,7 @@ internal sealed class Json
         throw new InvalidOperationException($"Cannot find deserializer for {typeof(T)}.");
     }
 
-    internal T? OptionalPropertyBind<T>(JsonElement element, string? property = null)
+    internal T? OptionalBind<T>(JsonElement element, string? property = null)
     {
         if (property != null && !element.TryGetProperty(property, out element))
         {

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -623,26 +623,23 @@ internal sealed class Json
               int id = json.Bind<int>(jsonElement, JsonRpcStrings.Id);
               var error = jsonElement.GetProperty(JsonRpcStrings.Error);
 
-#if !NETCOREAPP
-                      var data = json.OptionalPropertyBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
-                      if (data is not null)
-                      {
-                          if (data is Dictionary<string, object?> error && error.Count == 0)
-                          {
-                              data = null!;
-                          }
-                      }
-#endif
+              var dataObj = json.OptionalPropertyBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
+              if (dataObj is not null)
+              {
+                  if (dataObj is Dictionary<string, object?> data && data.Count == 0)
+                  {
+                      dataObj = null!;
+                  }
+              }
+
               var code = json.Bind<int>(error, JsonRpcStrings.Code);
               var message = json.Bind<string>(error, JsonRpcStrings.Message);
-
-              var data = json.OptionalPropertyBind<IDictionary<string, object?>>(error, JsonRpcStrings.Data);
 
               return new ErrorMessage(
                   Id: id,
                   ErrorCode: code,
                   Message: message ?? string.Empty,
-                  Data: data);
+                  Data: dataObj);
           });
 
         // Try to add serializers passed from outside

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/Json/Json.cs
@@ -617,13 +617,11 @@ internal sealed class Json
 
                 if (json.TryBind(properties, out string? locationFile, "location.file"))
                 {
-                    ApplicationStateGuard.Ensure(locationFile is not null);
-
                     json.TryBind(properties, out int locationLineStart, "location.line-start");
                     json.TryBind(properties, out int locationLineEnd, "location.line-end");
 
                     var testFileLocationProperty = new TestFileLocationProperty(
-                        locationFile,
+                        locationFile!,
                         new LinePositionSpan(new LinePosition(locationLineStart, 0), new LinePosition(locationLineEnd, 0)));
                     propertyBag.Add(testFileLocationProperty);
                 }
@@ -639,7 +637,7 @@ internal sealed class Json
         _deserializers[typeof(CancelRequestArgs)] = new JsonElementDeserializer<CancelRequestArgs>(
           (json, jsonElement) =>
           {
-              return json.TryBind(jsonElement, out int id, JsonRpcStrings.Id) ? new CancelRequestArgs(id) : throw new MessageFormatException("id field should be a string or an int");
+              return json.TryBind(jsonElement, out int id, JsonRpcStrings.Id) ? new CancelRequestArgs(id) : throw new MessageFormatException("id field should be an int");
           });
 
         _deserializers[typeof(ExitRequestArgs)] = new JsonElementDeserializer<ExitRequestArgs>(

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/SerializerUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/SerializerUtilities.cs
@@ -587,24 +587,19 @@ internal static class SerializerUtilities
                         displayName = p.Value as string ?? string.Empty;
                         continue;
                     }
+                }
 
-                    if (propertyBag.SingleOrDefault<TestFileLocationProperty>() is null)
+                if (properties.TryGetValue("location.file", out object? location_file))
+                {
+                    ApplicationStateGuard.Ensure(location_file is not null);
+                    if (properties.TryGetValue("location.line-start", out object? location_lineStart) && properties.TryGetValue("location.line-end", out object? location_lineEnd))
                     {
-                        if (properties.TryGetValue("location.file", out object? location_file))
-                        {
-                            ApplicationStateGuard.Ensure(location_file is not null);
-                            if (properties.TryGetValue("location.line-start", out object? location_lineStart) && properties.TryGetValue("location.line-end", out object? location_lineEnd))
-                            {
-                                ApplicationStateGuard.Ensure(location_lineStart is not null);
-                                ApplicationStateGuard.Ensure(location_lineEnd is not null);
-                                var testFileLocationProperty = new TestFileLocationProperty(
-                                    (string)location_file,
-                                    new LinePositionSpan(new LinePosition((int)location_lineStart, 0), new LinePosition((int)location_lineEnd, 0)));
-                                propertyBag.Add(testFileLocationProperty);
-                            }
-
-                            continue;
-                        }
+                        ApplicationStateGuard.Ensure(location_lineStart is not null);
+                        ApplicationStateGuard.Ensure(location_lineEnd is not null);
+                        var testFileLocationProperty = new TestFileLocationProperty(
+                            (string)location_file,
+                            new LinePositionSpan(new LinePosition((int)location_lineStart, 0), new LinePosition((int)location_lineEnd, 0)));
+                        propertyBag.Add(testFileLocationProperty);
                     }
                 }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -32,7 +32,7 @@ public class FormatterUtilitiesTests : TestBase
         RpcMessage msg = _formatter.Deserialize<RpcMessage>("""
             {
                 "jsonrpc": "2.0",
-                "id": "1",
+                "id": 1,
                 "result": null
             }
             """

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
@@ -206,7 +206,7 @@ public class ServerTests : TestBase
             {
                 "jsonrpc": "2.0",
                 "method": "$/cancelRequest",
-                "params": { "id": "2" }
+                "params": { "id": 2 }
             }
             """;
         await WriteMessageAsync(writer, cancelRequestMessage);


### PR DESCRIPTION
Currently, we are falling back to Jsonite in case of reference types, so we replaced System.Text.Json with Jsonite by adding serializers and deserializers.