### PR TITLE
Fix ThreadOperations to handle TaskCanceledException

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadOperations.cs
@@ -42,7 +42,9 @@ public class ThreadOperations : IThreadOperations
             // False means execution timed out.
             return executionTask.Wait(timeout, cancellationToken);
         }
-        catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
+        catch (Exception ex) when
+            ((ex is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
+            || (ex is TaskCanceledException tce && tce.CancellationToken == cancellationToken))
         {
             // Task execution canceled.
             return false;
@@ -78,7 +80,9 @@ public class ThreadOperations : IThreadOperations
             // If the execution thread completes before the timeout, the task will return true, otherwise false.
             return executionTask.Result;
         }
-        catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
+        catch (Exception ex) when
+            ((ex is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
+            || (ex is TaskCanceledException tce && tce.CancellationToken == cancellationToken))
         {
             // Task execution canceled.
             return false;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadOperations.cs
@@ -44,6 +44,7 @@ public class ThreadOperations : IThreadOperations
         }
         catch (Exception ex) when
             ((ex is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
+            // This exception occurs when the cancellation happens before the task is actually started.
             || (ex is TaskCanceledException tce && tce.CancellationToken == cancellationToken))
         {
             // Task execution canceled.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadOperations.cs
@@ -83,6 +83,7 @@ public class ThreadOperations : IThreadOperations
         }
         catch (Exception ex) when
             ((ex is OperationCanceledException oce && oce.CancellationToken == cancellationToken)
+            // This exception occurs when the cancellation happens before the task is actually started.
             || (ex is TaskCanceledException tce && tce.CancellationToken == cancellationToken))
         {
             // Task execution canceled.


### PR DESCRIPTION
This exception occurs when the cancellation happens before the task is actually started.