### PR TITLE
Add code fix for ClassCleanupShouldBeValidAnalyzer

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyCleanupShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyCleanupShouldBeValidFixer.cs
@@ -72,7 +72,7 @@ public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
-            // Ensure that the method will be static.
+            // The fixer is common to all fixture methods, so we need to hint it that we need 'static'.
             fixesToApply |= FixtureMethodSignatureChanges.MakeStatic;
 
             context.RegisterCodeFix(

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyInitializeShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AssemblyInitializeShouldBeValidFixer.cs
@@ -72,8 +72,9 @@ public sealed class AssemblyInitializeShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
-            // If we have some fixes to apply, we want to ensure the new method signature will have the TestContext parameter.
+            // The fixer is common to all fixture methods, so we need to hint it that we need 'static' and 'TestContext' parameter.
             fixesToApply |= FixtureMethodSignatureChanges.AddTestContextParameter;
+            fixesToApply |= FixtureMethodSignatureChanges.MakeStatic;
 
             context.RegisterCodeFix(
                 CodeAction.Create(

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/ClassCleanupShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/ClassCleanupShouldBeValidFixer.cs
@@ -14,12 +14,12 @@ using MSTest.Analyzers.Helpers;
 
 namespace MSTest.Analyzers;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AssemblyCleanupShouldBeValidFixer))]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ClassCleanupShouldBeValidFixer))]
 [Shared]
-public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
+public sealed class ClassCleanupShouldBeValidFixer : CodeFixProvider
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
-        = ImmutableArray.Create(DiagnosticIds.AssemblyCleanupShouldBeValidRuleId);
+        = ImmutableArray.Create(DiagnosticIds.ClassCleanupShouldBeValidRuleId);
 
     public override FixAllProvider GetFixAllProvider()
         // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
@@ -36,32 +36,32 @@ public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
 
         FixtureMethodSignatureChanges fixesToApply = context.Diagnostics.Aggregate(FixtureMethodSignatureChanges.None, (acc, diagnostic) =>
         {
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.StaticRule)
+            if (diagnostic.Descriptor == ClassCleanupShouldBeValidAnalyzer.StaticRule)
             {
                 return acc | FixtureMethodSignatureChanges.MakeStatic;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.PublicRule)
+            if (diagnostic.Descriptor == ClassCleanupShouldBeValidAnalyzer.PublicRule)
             {
                 return acc | FixtureMethodSignatureChanges.MakePublic;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.ReturnTypeRule)
+            if (diagnostic.Descriptor == ClassCleanupShouldBeValidAnalyzer.ReturnTypeRule)
             {
                 return acc | FixtureMethodSignatureChanges.FixReturnType;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.NotAsyncVoidRule)
+            if (diagnostic.Descriptor == ClassCleanupShouldBeValidAnalyzer.NotAsyncVoidRule)
             {
                 return acc | FixtureMethodSignatureChanges.FixAsyncVoid;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.NoParametersRule)
+            if (diagnostic.Descriptor == ClassCleanupShouldBeValidAnalyzer.NoParametersRule)
             {
                 return acc | FixtureMethodSignatureChanges.RemoveParameters;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.NotGenericRule)
+            if (diagnostic.Descriptor == ClassCleanupShouldBeValidAnalyzer.NotGenericRule)
             {
                 return acc | FixtureMethodSignatureChanges.RemoveGeneric;
             }
@@ -72,14 +72,11 @@ public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
-            // Ensure that the method will be static.
-            fixesToApply |= FixtureMethodSignatureChanges.MakeStatic;
-
             context.RegisterCodeFix(
                 CodeAction.Create(
                     CodeFixResources.FixSignatureCodeFix,
                     ct => FixtureMethodFixer.FixSignatureAsync(context.Document, root, node, fixesToApply, ct),
-                    nameof(AssemblyCleanupShouldBeValidFixer)),
+                    nameof(ClassCleanupShouldBeValidFixer)),
                 context.Diagnostics);
         }
     }

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/ClassCleanupShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/ClassCleanupShouldBeValidFixer.cs
@@ -72,6 +72,9 @@ public sealed class ClassCleanupShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
+            // The fixer is common to all fixture methods, so we need to hint it that we need 'static'.
+            fixesToApply |= FixtureMethodSignatureChanges.MakeStatic;
+
             context.RegisterCodeFix(
                 CodeAction.Create(
                     CodeFixResources.FixSignatureCodeFix,

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/ClassInitializeShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/ClassInitializeShouldBeValidFixer.cs
@@ -72,11 +72,13 @@ public sealed class ClassInitializeShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
+            // The fixer is common to all fixture methods, so we need to hint it that we need 'static' and 'TestContext' parameter.
             fixesToApply |= FixtureMethodSignatureChanges.AddTestContextParameter;
+            fixesToApply |= FixtureMethodSignatureChanges.MakeStatic;
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    CodeFixResources.AssemblyCleanupShouldBeValidCodeFix,
+                    CodeFixResources.FixSignatureCodeFix,
                     ct => FixtureMethodFixer.FixSignatureAsync(context.Document, root, node, fixesToApply, ct),
                     nameof(ClassInitializeShouldBeValidFixer)),
                 context.Diagnostics);

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -63,9 +63,9 @@ namespace MSTest.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix signature.
         /// </summary>
