### PR TITLE
Remove usage of pt images before decomissioning

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -169,7 +169,7 @@ extends:
             timeoutInMinutes: 90
             pool:
               name: $(DncEngInternalBuildPool)
-              image: 1es-ubuntu-2204-pt
+              image: 1es-ubuntu-2204
               os: linux
             steps:
             - script: eng/common/cibuild.sh


### PR DESCRIPTION
built on internal pipeline is green: https://dev.azure.com/dnceng/internal/_build/results?buildId=2436531&view=results