### PR TITLE
Code fix for TestCleanupShouldBeValidAnalyzer

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/FixtureMethodSignatureChanges.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/FixtureMethodSignatureChanges.cs
@@ -17,4 +17,5 @@ internal enum FixtureMethodSignatureChanges
     FixAsyncVoid = 32,
     FixReturnType = 64,
     RemoveGeneric = 128,
+    RemoveAbstract = 256,
 }

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/Helpers/FixtureMethodFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/Helpers/FixtureMethodFixer.cs
@@ -54,13 +54,15 @@ internal static class FixtureMethodFixer
 
     private static DeclarationModifiers GetModifiers(FixtureMethodSignatureChanges fixesToApply, IMethodSymbol methodSymbol)
     {
-        var currentModifiers = DeclarationModifiers.From(methodSymbol);
+        DeclarationModifiers newModifiers = methodSymbol.IsAsync
+            ? DeclarationModifiers.Async
+            : DeclarationModifiers.None;
 
         return fixesToApply.HasFlag(FixtureMethodSignatureChanges.MakeStatic)
-            ? currentModifiers.WithIsStatic(true)
+            ? newModifiers.WithIsStatic(true)
             : fixesToApply.HasFlag(FixtureMethodSignatureChanges.RemoveStatic)
-                ? currentModifiers.WithIsStatic(false)
-                : currentModifiers;
+                ? newModifiers.WithIsStatic(false)
+                : newModifiers;
     }
 
     private static Accessibility GetAccessibility(FixtureMethodSignatureChanges fixesToApply, IMethodSymbol methodSymbol)

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/TestCleanupShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/TestCleanupShouldBeValidFixer.cs
@@ -14,12 +14,12 @@ using MSTest.Analyzers.Helpers;
 
 namespace MSTest.Analyzers;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AssemblyCleanupShouldBeValidFixer))]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(TestCleanupShouldBeValidFixer))]
 [Shared]
-public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
+public sealed class TestCleanupShouldBeValidFixer : CodeFixProvider
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
-        = ImmutableArray.Create(DiagnosticIds.AssemblyCleanupShouldBeValidRuleId);
+        = ImmutableArray.Create(DiagnosticIds.TestCleanupShouldBeValidRuleId);
 
     public override FixAllProvider GetFixAllProvider()
         // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
@@ -36,34 +36,39 @@ public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
 
         FixtureMethodSignatureChanges fixesToApply = context.Diagnostics.Aggregate(FixtureMethodSignatureChanges.None, (acc, diagnostic) =>
         {
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.StaticRule)
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.NotStaticRule)
             {
-                return acc | FixtureMethodSignatureChanges.MakeStatic;
+                return acc | FixtureMethodSignatureChanges.RemoveStatic;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.PublicRule)
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.PublicRule)
             {
                 return acc | FixtureMethodSignatureChanges.MakePublic;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.ReturnTypeRule)
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
             {
                 return acc | FixtureMethodSignatureChanges.FixReturnType;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.NotAsyncVoidRule)
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.NotAsyncVoidRule)
             {
                 return acc | FixtureMethodSignatureChanges.FixAsyncVoid;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.NoParametersRule)
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.NoParametersRule)
             {
                 return acc | FixtureMethodSignatureChanges.RemoveParameters;
             }
 
-            if (diagnostic.Descriptor == AssemblyCleanupShouldBeValidAnalyzer.NotGenericRule)
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.NotGenericRule)
             {
                 return acc | FixtureMethodSignatureChanges.RemoveGeneric;
+            }
+
+            if (diagnostic.Descriptor == TestCleanupShouldBeValidAnalyzer.NotAbstractRule)
+            {
+                return acc | FixtureMethodSignatureChanges.RemoveAbstract;
             }
 
             // return accumulator unchanged, either the action cannot be fixed or it will be fixed by default.
