### PR TITLE
Use pools from variables and recommended image

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -40,6 +40,7 @@ parameters:
   default: False
 
 variables:
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: MSTest
@@ -87,7 +88,7 @@ extends:
     featureFlags:
       autoBaseline: true
     pool:
-      name: netcore1espool-internal
+      name: $(DncEngInternalBuildPool)
       image: windows.vs2022.amd64
       os: windows
     customBuildTags:
@@ -111,7 +112,7 @@ extends:
           - job: Windows
             timeoutInMinutes: 90
             pool:
-              name: netcore1espool-internal
+              name: $(DncEngInternalBuildPool)
               image: windows.vs2022.amd64
               os: windows
             steps:
@@ -167,7 +168,7 @@ extends:
           - job: Linux
             timeoutInMinutes: 90
             pool:
-              name: netcore1espool-internal
+              name: $(DncEngInternalBuildPool)
               image: 1es-ubuntu-2204-pt
               os: linux
             steps:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -40,7 +40,6 @@ parameters:
   default: False
 
 variables:
-  - template: /eng/common/templates-official/variables/pool-providers.yml@self
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: MSTest
@@ -88,7 +87,7 @@ extends:
     featureFlags:
       autoBaseline: true
     pool:
-      name: $(DncEngInternalBuildPool)
+      name: netcore1espool-internal
       image: windows.vs2022.amd64
       os: windows
     customBuildTags:
@@ -112,7 +111,7 @@ extends:
           - job: Windows
             timeoutInMinutes: 90
             pool:
-              name: $(DncEngInternalBuildPool)
+              name: netcore1espool-internal
               image: windows.vs2022.amd64
               os: windows
             steps:
@@ -168,8 +167,8 @@ extends:
           - job: Linux
             timeoutInMinutes: 90
             pool:
-              name: $(DncEngInternalBuildPool)
-              image: build.ubuntu.2204.amd64
+              name: netcore1espool-internal
+              image: 1es-ubuntu-2204-pt
               os: linux
             steps:
             - script: eng/common/cibuild.sh

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -40,6 +40,7 @@ parameters:
   default: False
 
 variables:
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: MSTest
@@ -87,8 +88,8 @@ extends:
     featureFlags:
       autoBaseline: true
     pool:
-      name: netcore1espool-internal
-      image: 1es-windows-2022-pt
+      name: $(DncEngInternalBuildPool)
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -111,8 +112,8 @@ extends:
           - job: Windows
             timeoutInMinutes: 90
             pool:
-              name: netcore1espool-internal
-              image: 1es-windows-2022-pt
+              name: $(DncEngInternalBuildPool)
+              image: windows.vs2022.amd64
               os: windows
             steps:
             - task: PowerShell@2
@@ -167,8 +168,8 @@ extends:
           - job: Linux
             timeoutInMinutes: 90
             pool:
-              name: netcore1espool-internal
-              image: 1es-ubuntu-2204-pt
+              name: $(DncEngInternalBuildPool)
+              image: build.ubuntu.2204.amd64
               os: linux
             steps:
             - script: eng/common/cibuild.sh


### PR DESCRIPTION
Use image that is owned by arcade and updated sooner than the other official image, so there is less chance that stuff will be temporarily broken after Arcade updates, e.g. SignTool missing dependencies.