### PR TITLE
simplify GetResolutionPaths

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AssemblyUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AssemblyUtility.cs
@@ -280,12 +280,9 @@ internal class AssemblyUtility
         string executingAssembly = Path.GetDirectoryName(Path.GetFullPath(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath))!;
 
         // Add the application base for this domain.
-        if (string.Equals(executingAssembly, baseDirectory, StringComparison.OrdinalIgnoreCase))
-        {
-            return [executingAssembly];
-        }
-
-        return [executingAssembly, baseDirectory];
+        return string.Equals(executingAssembly, baseDirectory, StringComparison.OrdinalIgnoreCase) ?
+            [executingAssembly] :
+            [executingAssembly, baseDirectory];
     }
 #endif
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AssemblyUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AssemblyUtility.cs
@@ -274,24 +274,18 @@ internal class AssemblyUtility
     /// <returns> The <see cref="IList{T}"/> of resolution paths. </returns>
     internal static IList<string> GetResolutionPaths()
     {
-        // Use dictionary to ensure we get a list of unique paths, but keep a list as the
-        // dictionary does not guarantee order.
-        Dictionary<string, object?> resolutionPathsDictionary = new(StringComparer.OrdinalIgnoreCase);
-        List<string> resolutionPaths = [];
+        string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
-        // Add the path of the currently executing assembly (use Uri(CodeBase).LocalPath as Location can be on shadow dir).
-        string currentlyExecutingAssembly = Path.GetDirectoryName(Path.GetFullPath(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath));
-        resolutionPaths.Add(currentlyExecutingAssembly);
-        resolutionPathsDictionary[currentlyExecutingAssembly] = null;
+        // Use the path of the currently executing assembly (use Uri(CodeBase).LocalPath as Location can be on shadow dir).
+        string executingAssembly = Path.GetDirectoryName(Path.GetFullPath(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath))!;
 
         // Add the application base for this domain.
-        if (!resolutionPathsDictionary.ContainsKey(AppDomain.CurrentDomain.BaseDirectory))
+        if (string.Equals(executingAssembly, baseDirectory, StringComparison.OrdinalIgnoreCase))
         {
-            resolutionPaths.Add(AppDomain.CurrentDomain.BaseDirectory);
-            resolutionPathsDictionary[AppDomain.CurrentDomain.BaseDirectory] = null;
+            return [executingAssembly];
         }
 
-        return resolutionPaths;
+        return [executingAssembly, baseDirectory];
     }
 #endif
 }


### PR DESCRIPTION
the resolutionPathsDictionary is only used for a key check. values are not used and there is only one key