### PR TITLE
re-use currentPID

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -80,10 +80,11 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
         IConfiguration configuration = ServiceProvider.GetConfiguration();
         try
         {
+            string processIdString = process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
             List<string> partialCommandLine = new(executableInfo.Arguments)
             {
                 $"--{PlatformCommandLineProvider.TestHostControllerPIDOptionKey}",
-                process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture),
+                processIdString,
             };
             CommandLineInfo finalCommandLine = new(executableInfo.FileName, partialCommandLine, testApplicationFullPath);
 
@@ -107,7 +108,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
             // Prepare the environment variables used by the test host
             string processCorrelationId = Guid.NewGuid().ToString("N");
             processStartInfo.EnvironmentVariables.Add($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_CORRELATIONID}_{currentPID}", processCorrelationId);
-            processStartInfo.EnvironmentVariables.Add($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_PARENTPID}_{currentPID}", process.GetCurrentProcess()?.Id.ToString(CultureInfo.InvariantCulture) ?? "null pid");
+            processStartInfo.EnvironmentVariables.Add($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_PARENTPID}_{currentPID}", processIdString);
             processStartInfo.EnvironmentVariables.Add($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_SKIPEXTENSION}_{currentPID}", "1");
             await _logger.LogDebugAsync($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_CORRELATIONID}_{currentPID} '{processCorrelationId}'");
 


### PR DESCRIPTION
and 

 * remove null check, since the id is accessed above and a null ref would throw if it was null
 * re-use the string value for the pid