### PR TITLE
Dont rebuild test properties

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TcmTestPropertiesProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TcmTestPropertiesProvider.cs
@@ -14,37 +14,34 @@ internal static class TcmTestPropertiesProvider
     /// Gets tcm properties from test case.
     /// </summary>
     /// <param name="testCase">Test case.</param>
-    /// <returns>Tcm properties.</returns>
-    public static IDictionary<TestPlatformObjectModel.TestProperty, object?> GetTcmProperties(TestPlatformObjectModel.TestCase testCase)
+    public static void AddTcmProperties(TestPlatformObjectModel.TestCase testCase, IDictionary<string, object?> properties)
     {
-        var tcmProperties = new Dictionary<TestPlatformObjectModel.TestProperty, object?>();
-
-        // Return empty properties when testCase is null or when test case id is zero.
-        if (testCase == null ||
-            testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default) == 0)
+        if (testCase == null || testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default) == 0)
         {
-            return tcmProperties;
+            return;
         }
 
         // Step 1: Add common properties.
-        tcmProperties[Constants.TestRunIdProperty] = testCase.GetPropertyValue<int>(Constants.TestRunIdProperty, default);
-        tcmProperties[Constants.TestPlanIdProperty] = testCase.GetPropertyValue<int>(Constants.TestPlanIdProperty, default);
-        tcmProperties[Constants.BuildConfigurationIdProperty] = testCase.GetPropertyValue<int>(Constants.BuildConfigurationIdProperty, default);
-        tcmProperties[Constants.BuildDirectoryProperty] = testCase.GetPropertyValue<string>(Constants.BuildDirectoryProperty, default);
-        tcmProperties[Constants.BuildFlavorProperty] = testCase.GetPropertyValue<string>(Constants.BuildFlavorProperty, default);
-        tcmProperties[Constants.BuildNumberProperty] = testCase.GetPropertyValue<string>(Constants.BuildNumberProperty, default);
-        tcmProperties[Constants.BuildPlatformProperty] = testCase.GetPropertyValue<string>(Constants.BuildPlatformProperty, default);
-        tcmProperties[Constants.BuildUriProperty] = testCase.GetPropertyValue<string>(Constants.BuildUriProperty, default);
-        tcmProperties[Constants.TfsServerCollectionUrlProperty] = testCase.GetPropertyValue<string>(Constants.TfsServerCollectionUrlProperty, default);
-        tcmProperties[Constants.TfsTeamProjectProperty] = testCase.GetPropertyValue<string>(Constants.TfsTeamProjectProperty, default);
-        tcmProperties[Constants.IsInLabEnvironmentProperty] = testCase.GetPropertyValue<bool>(Constants.IsInLabEnvironmentProperty, default);
+        properties[Constants.TestRunIdProperty.Id] = testCase.GetPropertyValue<int>(Constants.TestRunIdProperty, default);
+        properties[Constants.TestPlanIdProperty.Id] = testCase.GetPropertyValue<int>(Constants.TestPlanIdProperty, default);
+        properties[Constants.BuildConfigurationIdProperty.Id] = testCase.GetPropertyValue<int>(Constants.BuildConfigurationIdProperty, default);
+        properties[Constants.BuildDirectoryProperty.Id] = testCase.GetPropertyValue<string>(Constants.BuildDirectoryProperty, default);
+        properties[Constants.BuildFlavorProperty.Id] = testCase.GetPropertyValue<string>(Constants.BuildFlavorProperty, default);
+        properties[Constants.BuildNumberProperty.Id] = testCase.GetPropertyValue<string>(Constants.BuildNumberProperty, default);
+        properties[Constants.BuildPlatformProperty.Id] = testCase.GetPropertyValue<string>(Constants.BuildPlatformProperty, default);
+        properties[Constants.BuildUriProperty.Id] = testCase.GetPropertyValue<string>(Constants.BuildUriProperty, default);
+        properties[Constants.TfsServerCollectionUrlProperty.Id] = testCase.GetPropertyValue<string>(Constants.TfsServerCollectionUrlProperty, default);
+        properties[Constants.TfsTeamProjectProperty.Id] = testCase.GetPropertyValue<string>(Constants.TfsTeamProjectProperty, default);
+        properties[Constants.IsInLabEnvironmentProperty.Id] = testCase.GetPropertyValue<bool>(Constants.IsInLabEnvironmentProperty, default);
 
         // Step 2: Add test case specific properties.
-        tcmProperties[Constants.TestCaseIdProperty] = testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default);
-        tcmProperties[Constants.TestConfigurationIdProperty] = testCase.GetPropertyValue<int>(Constants.TestConfigurationIdProperty, default);
-        tcmProperties[Constants.TestConfigurationNameProperty] = testCase.GetPropertyValue<string>(Constants.TestConfigurationNameProperty, default);
-        tcmProperties[Constants.TestPointIdProperty] = testCase.GetPropertyValue<int>(Constants.TestPointIdProperty, default);
+        properties[Constants.TestCaseIdProperty.Id] = testCase.GetPropertyValue<int>(Constants.TestCaseIdProperty, default);
+        properties[Constants.TestConfigurationIdProperty.Id] = testCase.GetPropertyValue<int>(Constants.TestConfigurationIdProperty, default);
+        properties[Constants.TestConfigurationNameProperty.Id] = testCase.GetPropertyValue<string>(Constants.TestConfigurationNameProperty, default);
+        properties[Constants.TestPointIdProperty.Id] = testCase.GetPropertyValue<int>(Constants.TestPointIdProperty, default);
 
