### PR TITLE
ExecutionThreadAppartment.STA in runsettings doesn't work when tests are parallelized

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
@@ -316,10 +316,11 @@ public class TestExecutionManager
 
                 var tasks = new List<Task>();
                 bool isSTA = false;
+
                 for (int i = 0; i < parallelWorkers; i++)
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                        && Thread.CurrentThread.GetApartmentState() == ApartmentState.STA)
+                        && MSTestSettings.RunConfigurationSettings.ExecutionApartmentState == ApartmentState.STA)
                     {
                         isSTA = true;
                         Thread entryPointThread = new(new ThreadStart(RunTest));


### PR DESCRIPTION
fix: https://github.com/microsoft/testfx/issues/3208