### PR TITLE
Fix parameters/arguments check for data driven tests

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -205,5 +205,5 @@ internal static class MethodInfoExtensions
                 methodParametersLengthOrZero,
                 string.Join(", ", methodParameters?.Select(p => p.ParameterType.Name) ?? Array.Empty<string>()),
                 argumentsLengthOrZero,
-                string.Join(", ", arguments?.Select(a => a?.GetType().Name ?? "null") ?? Array.Empty<string>())));
+                string.Join(", ", arguments?.Select(a => a?.GetType().Name ?? "null") ?? Array.Empty<string>())), innerException);
 }

--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -171,55 +171,39 @@ internal static class MethodInfoExtensions
         {
             int methodParametersLengthOrZero = methodParameters?.Length ?? 0;
             int argumentsLengthOrZero = arguments?.Length ?? 0;
-            if (methodParametersLengthOrZero != argumentsLengthOrZero
-                || !AreArgumentAndParameterTypesAssignable(arguments, methodParameters))
+            if (methodParametersLengthOrZero != argumentsLengthOrZero)
             {
-                throw new TestFailedException(
-                    ObjectModel.UnitTestOutcome.Error,
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        Resource.CannotRunTestArgumentsMismatchError,
-                        methodInfo.DeclaringType!.FullName,
-                        methodInfo.Name,
-                        methodParametersLengthOrZero,
-                        string.Join(", ", methodParameters?.Select(p => p.ParameterType.Name) ?? Array.Empty<string>()),
-                        argumentsLengthOrZero,
-                        string.Join(", ", arguments?.Select(a => a?.GetType().Name ?? "null") ?? Array.Empty<string>())));
+                throw GetParameterCountMismatchException(methodInfo, arguments, methodParameters, methodParametersLengthOrZero, argumentsLengthOrZero, innerException: null);
             }
 
-            task = methodInfo.Invoke(classInstance, arguments) as Task;
+            try
+            {
+                task = methodInfo.Invoke(classInstance, arguments) as Task;
+            }
+            catch (TargetParameterCountException ex)
+            {
+                throw GetParameterCountMismatchException(methodInfo, arguments, methodParameters, methodParametersLengthOrZero, argumentsLengthOrZero, ex);
+            }
+            catch (ArgumentException ex)
+            {
+                throw GetParameterCountMismatchException(methodInfo, arguments, methodParameters, methodParametersLengthOrZero, argumentsLengthOrZero, ex);
+            }
         }
 
         // If methodInfo is an async method, wait for returned task
         task?.GetAwaiter().GetResult();
     }
 
-    private static bool AreArgumentAndParameterTypesAssignable(object?[]? arguments, ParameterInfo[]? parameters)
-    {
-        if (arguments is null or { Length: 0 } && parameters is null or { Length: 0 })
-        {
-            return true;
-        }
-
-        if (arguments is null)
-        {
-            return false;
-        }
-
-        if (parameters is null)
-        {
-            return false;
-        }
-
-        for (int i = 0; i < parameters.Length; i++)
-        {
-            if (arguments[i] is { } argument
-                && !parameters[i].ParameterType.IsAssignableFrom(argument.GetType()))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    private static TestFailedException GetParameterCountMismatchException(MethodInfo methodInfo, object?[]? arguments, ParameterInfo[]? methodParameters, int methodParametersLengthOrZero, int argumentsLengthOrZero, Exception? innerException) =>
+        new(
+            ObjectModel.UnitTestOutcome.Error,
+            string.Format(
+                CultureInfo.InvariantCulture,
+                Resource.CannotRunTestArgumentsMismatchError,
+                methodInfo.DeclaringType!.FullName,
+                methodInfo.Name,
+                methodParametersLengthOrZero,
+                string.Join(", ", methodParameters?.Select(p => p.ParameterType.Name) ?? Array.Empty<string>()),
+                argumentsLengthOrZero,
+                string.Join(", ", arguments?.Select(a => a?.GetType().Name ?? "null") ?? Array.Empty<string>())));
 }


### PR DESCRIPTION
This fixes regression, where we validate types of provided data (e.g. in `[DataRow]`) to the expected parameters of the test method exactly by their types. This is too strict and will fail for any types that can implicitly convert. 

This PR simply invokes the method, and relies on runtime to do the right checks, and we just handle and improve the exceptions that it throws. We only handle the two that are documented here: https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.invoke?view=net-8.0 as happening when parameters don't match the target method. 

As a result, user can provide int32 number to int64 parameter and it will work. As mentioned in the linked issue.

Fix #2828