### PR TITLE
Add explicit hrefs for all versions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -88,7 +88,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.3.1...HEAD)
 
 ### Artifacts
 
-## [3.3.1] - 2024-04-04
+## <a name="3.3.1"></a>[3.3.1] - 2024-04-04
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.3.0...v3.3.1)
 
@@ -109,7 +109,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.3.0...v3.3.1)
 * Microsoft.Testing.Extensions.Retry: [1.1.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.1.0)
 * Microsoft.Testing.Extensions.TrxReport: [1.1.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.1.0)
 
-## [3.3.0] - 2024-04-03
+## <a name="3.3.0"></a>[3.3.0] - 2024-04-03
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.2.2...v3.3.0)
 
@@ -182,7 +182,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.2.2...v3.3.0)
 * Microsoft.Testing.Extensions.Retry: [1.1.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.1.0)
 * Microsoft.Testing.Extensions.TrxReport: [1.1.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.1.0)
 
-## [3.2.2] - 2024-02-22
+## <a name="3.2.2"></a>[3.2.2] - 2024-02-22
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.2.1...v3.2.2)
 
@@ -206,7 +206,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.2.1...v3.2.2)
 * Microsoft.Testing.Extensions.Retry: [1.0.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.0.2)
 * Microsoft.Testing.Extensions.TrxReport: [1.0.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.0.2)
 
-## [3.2.1] - 2024-02-13
+## <a name="3.2.1"></a>[3.2.1] - 2024-02-13
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.2.0...v.3.2.1)
 
@@ -236,7 +236,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.2.0...v.3.2.1
 * Microsoft.Testing.Extensions.Retry: [1.0.1](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.0.1)
 * Microsoft.Testing.Extensions.TrxReport: [1.0.1](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.0.1)
 
-## [3.2.0] - 2024-01-24
+## <a name="3.2.0"></a>[3.2.0] - 2024-01-24
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.1.1...v.3.2.0)
 
@@ -317,7 +317,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.1.1...v.3.2.0
 * Microsoft.Testing.Extensions.Retry: [1.0.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.0.0)
 * Microsoft.Testing.Extensions.TrxReport: [1.0.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.0.0)
 
-## [3.2.0-preview.24069.3] - 2024-01-19
+## <a name="3.2.0-preview.24069.3"></a>[3.2.0-preview.24069.3] - 2024-01-19
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.2.0-preview.23623.1...v3.2.0-preview.24069.3)
 
@@ -370,7 +370,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.2.0-preview.2
 * Microsoft.Testing.Extensions.Retry: [1.0.0-preview.24068.6](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.0.0-preview.24068.6)
 * Microsoft.Testing.Extensions.TrxReport: [1.0.0-preview.24068.6](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.0.0-preview.24068.6)
 
