### PR TITLE
Skip testing intermediate netcore TFMs in PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ stages:
             filePath: './eng/install-windows-sdk.ps1'
             failOnStderr: true
             showWarnings: true
-        
+
         - task: PowerShell@2
           displayName: 'Install procdump'
           inputs:
@@ -130,7 +130,7 @@ stages:
         timeoutInMinutes: 90
         pool:
           name: NetCore-Public
-          demands: ImageOverride -equals build.ubuntu.2004.amd64.open          
+          demands: ImageOverride -equals build.ubuntu.2004.amd64.open
         strategy:
           matrix:
             Release:
@@ -143,6 +143,7 @@ stages:
             -prepareMachine
             /p:Test=false
             /p:NonWindowsBuild=true
+            /p:FastAcceptanceTest=true
           displayName: Build
 
         - ${{ if eq(parameters.SkipTests, False) }}:

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(MicrosoftTestingTargetFrameworks);netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <DefineConstants Condition=" '$(FastAcceptanceTest)' == 'true'">$(DefineConstants);SKIP_INTERMEDIATE_TARGET_FRAMEWORKS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TargetFrameworks.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TargetFrameworks.cs
@@ -12,17 +12,21 @@ public static class TargetFrameworks
     public static TestArgumentsEntry<string>[] Net { get; } =
     [
         new("net8.0", "net8.0"),
+#if !SKIP_INTERMEDIATE_TARGET_FRAMEWORKS
         new("net7.0", "net7.0"),
-        new("net6.0", "net6.0")
+        new("net6.0", "net6.0"),
+#endif
     ];
 
     public static TestArgumentsEntry<string> NetCurrent { get; } = Net[0];
 
     public static TestArgumentsEntry<string>[] NetFramework { get; } = [new("net462", "net462")];
 
-    public static TestArgumentsEntry<string>[] All { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? Net.Concat(NetFramework).ToArray()
-        : Net;
+    public static TestArgumentsEntry<string>[] All { get; }
+        = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? Net.Concat(NetFramework).ToArray()
+            : Net;
 
-    public static string ToMSBuildTargetFrameworks(this TestArgumentsEntry<string>[] targetFrameworksEntries) => string.Join(";", targetFrameworksEntries.Select(x => x.Arguments));
+    public static string ToMSBuildTargetFrameworks(this TestArgumentsEntry<string>[] targetFrameworksEntries)
+        => string.Join(";", targetFrameworksEntries.Select(x => x.Arguments));
 }


### PR DESCRIPTION
Speedup PR feedback loop by testing only latest supported TFM for netcore. As of today, that means the PR CI will test only `net8.0` and no longer `net6.0` and `net7.0`. The main CI will still run all tests to ensure quality.