### PR TITLE
Refactor `IDataConsumer` for the `TestHostController`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Extensions/CompositeExtensionsFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/CompositeExtensionsFactory.cs
@@ -94,7 +94,7 @@ TestHost: IDataConsumer, ITestApplicationLifetime
         }
     }
 
-    private bool ContainsTestHostExtension() => _instance is IDataConsumer or ITestSessionLifetimeHandler;
+    private bool ContainsTestHostExtension() => _instance is ITestSessionLifetimeHandler;
 
     private bool ContainsTestHostControllerExtension() => _instance is ITestHostProcessLifetimeHandler or ITestHostEnvironmentVariableProvider;
 }

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
@@ -154,7 +154,7 @@ internal sealed class TestHostManager : ITestHostManager
 
     internal async Task<(IExtension Consumer, int RegistrationOrder)[]> BuildDataConsumersAsync(ServiceProvider serviceProvider, List<ICompositeExtensionFactory> alreadyBuiltServices)
     {
-        List<(IExtension Consumer, int RegistrtionOrder)> dataConsumers = [];
+        List<(IExtension Consumer, int RegistrationOrder)> dataConsumers = [];
         foreach (Func<IServiceProvider, IDataConsumer> dataConsumerFactory in _dataConsumerFactories)
         {
             IDataConsumer service = dataConsumerFactory(serviceProvider);

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllerConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllerConfiguration.cs
@@ -1,16 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Extensions.TestHostControllers;
 
 namespace Microsoft.Testing.Platform.TestHostControllers;
 
 internal sealed class TestHostControllerConfiguration(ITestHostEnvironmentVariableProvider[] environmentVariableProviders,
-    ITestHostProcessLifetimeHandler[] lifetimeHandlers, bool requireProcessRestart)
+    ITestHostProcessLifetimeHandler[] lifetimeHandlers,
+    IDataConsumer[] dataConsumer,
+    bool requireProcessRestart)
 {
     public ITestHostEnvironmentVariableProvider[] EnvironmentVariableProviders { get; } = environmentVariableProviders;
 
     public ITestHostProcessLifetimeHandler[] LifetimeHandlers { get; } = lifetimeHandlers;
+
+    public IDataConsumer[] DataConsumer { get; } = dataConsumer;
 
     public bool RequireProcessRestart { get; } = requireProcessRestart;
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
@@ -171,7 +171,7 @@ public sealed class TestApplicationBuilderTests : TestBase
     }
 
     [SuppressMessage("Design", "TA0001:Extension should not implement cross-functional areas", Justification = "Done on purpose for testing error")]
-    private sealed class InvalidComposition : ITestHostProcessLifetimeHandler, IDataConsumer
+    private sealed class InvalidComposition : ITestHostProcessLifetimeHandler, ITestSessionLifetimeHandler
     {
         private readonly IServiceProvider? _serviceProvider;
 
@@ -192,17 +192,15 @@ public sealed class TestApplicationBuilderTests : TestBase
 
         public string Description => nameof(InvalidComposition);
 
-        public Type[] DataTypesConsumed => Array.Empty<Type>();
-
         public Task BeforeTestHostProcessStartAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
-
-        public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public Task<bool> IsEnabledAsync() => throw new NotImplementedException();
 
         public Task OnTestHostProcessExitedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellation) => throw new NotImplementedException();
 
         public Task OnTestHostProcessStartedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellation) => throw new NotImplementedException();
+        public Task OnTestSessionStartingAsync(SessionUid sessionUid, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task OnTestSessionFinishingAsync(SessionUid sessionUid, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 
     private sealed class TestHostProcessLifetimeHandlerPlusTestHostEnvironmentVariableProvider : ITestHostProcessLifetimeHandler, ITestHostEnvironmentVariableProvider

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
@@ -199,7 +199,9 @@ public sealed class TestApplicationBuilderTests : TestBase
         public Task OnTestHostProcessExitedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellation) => throw new NotImplementedException();
 
         public Task OnTestHostProcessStartedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellation) => throw new NotImplementedException();
+
         public Task OnTestSessionStartingAsync(SessionUid sessionUid, CancellationToken cancellationToken) => throw new NotImplementedException();
+
         public Task OnTestSessionFinishingAsync(SessionUid sessionUid, CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 


### PR DESCRIPTION
Make the `IDataConsumer` registration symmetric in both model. Historically we added a way to have data consumer inside the test host for "questionable" trx needs.

So we were foreaching the extension and in case of `IDataConsumer` implementation we were adding as listener to the `IMessageBus` to allow for instance the codecov old version to push the file that the trx could take to put inside the report self.

Nowadays where we run the trx and cc in-process this is mostly non needed but anyway we have a feature to collect artifacts inside the test host controller to "add attachments" if someone there is producing something.
This is an "hidden" and not documented behavior used only by our trx extension. So it's fine to update and make it coherent with the rest, but won't be exposed yet and most probably never. I don't know if we will never have reason to do it. The logic is that outside you push artifacts and stop, like the current VSTest logger, so I would not expose this feature but for now I'll internalize the method only to keep the current trx behavior.

I'll update the trx extension as soon as we'll flow this there.

cc: @Evangelink  wait the trx update on the other side before to ship