### PR TITLE
Fix ResultFiles placement in TRX report

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
@@ -525,6 +525,12 @@ internal sealed partial class TrxReportEngine
                 output.Add(errorInfoElement);
             }
 
+            // add collectorDataEntries details
+            if (output.HasElements && outcome != "NotExecuted")
+            {
+                unitTestResult.Add(output);
+            }
+
             if (_artifactsByTestNode.TryGetValue(testNode.Uid, out List<SessionFileArtifact>? fileArtifacts))
             {
                 var resultFiles = new XElement("ResultFiles");
@@ -536,13 +542,7 @@ internal sealed partial class TrxReportEngine
                         new XAttribute("path", fileArtifact.FileInfo.FullName)));
                 }
 
-                output.Add(resultFiles);
-            }
-
-            // add collectorDataEntries details
-            if (output.HasElements && outcome != "NotExecuted")
-            {
-                unitTestResult.Add(output);
+                unitTestResult.Add(resultFiles);
             }
 
             results.Add(unitTestResult);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -299,11 +299,9 @@ public class TrxTests(ITestExecutionContext testExecutionContext) : TestBase(tes
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
     <UnitTestResult .* testName=""TestMethod"" .* outcome=""Passed"" .*>
-      <Output>
-        <ResultFiles>
-          <ResultFile path=.*fileName"" />
-        </ResultFiles>
-      </Output>
+      <ResultFiles>
+        <ResultFile path=.*fileName"" />
+      </ResultFiles>
     </UnitTestResult>
  ";
         Assert.That(Regex.IsMatch(trxContent, trxContentsPattern));


### PR DESCRIPTION
ResultFiles tag was incorrectly placed in the Output. Move it out under TestResults where it belongs.

Fix https://github.com/microsoft/testfx/issues/3260