### PR TITLE
Fix test infra to handle package mapping from CPM

### DIFF
--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAsset.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAsset.cs
@@ -85,7 +85,7 @@ public class TestAsset : IDisposable
             <packageSource key="nuget.org">
                 <package pattern="*" />
             </packageSource>
-                <packageSource key="test-tools">
+            <packageSource key="test-tools">
                 <package pattern="*" />
             </packageSource>
             """

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAsset.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAsset.cs
@@ -80,6 +80,17 @@ public class TestAsset : IDisposable
             """
             : string.Empty;
 
+        string publicFeedsMapping = addPublicFeeds
+            ? """
+            <packageSource key="nuget.org">
+                <package pattern="*" />
+            </packageSource>
+                <packageSource key="test-tools">
+                <package pattern="*" />
+            </packageSource>
+            """
+            : string.Empty;
+
         string defaultNuGetConfig = $"""
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
@@ -95,6 +106,7 @@ public class TestAsset : IDisposable
         <add key="globalPackagesFolder" value=".packages" />
     </config>
     <packageSourceMapping>
+        {publicFeedsMapping}
         <packageSource key="local-nonshipping">
             <package pattern="*" />
         </packageSource>


### PR DESCRIPTION
Add source mapping for the public sources we insert when we are restoring in testfx repo, and not in the parent repo. 

When this is not added, nuget.org or test-tools are not used for restore. 

Fix #2783
