### PR TITLE
Refactor command line validation to ease testing

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -114,7 +114,7 @@ public sealed class TestApplication : ITestApplication
         }
 
         // All checks are fine, create the TestApplication.
-        return new TestApplicationBuilder(args, loggingState, createBuilderStart, testApplicationOptions, s_unhandledExceptionHandler);
+        return new TestApplicationBuilder(loggingState, createBuilderStart, testApplicationOptions, s_unhandledExceptionHandler);
     }
 
     private static async Task LogInformationAsync(

--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Testing.Platform.Builder;
 /// </summary>
 internal sealed class TestApplicationBuilder : ITestApplicationBuilder
 {
-    private readonly string[] _args;
     private readonly DateTimeOffset _createBuilderStart;
     private readonly ApplicationLoggingState _loggingState;
     private readonly TestApplicationOptions _testApplicationOptions;
@@ -37,14 +36,12 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
     private Func<IServiceProvider, ITestFrameworkCapabilities>? _testFrameworkCapabilitiesFactory;
 
     internal TestApplicationBuilder(
-        string[] args,
         ApplicationLoggingState loggingState,
         DateTimeOffset createBuilderStart,
         TestApplicationOptions testApplicationOptions,
         IUnhandledExceptionsHandler unhandledExceptionsHandler)
     {
         _testHostBuilder = new TestHostBuilder(new SystemFileSystem(), new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler(), new CurrentTestApplicationModuleInfo(new SystemEnvironment(), new SystemProcessHandler()));
-        _args = args;
         _createBuilderStart = createBuilderStart;
         _loggingState = loggingState;
         _testApplicationOptions = testApplicationOptions;
@@ -110,12 +107,7 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
             throw new InvalidOperationException(PlatformResources.TestApplicationBuilderApplicationAlreadyRegistered);
         }
 
-        _testHost = await _testHostBuilder.BuildAsync(
-            _args,
-            _loggingState,
-            _testApplicationOptions,
-            _unhandledExceptionsHandler,
-            _createBuilderStart);
+        _testHost = await _testHostBuilder.BuildAsync(_loggingState, _testApplicationOptions, _unhandledExceptionsHandler, _createBuilderStart);
 
         return new TestApplication(_testHost);
     }

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineManager.cs
@@ -23,7 +23,7 @@ internal sealed class CommandLineManager(IRuntimeFeature runtimeFeature, IEnviro
         _commandLineProviderFactory.Add(commandLineProviderFactory);
     }
 
-    internal async Task<CommandLineHandler> BuildAsync(string[] args, IPlatformOutputDevice platformOutputDisplay, CommandLineParseResult parseResult)
+    internal async Task<CommandLineHandler> BuildAsync(IPlatformOutputDevice platformOutputDisplay, CommandLineParseResult parseResult)
     {
         List<ICommandLineOptionsProvider> commandLineOptionsProviders = [];
         foreach (Func<ICommandLineOptionsProvider> commandLineProviderFactory in _commandLineProviderFactory)
@@ -44,7 +44,7 @@ internal sealed class CommandLineManager(IRuntimeFeature runtimeFeature, IEnviro
             new PlatformCommandLineProvider()
         ];
 
-        return new CommandLineHandler(args, parseResult, commandLineOptionsProviders.ToArray(),
+        return new CommandLineHandler(parseResult, commandLineOptionsProviders.ToArray(),
             systemCommandLineOptionsProviders, _testApplicationModuleInfo, _runtimeFeature, platformOutputDisplay, _environment, _processHandler);
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Text;
+
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Resources;
+
+namespace Microsoft.Testing.Platform.CommandLine;
+
+internal static class CommandLineOptionsValidator
+{
+    public static async Task<ValidationResult> ValidateAsync(
+        CommandLineParseResult commandLineParseResult,
+        IEnumerable<ICommandLineOptionsProvider> systemCommandLineOptionsProviders,
+        IEnumerable<ICommandLineOptionsProvider> extensionCommandLineOptionsProviders,
+        ICommandLineOptions commandLineOptions)
+    {
+        if (commandLineParseResult.HasError)
+        {
+            StringBuilder stringBuilder = new();
+            stringBuilder.AppendLine(PlatformResources.InvalidCommandLineArguments);
+            foreach (string error in commandLineParseResult.Errors)
+            {
+                stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"\t- {error}");
+            }
+
+            return ValidationResult.Invalid(stringBuilder.ToString());
+        }
+
+        var extensionOptionsByProvider = extensionCommandLineOptionsProviders.ToDictionary(p => p, p => p.GetCommandLineOptions());
+        if (ValidateExtensionOptionsDoNotContainReservedPrefix(extensionOptionsByProvider) is { IsValid: false } result)
+        {
+            return result;
+        }
+
+        var systemOptionsByProvider = systemCommandLineOptionsProviders.ToDictionary(p => p, p => p.GetCommandLineOptions());
+        if (ValidateExtensionOptionsDoNotContainReservedOptions(extensionOptionsByProvider, systemOptionsByProvider) is { IsValid: false } result2)
+        {
+            return result2;
+        }
+
+        if (ValidateOptionsAreNotDuplicated(extensionOptionsByProvider) is { IsValid: false } result3)
+        {
+            return result3;
+        }
+
+        if (ValidateNoUnknownOptions(commandLineParseResult, extensionOptionsByProvider, systemOptionsByProvider) is { IsValid: false } result4)
+        {
+            return result4;
+        }
+
+        var providerAndOptionByOptionName = extensionOptionsByProvider.Union(systemOptionsByProvider)
+            .SelectMany(tuple => tuple.Value.Select(option => (provider: tuple.Key, option)))
+            .ToDictionary(tuple => tuple.option.Name);
+
+        if (ValidateOptionsArgumentArity(commandLineParseResult, providerAndOptionByOptionName) is { IsValid: false } result5)
+        {
+            return result5;
+        }
+
+        if (await ValidateOptionsArgumentsAsync(commandLineParseResult, providerAndOptionByOptionName) is { IsValid: false } result6)
+        {
+            return result6;
+        }
+
+        // Last validation step
+        return await ValidateConfigurationAsync(extensionOptionsByProvider.Keys, systemOptionsByProvider.Keys, commandLineOptions);
+    }
+
+    private static ValidationResult ValidateExtensionOptionsDoNotContainReservedPrefix(
+        Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> extensionOptionsByProvider)
+    {
+        StringBuilder? stringBuilder = null;
+        foreach (KeyValuePair<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> providerWithOptions in extensionOptionsByProvider)
+        {
+            foreach (CommandLineOption option in providerWithOptions.Value)
+            {
+                if (option.IsBuiltIn)
+                {
+                    continue;
+                }
+
+                string trimmedOption = option.Name.Trim(CommandLineParseResult.OptionPrefix);
+                if (trimmedOption.StartsWith("internal", StringComparison.OrdinalIgnoreCase)
+                    || option.Name.StartsWith("-internal", StringComparison.OrdinalIgnoreCase))
+                {
+                    stringBuilder ??= new();
+                    ICommandLineOptionsProvider commandLineOptionsProvider = providerWithOptions.Key;
+                    stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionIsUsingReservedPrefix, trimmedOption, commandLineOptionsProvider.DisplayName, commandLineOptionsProvider.Uid));
+                }
+            }
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToString())
+            : ValidationResult.Valid();
+    }
+
+    private static ValidationResult ValidateExtensionOptionsDoNotContainReservedOptions(
+        Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> extensionOptionsByProvider,
+        Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> systemOptionsByProvider)
+    {
+        IEnumerable<string> allExtensionOptions = extensionOptionsByProvider.Values.SelectMany(x => x).Select(x => x.Name).Distinct();
+        IEnumerable<string> allSystemOptions = systemOptionsByProvider.Values.SelectMany(x => x).Select(x => x.Name).Distinct();
+
+        IEnumerable<string> invalidReservedOptions = allSystemOptions.Intersect(allExtensionOptions);
+        if (invalidReservedOptions.Any())
+        {
+            var stringBuilder = new StringBuilder();
+            foreach (string reservedOption in invalidReservedOptions)
+            {
+                IEnumerable<string> faultyProviderNames = extensionOptionsByProvider.Where(tuple => tuple.Value.Any(x => x.Name == reservedOption)).Select(tuple => tuple.Key.DisplayName);
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionIsReserved, reservedOption, string.Join("', '", faultyProviderNames)));
+            }
+
+            return ValidationResult.Invalid(stringBuilder.ToString());
+        }
+
+        return ValidationResult.Valid();
+    }
+
+    private static ValidationResult ValidateOptionsAreNotDuplicated(
+        Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> extensionOptionsByProvider)
+    {
+        IEnumerable<string> duplications = extensionOptionsByProvider.Values.SelectMany(x => x)
+            .Select(x => x.Name)
+            .GroupBy(x => x)
+            .Where(x => x.Skip(1).Any())
+            .Select(x => x.Key);
+
+        StringBuilder? stringBuilder = null;
+        foreach (string duplicatedOption in duplications)
+        {
+            IEnumerable<string> faultyProvidersDisplayNames = extensionOptionsByProvider.Where(tuple => tuple.Value.Any(x => x.Name == duplicatedOption)).Select(tuple => tuple.Key.DisplayName);
+            stringBuilder ??= new();
+            stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionIsDeclaredByMultipleProviders, duplicatedOption, string.Join("', '", faultyProvidersDisplayNames)));
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToString())
+            : ValidationResult.Valid();
+    }
+
+    private static ValidationResult ValidateNoUnknownOptions(
+        CommandLineParseResult parseResult,
+        Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> extensionOptionsByProvider,
+        Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> systemOptionsByProvider)
+    {
+        StringBuilder? stringBuilder = null;
+        foreach (OptionRecord optionRecord in parseResult.Options)
+        {
+            if (!extensionOptionsByProvider.Union(systemOptionsByProvider).Any(tuple => tuple.Value.Any(x => x.Name == optionRecord.Option)))
+            {
+                stringBuilder ??= new();
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineUnknownOption, optionRecord.Option));
+            }
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToString())
+            : ValidationResult.Valid();
+    }
+
+    private static ValidationResult ValidateOptionsArgumentArity(
+        CommandLineParseResult parseResult,
+        Dictionary<string, (ICommandLineOptionsProvider Provider, CommandLineOption Option)> providerAndOptionByOptionName)
+    {
+        StringBuilder stringBuilder = new();
+        foreach (IGrouping<string, OptionRecord> groupedOptions in parseResult.Options.GroupBy(x => x.Option))
+        {
+            // getting the arguments count for an option.
+            int arity = 0;
+            foreach (OptionRecord optionEntry in groupedOptions)
+            {
+                arity += optionEntry.Arguments.Length;
+            }
+
+            string optionName = groupedOptions.Key;
+            (ICommandLineOptionsProvider provider, CommandLineOption option) = providerAndOptionByOptionName[optionName];
+
+            if (arity > option!.Arity.Max && option.Arity.Max == 0)
+            {
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionExpectsNoArguments, optionName, provider.DisplayName, provider.Uid));
+            }
+            else if (arity < option.Arity.Min)
+            {
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionExpectsAtLeastArguments, optionName, provider.DisplayName, provider.Uid, option.Arity.Min));
+            }
+            else if (arity > option.Arity.Max)
+            {
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionExpectsAtMostArguments, optionName, provider.DisplayName, provider.Uid, option.Arity.Max));
+            }
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToString())
+            : ValidationResult.Valid();
+    }
+
+    private static async Task<ValidationResult> ValidateOptionsArgumentsAsync(
+        CommandLineParseResult parseResult,
+        Dictionary<string, (ICommandLineOptionsProvider Provider, CommandLineOption Option)> providerAndOptionByOptionName)
+    {
+        ApplicationStateGuard.Ensure(parseResult is not null);
+
+        StringBuilder? stringBuilder = null;
+        foreach (OptionRecord optionRecord in parseResult.Options)
+        {
+            (ICommandLineOptionsProvider provider, CommandLineOption option) = providerAndOptionByOptionName[optionRecord.Option];
+            ValidationResult result = await provider.ValidateOptionArgumentsAsync(option, optionRecord.Arguments);
+            if (!result.IsValid)
+            {
+                stringBuilder ??= new();
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineInvalidArgumentsForOption, optionRecord.Option, result.ErrorMessage));
+            }
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToString())
+            : ValidationResult.Valid();
+    }
+
+    private static async Task<ValidationResult> ValidateConfigurationAsync(
+        IEnumerable<ICommandLineOptionsProvider> extensionsProviders,
+        IEnumerable<ICommandLineOptionsProvider> systemProviders,
+        ICommandLineOptions commandLineOptions)
+    {
+        StringBuilder? stringBuilder = null;
+        foreach (ICommandLineOptionsProvider commandLineOptionsProvider in systemProviders.Union(extensionsProviders))
+        {
+            ValidationResult result = await commandLineOptionsProvider.ValidateCommandLineOptionsAsync(commandLineOptions);
+            if (!result.IsValid)
+            {
+                stringBuilder ??= new();
+                stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineInvalidConfiguration, commandLineOptionsProvider.DisplayName, commandLineOptionsProvider.Uid, result.ErrorMessage));
+                stringBuilder.AppendLine();
+            }
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToString())
+            : ValidationResult.Valid();
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
@@ -28,7 +28,7 @@ internal static class CommandLineOptionsValidator
                 stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"\t- {error}");
             }
 
