### PR TITLE
Fix: VSTest bridge - use TestCase.Id for the TestNodeUID

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -30,7 +30,7 @@ internal static class ObjectModelConverters
     public static TestNode ToTestNode(this TestCase testCase, bool isTrxEnabled, ClientInfo client)
     {
         string testNodeUid = testCase.GetPropertyValue<string>(TestNodeUidProperty, null)
-            ?? testCase.FullyQualifiedName;
+            ?? testCase.Id.ToString();
 
         TestNode testNode = new()
         {


### PR DESCRIPTION
Fixes #3247