### PR TITLE
Use GetTypes() instead of DefinedTypes

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
@@ -124,11 +124,11 @@ internal class AssemblyEnumerator : MarshalByRefObject
     /// <param name="assemblyFileName">The file name of the assembly.</param>
     /// <param name="warningMessages">Contains warnings if any, that need to be passed back to the caller.</param>
     /// <returns>Gets the types defined in the provided assembly.</returns>
-    internal static IReadOnlyList<Type> GetTypes(Assembly assembly, string assemblyFileName, ICollection<string>? warningMessages)
+    internal static Type[] GetTypes(Assembly assembly, string assemblyFileName, ICollection<string>? warningMessages)
     {
         try
         {
-            return assembly.DefinedTypes.Select(typeInfo => typeInfo.AsType()).ToList();
+            return assembly.GetTypes();
         }
         catch (ReflectionTypeLoadException ex)
         {

--- a/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorTests.cs
@@ -88,19 +88,19 @@ public class AssemblyEnumeratorTests : TestContainer
         Mock<TestableAssembly> mockAssembly = new();
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Returns(new List<TypeInfo>());
+        mockAssembly.Setup(a => a.GetTypes()).Returns(Array.Empty<Type>());
 
-        Verify(AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings).Count == 0);
+        Verify(AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings).Length == 0);
     }
 
     public void GetTypesShouldReturnSetOfDefinedTypes()
     {
         Mock<TestableAssembly> mockAssembly = new();
 
-        var expectedTypes = new List<TypeInfo>() { typeof(DummyTestClass).GetTypeInfo(), typeof(DummyTestClass).GetTypeInfo() };
+        Type[] expectedTypes = new[] { typeof(DummyTestClass), typeof(DummyTestClass) };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Returns(expectedTypes);
+        mockAssembly.Setup(a => a.GetTypes()).Returns(expectedTypes);
 
         IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings);
         Verify(expectedTypes.SequenceEqual(types));
@@ -111,7 +111,7 @@ public class AssemblyEnumeratorTests : TestContainer
         Mock<TestableAssembly> mockAssembly = new();
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Throws(new ReflectionTypeLoadException(null, null));
+        mockAssembly.Setup(a => a.GetTypes()).Throws(new ReflectionTypeLoadException(null, null));
 
         AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings);
     }
@@ -122,7 +122,7 @@ public class AssemblyEnumeratorTests : TestContainer
         var reflectedTypes = new Type[] { typeof(DummyTestClass) };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Throws(new ReflectionTypeLoadException(reflectedTypes, null));
+        mockAssembly.Setup(a => a.GetTypes()).Throws(new ReflectionTypeLoadException(reflectedTypes, null));
 
         IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings);
 
@@ -136,7 +136,7 @@ public class AssemblyEnumeratorTests : TestContainer
         var exceptions = new Exception[] { new("DummyLoaderException") };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Throws(new ReflectionTypeLoadException(null, exceptions));
+        mockAssembly.Setup(a => a.GetTypes()).Throws(new ReflectionTypeLoadException(null, exceptions));
 
         IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(mockAssembly.Object, "DummyAssembly", _warnings);
 
@@ -220,7 +220,7 @@ public class AssemblyEnumeratorTests : TestContainer
         Mock<TestableAssembly> mockAssembly = CreateMockTestableAssembly();
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Returns(new List<TypeInfo>());
+        mockAssembly.Setup(a => a.GetTypes()).Returns(Array.Empty<Type>());
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
 
@@ -233,8 +233,8 @@ public class AssemblyEnumeratorTests : TestContainer
         var testableAssemblyEnumerator = new TestableAssemblyEnumerator();
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(DummyTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(DummyTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out _warnings))
@@ -250,8 +250,8 @@ public class AssemblyEnumeratorTests : TestContainer
         var unitTestElement = new UnitTestElement(new TestMethod("DummyMethod", "DummyClass", "DummyAssembly", false));
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(DummyTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(DummyTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out _warnings))
@@ -270,8 +270,8 @@ public class AssemblyEnumeratorTests : TestContainer
         var expectedTestElements = new Collection<UnitTestElement> { unitTestElement, unitTestElement };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(DummyTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(DummyTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out _warnings))
@@ -290,8 +290,8 @@ public class AssemblyEnumeratorTests : TestContainer
         var expectedTestElements = new Collection<UnitTestElement> { unitTestElement, unitTestElement };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(DummyTestClass).GetTypeInfo(), typeof(DummyTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(DummyTestClass), typeof(DummyTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out _warnings))
@@ -311,8 +311,8 @@ public class AssemblyEnumeratorTests : TestContainer
         ICollection<string> warningsFromTypeEnumerator = [];
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(InternalTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(InternalTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out warningsFromTypeEnumerator));
@@ -331,8 +331,8 @@ public class AssemblyEnumeratorTests : TestContainer
         };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(InternalTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(InternalTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out warningsFromTypeEnumerator));
@@ -349,8 +349,8 @@ public class AssemblyEnumeratorTests : TestContainer
         var exception = new Exception("TypeEnumerationException");
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes)
-            .Returns(new List<TypeInfo>() { typeof(InternalTestClass).GetTypeInfo() });
+        mockAssembly.Setup(a => a.GetTypes())
+            .Returns(new[] { typeof(InternalTestClass) });
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
         testableAssemblyEnumerator.MockTypeEnumerator.Setup(te => te.Enumerate(out _warnings)).Throws(exception);


### PR DESCRIPTION
Extracted from #2915. This part seems to be working on my machine so I will merge this part and then move on by taking on the rest of the changes.

cc @SimonCropp 