-            return ValidationResult.Invalid(stringBuilder.ToString());
+            return ValidationResult.Invalid(stringBuilder.ToTrimmedString());
         }
 
         var extensionOptionsByProvider = extensionCommandLineOptionsProviders.ToDictionary(p => p, p => p.GetCommandLineOptions());
@@ -96,7 +96,7 @@ internal static class CommandLineOptionsValidator
         }
 
         return stringBuilder?.Length > 0
-            ? ValidationResult.Invalid(stringBuilder.ToString())
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
             : ValidationResult.Valid();
     }
 
@@ -117,7 +117,7 @@ internal static class CommandLineOptionsValidator
                 stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionIsReserved, reservedOption, string.Join("', '", faultyProviderNames)));
             }
 
-            return ValidationResult.Invalid(stringBuilder.ToString());
+            return ValidationResult.Invalid(stringBuilder.ToTrimmedString());
         }
 
         return ValidationResult.Valid();
@@ -141,7 +141,7 @@ internal static class CommandLineOptionsValidator
         }
 
         return stringBuilder?.Length > 0
-            ? ValidationResult.Invalid(stringBuilder.ToString())
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
             : ValidationResult.Valid();
     }
 
@@ -161,7 +161,7 @@ internal static class CommandLineOptionsValidator
         }
 
         return stringBuilder?.Length > 0
