### PR TITLE
Retrieve PID inside try/catch

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -69,8 +69,6 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
         var consoleRunStarted = Stopwatch.StartNew();
         IEnvironment environment = ServiceProvider.GetEnvironment();
         IProcessHandler process = ServiceProvider.GetProcessHandler();
-        using IProcess currentProcess = process.GetCurrentProcess();
-        int currentPID = currentProcess.Id;
         ITestApplicationModuleInfo testApplicationModuleInfo = ServiceProvider.GetTestApplicationModuleInfo();
         ExecutableInfo executableInfo = testApplicationModuleInfo.GetCurrentExecutableInfo();
         ITelemetryCollector telemetry = ServiceProvider.GetTelemetryCollector();
@@ -80,7 +78,9 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
         IConfiguration configuration = ServiceProvider.GetConfiguration();
         try
         {
-            string processIdString = currentProcess.Id.ToString(CultureInfo.InvariantCulture);
+            using IProcess currentProcess = process.GetCurrentProcess();
+            int currentPID = currentProcess.Id;
+            string processIdString = currentPID.ToString(CultureInfo.InvariantCulture);
             List<string> partialCommandLine =
             [
                 .. executableInfo.Arguments,
@@ -112,7 +112,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
                 EnvironmentVariables =
                 {
                     { $"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_CORRELATIONID}_{currentPID}", processCorrelationId },
-                    { $"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_PARENTPID}_{currentPID}", currentProcess?.Id.ToString(CultureInfo.InvariantCulture) ?? "null pid" },
+                    { $"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_PARENTPID}_{currentPID}", processIdString },
                     { $"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_SKIPEXTENSION}_{currentPID}", "1" },
                     { $"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_PIPENAME}_{currentPID}", testHostControllerIpc.PipeName.Name },
                 },


### PR DESCRIPTION
We have noticed the following exception being sometimes thrown:

```
Unhandled Exception: System.InvalidOperationException: No process is associated with this object.
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_Id()
   at Microsoft.Testing.Platform.Hosts.TestHostControllersTestHost.<InternalRunAsync>b__21_0(Object sender, EventArgs e)
   at System.Diagnostics.Process.OnExited()
   at System.Diagnostics.Process.RaiseOnExited()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading._ThreadPoolWaitOrTimerCallback.PerformWaitOrTimerCallback(Object state, Boolean timedOut)
```