### PR TITLE
Handle InvalidOperationException when accessing process ID

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
@@ -26,7 +26,7 @@ internal interface IProcess : IDisposable
 
 #if NETCOREAPP
     /// <inheritdoc cref="System.Diagnostics.Process.WaitForExitAsync(CancellationToken)" />
-    Task WaitForExitAsync(CancellationToken cancellationToken = default);
+    Task WaitForExitAsync();
 
 #endif
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
@@ -7,23 +7,32 @@ internal interface IProcess : IDisposable
 {
     public event EventHandler Exited;
 
+    /// <inheritdoc cref="System.Diagnostics.Process.Id" />
     int Id { get; }
 
+    /// <inheritdoc cref="System.Diagnostics.Process.ExitCode" />
     int ExitCode { get; }
 
+    /// <inheritdoc cref="System.Diagnostics.Process.HasExited" />
     bool HasExited { get; }
 
 #if NETCOREAPP
+    /// <inheritdoc cref="System.Diagnostics.Process.MainModule" />
     IMainModule? MainModule { get; }
 #else
+    /// <inheritdoc cref="System.Diagnostics.Process.MainModule" />
     IMainModule MainModule { get; }
 #endif
 
 #if NETCOREAPP
-    Task WaitForExitAsync();
+    /// <inheritdoc cref="System.Diagnostics.Process.WaitForExitAsync(CancellationToken)" />
+    Task WaitForExitAsync(CancellationToken cancellationToken = default);
 
 #endif
+
+    /// <inheritdoc cref="System.Diagnostics.Process.WaitForExit()" />
     void WaitForExit();
 
+    /// <inheritdoc cref="System.Diagnostics.Process.Kill()" />
     void Kill();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
@@ -40,8 +40,8 @@ internal sealed class SystemProcess : IProcess, IDisposable
         => _process.WaitForExit();
 
 #if NETCOREAPP
-    public Task WaitForExitAsync()
-        => _process.WaitForExitAsync();
+    public Task WaitForExitAsync(CancellationToken cancellationToken = default)
+        => _process.WaitForExitAsync(cancellationToken);
 #endif
 
 #if NETCOREAPP

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
@@ -40,8 +40,8 @@ internal sealed class SystemProcess : IProcess, IDisposable
         => _process.WaitForExit();
 
 #if NETCOREAPP
-    public Task WaitForExitAsync(CancellationToken cancellationToken = default)
-        => _process.WaitForExitAsync(cancellationToken);
+    public Task WaitForExitAsync()
+        => _process.WaitForExitAsync();
 #endif
 
 #if NETCOREAPP

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -211,7 +211,15 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
                 _logger.LogDebug($"Test host process exited, PID: '{processExited?.Id}'");
             };
 
-            await _logger.LogDebugAsync($"Started test host process '{testHostProcess.Id}' HasExited: {testHostProcess.HasExited}");
+            try
+            {
+                await _logger.LogDebugAsync($"Started test host process '{testHostProcess.Id}' HasExited: {testHostProcess.HasExited}");
+            }
+            catch (InvalidOperationException)
+            {
+                // Access PID can throw InvalidOperationException if the process has already exited:
+                // System.InvalidOperationException: No process is associated with this object.
+            }
 
             string? seconds = configuration[PlatformConfigurationConstants.PlatformTestHostControllersManagerSingleConnectionNamedPipeServerWaitConnectionTimeoutSeconds];
             int timeoutSeconds = seconds is null ? TimeoutHelper.DefaultHangTimeoutSeconds : int.Parse(seconds, CultureInfo.InvariantCulture);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -215,7 +215,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
             {
                 await _logger.LogDebugAsync($"Started test host process '{testHostProcess.Id}' HasExited: {testHostProcess.HasExited}");
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException) when (testHostProcess.HasExited)
             {
                 // Access PID can throw InvalidOperationException if the process has already exited:
                 // System.InvalidOperationException: No process is associated with this object.


### PR DESCRIPTION
Got some exception in our testing suite:

```
Unhandled Exception: System.InvalidOperationException: No process is associated with this object.
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_Id()
   at Microsoft.Testing.Platform.Hosts.TestHostControllersTestHost.<InternalRunAsync>b__21_0(Object sender, EventArgs e)
   at System.Diagnostics.Process.OnExited()
   at System.Diagnostics.Process.RaiseOnExited()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading._ThreadPoolWaitOrTimerCallback.PerformWaitOrTimerCallback(Object state, Boolean timedOut)
```