-            ? ValidationResult.Invalid(stringBuilder.ToString())
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
             : ValidationResult.Valid();
     }
 
@@ -197,7 +197,7 @@ internal static class CommandLineOptionsValidator
         }
 
         return stringBuilder?.Length > 0
-            ? ValidationResult.Invalid(stringBuilder.ToString())
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
             : ValidationResult.Valid();
     }
 
@@ -220,7 +220,7 @@ internal static class CommandLineOptionsValidator
         }
 
         return stringBuilder?.Length > 0
-            ? ValidationResult.Invalid(stringBuilder.ToString())
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
             : ValidationResult.Valid();
     }
 
@@ -242,7 +242,12 @@ internal static class CommandLineOptionsValidator
         }
 
         return stringBuilder?.Length > 0
-            ? ValidationResult.Invalid(stringBuilder.ToString())
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
             : ValidationResult.Valid();
     }
+
+    private static string ToTrimmedString(this StringBuilder stringBuilder)
+#pragma warning disable RS0030 // Do not use banned APIs
+        => stringBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray());
+#pragma warning restore RS0030 // Do not use banned APIs
 }

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineHandler.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Testing.Platform.CommandLine;
 
 internal interface ICommandLineHandler
 {
-    string[] Arguments { get; }
-
     bool IsHelpInvoked();
 
     Task PrintHelpAsync(ITool[]? availableTools = null);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ITestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ITestHostBuilder.cs
@@ -41,5 +41,5 @@ internal interface ITestHostBuilder
 
     IToolsManager Tools { get; }
 
-    Task<ITestHost> BuildAsync(string[] args, ApplicationLoggingState loggingState, TestApplicationOptions testApplicationOptions, IUnhandledExceptionsHandler unhandledExceptionsHandler, DateTimeOffset createBuilderStart);
+    Task<ITestHost> BuildAsync(ApplicationLoggingState loggingState, TestApplicationOptions testApplicationOptions, IUnhandledExceptionsHandler unhandledExceptionsHandler, DateTimeOffset createBuilderStart);
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/ArgumentArityTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/ArgumentArityTests.cs
@@ -43,7 +43,7 @@ public class ArgumentArityTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--zeroArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments{Environment.NewLine}", result.ErrorMessage, StringComparer.Ordinal);
+        Assert.AreEqual("Option '--zeroArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments", result.ErrorMessage, StringComparer.Ordinal);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityExactlyOneIsCalledWithTwoArguments_ReturnsFalse()
@@ -58,7 +58,7 @@ public class ArgumentArityTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual("a", result.ErrorMessage);
+        Assert.AreEqual("Option '--exactlyOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at most 1 arguments", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityExactlyOneIsCalledWithoutArguments_ReturnsFalse()
@@ -73,7 +73,7 @@ public class ArgumentArityTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--exactlyOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option '--exactlyOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityZeroOrOneIsCalledWithTwoArguments_ReturnsFalse()
@@ -88,7 +88,7 @@ public class ArgumentArityTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--zeroOrOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at most 1 arguments{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option '--zeroOrOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at most 1 arguments", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityOneOrMoreIsCalledWithoutArguments_ReturnsFalse()
@@ -103,7 +103,7 @@ public class ArgumentArityTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--oneOrMoreArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option '--oneOrMoreArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionsGetsTheExpectedNumberOfArguments_ReturnsTrue()

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/ArgumentArityTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/ArgumentArityTests.cs
@@ -6,10 +6,7 @@ using Microsoft.Testing.Internal.Framework;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
-using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.OutputDevice;
-using Microsoft.Testing.Platform.Services;
 using Microsoft.Testing.TestInfrastructure;
 
 using Moq;
@@ -19,11 +16,6 @@ namespace Microsoft.Testing.Platform.UnitTests;
 [TestGroup]
 public class ArgumentArityTests : TestBase
 {
-    private readonly Mock<IPlatformOutputDevice> _outputDisplayMock = new();
-    private readonly Mock<ITestApplicationModuleInfo> _testApplicationModuleInfoMock = new();
-    private readonly Mock<IRuntimeFeature> _runtimeFeatureMock = new();
-    private readonly Mock<IEnvironment> _environmentMock = new();
-    private readonly Mock<IProcessHandler> _processHandlerMock = new();
     private readonly ICommandLineOptionsProvider[] _systemCommandLineOptionsProviders =
     [
         new PlatformCommandLineProvider()
@@ -44,18 +36,14 @@ public class ArgumentArityTests : TestBase
         // Arrange
         string[] args = ["--zeroArgumentsOption arg"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-        .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            Assert.AreEqual($"Option '--zeroArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments{Environment.NewLine}", ((TextOutputDeviceData)data).Text, StringComparer.Ordinal));
-
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsFalse(result);
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--zeroArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments{Environment.NewLine}", result.ErrorMessage, StringComparer.Ordinal);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityExactlyOneIsCalledWithTwoArguments_ReturnsFalse()
@@ -64,14 +52,13 @@ public class ArgumentArityTests : TestBase
         string[] args = ["--exactlyOneArgumentsOption arg1", "arg2"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
 
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsFalse(result);
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual("a", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityExactlyOneIsCalledWithoutArguments_ReturnsFalse()
@@ -79,18 +66,14 @@ public class ArgumentArityTests : TestBase
         // Arrange
         string[] args = ["--exactlyOneArgumentsOption"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-        .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            Assert.AreEqual($"Option '--exactlyOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments{Environment.NewLine}", ((TextOutputDeviceData)data).Text, StringComparer.Ordinal));
-
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsFalse(result);
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--exactlyOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments{Environment.NewLine}", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityZeroOrOneIsCalledWithTwoArguments_ReturnsFalse()
@@ -98,18 +81,14 @@ public class ArgumentArityTests : TestBase
         // Arrange
         string[] args = ["--zeroOrOneArgumentsOption arg1", "--zeroOrOneArgumentsOption arg2"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-        .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            Assert.AreEqual($"Option '--zeroOrOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at most 1 arguments{Environment.NewLine}", ((TextOutputDeviceData)data).Text, StringComparer.Ordinal));
-
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsFalse(result);
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--zeroOrOneArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at most 1 arguments{Environment.NewLine}", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionWithArityOneOrMoreIsCalledWithoutArguments_ReturnsFalse()
@@ -117,18 +96,14 @@ public class ArgumentArityTests : TestBase
         // Arrange
         string[] args = ["--oneOrMoreArgumentsOption"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-        .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            Assert.AreEqual($"Option '--oneOrMoreArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments{Environment.NewLine}", ((TextOutputDeviceData)data).Text, StringComparer.Ordinal));
-
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsFalse(result);
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--oneOrMoreArgumentsOption' from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) expects at least 1 arguments{Environment.NewLine}", result.ErrorMessage);
     }
 
     public async Task ParseAndValidate_WhenOptionsGetsTheExpectedNumberOfArguments_ReturnsTrue()
@@ -136,14 +111,14 @@ public class ArgumentArityTests : TestBase
         // Arrange
         string[] args = ["--zeroArgumentsOption", "--zeroOrOneArgumentsOption", "--zeroOrMoreArgumentsOption arg2", "--exactlyOneArgumentsOption arg1", "oneOrMoreArgumentsOption arg1"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsTrue(result);
+        Assert.IsTrue(result.IsValid);
+        Assert.IsNull(result.ErrorMessage);
     }
 
     private sealed class ExtensionCommandLineProviderMockOptionsWithDifferentArity : ICommandLineOptionsProvider
@@ -162,14 +137,15 @@ public class ArgumentArityTests : TestBase
         /// <inheritdoc />
         public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
-        public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions() => new CommandLineOption[]
-                    {
+        public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions()
+            => new CommandLineOption[]
+            {
                 new("zeroArgumentsOption", "Show command line zeroArgumentsOption.", ArgumentArity.Zero, false),
                 new("zeroOrOneArgumentsOption", "Show command line zeroOrOneArgumentsOption.", ArgumentArity.ZeroOrOne, false),
                 new("zeroOrMoreArgumentsOption", "Show command line zeroOrMoreArgumentsOption.", ArgumentArity.ZeroOrMore, false),
                 new("exactlyOneArgumentsOption", "Show command line exactlyOneArgumentsOption.", ArgumentArity.ExactlyOne, false),
                 new("oneOrMoreArgumentsOption", "Show command line oneOrMoreArgumentsOption.", ArgumentArity.OneOrMore, false),
-                    };
+            };
 
         public Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions) => ValidationResult.ValidTask;
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -40,21 +40,15 @@ public class CommandLineHandlerTests : TestBase
         // Arrange
         string[] args = ["option1", "'a'"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-            .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            {
-                Assert.IsTrue(((TextOutputDeviceData)data).Text.Contains("Invalid command line arguments:"));
-                Assert.IsTrue(((TextOutputDeviceData)data).Text.Contains("Unexpected argument 'a'"));
-            });
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsFalse(result);
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains("Invalid command line arguments:", result.ErrorMessage);
+        Assert.Contains("Unexpected argument 'a'", result.ErrorMessage);
     }
 
     public async Task ParseAndValidateAsync_EmptyCommandLineArguments_ReturnsTrue()
@@ -62,16 +56,140 @@ public class CommandLineHandlerTests : TestBase
         // Arrange
         string[] args = [];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-             _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
-        bool result = await commandLineHandler.ValidateAsync();
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
 
         // Assert
-        Assert.IsTrue(result);
-        _outputDisplayMock.Verify(o => o.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()), Times.Never);
-        _outputDisplayMock.Verify(o => o.DisplayBannerAsync(It.IsAny<string?>()), Times.Never);
+        Assert.IsTrue(result.IsValid);
+    }
+
+    public async Task ParseAndValidateAsync_DuplicateOption_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = [];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+        ICommandLineOptionsProvider[] extensionCommandLineOptionsProviders =
+        [
+            new ExtensionCommandLineProviderMockInvalidConfiguration("userOption"),
+            new ExtensionCommandLineProviderMockInvalidConfiguration("userOption")
+        ];
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains("Option '--userOption' is declared by multiple extensions: 'userOption'", result.ErrorMessage);
+    }
+
+    public async Task ParseAndValidateAsync_InvalidOption_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = ["--diagnostic-verbosity", "r"];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--diagnostic-verbosity' has invalid arguments: '--diagnostic-verbosity' expects a single level argument ('Trace', 'Debug', 'Information', 'Warning', 'Error', or 'Critical'){Environment.NewLine}", result.ErrorMessage);
+    }
+
+    public async Task ParseAndValidateAsync_InvalidArgumentArity_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = ["--help arg"];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--help' from provider 'Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments{Environment.NewLine}", result.ErrorMessage);
+    }
+
+    public async Task ParseAndValidateAsync_ReservedOptions_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = [];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+        ICommandLineOptionsProvider[] extensionCommandLineProvider =
+        [
+            new ExtensionCommandLineProviderMockReservedOptions()
+        ];
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            extensionCommandLineProvider, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option '--help' is reserved and cannot be used by providers: 'help'{Environment.NewLine}", result.ErrorMessage);
+    }
+
+    public async Task ParseAndValidateAsync_ReservedOptionsPrefix_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = [];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+        ICommandLineOptionsProvider[] extensionCommandLineProvider =
+        [
+            new ExtensionCommandLineProviderMockInvalidConfiguration("--internal-customextension")
+        ];
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            extensionCommandLineProvider, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Option `--internal-customextension` from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) is using the reserved prefix '--internal'{Environment.NewLine}", result.ErrorMessage);
+    }
+
+    public async Task ParseAndValidateAsync_UnknownOption_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = ["--x"];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+
+        ICommandLineOptionsProvider[] extensionCommandLineProvider =
+        [
+            new ExtensionCommandLineProviderMockUnknownOption()
+        ];
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            extensionCommandLineProvider, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Unknown option '--x'{Environment.NewLine}", result.ErrorMessage);
+    }
+
+    public async Task ParseAndValidateAsync_InvalidValidConfiguration_ReturnsFalse()
+    {
+        // Arrange
+        string[] args = ["--option"];
+        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
+        ICommandLineOptionsProvider[] extensionCommandLineProvider =
+        [
+            new ExtensionCommandLineProviderMockInvalidConfiguration()
+        ];
+
+        // Act
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(parseResult, _systemCommandLineOptionsProviders,
+            extensionCommandLineProvider, new Mock<ICommandLineOptions>().Object);
+
+        // Assert
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual($"Invalid configuration for provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider). Error: Invalid configuration errorMessage{Environment.NewLine}{Environment.NewLine}", result.ErrorMessage);
     }
 
     public void IsHelpInvoked_HelpOptionSet_ReturnsTrue()
