### PR TITLE
MSTest runner: allow overriding TestRunParameters

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class TestApplicationBuilderExtensions
         MSTestExtension extension = new();
         testApplicationBuilder.AddRunSettingsService(extension);
         testApplicationBuilder.AddTestCaseFilterService(extension);
+        testApplicationBuilder.AddTestRunParametersService(extension);
         testApplicationBuilder.RegisterTestFramework(
             _ => new TestFrameworkCapabilities(new VSTestBridgeExtensionBaseCapabilities()),
             (capabilities, serviceProvider) => new MSTestBridgedTestFramework(extension, getTestAssemblies, serviceProvider, capabilities));

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
@@ -18,10 +18,21 @@ public sealed class TestRunParametersTests : AcceptanceTestBase
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
-    public async Task CanProvideTestRunParameters(string tfm)
+    public async Task TestRunParameters_WhenProvidingMultipleArgumentsToTheOption(string tfm)
     {
         var testHost = TestHost.LocateFrom(_testAssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --test-parameter MyParameter2=MyValue2 MyParameter3=MyValue3");
+
+        // Assert
+        testHostResult.AssertExitCodeIs(0);
+        testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task TestRunParameters_WhenProvidingMultipleMultipleTimesTheOptionAndArgument(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --test-parameter MyParameter2=MyValue2 --test-parameter MyParameter3=MyValue3");
 
         // Assert
         testHostResult.AssertExitCodeIs(0);

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+[TestGroup]
+public sealed class TestRunParametersTests : AcceptanceTestBase
+{
+    private readonly TestAssetFixture _testAssetFixture;
+
+    public TestRunParametersTests(ITestExecutionContext testExecutionContext, TestAssetFixture testAssetFixture)
+        : base(testExecutionContext)
+    {
+        _testAssetFixture = testAssetFixture;
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CanProvideTestRunParameters(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --test-parameter MyParameter2=MyValue2 MyParameter3=MyValue3");
+
+        // Assert
+        testHostResult.AssertExitCodeIs(0);
+        testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1");
+    }
+
+    [TestFixture(TestFixtureSharingStrategy.PerTestGroup)]
+    public sealed class TestAssetFixture(AcceptanceFixture acceptanceFixture) : TestAssetFixtureBase(acceptanceFixture.NuGetGlobalPackagesFolder)
+    {
+        public const string ProjectName = "TestRunParameters";
+
+        public string ProjectPath => GetAssetPath(ProjectName);
+
+        public override IEnumerable<(string ID, string Name, string Code)> GetAssetsToGenerate()
+        {
+            yield return (ProjectName, ProjectName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+        }
+
+        private const string SourceCode = """
+#file TestRunParameters.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="*.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>
+
+#file my.runsettings
+<RunSettings>
+    <TestRunParameters>
+        <Parameter name="MyParameter1" value="MyValue1" />
+        <Parameter name="MyParameter2" value="" />
+    </TestRunParameters>
+</RunSettings>
+
+#file UnitTest1.cs
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class UnitTest1
+{
+    public TestContext TestContext { get; set; }
+
+    [TestMethod]
+    public void MyTestMethod()
+    {
+        Assert.AreEqual("MyValue1", TestContext.Properties["MyParameter1"]);
+        Assert.AreEqual("MyValue2", TestContext.Properties["MyParameter2"]);
+        Assert.AreEqual("MyValue3", TestContext.Properties["MyParameter3"]);
+    }
+}
+""";
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpTests.cs
@@ -109,8 +109,9 @@ Options:
   --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run\.
   --results-directory                      The directory where the test results are going to be placed\. If the specified directory doesn't exist, it's created\. The default is TestResults in the directory that contains the test application\.
 Extension options:
-  --filter   Filters tests using the given expression\. For more information, see the Filter option details section\. For more information and examples on how to use selective unit test filtering, see https://learn\.microsoft\.com/dotnet/core/testing/selective-unit-tests\.
-  --settings The path, relative or absolute, to the \.runsettings file\. For more information and examples on how to configure test run, see https://learn\.microsoft\.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file
+  --filter         Filters tests using the given expression\. For more information, see the Filter option details section\. For more information and examples on how to use selective unit test filtering, see https://learn\.microsoft\.com/dotnet/core/testing/selective-unit-tests\.
+  --settings       The path, relative or absolute, to the \.runsettings file\. For more information and examples on how to configure test run, see https://learn\.microsoft\.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file
+  --test-parameter Specify or override a key-value pair parameter\. For more information and examples, see https://learn\.microsoft\.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
 """;
 
         testHostResult.AssertOutputMatchesRegex(RegexMatchPattern);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/InfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/InfoTests.cs
@@ -162,6 +162,10 @@ Registered command line providers:
         Arity: 1
         Hidden: False
         Description: Filters tests using the given expression\. For more information, see the Filter option details section\. For more information and examples on how to use selective unit test filtering, see https://learn\.microsoft\.com/dotnet/core/testing/selective-unit-tests\.
+      --test-parameter
+        Arity: 1\.\.*
+        Hidden: False
+        Description: Specify or override a key-value pair parameter\. For more information and examples, see https://learn\.microsoft\.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
 """;
 
         testHostResult.AssertOutputMatchesRegex(RegexMatchPattern);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/InfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/InfoTests.cs
@@ -163,9 +163,11 @@ Registered command line providers:
         Hidden: False
         Description: Filters tests using the given expression\. For more information, see the Filter option details section\. For more information and examples on how to use selective unit test filtering, see https://learn\.microsoft\.com/dotnet/core/testing/selective-unit-tests\.
       --test-parameter
-        Arity: 1\.\.*
+        Arity: 1\.\.2147483647
         Hidden: False
         Description: Specify or override a key-value pair parameter\. For more information and examples, see https://learn\.microsoft\.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
+Registered tools:
+  There are no registered tools.
 """;
 
         testHostResult.AssertOutputMatchesRegex(RegexMatchPattern);


### PR DESCRIPTION
When using MSTest runner it wasn't possible to override or provide `TestRunParameters` entries while with VSTest we could override any entry from runsettings. We have decided to not allow to change any runsettings entry but to provide first-class level support for test run parameters.

The syntax is `--test-parameter Key=Value` and we can provide multiple pairs.