### PR TITLE
Add code fix for AssemblyInitializeShouldBeValidAnalyzer

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyInitializeShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyInitializeShouldBeValidFixer.cs
@@ -72,6 +72,9 @@ public sealed class AssemblyInitializeShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
+            // If we have some fixes to apply, we want to ensure the new method signature will have the TestContext parameter.
+            fixesToApply |= FixtureMethodSignatureChanges.AddTestContextParameter;
+
             context.RegisterCodeFix(
                 CodeAction.Create(
                     CodeFixResources.AssemblyInitializeShouldBeValidCodeFix,

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyInitializeShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyInitializeShouldBeValidFixer.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+
+using Analyzer.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AssemblyInitializeShouldBeValidFixer))]
+[Shared]
+public sealed class AssemblyInitializeShouldBeValidFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(DiagnosticIds.AssemblyInitializeShouldBeValidRuleId);
+
+    public override FixAllProvider GetFixAllProvider()
+        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        SyntaxNode node = root.FindNode(context.Span);
+        if (node == null)
+        {
+            return;
+        }
+
+        FixtureMethodSignatureChanges fixesToApply = context.Diagnostics.Aggregate(FixtureMethodSignatureChanges.None, (acc, diagnostic) =>
+        {
+            if (diagnostic.Descriptor == AssemblyInitializeShouldBeValidAnalyzer.StaticRule)
+            {
+                return acc | FixtureMethodSignatureChanges.MakeStatic;
+            }
+
+            if (diagnostic.Descriptor == AssemblyInitializeShouldBeValidAnalyzer.PublicRule)
+            {
+                return acc | FixtureMethodSignatureChanges.MakePublic;
+            }
+
+            if (diagnostic.Descriptor == AssemblyInitializeShouldBeValidAnalyzer.ReturnTypeRule)
+            {
+                return acc | FixtureMethodSignatureChanges.FixReturnType;
+            }
+
+            if (diagnostic.Descriptor == AssemblyInitializeShouldBeValidAnalyzer.NotAsyncVoidRule)
+            {
+                return acc | FixtureMethodSignatureChanges.FixAsyncVoid;
+            }
+
+            if (diagnostic.Descriptor == AssemblyInitializeShouldBeValidAnalyzer.SingleContextParameterRule)
+            {
+                return acc | FixtureMethodSignatureChanges.AddTestContextParameter;
+            }
+
+            if (diagnostic.Descriptor == AssemblyInitializeShouldBeValidAnalyzer.NotGenericRule)
+            {
+                return acc | FixtureMethodSignatureChanges.RemoveGeneric;
+            }
+
+            // return accumulator unchanged, either the action cannot be fixed or it will be fixed by default.
+            return acc;
+        });
+
+        if (fixesToApply != FixtureMethodSignatureChanges.None)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    CodeFixResources.AssemblyInitializeShouldBeValidCodeFix,
+                    ct => FixtureMethodFixer.FixSignatureAsync(context.Document, root, node, fixesToApply, ct),
+                    nameof(CodeFixResources.AssemblyInitializeShouldBeValidCodeFix)),
+                context.Diagnostics);
+        }
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -68,5 +68,14 @@ namespace MSTest.Analyzers {
                 return ResourceManager.GetString("AssemblyCleanupShouldBeValidCodeFix", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix signature.
+        /// </summary>
+        internal static string AssemblyInitializeShouldBeValidCodeFix {
+            get {
+                return ResourceManager.GetString("AssemblyInitializeShouldBeValidCodeFix", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -120,4 +120,7 @@
   <data name="AssemblyCleanupShouldBeValidCodeFix" xml:space="preserve">
     <value>Fix signature</value>
   </data>
+  <data name="AssemblyInitializeShouldBeValidCodeFix" xml:space="preserve">
+    <value>Fix signature</value>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">Fix signature</target>
         <note />
       </trans-unit>
+      <trans-unit id="AssemblyInitializeShouldBeValidCodeFix">
+        <source>Fix signature</source>
+        <target state="new">Fix signature</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Add a single code fixer `Fix signature` that will ensure that the signature:

- accessibility is `public`
- return type is `void`, `Task` or `ValueTask`
- method is `static`
- method takes a single `TestContext` parameter
- method isn't generic

The following issues are not fixed:
- method is not a "normal method" (e.g. operator, finalizer...)
- class is generic