@@ -79,8 +197,9 @@ public class CommandLineHandlerTests : TestBase
         // Arrange
         string[] args = ["--help"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
+        CommandLineHandler commandLineHandler = new(parseResult, _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders,
+            _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object,
+            _processHandlerMock.Object);
 
         // Act
         bool result = commandLineHandler.IsHelpInvoked();
@@ -96,8 +215,9 @@ public class CommandLineHandlerTests : TestBase
         // Arrange
         string[] args = ["--info"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
+        CommandLineHandler commandLineHandler = new(parseResult, _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders,
+            _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object,
+            _processHandlerMock.Object);
 
         // Act
         bool result = commandLineHandler.IsInfoInvoked();
@@ -113,8 +233,9 @@ public class CommandLineHandlerTests : TestBase
         // Arrange
         string[] args = ["--version"];
         CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
+        CommandLineHandler commandLineHandler = new(parseResult, _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders,
+            _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object,
+            _processHandlerMock.Object);
 
         // Act
         bool result = commandLineHandler.IsOptionSet("version");
@@ -129,8 +250,10 @@ public class CommandLineHandlerTests : TestBase
     {
         // Arrange
         OptionRecord optionRecord = new("name", ["value1", "value2"]);
-        CommandLineHandler commandLineHandler = new([], new CommandLineParseResult(string.Empty, [optionRecord], [], []),
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
+        CommandLineHandler commandLineHandler = new(
+            new CommandLineParseResult(string.Empty, [optionRecord], [], []), _extensionCommandLineOptionsProviders,
+            _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object,
+            _environmentMock.Object, _processHandlerMock.Object);
 
         // Act
         bool result = commandLineHandler.TryGetOptionArgumentList("name", out string[]? optionValue);
@@ -156,8 +279,9 @@ public class CommandLineHandlerTests : TestBase
                 Assert.IsTrue(((TextOutputDeviceData)data).Text.Contains("Unexpected argument"));
             });
 
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
+        CommandLineHandler commandLineHandler = new(parseResult, _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders,
+            _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object,
+            _processHandlerMock.Object);
 
         // Act
         bool result = commandLineHandler.TryGetOptionArgumentList("name", out string[]? optionValue);
@@ -165,160 +289,6 @@ public class CommandLineHandlerTests : TestBase
         // Assert
         Assert.IsFalse(result);
         Assert.IsTrue(optionValue is null);
-    }
-
-    public async Task ParseAndValidateAsync_DuplicateOption_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = [];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-            .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-                Assert.IsTrue(((TextOutputDeviceData)data).Text.Contains("Option '--userOption' is declared by multiple extensions: 'userOption'")));
-
-        ICommandLineOptionsProvider[] extensionCommandLineOptionsProviders =
-        [
-            new ExtensionCommandLineProviderMockInvalidConfiguration("userOption"),
-            new ExtensionCommandLineProviderMockInvalidConfiguration("userOption")
-        ];
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-           extensionCommandLineOptionsProviders, [], _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
-    }
-
-    public async Task ParseAndValidateAsync_InvalidOption_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = ["--diagnostic-verbosity", "r"];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-            .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-                Assert.IsTrue(((TextOutputDeviceData)data).Text.Equals($"Option '--diagnostic-verbosity' has invalid arguments: '--diagnostic-verbosity' expects a single level argument ('Trace', 'Debug', 'Information', 'Warning', 'Error', or 'Critical'){Environment.NewLine}", StringComparison.Ordinal)));
-
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
-    }
-
-    public async Task ParseAndValidateAsync_InvalidArgumentArity_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = ["--help arg"];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-            .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-                Assert.IsTrue(((TextOutputDeviceData)data).Text.Equals($"Option '--help' from provider 'Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments{Environment.NewLine}", StringComparison.Ordinal)));
-
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            _extensionCommandLineOptionsProviders, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
-    }
-
-    public async Task ParseAndValidateAsync_ReservedOptions_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = [];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-            .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-                Assert.IsTrue(((TextOutputDeviceData)data).Text.Equals($"Option '--help' is reserved and cannot be used by providers: 'help'{Environment.NewLine}", StringComparison.Ordinal)));
-
-        ICommandLineOptionsProvider[] extensionCommandLineProvider =
-        [
-            new ExtensionCommandLineProviderMockReservedOptions()
-        ];
-        CommandLineHandler commandLineHandler = new(args, parseResult, extensionCommandLineProvider,
-            _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
-    }
-
-    public async Task ParseAndValidateAsync_ReservedOptionsPrefix_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = [];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-        .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            Assert.IsTrue(((TextOutputDeviceData)data).Text.Equals($"Option `--internal-customextension` from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) is using the reserved prefix '--internal'{Environment.NewLine}", StringComparison.Ordinal)));
-
-        ICommandLineOptionsProvider[] extensionCommandLineProvider =
-        [
-            new ExtensionCommandLineProviderMockInvalidConfiguration("--internal-customextension")
-        ];
-        CommandLineHandler commandLineHandler = new(args, parseResult, extensionCommandLineProvider,
-            _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object, _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
-    }
-
-    public async Task ParseAndValidateAsync_UnknownOption_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = ["--x"];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-
-        ICommandLineOptionsProvider[] extensionCommandLineProvider =
-        [
-            new ExtensionCommandLineProviderMockUnknownOption()
-        ];
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            extensionCommandLineProvider, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object,
-            _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
-        Assert.IsTrue(string.Equals(commandLineHandler._validationError, $"Unknown option '--x'{Environment.NewLine}", StringComparison.Ordinal));
-    }
-
-    public async Task ParseAndValidateAsync_InvalidValidConfiguration_ReturnsFalse()
-    {
-        // Arrange
-        string[] args = ["--option"];
-        CommandLineParseResult parseResult = CommandLineParser.Parse(args, new SystemEnvironment());
-        _outputDisplayMock.Setup(x => x.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>()))
-        .Callback((IOutputDeviceDataProducer message, IOutputDeviceData data) =>
-            Assert.IsTrue(((TextOutputDeviceData)data).Text.Equals($"Invalid configuration for provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider). Error: Invalid configuration errorMessage{Environment.NewLine}{Environment.NewLine}", StringComparison.Ordinal)));
-
-        ICommandLineOptionsProvider[] extensionCommandLineProvider =
-        [
-            new ExtensionCommandLineProviderMockInvalidConfiguration()
-        ];
-        CommandLineHandler commandLineHandler = new(args, parseResult,
-            extensionCommandLineProvider, _systemCommandLineOptionsProviders, _testApplicationModuleInfoMock.Object,
-            _runtimeFeatureMock.Object, _outputDisplayMock.Object, _environmentMock.Object, _processHandlerMock.Object);
-
-        // Act
-        bool result = await commandLineHandler.ValidateAsync();
-
-        // Assert
-        Assert.IsFalse(result);
     }
 
     private sealed class ExtensionCommandLineProviderMockReservedOptions : ICommandLineOptionsProvider
