### PR TITLE
Cleanup `TestApplicationBuilder`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
@@ -31,7 +31,7 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
     private readonly ApplicationLoggingState _loggingState;
     private readonly TestApplicationOptions _testApplicationOptions;
     private readonly IUnhandledExceptionsHandler _unhandledExceptionsHandler;
-    private readonly ITestHostBuilder _testHostBuilder;
+    private readonly TestHostBuilder _testHostBuilder;
     private ITestHost? _testHost;
     private Func<ITestFrameworkCapabilities, IServiceProvider, ITestFramework>? _testFrameworkAdapterFactory;
     private Func<IServiceProvider, ITestFrameworkCapabilities>? _testFrameworkCapabilitiesFactory;
@@ -43,7 +43,7 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
         TestApplicationOptions testApplicationOptions,
         IUnhandledExceptionsHandler unhandledExceptionsHandler)
     {
-        _testHostBuilder = TestHostBuilderFactory();
+        _testHostBuilder = new TestHostBuilder(new SystemFileSystem(), new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler(), new CurrentTestApplicationModuleInfo(new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler()));
         _args = args;
         _createBuilderStart = createBuilderStart;
         _loggingState = loggingState;
@@ -70,11 +70,6 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
     internal ITelemetryManager TelemetryManager => _testHostBuilder.Telemetry;
 
     internal IToolsManager Tools => _testHostBuilder.Tools;
-
-    // Callers from the outside can substitute the builder and the services that are used
-    // to build a testhost. We use this to provide a different builder for VSTest tests.
-    internal static Func<ITestHostBuilder> TestHostBuilderFactory { get; set; }
-        = () => new TestHostBuilder(new SystemFileSystem(), new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler(), new CurrentTestApplicationModuleInfo(new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler()));
 
     public ITestApplicationBuilder RegisterTestFramework(
         Func<IServiceProvider, ITestFrameworkCapabilities> capabilitiesFactory,


### PR DESCRIPTION
@Evangelink  this is not more needed right?
I don't see any usage in TA repo I think that now we use the bridge for console and the "default VSTest integration" for compat mode right?