### PR TITLE
Get real exception in case of error in AssemblyInitialize

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestAssemblyInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestAssemblyInfo.cs
@@ -172,7 +172,7 @@ public class TestAssemblyInfo
             throw AssemblyInitializationException;
         }
 
-        var realException = AssemblyInitializationException.InnerException ?? AssemblyInitializationException;
+        var realException = AssemblyInitializationException.GetRealException();
 
         var outcome = realException is AssertInconclusiveException ? UnitTestOutcome.Inconclusive : UnitTestOutcome.Failed;
 

--- a/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
@@ -27,18 +27,10 @@ internal static class ExceptionExtensions
         // TargetInvocationException: Because .NET Framework wraps method.Invoke() into TargetInvocationException.
         // TypeInitializationException: Because AssemblyInitialize is static, and often helpers that are also static
         // are used to implement it, and they fail in constructor.
-        while (exception is TargetInvocationException or TypeInitializationException)
+        while (exception is TargetInvocationException or TypeInitializationException 
+            && exception.InnerException is not null)
         {
-            if (exception.InnerException is not null)
-            {
-                exception = exception.InnerException;
-            }
-            else
-            {
-                // Break because we want to return TargetInvocationException (or TypeInitializationException)
-                // when there is no inner exception, and don't want this loop to run forever.
-                break;
-            }
+            exception = exception.InnerException;
         }
 
         return exception;

--- a/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
@@ -27,7 +27,7 @@ internal static class ExceptionExtensions
         // TargetInvocationException: Because .NET Framework wraps method.Invoke() into TargetInvocationException.
         // TypeInitializationException: Because AssemblyInitialize is static, and often helpers that are also static
         // are used to implement it, and they fail in constructor.