@@ -340,9 +310,9 @@ public class CommandLineHandlerTests : TestBase
         public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
         public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions() => new CommandLineOption[]
-                {
+        {
             new(HelpOption, "Show command line help.", ArgumentArity.ZeroOrOne, false),
-                };
+        };
 
         public Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions) => throw new NotImplementedException();
 
@@ -368,9 +338,9 @@ public class CommandLineHandlerTests : TestBase
         public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
         public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions() => new CommandLineOption[]
-                {
+        {
             new(Option, "Show command line option.", ArgumentArity.ZeroOrOne, false),
-                };
+        };
 
         public Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions) => throw new NotImplementedException();
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -97,7 +97,7 @@ public class CommandLineHandlerTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--diagnostic-verbosity' has invalid arguments: '--diagnostic-verbosity' expects a single level argument ('Trace', 'Debug', 'Information', 'Warning', 'Error', or 'Critical'){Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option '--diagnostic-verbosity' has invalid arguments: '--diagnostic-verbosity' expects a single level argument ('Trace', 'Debug', 'Information', 'Warning', 'Error', or 'Critical')", result.ErrorMessage);
     }
 
     public async Task ParseAndValidateAsync_InvalidArgumentArity_ReturnsFalse()
@@ -112,7 +112,7 @@ public class CommandLineHandlerTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--help' from provider 'Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option '--help' from provider 'Platform command line provider' (UID: PlatformCommandLineProvider) expects no arguments", result.ErrorMessage);
     }
 
     public async Task ParseAndValidateAsync_ReservedOptions_ReturnsFalse()