-        internal static string AssemblyCleanupShouldBeValidCodeFix {
+        internal static string FixSignatureCodeFix {
             get {
-                return ResourceManager.GetString("AssemblyCleanupShouldBeValidCodeFix", resourceCulture);
+                return ResourceManager.GetString("FixSignatureCodeFix", resourceCulture);
             }
         }
         

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -63,18 +63,18 @@ namespace MSTest.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Fix signature.
         /// </summary>
-        internal static string FixSignatureCodeFix {
+        internal static string AssemblyInitializeShouldBeValidCodeFix {
             get {
-                return ResourceManager.GetString("FixSignatureCodeFix", resourceCulture);
+                return ResourceManager.GetString("AssemblyInitializeShouldBeValidCodeFix", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Fix signature.
         /// </summary>
-        internal static string AssemblyInitializeShouldBeValidCodeFix {
+        internal static string FixSignatureCodeFix {
             get {
-                return ResourceManager.GetString("AssemblyInitializeShouldBeValidCodeFix", resourceCulture);
+                return ResourceManager.GetString("FixSignatureCodeFix", resourceCulture);
             }
         }
     }

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AssemblyCleanupShouldBeValidCodeFix" xml:space="preserve">
+  <data name="FixSignatureCodeFix" xml:space="preserve">
     <value>Fix signature</value>
   </data>
   <data name="AssemblyInitializeShouldBeValidCodeFix" xml:space="preserve">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/Helpers/FixtureMethodFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/Helpers/FixtureMethodFixer.cs
@@ -45,6 +45,9 @@ internal static class FixtureMethodFixer
         // Copy the attributes from the old method to the new method.
         fixedMethodDeclarationNode = syntaxGenerator.AddAttributes(fixedMethodDeclarationNode, syntaxGenerator.GetAttributes(node));
 
+        // Copy the attributes from the old method to the new method.
+        fixedMethodDeclarationNode = syntaxGenerator.AddAttributes(fixedMethodDeclarationNode, syntaxGenerator.GetAttributes(node));
+
         return document.WithSyntaxRoot(root.ReplaceNode(node, fixedMethodDeclarationNode)).Project.Solution;
     }
 

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/Helpers/FixtureMethodFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/Helpers/FixtureMethodFixer.cs
@@ -45,9 +45,6 @@ internal static class FixtureMethodFixer
         // Copy the attributes from the old method to the new method.
         fixedMethodDeclarationNode = syntaxGenerator.AddAttributes(fixedMethodDeclarationNode, syntaxGenerator.GetAttributes(node));
 
-        // Copy the attributes from the old method to the new method.
-        fixedMethodDeclarationNode = syntaxGenerator.AddAttributes(fixedMethodDeclarationNode, syntaxGenerator.GetAttributes(node));
-
         return document.WithSyntaxRoot(root.ReplaceNode(node, fixedMethodDeclarationNode)).Project.Solution;
     }
 

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/TestCleanupShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/TestCleanupShouldBeValidFixer.cs
@@ -79,7 +79,7 @@ public sealed class TestCleanupShouldBeValidFixer : CodeFixProvider
         {
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    CodeFixResources.AssemblyCleanupShouldBeValidCodeFix,
+                    CodeFixResources.FixSignatureCodeFix,
                     ct => FixtureMethodFixer.FixSignatureAsync(context.Document, root, node, fixesToApply, ct),
                     nameof(TestCleanupShouldBeValidFixer)),
                 context.Diagnostics);

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CodeFixResources.resx">
     <body>
-      <trans-unit id="AssemblyCleanupShouldBeValidCodeFix">
+      <trans-unit id="FixSignatureCodeFix">
         <source>Fix signature</source>
         <target state="new">Fix signature</target>
         <note />


### PR DESCRIPTION
Add a single code fixer `Fix signature` that will ensures that:
- accessibility is `public`
- return type is `void`, `Task` or `ValueTask`
- method is `static`
- method doesn't take any parameter
- method isn't generic

The following issues are not fixed:
- method is not a "normal method" (e.g. operator, finalizer...)
- class is generic