-        return tcmProperties;
+        // PERF: initialize the capacity to what we are adding here + what we will add later so we don't have to copy.
+        // Please see TestExecutionManager.cs if you are adding properties, so far there are 15. Setting the capacity there
+        // helps us to not resize this dictionary later, this is on hot path, it happens for every test.
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/UnitTestRunner.cs
@@ -113,8 +113,7 @@ internal class UnitTestRunner : MarshalByRefObject
         try
         {
             using var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture, "context");
-            var properties = new Dictionary<string, object?>(testContextProperties);
-            ITestContext testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties);
+            ITestContext testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, testContextProperties);
             testContext.SetOutcome(UTF.UnitTestOutcome.InProgress);
 
             // Get the testMethod

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -85,13 +85,17 @@ public class TestContextImplementation : TestContext, ITestContext
 
         // Cannot get this type in constructor directly, because all signatures for all platforms need to be the same.
         _threadSafeStringWriter = stringWriter as ThreadSafeStringWriter;
-        _properties = new Dictionary<string, object?>(properties)
-        {
-            [FullyQualifiedTestClassNameLabel] = _testMethod.FullClassName,
-            [ManagedTypeLabel] = _testMethod.ManagedTypeName,
-            [ManagedMethodLabel] = _testMethod.ManagedMethodName,
-            [TestNameLabel] = _testMethod.Name,
-        };
+
+        // PERF: We cannot change the api because it is public, but do not copy the properties yet another time.
+        // When we re-build the collection, the capacity to be what we have plus the 4 properties we are adding.
+        Dictionary<string, object?> props = properties is Dictionary<string, object?> p
+            ? p
+            : new Dictionary<string, object?>(properties.Count + 4);
+        props[FullyQualifiedTestClassNameLabel] = _testMethod.FullClassName;
+        props[ManagedTypeLabel] = _testMethod.ManagedTypeName;
+        props[ManagedMethodLabel] = _testMethod.ManagedMethodName;
+        props[TestNameLabel] = _testMethod.Name;
+        _properties = props;
         _testResultFiles = [];
     }
 

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
@@ -33,7 +33,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
 
     public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIsNull()
     {
-        IDictionary<TestProperty, object> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(null);
+        IDictionary<TestProperty, object> tcmProperties = TcmTestPropertiesProvider.AddTcmProperties(null);
         Verify(tcmProperties.Count == 0);
     }
 
@@ -60,7 +60,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
         ];
         SetTestCaseProperties(testCase, propertiesValue);
 
-        IDictionary<TestProperty, object> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        IDictionary<TestProperty, object> tcmProperties = TcmTestPropertiesProvider.AddTcmProperties(testCase);
         Verify(tcmProperties.Count == 0);
     }
 
@@ -87,7 +87,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
         ];
         SetTestCaseProperties(testCase, propertiesValue);
 
-        IDictionary<TestProperty, object> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        IDictionary<TestProperty, object> tcmProperties = TcmTestPropertiesProvider.AddTcmProperties(testCase);
 
         VerifyTcmProperties(tcmProperties, testCase);
     }
@@ -115,7 +115,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             345
         ];
         SetTestCaseProperties(testCase1, propertiesValue1);
-        IDictionary<TestProperty, object> tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+        IDictionary<TestProperty, object> tcmProperties1 = TcmTestPropertiesProvider.AddTcmProperties(testCase1);
         VerifyTcmProperties(tcmProperties1, testCase1);
 
         // Verify 2nd call.
@@ -139,7 +139,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             346
         ];
         SetTestCaseProperties(testCase2, propertiesValue2);
-        IDictionary<TestProperty, object> tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+        IDictionary<TestProperty, object> tcmProperties2 = TcmTestPropertiesProvider.AddTcmProperties(testCase2);
         VerifyTcmProperties(tcmProperties2, testCase2);
     }
 
@@ -166,7 +166,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             345
         ];
         SetTestCaseProperties(testCase1, propertiesValue1);
-        IDictionary<TestProperty, object> tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+        IDictionary<TestProperty, object> tcmProperties1 = TcmTestPropertiesProvider.AddTcmProperties(testCase1);
         VerifyTcmProperties(tcmProperties1, testCase1);
 
         // Verify 2nd call.
@@ -190,7 +190,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             346
         ];
         SetTestCaseProperties(testCase2, propertiesValue2);
-        IDictionary<TestProperty, object> tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+        IDictionary<TestProperty, object> tcmProperties2 = TcmTestPropertiesProvider.AddTcmProperties(testCase2);
         VerifyTcmProperties(tcmProperties2, testCase2);
 
         // Verify 3rd call.
@@ -214,7 +214,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             347
         ];
         SetTestCaseProperties(testCase3, propertiesValue3);
-        IDictionary<TestProperty, object> tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
+        IDictionary<TestProperty, object> tcmProperties3 = TcmTestPropertiesProvider.AddTcmProperties(testCase3);
         VerifyTcmProperties(tcmProperties3, testCase3);
     }
 


### PR DESCRIPTION
This avoids re-creating test properties multiple times. 

It does not have a huge impact on run time, we save about 20ms.