@@ -131,7 +131,7 @@ public class CommandLineHandlerTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option '--help' is reserved and cannot be used by providers: 'help'{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option '--help' is reserved and cannot be used by providers: 'help'", result.ErrorMessage);
     }
 
     public async Task ParseAndValidateAsync_ReservedOptionsPrefix_ReturnsFalse()
@@ -150,7 +150,7 @@ public class CommandLineHandlerTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Option `--internal-customextension` from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) is using the reserved prefix '--internal'{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Option `--internal-customextension` from provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider) is using the reserved prefix '--internal'", result.ErrorMessage);
     }
 
     public async Task ParseAndValidateAsync_UnknownOption_ReturnsFalse()
@@ -170,7 +170,7 @@ public class CommandLineHandlerTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Unknown option '--x'{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Unknown option '--x'", result.ErrorMessage);
     }
 
     public async Task ParseAndValidateAsync_InvalidValidConfiguration_ReturnsFalse()
@@ -189,7 +189,7 @@ public class CommandLineHandlerTests : TestBase
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.AreEqual($"Invalid configuration for provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider). Error: Invalid configuration errorMessage{Environment.NewLine}{Environment.NewLine}", result.ErrorMessage);
+        Assert.AreEqual("Invalid configuration for provider 'Microsoft Testing Platform command line provider' (UID: PlatformCommandLineProvider). Error: Invalid configuration errorMessage", result.ErrorMessage);
     }
 
     public void IsHelpInvoked_HelpOptionSet_ReturnsTrue()


### PR DESCRIPTION
Refator `CommandLineHandler` to reduce responsibilities of the class. The new design is not yet optimal but allows to more easily do validation tests of command line providers without having to do a full end-to-end.

This is the first step of my plan to better validate our current providers as we keep discovering "stupid" mistakes around arity and missing validations.

This will also help to validate the test run parameter option by providing extensive test cases.