### PR TITLE
Add 3.4.0 href to changelog

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,9 @@
     "MD024": {
       "siblings_only": true
     },
+    "MD033": {
+      "allowed_elements": ["a"]
+    },
     "MD046": {
       "style": "fenced"
     },

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [3.4.0] - WIP
+## <a name="3.4.0"></a>[3.4.0] - WIP
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.3.1...HEAD)
 

--- a/docs/testingplatform/idataconsumer.md
+++ b/docs/testingplatform/idataconsumer.md
@@ -90,6 +90,8 @@ Finally, the api takes a `CancellationToken` which the extension is expected to 
 > [!IMPORTANT]
 > It's crucial to process the payload directly within the `ConsumeAsync` method. The [IMessageBus](imessagebus.md) can manage both synchronous and asynchronous processing, coordinating the execution with the [testing framework](itestframework.md). Although the consumption process is entirely asynchronous and doesn't block the [IMessageBus.Push](imessagebus.md) at the time of writing, this is an implementation detail that may change in the future due to feature requirements. However, we aim to maintain this interface's simplicity and ensure that this method is always called once, eliminating the need for complex synchronization. Additionally, we automatically manage the scalability of the consumers.
 
+<!-- avoid "No space in block quote" block quotes follow each other -->
+
 > [!WARNING]
 > When using `IDataConsumer` in conjunction with [ITestHostProcessLifetimeHandler](itestsessionlifetimehandler.md) within a [composite extension point](compositeextensionfactory.md), **it's crucial to disregard any data received post the execution of [ITestSessionLifetimeHandler.OnTestSessionFinishingAsync](itestsessionlifetimehandler.md)**. The `OnTestSessionFinishingAsync` is the final opportunity to process accumulated data and transmit new information to the [IMessageBus](imessagebus.md), hence, any data consumed beyond this point will not be *utilizable* by the extension.
 


### PR DESCRIPTION
Add `<a>` with name to changelog, so we can link to it with `https://github.com/microsoft/testfx/blob/main/docs/Changelog.md#340` no matter what the header says.

<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->