### PR TITLE
Use ConcurrentDictionary for fixtures

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/UnitTestRunner.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 /// </summary>
 internal class UnitTestRunner : MarshalByRefObject
 {
-    private readonly Dictionary<string, TestMethodInfo> _fixtureTests = new();
+    private readonly ConcurrentDictionary<string, TestMethodInfo> _fixtureTests = new();
 
     /// <summary>
     /// Type cache.
@@ -183,8 +183,8 @@ internal class UnitTestRunner : MarshalByRefObject
             DebugEx.Assert(testMethodInfo is not null, "testMethodInfo should not be null.");
 
             // Keep track of all non-runnable methods so that we can return the appropriate result at the end.
-            _fixtureTests[testMethod.AssemblyName] = testMethodInfo;
-            _fixtureTests[testMethod.AssemblyName + testMethod.FullClassName] = testMethodInfo;
+            _fixtureTests.TryAdd(testMethod.AssemblyName, testMethodInfo);
+            _fixtureTests.TryAdd(testMethod.AssemblyName + testMethod.FullClassName, testMethodInfo);
 
             var testMethodRunner = new TestMethodRunner(testMethodInfo, testMethod, testContext, MSTestSettings.CurrentSettings.CaptureDebugTraces);
             UnitTestResult[] result = testMethodRunner.Execute();


### PR DESCRIPTION
Fixes some race condition issues:

```
   at System.ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported() in System\ThrowHelper.cs:line 374
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior) in System.Collections.Generic\Dictionary.cs:line 1236
   at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value) in System.Collections.Generic\Dictionary.cs:line 711
   at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner.RunSingleTest(TestMethod testMethod, IDictionary`2 testContextProperties) in C:\src\testfx\src\Adapter\MSTest.TestAdapter\Execution\UnitTestRunner.cs:line 186
```