-## [3.2.0-preview.23623.1] - 2023-12-23
+## <a name="3.2.0-preview.23623.1"></a>[3.2.0-preview.23623.1] - 2023-12-23
 
 See full log [here](https://github.com/Microsoft/testfx/compare/v3.2.0-preview.23622.1...3.2.0-preview.23623.1)
 
@@ -385,7 +385,7 @@ See full log [here](https://github.com/Microsoft/testfx/compare/v3.2.0-preview.2
 * MSTest.TestAdapter: [3.2.0-preview.23623.1](https://www.nuget.org/packages/MSTest.TestAdapter/3.2.0-preview.23623.1)
 * MSTest.Analyzers: [3.2.0-preview.23623.1](https://www.nuget.org/packages/MSTest.Analyzers/3.2.0-preview.23623.1)
 
-## [3.2.0-preview.23622.1] - 2023-12-22
+## <a name="3.2.0-preview.23622.1"></a>[3.2.0-preview.23622.1] - 2023-12-22
 
 See full log [here](https://github.com/Microsoft/testfx/compare/v3.1.1...v3.2.0-preview.23622.1)
 
@@ -433,7 +433,7 @@ See full log [here](https://github.com/Microsoft/testfx/compare/v3.1.1...v3.2.0-
 * MSTest.TestAdapter: [3.2.0-preview.23622.1](https://www.nuget.org/packages/MSTest.TestAdapter/3.2.0-preview.23622.1)
 * MSTest.Analyzers: [3.2.0-preview.23622.1](https://www.nuget.org/packages/MSTest.Analyzers/3.2.0-preview.23622.1)
 
-## [3.1.1] - 2023-07-14
+## <a name="3.1.1"></a>[3.1.1] - 2023-07-14
 
 ### Fixed
 
@@ -447,7 +447,7 @@ See full log [here](https://github.com/Microsoft/testfx/compare/v3.1.0...v3.1.1)
 * MSTest.TestFramework: [3.1.1](https://www.nuget.org/packages/MSTest.TestFramework/3.1.1)
 * MSTest.TestAdapter: [3.1.1](https://www.nuget.org/packages/MSTest.TestAdapter/3.1.1)
 
-## [3.1.0] - 2023-07-14
+## <a name="3.1.0"></a>[3.1.0] - 2023-07-14
 
 See full log [here](https://github.com/Microsoft/testfx/compare/v3.0.4...v3.1.0)
 
@@ -493,7 +493,7 @@ See full log [here](https://github.com/Microsoft/testfx/compare/v3.0.4...v3.1.0)
 * MSTest.TestFramework: [3.1.0](https://www.nuget.org/packages/MSTest.TestFramework/3.1.0)
 * MSTest.TestAdapter: [3.1.0](https://www.nuget.org/packages/MSTest.TestAdapter/3.1.0)
 
-## [3.0.4] - 2023-06-01
+## <a name="3.0.4"></a>[3.0.4] - 2023-06-01
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.0.3...v3.0.4)
 
@@ -508,7 +508,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.0.3...v3.0.4)
 * MSTest.TestFramework: [3.0.4](https://www.nuget.org/packages/MSTest.TestFramework/3.0.4)
 * MSTest.TestAdapter: [3.0.4](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.4)
 
-## [3.0.3] - 2023-05-24
+## <a name="3.0.3"></a>[3.0.3] - 2023-05-24
 
 See full log [here](https://github.com/Microsoft/testfx/compare/v3.0.2...v3.0.3)
 
@@ -529,7 +529,7 @@ See full log [here](https://github.com/Microsoft/testfx/compare/v3.0.2...v3.0.3)
 * MSTest.TestFramework: [3.0.3](https://www.nuget.org/packages/MSTest.TestFramework/3.0.3)
 * MSTest.TestAdapter: [3.0.3](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.3)
 
-## [3.0.2] - 2022-12-27
+## <a name="3.0.2"></a>[3.0.2] - 2022-12-27
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.0.1...v3.0.2)
 
@@ -543,7 +543,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.0.1...v3.0.2)
 * MSTest.TestFramework: [3.0.2](https://www.nuget.org/packages/MSTest.TestFramework/3.0.2)
 * MSTest.TestAdapter: [3.0.2](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.2)
 
-## [3.0.1] - 2022-12-20
+## <a name="3.0.1"></a>[3.0.1] - 2022-12-20
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.0.0...v3.0.1)
 
@@ -566,7 +566,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.0.0...v3.0.1)
 * MSTest.TestFramework: [3.0.1](https://www.nuget.org/packages/MSTest.TestFramework/3.0.1)
 * MSTest.TestAdapter: [3.0.1](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.1)
 
-## [3.0.0] - 2022-12-06
+## <a name="3.0.0"></a>[3.0.0] - 2022-12-06
 
 See full log [here](https://github.com/microsoft/testfx/compare/v2.2.10...v3.0.0)
 
@@ -623,7 +623,7 @@ Breaking changes announcements [#1274](https://github.com/microsoft/testfx/issue
 * MSTest.TestFramework: [3.0.0](https://www.nuget.org/packages/MSTest.TestFramework/3.0.0)
 * MSTest.TestAdapter: [3.0.0](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.0)
 
-## [3.0.0-preview-20221122-01] - 2022-11-23
+## <a name="3.0.0-preview-20221122-01"></a>[3.0.0-preview-20221122-01] - 2022-11-23
 
 See full log [here](https://github.com/microsoft/testfx/compare/v3.0.0-preview-20221110-04...v3.0.0-preview-20221122-01)
 
@@ -667,7 +667,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v3.0.0-preview-2
 * MSTest.TestFramework: [3.0.0-preview-20221122-01](https://www.nuget.org/packages/MSTest.TestFramework/3.0.0-preview-20221122-01)
 * MSTest.TestAdapter: [3.0.0-preview-20221122-01](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.0-preview-20221122-01)
 
-## [3.0.0-preview-20221110-04] - 2022-11-11
+## <a name="3.0.0-preview-20221110-04"></a>[3.0.0-preview-20221110-04] - 2022-11-11
 
 See full log [here](https://github.com/microsoft/testfx/compare/v2.3.0-preview-20220810-02...v3.0.0-preview-20221110-04)
 
@@ -800,7 +800,7 @@ See full log [here](https://github.com/microsoft/testfx/compare/v2.3.0-preview-2
 * MSTest.TestFramework: [3.0.0-preview-20221110-04](https://www.nuget.org/packages/MSTest.TestFramework/3.0.0-preview-20221110-04)
 * MSTest.TestAdapter: [3.0.0-preview-20221110-04](https://www.nuget.org/packages/MSTest.TestAdapter/3.0.0-preview-20221110-04)
 
-## [2.3.0-preview-20220810-02] 2022-08-10
+## <a name="2.3.0-preview-20220810-02"></a>[2.3.0-preview-20220810-02] 2022-08-10
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.10...v2.3.0-preview-20220810-02)
 
@@ -833,7 +833,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.3.0-preview-20220810-02](https://www.nuget.org/packages/MSTest.TestFramework/2.3.0-preview-20220810-02)
 * MSTest.TestAdapter: [2.3.0-preview-20220810-02](https://www.nuget.org/packages/MSTest.TestAdapter/2.3.0-preview-20220810-02)
 
-## [2.2.10] - 2022-04-26
+## <a name="2.2.10"></a>[2.2.10] - 2022-04-26
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.10-preview-20220414-01...v2.2.10)
 
@@ -860,7 +860,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.10](https://www.nuget.org/packages/MSTest.TestFramework/2.2.10)
 * MSTest.TestAdapter: [2.2.10](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.10)
 
-## [2.2.10-preview-20220414-01] - 2022-04-14
+## <a name="2.2.10-preview-20220414-01"></a>[2.2.10-preview-20220414-01] - 2022-04-14
 
 ### Fixed
 
@@ -873,7 +873,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.10-preview-20220414-01](https://www.nuget.org/packages/MSTest.TestFramework/2.2.10-preview-20220414-01)
 * MSTest.TestAdapter: [2.2.10-preview-20220414-01](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.10-preview-20220414-01)
 
-## [2.2.9] 2022-04-08
+## <a name="2.2.9"></a>[2.2.9] 2022-04-08
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.8...v2.2.9)
 
@@ -907,7 +907,7 @@ Due to the way that class and assembly initialize, and cleanup are invoked, thei
 * MSTest.TestFramework: [2.2.9](https://www.nuget.org/packages/MSTest.TestFramework/2.2.9)
 * MSTest.TestAdapter: [2.2.9](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.9)
 
-## [2.2.8] - 2021-11-23
+## <a name="2.2.8"></a>[2.2.8] - 2021-11-23
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.7...v2.2.8)
 
@@ -939,7 +939,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.8](https://www.nuget.org/packages/MSTest.TestFramework/2.2.8)
 * MSTest.TestAdapter: [2.2.8](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.8)
 
-## [2.2.7] - 2021-09-03
+## <a name="2.2.7"></a>[2.2.7] - 2021-09-03
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.6...v2.2.7)
 
@@ -956,7 +956,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.7](https://www.nuget.org/packages/MSTest.TestFramework/2.2.7)
 * MSTest.TestAdapter: [2.2.7](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.7)
 
-## [2.2.6] - 2021-08-25
+## <a name="2.2.6"></a>[2.2.6] - 2021-08-25
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.5...v2.2.6)
 
@@ -974,7 +974,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.6](https://www.nuget.org/packages/MSTest.TestFramework/2.2.6)
 * MSTest.TestAdapter: [2.2.6](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.6)
 
-## [2.2.5] - 2021-06-28
+## <a name="2.2.5"></a>[2.2.5] - 2021-06-28
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.4...v2.2.5)
 
@@ -999,7 +999,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.5](https://www.nuget.org/packages/MSTest.TestFramework/2.2.5)
 * MSTest.TestAdapter: [2.2.5](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.5)
 
-## [2.2.4] - 2021-05-25
+## <a name="2.2.4"></a>[2.2.4] - 2021-05-25
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/0b95a26282eae17f896d732381e5c77b9a603382...v2.2.4)
 
@@ -1008,7 +1008,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.4](https://www.nuget.org/packages/MSTest.TestFramework/2.2.4)
 * MSTest.TestAdapter: [2.2.4](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.4)
 
-## [2.2.4-preview-20210331-02] - 2021-04-02
+## <a name="2.2.4-preview-20210331-02"></a>[2.2.4-preview-20210331-02] - 2021-04-02
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.3...v2.2.4-preview-20210331-02)
 
@@ -1030,7 +1030,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.4-preview-20210331-02](https://www.nuget.org/packages/MSTest.TestFramework/2.2.4-preview-20210331-02)
 * MSTest.TestAdapter: [2.2.4-preview-20210331-02](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.4-preview-20210331-02)
 
-## [2.2.3] - 2021-03-16
+## <a name="2.2.3"></a>[2.2.3] - 2021-03-16
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.2...v2.2.3)
 
@@ -1043,7 +1043,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.3](https://www.nuget.org/packages/MSTest.TestFramework/2.2.3)
 * MSTest.TestAdapter: [2.2.3](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.3)
 
-## [2.2.2] - 2021-03-15
+## <a name="2.2.2"></a>[2.2.2] - 2021-03-15
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.1...v2.2.2)
 
@@ -1062,7 +1062,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.2](https://www.nuget.org/packages/MSTest.TestFramework/2.2.2)
 * MSTest.TestAdapter: [2.2.2](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.2)
 
-## [2.2.1] - 2021-03-01
+## <a name="2.2.1"></a>[2.2.1] - 2021-03-01
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.0-preview-20210115-03...v2.2.1)
 
@@ -1091,7 +1091,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.1](https://www.nuget.org/packages/MSTest.TestFramework/2.2.1)
 * MSTest.TestAdapter: [2.2.1](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.1)
 
-## [2.2.0-preview-20210115-03] - 2021-01-20
+## <a name="2.2.0-preview-20210115-03"></a>[2.2.0-preview-20210115-03] - 2021-01-20
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.2.0-preview-20201126-03...v2.2.0-preview-20210115-03)
 
@@ -1118,7 +1118,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.0-preview-20210115-03](https://www.nuget.org/packages/MSTest.TestFramework/2.2.0-preview-20210115-03)
 * MSTest.TestAdapter: [2.2.0-preview-20210115-03](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.0-preview-20210115-03)
 
-## [2.2.0-preview-20201126-03] - 2020-11-26
+## <a name="2.2.0-preview-20201126-03"></a>[2.2.0-preview-20201126-03] - 2020-11-26
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.1.2...v2.2.0-preview-20201126-03)
 
@@ -1148,7 +1148,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.2.0-preview-20201126-03](https://www.nuget.org/packages/MSTest.TestFramework/2.2.0-preview-20201126-03)
 * MSTest.TestAdapter: [2.2.0-preview-20201126-03](https://www.nuget.org/packages/MSTest.TestAdapter/2.2.0-preview-20201126-03)
 
-## [2.1.2] - 2020-06-08
+## <a name="2.1.2"></a>[2.1.2] - 2020-06-08
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.1.1...v2.1.2)
 
@@ -1169,7 +1169,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.1.2](https://www.nuget.org/packages/MSTest.TestFramework/2.1.2)
 * MSTest.TestAdapter: [2.1.2](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.2)
 
-## [2.1.1] - 2020-04-01
+## <a name="2.1.1"></a>[2.1.1] - 2020-04-01
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.1.0...v2.1.1)
 
@@ -1196,7 +1196,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.1.1](https://www.nuget.org/packages/MSTest.TestFramework/2.1.1)
 * MSTest.TestAdapter: [2.1.1](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.1)
 
-## [2.1.0] - 2020-02-03
+## <a name="2.1.0"></a>[2.1.0] - 2020-02-03
 
 A list of changes since last release are available [here](https://github.com/microsoft/testfx/compare/v2.1.0-beta2...v2.1.0)
 
@@ -1214,7 +1214,7 @@ A list of changes since last release are available [here](https://github.com/mic
 * MSTest.TestFramework: [2.1.0](https://www.nuget.org/packages/MSTest.TestFramework/2.1.0)
 * MSTest.TestAdapter: [2.1.0](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.0)
 
-## [2.1.0-beta2] - 2019-12-18
+## <a name="2.1.0-beta2"></a>[2.1.0-beta2] - 2019-12-18
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v2.1.0-beta...v2.1.0-beta2)
 
@@ -1227,7 +1227,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [2.1.0-beta2](https://www.nuget.org/packages/MSTest.TestFramework/2.1.0-beta2)
 * MSTest.TestAdapter: [2.1.0-beta2](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.0-beta2)
 
-## [2.1.0-beta] - 2019-11-28
+## <a name="2.1.0-beta"></a>[2.1.0-beta] - 2019-11-28
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v2.0.0...v2.1.0-beta)
 
@@ -1241,7 +1241,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [2.1.0-beta](https://www.nuget.org/packages/MSTest.TestFramework/2.1.0-beta)
 * MSTest.TestAdapter: [2.1.0-beta](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.0-beta)
 
-## [2.0.0] 2019-09-03
+## <a name="2.0.0"></a>[2.0.0] 2019-09-03
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v2.0.0-beta4...v2.0.0)
 
@@ -1265,7 +1265,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [2.0.0](https://www.nuget.org/packages/MSTest.TestFramework/2.0.0)
 * MSTest.TestAdapter: [2.0.0](https://www.nuget.org/packages/MSTest.TestAdapter/2.0.0)
 
-## [2.0.0-beta4] - 2019-04-10
+## <a name="2.0.0-beta4"></a>[2.0.0-beta4] - 2019-04-10
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/2.0.0-beta2...v2.0.0-beta4)
 
@@ -1280,7 +1280,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [2.0.0-beta4](https://www.nuget.org/packages/MSTest.TestFramework/2.0.0-beta4)
 * MSTest.TestAdapter: [2.0.0-beta4](https://www.nuget.org/packages/MSTest.TestAdapter/2.0.0-beta4)
 
-## [2.0.0-beta2] - 2019-02-15
+## <a name="2.0.0-beta2"></a>[2.0.0-beta2] - 2019-02-15
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/1.4.0...2.0.0-beta2)
 
@@ -1295,7 +1295,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [2.0.0-beta2](https://www.nuget.org/packages/MSTest.TestFramework/2.0.0-beta2)
 * MSTest.TestAdapter: [2.0.0-beta2](https://www.nuget.org/packages/MSTest.TestAdapter/2.0.0-beta2)
 
-## [1.4.0] - 2018-11-26
+## <a name="1.4.0"></a>[1.4.0] - 2018-11-26
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/1.4.0-beta...1.4.0)
 
@@ -1317,7 +1317,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.4.0](https://www.nuget.org/packages/MSTest.TestFramework/1.4.0)
 * MSTest.TestAdapter: [1.4.0](https://www.nuget.org/packages/MSTest.TestAdapter/1.4.0)
 
-## [1.4.0-beta] 2018-10-17
+## <a name="1.4.0-beta"></a>[1.4.0-beta] 2018-10-17
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/1.3.2...1.4.0-beta)
 
@@ -1335,7 +1335,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.4.0-beta](https://www.nuget.org/packages/MSTest.TestFramework/1.4.0-beta)
 * MSTest.TestAdapter: [1.4.0-beta](https://www.nuget.org/packages/MSTest.TestAdapter/1.4.0-beta)
 
-## [1.3.2] - 2018-06-06
+## <a name="1.3.2"></a>[1.3.2] - 2018-06-06
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.3.1...v1.3.2)
 
@@ -1348,7 +1348,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.3.2](https://www.nuget.org/packages/MSTest.TestFramework/1.3.2)
 * MSTest.TestAdapter: [1.3.2](https://www.nuget.org/packages/MSTest.TestAdapter/1.3.2)
 
-## [1.3.1] - 2018-05-25
+## <a name="1.3.1"></a>[1.3.1] - 2018-05-25
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.3.0...v1.3.1)
 
@@ -1362,7 +1362,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.3.1](https://www.nuget.org/packages/MSTest.TestFramework/1.3.1)
 * MSTest.TestAdapter: [1.3.1](https://www.nuget.org/packages/MSTest.TestAdapter/1.3.1)
 
-## [1.3.0] - 2018-05-11
+## <a name="1.3.0"></a>[1.3.0] - 2018-05-11
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.2.1...v1.3.0)
 
@@ -1384,7 +1384,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.3.0](https://www.nuget.org/packages/MSTest.TestFramework/1.3.0)
 * MSTest.TestAdapter: [1.3.0](https://www.nuget.org/packages/MSTest.TestAdapter/1.3.0)
 
-## [1.3.0-beta2] - 2018-01-15
+## <a name="1.3.0-beta2"></a>[1.3.0-beta2] - 2018-01-15
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.2.0...v1.3.0-beta2)
 
@@ -1410,7 +1410,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.3.0-beta2](https://www.nuget.org/packages/MSTest.TestFramework/1.3.0-beta2)
 * MSTest.TestAdapter: [1.3.0-beta2](https://www.nuget.org/packages/MSTest.TestAdapter/1.3.0-beta2)
 
-## [1.2.1] - 2018-04-05
+## <a name="1.2.1"></a>[1.2.1] - 2018-04-05
 
 ### Changed
 
@@ -1427,7 +1427,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.2.1](https://www.nuget.org/packages/MSTest.TestFramework/1.2.1)
 * MSTest.TestAdapter: [1.2.1](https://www.nuget.org/packages/MSTest.TestAdapter/1.2.1)
 
-## [1.2.0] - 2017-10-11
+## <a name="1.2.0"></a>[1.2.0] - 2017-10-11
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.2.0-beta3...v1.2.0)
 
@@ -1447,7 +1447,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.2.0](https://www.nuget.org/packages/MSTest.TestFramework/1.2.0)
 * MSTest.TestAdapter: [1.2.0](https://www.nuget.org/packages/MSTest.TestAdapter/1.2.0)
 
-## [1.2.0-beta3] - 2017-08-09
+## <a name="1.2.0-beta3"></a>[1.2.0-beta3] - 2017-08-09
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.2.0-beta...v1.2.0-beta3)
 
@@ -1467,7 +1467,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.2.0-beta3](https://www.nuget.org/packages/MSTest.TestFramework/1.2.0-beta3)
 * MSTest.TestAdapter: [1.2.0-beta3](https://www.nuget.org/packages/MSTest.TestAdapter/1.2.0-beta3)
 
-## [1.2.0-beta] - 2017-06-29
+## <a name="1.2.0-beta"></a>[1.2.0-beta] - 2017-06-29
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.1.18...v1.2.0-beta)
 
@@ -1482,7 +1482,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.2.0-beta](https://www.nuget.org/packages/MSTest.TestFramework/1.2.0-beta)
 * MSTest.TestAdapter: [1.2.0-beta](https://www.nuget.org/packages/MSTest.TestAdapter/1.2.0-beta)
 
-## [1.1.18] - 2017-06-01
+## <a name="1.1.18"></a>[1.1.18] - 2017-06-01
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.1.17...v1.1.18)
 
@@ -1500,7 +1500,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.1.18](https://www.nuget.org/packages/MSTest.TestFramework/1.1.18)
 * MSTest.TestAdapter: [1.1.18](https://www.nuget.org/packages/MSTest.TestAdapter/1.1.18)
 
-## [1.1.17] - 2017-04-21
+## <a name="1.1.17"></a>[1.1.17] - 2017-04-21
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.1.14...v1.1.17)
 
@@ -1518,7 +1518,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.1.17](https://www.nuget.org/packages/MSTest.TestFramework/1.1.17)
 * MSTest.TestAdapter: [1.1.17](https://www.nuget.org/packages/MSTest.TestAdapter/1.1.17)
 
-## [1.1.14] - 2017-03-31
+## <a name="1.1.14"></a>[1.1.14] - 2017-03-31
 
 A list of changes since last release are available [here](https://github.com/Microsoft/testfx/compare/v1.1.13...v1.1.14)
 
@@ -1535,7 +1535,7 @@ A list of changes since last release are available [here](https://github.com/Mic
 * MSTest.TestFramework: [1.1.14](https://www.nuget.org/packages/MSTest.TestFramework/1.1.14)
 * MSTest.TestAdapter: [1.1.14](https://www.nuget.org/packages/MSTest.TestAdapter/1.1.14)
 
-## [1.1.13] - 2017-03-10
+## <a name="1.1.13"></a>[1.1.13] - 2017-03-10
 
 This is also the first release from GitHub and with source code building against Dev15 tooling.
 
@@ -1550,7 +1550,7 @@ This is also the first release from GitHub and with source code building against
 * MSTest.TestFramework: [1.1.13](https://www.nuget.org/packages/MSTest.TestFramework/1.1.13)
 * MSTest.TestAdapter: [1.1.13](https://www.nuget.org/packages/MSTest.TestAdapter/1.1.13)
 
-## [1.1.11] - 2017-02-17
+## <a name="1.1.11"></a>[1.1.11] - 2017-02-17
 
 Initial release.
 


### PR DESCRIPTION
Add explicit name to each version so we can link directly to it, with name that includes the dots and does not include the publish date. E.g.  `https://github.com/microsoft/testfx/blob/main/docs/Changelog.md#3.4.0` rather than `https://github.com/microsoft/testfx/blob/main/docs/Changelog.md#340---wip`