### PR TITLE
Fix --info when tools are present

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
@@ -221,7 +221,14 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"    Version: {tool.Version}"));
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"    Description: {tool.Description}"));
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData("    Tool command line providers:"));
-                    await DisplayProvidersAsync(groupedToolExtensions[tool.Name], 3);
+                    if (groupedToolExtensions.TryGetValue(tool.Name, out List<IToolCommandLineOptionsProvider>? providers))
+                    {
+                        await DisplayProvidersAsync(providers, 3);
+                    }
+                    else
+                    {
+                        await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData("      There are no registered command line providers."));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #3096

I have been working on an integration test but I can't seem to understand why the regex doesn't match (regex101 seems to say it's matching). I have been fighting for 2h now so creating the PR without the test, might add it later.