### PR TITLE
remove set for toolname on CommandLineParseResult

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs
@@ -11,7 +11,7 @@ internal sealed class CommandLineParseResult(string? toolName, OptionRecord[] op
 
     public static CommandLineParseResult Empty => new(null, [], [], []);
 
-    public string? ToolName { get; set; } = toolName;
+    public string? ToolName { get; } = toolName;
 
     public OptionRecord[] Options { get; } = options;
 


### PR DESCRIPTION
since it looks like the intent is for it to be a readonly type