### PR TITLE
Speedup further acceptance tests in PRs

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -151,13 +151,13 @@ public class UnitTest1
             // So we need to find a package that contains a number after the prefix.
             // Ideally, we would want to do a full validation to check this is a nuget version number, but that's too much work for now.
             matches = matches
-                    // (full path, file name without prefix)
-                    .Select(path => (path, fileName: Path.GetFileName(path)[packagePrefixName.Length..]))
-                    // check if first character of file name without prefix is number
-                    .Where(tuple => int.TryParse(tuple.fileName[0].ToString(), CultureInfo.InvariantCulture, out _))
-                    // take the full path
-                    .Select(tuple => tuple.path)
-                    .ToArray();
+                // (full path, file name without prefix)
+                .Select(path => (path, fileName: Path.GetFileName(path)[packagePrefixName.Length..]))
+                // check if first character of file name without prefix is number
+                .Where(tuple => int.TryParse(tuple.fileName[0].ToString(), CultureInfo.InvariantCulture, out _))
+                // take the full path
+                .Select(tuple => tuple.path)
+                .ToArray();
         }
 
         if (matches.Length != 1)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
@@ -87,7 +88,7 @@ public class UnitTest1
     {
         foreach (TestArgumentsEntry<string> tfm in TargetFrameworks.All)
         {
-            foreach (BuildConfiguration compilationMode in Enum.GetValues<BuildConfiguration>())
+            foreach (BuildConfiguration compilationMode in GetBuildConfigurations())
             {
                 foreach (Verb verb in Enum.GetValues<Verb>())
                 {
@@ -101,7 +102,7 @@ public class UnitTest1
     {
         foreach (TestArgumentsEntry<string> tfm in TargetFrameworks.All)
         {
-            foreach (BuildConfiguration compilationMode in Enum.GetValues<BuildConfiguration>())
+            foreach (BuildConfiguration compilationMode in GetBuildConfigurations())
             {
                 yield return new TestArgumentsEntry<(string Tfm, BuildConfiguration BuildConfiguration)>((tfm.Arguments, compilationMode), $"{tfm.Arguments},{compilationMode}");
             }
@@ -110,7 +111,7 @@ public class UnitTest1
 
     internal static IEnumerable<TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration)>> GetBuildMatrixMultiTfmFoldedBuildConfiguration()
     {
-        foreach (BuildConfiguration compilationMode in Enum.GetValues<BuildConfiguration>())
+        foreach (BuildConfiguration compilationMode in GetBuildConfigurations())
         {
             yield return new TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration)>((TargetFrameworks.All.ToMSBuildTargetFrameworks(), compilationMode), $"multitfm,{compilationMode}");
         }
@@ -118,7 +119,7 @@ public class UnitTest1
 
     internal static IEnumerable<TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration)>> GetBuildMatrixMultiTfmBuildConfiguration()
     {
-        foreach (BuildConfiguration compilationMode in Enum.GetValues<BuildConfiguration>())
+        foreach (BuildConfiguration compilationMode in GetBuildConfigurations())
         {
             yield return new TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration)>((TargetFrameworks.All.ToMSBuildTargetFrameworks(), compilationMode), $"{TargetFrameworks.All.ToMSBuildTargetFrameworks()},{compilationMode}");
         }
@@ -175,5 +176,15 @@ public class UnitTest1
         return matches.Length != 1
             ? throw new InvalidOperationException($"Was expecting to find a single entry for '{entryName}' but found {matches.Length}.")
             : matches[0].Value;
+    }
+
+    private static IEnumerable<BuildConfiguration> GetBuildConfigurations()
+    {
+#if !FAST_ACCEPTANCE_TEST || DEBUG
+        yield return BuildConfiguration.Debug;
+#endif
+#if !FAST_ACCEPTANCE_TEST || RELEASE
+        yield return BuildConfiguration.Debug;
+#endif
     }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/BuildConfiguration.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/BuildConfiguration.cs
@@ -5,6 +5,14 @@ namespace Microsoft.Testing.TestInfrastructure;
 
 public enum BuildConfiguration
 {
+#if FAST_ACCEPTANCE_TEST
+#if DEBUG
+    Debug,
+#else
+    Release,
+#endif
+#else
     Debug,
     Release,
+#endif
 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/BuildConfiguration.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/BuildConfiguration.cs
@@ -5,14 +5,6 @@ namespace Microsoft.Testing.TestInfrastructure;
 
 public enum BuildConfiguration
 {
-#if FAST_ACCEPTANCE_TEST
-#if DEBUG
-    Debug,
-#else
-    Release,
-#endif
-#else
     Debug,
     Release,
-#endif
 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(MicrosoftTestingTargetFrameworks);netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition=" '$(FastAcceptanceTest)' == 'true'">$(DefineConstants);SKIP_INTERMEDIATE_TARGET_FRAMEWORKS</DefineConstants>
+    <DefineConstants Condition=" '$(FastAcceptanceTest)' == 'true'">$(DefineConstants);FAST_ACCEPTANCE_TEST</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TargetFrameworks.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TargetFrameworks.cs
@@ -12,7 +12,7 @@ public static class TargetFrameworks
     public static TestArgumentsEntry<string>[] Net { get; } =
     [
         new("net8.0", "net8.0"),
-#if !SKIP_INTERMEDIATE_TARGET_FRAMEWORKS
+#if !FAST_ACCEPTANCE_TEST
         new("net7.0", "net7.0"),
         new("net6.0", "net6.0"),
 #endif


### PR DESCRIPTION
For PRs, only test debug/release modes in the respective legs instead of double testing on all legs.

cc @MarcoRossignoli