### PR TITLE
cleanup GetMethodInfoUsingRuntimeMethods

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -828,7 +828,9 @@ internal class TypeCache : MarshalByRefObject
 
     private static MethodInfo? GetMethodInfoUsingRuntimeMethods(TestMethod testMethod, TestClassInfo testClassInfo, bool discoverInternals)
     {
-        IEnumerable<MethodInfo> methods = testClassInfo.ClassType.GetRuntimeMethods()
+        IEnumerable<MethodInfo> methods = testClassInfo
+            .ClassType
+            .GetRuntimeMethods()
             .Where(method => method.Name == testMethod.Name &&
                              method.HasCorrectTestMethodSignature(true, discoverInternals));
 

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -834,15 +834,19 @@ internal class TypeCache : MarshalByRefObject
             .Where(method => method.Name == testMethod.Name &&
                              method.HasCorrectTestMethodSignature(true, discoverInternals));
 
-        string? className =
+        if (testMethod.DeclaringClassFullName == null)
+        {
             // Either the declaring class is the same as the test class, or
             // the declaring class information wasn't passed in the test case.
             // Prioritize the former while maintaining previous behavior for the latter.
-            testMethod.DeclaringClassFullName ??
-            // Only find methods that match the given declaring name.
-            testClassInfo.ClassType.FullName;
+            string? className = testClassInfo.ClassType.FullName;
+            return methods
+                .OrderByDescending(method => method.DeclaringType!.FullName == className)
+                .FirstOrDefault();
+        }
 
-        return methods.FirstOrDefault(method => method.DeclaringType!.FullName == className);
+        // Only find methods that match the given declaring name.
+        return methods.FirstOrDefault(method => method.DeclaringType!.FullName == testMethod.DeclaringClassFullName);
     }
 
     /// <summary>

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -834,19 +834,15 @@ internal class TypeCache : MarshalByRefObject
             .Where(method => method.Name == testMethod.Name &&
                              method.HasCorrectTestMethodSignature(true, discoverInternals));
 
-        if (testMethod.DeclaringClassFullName == null)
-        {
+        string? className =
             // Either the declaring class is the same as the test class, or
             // the declaring class information wasn't passed in the test case.
             // Prioritize the former while maintaining previous behavior for the latter.
-            string? className = testClassInfo.ClassType.FullName;
-            return methods
-                .OrderByDescending(method => method.DeclaringType!.FullName == className)
-                .FirstOrDefault();
-        }
+            testMethod.DeclaringClassFullName ??
+            // Only find methods that match the given declaring name.
+            testClassInfo.ClassType.FullName;
 
-        // Only find methods that match the given declaring name.
-        return methods.FirstOrDefault(method => method.DeclaringType!.FullName == testMethod.DeclaringClassFullName);
+        return methods.FirstOrDefault(method => method.DeclaringType!.FullName == className);
     }
 
     /// <summary>

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -840,7 +840,9 @@ internal class TypeCache : MarshalByRefObject
             // the declaring class information wasn't passed in the test case.
             // Prioritize the former while maintaining previous behavior for the latter.
             string? className = testClassInfo.ClassType.FullName;
-            return methods.MaxBy(method => method.DeclaringType!.FullName == className);
+            return methods
+                .OrderByDescending(method => method.DeclaringType!.FullName == className)
+                .FirstOrDefault();
         }
 
         // Only find methods that match the given declaring name.


### PR DESCRIPTION
 * make more readable
 * remove an array alloc
 * remove some unnecessary linq