### PR TITLE
Fix Assert.AreEqual using null dynamic

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
@@ -275,6 +275,11 @@ public sealed partial class Assert
     /// </exception>
     public static void AreEqual<T>(IEquatable<T>? expected, IEquatable<T>? actual, string? message, params object?[]? parameters)
     {
+        if (actual is null && expected is null)
+        {
+            return;
+        }
+
         if (actual?.Equals(expected) == true)
         {
             return;

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #nullable enable
@@ -380,6 +380,14 @@ public partial class AssertTests : TestContainer
 
         // This one doesn't work
         VerifyThrows(() => Assert.AreEqual(instanceOfB, instanceOfA));
+    }
+
+    public void AreEqualUsingDynamicsDoesNotFail()
+    {
+        Assert.AreEqual<dynamic>((dynamic?)null, (dynamic?)null);
+        Assert.AreEqual<dynamic>((dynamic)1, (dynamic)1);
+        Assert.AreEqual<dynamic>((dynamic)"a", (dynamic)"a");
+        Assert.AreEqual<dynamic>((dynamic)'a', (dynamic)'a');
     }
 
     private CultureInfo? GetCultureInfo() => CultureInfo.CurrentCulture;


### PR DESCRIPTION
Fixes #3145 

`Assert.AreEqual<T>(IEquatable<T>, IEquatable<T>)` now handles the 2 arguments being null which fixes the case mentioned with `dynamic`.