### PR TITLE
Cache `CommandLineOption` from the providers

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineManager.cs
@@ -39,7 +39,7 @@ internal sealed class CommandLineManager(IRuntimeFeature runtimeFeature, IEnviro
                 await async.InitializeAsync();
             }
 
-            commandLineOptionsProviders.Add(serviceInstance);
+            commandLineOptionsProviders.Add(new CommandLineOptionsProviderCache(serviceInstance));
         }
 
         ICommandLineOptionsProvider[] systemCommandLineOptionsProviders = new[]

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderCache.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderCache.cs
@@ -6,15 +6,10 @@ using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Platform.CommandLine;
 
-internal struct CommandLineOptionsProviderCache : ICommandLineOptionsProvider
+internal struct CommandLineOptionsProviderCache(ICommandLineOptionsProvider commandLineOptionsProvider) : ICommandLineOptionsProvider
 {
-    private readonly ICommandLineOptionsProvider _commandLineOptionsProvider;
+    private readonly ICommandLineOptionsProvider _commandLineOptionsProvider = commandLineOptionsProvider;
     private CommandLineOption[]? _commandLineOptions;
-
-    public CommandLineOptionsProviderCache(ICommandLineOptionsProvider commandLineOptionsProvider)
-    {
-        _commandLineOptionsProvider = commandLineOptionsProvider;
-    }
 
     public readonly string Uid => _commandLineOptionsProvider.Uid;
 

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderCache.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderCache.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+
+namespace Microsoft.Testing.Platform.CommandLine;
+
+internal struct CommandLineOptionsProviderCache : ICommandLineOptionsProvider
+{
+    private readonly ICommandLineOptionsProvider _commandLineOptionsProvider;
+    private CommandLineOption[]? _commandLineOptions;
+
+    public CommandLineOptionsProviderCache(ICommandLineOptionsProvider commandLineOptionsProvider)
+    {
+        _commandLineOptionsProvider = commandLineOptionsProvider;
+    }
+
+    public readonly string Uid => _commandLineOptionsProvider.Uid;
+
+    public readonly string Version => _commandLineOptionsProvider.Version;
+
+    public readonly string DisplayName => _commandLineOptionsProvider.DisplayName;
+
+    public readonly string Description => _commandLineOptionsProvider.Description;
+
+    public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions()
+    {
+        _commandLineOptions ??= _commandLineOptionsProvider.GetCommandLineOptions().ToArray();
+
+        return _commandLineOptions;
+    }
+
+    public readonly Task<bool> IsEnabledAsync()
+        => _commandLineOptionsProvider.IsEnabledAsync();
+
+    public readonly Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
+        => _commandLineOptionsProvider.ValidateCommandLineOptionsAsync(commandLineOptions);
+
+    public readonly Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
+        => _commandLineOptionsProvider.ValidateOptionArgumentsAsync(commandOption, arguments);
+}


### PR DESCRIPTION
closes https://github.com/microsoft/testfx/issues/2412

Before
<img width="971" alt="pre" src="https://github.com/microsoft/testfx/assets/7894084/8c0cfea5-b87d-485b-85cc-c62d3659ed4a">

After
<img width="932" alt="post" src="https://github.com/microsoft/testfx/assets/7894084/880577e1-7bb4-448d-b7c0-58e807faf41b">

Tested only with 1 extension the trx one.