### PR TITLE
remove use of GetTypeInfo().DeclaredProperties

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/TypeValidator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/TypeValidator.cs
@@ -106,7 +106,7 @@ internal class TypeValidator
     {
         DebugEx.Assert(type != null, "HasCorrectTestContextSignature type is null");
 
-        IEnumerable<PropertyInfo> propertyInfoEnumerable = type.GetTypeInfo().DeclaredProperties;
+        IEnumerable<PropertyInfo> propertyInfoEnumerable = type.GetProperties(BindingFlags.DeclaredOnly);
         var propertyInfo = new List<PropertyInfo>();
 
         foreach (PropertyInfo pinfo in propertyInfoEnumerable)


### PR DESCRIPTION
functionally equivalent. but less allocation 