### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
-* @Evangelink
-
 src/Package/MSTest.Sdk @MarcoRossignoli
 src/Platform @MarcoRossignoli @Evangelink


### PR DESCRIPTION
Remove Evangelink as owner of all code, so every PR does not require his approval, and we can automerge when he is not working (which is rare, but happens).

![image](https://github.com/microsoft/testfx/assets/5735905/b86b0e96-a958-4673-9ef6-13f6dc6af854)