@@ -72,14 +77,11 @@ public sealed class AssemblyCleanupShouldBeValidFixer : CodeFixProvider
 
         if (fixesToApply != FixtureMethodSignatureChanges.None)
         {
-            // Ensure that the method will be static.
-            fixesToApply |= FixtureMethodSignatureChanges.MakeStatic;
-
             context.RegisterCodeFix(
                 CodeAction.Create(
                     CodeFixResources.AssemblyCleanupShouldBeValidCodeFix,
                     ct => FixtureMethodFixer.FixSignatureAsync(context.Document, root, node, fixesToApply, ct),
-                    nameof(CodeFixResources.AssemblyCleanupShouldBeValidCodeFix)),
+                    nameof(TestCleanupShouldBeValidFixer)),
                 context.Diagnostics);
         }
     }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestCleanupShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestCleanupShouldBeValidAnalyzerTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Testing.TestInfrastructure;
 
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
     MSTest.Analyzers.TestCleanupShouldBeValidAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    MSTest.Analyzers.TestCleanupShouldBeValidFixer>;
 
 namespace MSTest.Analyzers.Test;
 
@@ -68,11 +68,27 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: DiscoverInternals]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.PublicRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 
     [Arguments("protected")]
@@ -94,11 +110,25 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.PublicRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 
     public async Task WhenTestCleanupIsNotOrdinary_Diagnostic()
@@ -116,11 +146,12 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.OrdinaryRule)
                 .WithLocation(0)
-                .WithArguments("Finalize"));
+                .WithArguments("Finalize"),
+            code);
     }
 
     public async Task WhenTestCleanupIsAbstract_Diagnostic()
@@ -136,11 +167,25 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public abstract class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.NotAbstractRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 
     public async Task WhenTestCleanupIsGeneric_Diagnostic()
@@ -158,11 +203,25 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.NotGenericRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 
     public async Task WhenTestCleanupIsStatic_Diagnostic()
@@ -180,11 +239,25 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.NotStaticRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 
     public async Task WhenTestCleanupHasParameters_Diagnostic()
@@ -202,11 +275,25 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.NoParametersRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 
     public async Task WhenTestCleanupReturnTypeIsNotValid_Diagnostic()
@@ -244,20 +331,53 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup0()
+                {
+                }
+
+                [TestCleanup]
+                public void TestCleanup1()
+                {
+                }
+
+                [TestCleanup]
+                public Task {|CS0161:TestCleanup2|}()
+                {
+                }
+
+                [TestCleanup]
+                public ValueTask {|CS0161:TestCleanup3|}()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
-                .WithLocation(0)
-                .WithArguments("TestCleanup0"),
-            VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
-                .WithLocation(1)
-                .WithArguments("TestCleanup1"),
-            VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
-                .WithLocation(2)
-                .WithArguments("TestCleanup2"),
-            VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
-                .WithLocation(3)
-                .WithArguments("TestCleanup3"));
+            new[]
+            {
+                VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
+                    .WithLocation(0)
+                    .WithArguments("TestCleanup0"),
+                VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
+                    .WithLocation(1)
+                    .WithArguments("TestCleanup1"),
+                VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
+                    .WithLocation(2)
+                    .WithArguments("TestCleanup2"),
+                VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.ReturnTypeRule)
+                    .WithLocation(3)
+                    .WithArguments("TestCleanup3"),
+            },
+            fixedCode);
     }
 
     public async Task WhenTestCleanupReturnTypeIsValid_NoDiagnostic()
@@ -308,10 +428,26 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests(ITestExecutionContext 
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public async Task TestCleanup()
+                {
+                    await Task.Delay(0);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.NotAsyncVoidRule)
                 .WithLocation(0)
-                .WithArguments("TestCleanup"));
+                .WithArguments("TestCleanup"),
+            fixedCode);
     }
 }


### PR DESCRIPTION
Add a single code fixer `Fix signature` that will ensures that:
- accessibility is `public`
- return type is `void`, `Task` or `ValueTask`
- method is not `static`
- method takes no parameter
- method isn't generic
- method isn't abstract

The following issues are not fixed:
- method is not a "normal method" (e.g. operator, finalizer...)
- class is generic