-        while (exception is TargetInvocationException or TypeInitializationException 
+        while (exception is TargetInvocationException or TypeInitializationException
             && exception.InnerException is not null)
         {
             exception = exception.InnerException;

--- a/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
@@ -19,15 +19,30 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 internal static class ExceptionExtensions
 {
     /// <summary>
-    /// In .NET framework, the exception thrown by the test method invocation is wrapped in a TargetInvocationException, so we
-    /// need to unwrap it to get the real exception.
+    /// TargetInvocationException and TypeInitializationException do not carry any useful information
+    /// to the user. Find the first inner exception that has useful information.
     /// </summary>
     internal static Exception GetRealException(this Exception exception)
-        => exception.GetType() == typeof(TargetInvocationException)
-            && exception.Source is "mscorlib" or "System.Private.CoreLib"
-            && exception.InnerException is not null
-                ? exception.InnerException
-                : exception;
+    {
+        // TargetInvocationException: Because .NET Framework wraps method.Invoke() into TargetInvocationException.
+        // TypeInitializationException: Because AssemblyInitialize is static, and often helpers that are also static
+        // are used to implement it, and they fail in constructor.
+        while (exception is TargetInvocationException or TypeInitializationException)
+        {
+            if (exception.InnerException is not null)
+            {
+                exception = exception.InnerException;
+            }
+            else
+            {
+                // Break because we want to return TargetInvocationException (or TypeInitializationException)
+                // when there is no inner exception, and don't want this loop to run forever.
+                break;
+            }
+        }
+
+        return exception;
+    }
 
     /// <summary>
     /// Get the exception message if available, empty otherwise.

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestAssemblyInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestAssemblyInfoTests.cs
@@ -206,7 +206,8 @@ public class TestAssemblyInfoTests : TestContainer
 
     public void RunAssemblyInitializeShouldThrowTheInnerMostExceptionWhenThereAreMultipleNestedTypeInitializationExceptions()
     {
-        DummyTestClass.AssemblyInitializeMethodBody = tc => {
+        DummyTestClass.AssemblyInitializeMethodBody = tc =>
+        {
             // This helper calls inner helper, and the inner helper ctor throws.
             // We want to see the real exception on screen, and not TypeInitializationException
             // which has no info about what failed.
@@ -332,10 +333,11 @@ public class TestAssemblyInfoTests : TestContainer
         static FailingStaticHelper()
         {
             throw new InvalidOperationException("I fail.");
-            // FailingInnerStaticHelper.Initialize();
         }
 
-        public static void DoWork() { }
+        public static void DoWork()
+        {
+        }
     }
 
     private static class FailingInnerStaticHelper
@@ -345,6 +347,8 @@ public class TestAssemblyInfoTests : TestContainer
             throw new InvalidOperationException("I fail.");
         }
 
-        public static void Initialize() { }
+        public static void Initialize()
+        {
+        }
     }
 }

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/ExceptionExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
@@ -146,6 +147,82 @@ public class ExceptionExtensionsTests : TestContainer
 
         Verify(outcome == UTF.UnitTestOutcome.Failed);
         Verify(exceptionMessage == "Dummy Message");
+    }
+    #endregion
+
+    #region GetRealException scenarios
+    public void GetRealExceptionGetsTheTopExceptionWhenThereIsJustOne()
+    {
+        var exception = new InvalidOperationException();
+        var actual = exception.GetRealException();
+
+        Verify(actual is InvalidOperationException);
+    }
+
+    public void GetRealExceptionGetsTheInnerExceptionWhenTheExceptionIsTargetInvocation()
+    {
+        var exception = new TargetInvocationException(new InvalidOperationException());
+        var actual = exception.GetRealException();
+
+        Verify(actual is InvalidOperationException);
+    }
+
+    public void GetRealExceptionGetsTheTargetInvocationExceptionWhenTargetInvocationIsProvidedWithNullInnerException()
+    {
+        var exception = new TargetInvocationException(null);
+        var actual = exception.GetRealException();
+
+        Verify(actual is TargetInvocationException);
+    }
+
+    public void GetRealExceptionGetsTheInnerMostRealException()
+    {
+        var exception = new TargetInvocationException(new TargetInvocationException(new TargetInvocationException(new InvalidOperationException())));
+        var actual = exception.GetRealException();
+
+        Verify(actual is InvalidOperationException);
+    }
+
+    public void GetRealExceptionGetsTheInnerMostTargetInvocationException()
+    {
+        var exception = new TargetInvocationException(new TargetInvocationException(new TargetInvocationException("inner most", null)));
+        var actual = exception.GetRealException();
+
+        Verify(actual is TargetInvocationException);
+        Verify(actual.Message == "inner most");
+    }
+
+    public void GetRealExceptionGetsTheInnerExceptionWhenTheExceptionIsTypeInitialization()
+    {
+        var exception = new TypeInitializationException("some type", new InvalidOperationException());
+        var actual = exception.GetRealException();
+
+        Verify(actual is InvalidOperationException);
+    }
+
+    public void GetRealExceptionGetsTheTypeInitializationExceptionWhenTypeInitializationIsProvidedWithNullInnerException()
+    {
+        var exception = new TypeInitializationException("some type", null);
+        var actual = exception.GetRealException();
+
+        Verify(actual is TypeInitializationException);
+    }
+
+    public void GetRealExceptionGetsTheInnerMostRealExceptionOfTypeInitialization()
+    {
+        var exception = new TypeInitializationException("some type", new TypeInitializationException("some type", new TypeInitializationException("some type", new InvalidOperationException())));
+        var actual = exception.GetRealException();
+
+        Verify(actual is InvalidOperationException);
+    }
+
+    public void GetRealExceptionGetsTheInnerMostTypeInitializationException()
+    {
+        var exception = new TypeInitializationException("some type", new TypeInitializationException("some type", new TypeInitializationException("inner most", null)));
+        var actual = exception.GetRealException();
+
+        Verify(actual is TypeInitializationException);
+        Verify(actual.Message == "The type initializer for 'inner most' threw an exception.");
     }
     #endregion
 }


### PR DESCRIPTION
When my test fails with TargetInvocationException or TypeInitializationException, I get no useful info from the exception. Find the first inner exception that is not this common wrapper exception so user has more information about the fail.


Fix #2307