### PR TITLE
Make MSTest.Acceptance an Exe OutputType

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateProgramFile>false</GenerateProgramFile>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Make MSTest.Acceptance an Exe OutputType.
This is required for TestExplorer to be able to run such tests using protocol.