### PR TITLE
Fix test run footer color to be red when not successful

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestFilterTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestFilterTests.cs
@@ -84,6 +84,7 @@ UTA023: TestClass: Cannot define predefined property Owner on method OwnerTest.
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter TestCategory=category|Priority=1");
 
         testHostResult.AssertOutputContains("Zero tests ran");
+        testHostResult.AssertExitCodeIs(8);
     }
 
     [TestFixture(TestFixtureSharingStrategy.PerTestGroup)]


### PR DESCRIPTION
Fixes #3178

Some refactoring was done when introducing localization for the console service (cc @nohwnd) that broke the logic, I am fixing it back here.

@MarcoRossignoli I have also considered the cancellation requested as first failure to display.