### PR TITLE
Improve display name for DynamicDataAttribute

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
@@ -88,9 +88,10 @@ internal class AssemblyEnumerator : MarshalByRefObject
         TestIdGenerationStrategy testIdGenerationStrategy = assembly.GetCustomAttribute<TestIdGenerationStrategyAttribute>()?.Strategy
             ?? TestIdGenerationStrategy.FullyQualified;
 
-        // Set the test ID generation strategy for the data row attribute so we can improve display name without causing
-        // a breaking change.
+        // Set the test ID generation strategy for DataRowAttribute and DynamicDataAttribute so we can improve display name without
+        // causing a breaking change.
         DataRowAttribute.TestIdGenerationStrategy = testIdGenerationStrategy;
+        DynamicDataAttribute.TestIdGenerationStrategy = testIdGenerationStrategy;
 
         TestDataSourceDiscoveryOption testDataSourceDiscovery = assembly.GetCustomAttribute<TestDataSourceDiscoveryAttribute>()?.DiscoveryOption
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataRowAttribute.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Globalization;
 using System.Reflection;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting.Internal;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -87,37 +88,6 @@ public class DataRowAttribute : Attribute, ITestDataSource
             : data.AsEnumerable();
 
         return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name,
-            string.Join(",", displayData.Select(GetObjectString)));
-    }
-
-    /// <summary>
-    /// Recursively resolve collections of objects to a proper string representation.
-    /// </summary>
-    private static string? GetObjectString(object? obj)
-    {
-        if (TestIdGenerationStrategy != TestIdGenerationStrategy.FullyQualified)
-        {
-            return obj?.ToString();
-        }
-
-        if (obj == null)
-        {
-            return "null";
-        }
-
-        if (!obj.GetType().IsArray)
-        {
-            return obj switch
-            {
-                string s => $"\"{s}\"",
-                char c => $"'{c}'",
-                _ => obj.ToString(),
-            };
-        }
-
-        // We need to box the object here so that we can support value types
-        IEnumerable<object> boxedObjectEnumerable = ((IEnumerable)obj).Cast<object>();
-        IEnumerable<string?> elementStrings = boxedObjectEnumerable.Select(GetObjectString);
-        return $"[{string.Join(",", elementStrings)}]";
+            string.Join(",", displayData.Select(x => TestDataSourceUtilities.GetHumanizedArguments(x, TestIdGenerationStrategy))));
     }
 }

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DynamicDataAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DynamicDataAttribute.cs
@@ -9,6 +9,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
+using Microsoft.VisualStudio.TestTools.UnitTesting.Internal;
+
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
@@ -72,6 +74,8 @@ public sealed class DynamicDataAttribute : Attribute, ITestDataSource
     {
         _dynamicDataDeclaringType = dynamicDataDeclaringType;
     }
+
+    internal static TestIdGenerationStrategy TestIdGenerationStrategy { get; set; }
 
     /// <summary>
     /// Gets or sets the name of method used to customize the display name in test results.
@@ -194,7 +198,7 @@ public sealed class DynamicDataAttribute : Attribute, ITestDataSource
             // so that null do appear as "null". If you remove the call, and do string.Join(",", new object[] { null, "a" }),
             // you will get empty string while with the call you will get "null,a".
             return string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DataDrivenResultDisplayName, methodInfo.Name,
-                string.Join(",", data.AsEnumerable()));
+                string.Join(",", data.AsEnumerable().Select(x => TestDataSourceUtilities.GetHumanizedArguments(x, TestIdGenerationStrategy))));
         }
 
         return null;

--- a/src/TestFramework/TestFramework/Internal/TestDataSourceUtilities.cs
+++ b/src/TestFramework/TestFramework/Internal/TestDataSourceUtilities.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting.Internal;
+
+internal static class TestDataSourceUtilities
+{
+    /// <summary>
+    /// Recursively resolve collections of objects to a proper string representation.
+    /// </summary>
+    /// <param name="data">The method arguments.</param>
+    /// <param name="testIdGenerationStrategy">The strategy for creating the test ID.</param>
+    /// <returns>The humanized representation of the data.</returns>
+    public static string? GetHumanizedArguments(object? data, TestIdGenerationStrategy testIdGenerationStrategy)
+    {
+        // To avoid breaking changes, we will return the string representation of the arguments if the testIdGenerationStrategy
+        // is not set to FullyQualified. This is the logic that was present in the previous implementation.
+        if (testIdGenerationStrategy != TestIdGenerationStrategy.FullyQualified)
+        {
+            return data?.ToString();
+        }
+
+        if (data is null)
+        {
+            return "null";
+        }
+
+        if (!data.GetType().IsArray)
+        {
+            return data switch
+            {
+                string s => $"\"{s}\"",
+                char c => $"'{c}'",
+                _ => data.ToString(),
+            };
+        }
+
+        // We need to box the object here so that we can support value types
+        IEnumerable<object> boxedObjectEnumerable = ((IEnumerable)data).Cast<object>();
+        IEnumerable<string?> elementStrings = boxedObjectEnumerable.Select(x => GetHumanizedArguments(x, testIdGenerationStrategy));
+        return $"[{string.Join(",", elementStrings)}]";
+    }
+}

--- a/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DynamicDataTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DynamicDataTests.cs
@@ -21,33 +21,33 @@ public class DynamicDataTests : CLITestBase
         // Assert
         VerifyE2E.ContainsTestsPassed(
             testResults,
-            "DynamicDataTest_SourceMethod (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceMethod (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceProperty (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceProperty (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceProperty (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "Custom DynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayName with 2 parameters",
+            "Custom DynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayName with 2 parameters",
+            "UserDynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayNameOtherType with 2 parameters",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayName with 2 parameters",
-            "Custom DynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayName with 2 parameters",
-            "Custom DynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayName with 2 parameters",
+            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
+            "DynamicDataTest_SourceMethod (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "UserDynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayNameOtherType with 2 parameters",
+            "StackOverflowException_Example (DataSourceTestProject.DynamicDataTests+ExampleTestCase)",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayName with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayNameOtherType with 2 parameters",
+            "DynamicDataTest_SourceMethodOtherType (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceMethodOtherType (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "Custom DynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayName with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayNameOtherType with 2 parameters",
+            "Custom DynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayName with 2 parameters",
+            "DynamicDataTest_SourcePropertyOtherType (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTestWithTestCategory (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTestWithTestCategory (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
             "UserDynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayNameOtherType with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayNameOtherType with 2 parameters",
-            "DynamicDataTest_SourceMethodOtherType (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceMethodOtherType (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourcePropertyOtherType (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourcePropertyOtherType (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "Custom DynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayName with 2 parameters",
-            "Custom DynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayName with 2 parameters",
-            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
-            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
+            "DynamicDataTest_SourceMethod (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
             "Custom DynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayName with 2 parameters",
-            "Custom DynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayName with 2 parameters",
-            "UserDynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayNameOtherType with 2 parameters",
-            "UserDynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayNameOtherType with 2 parameters",
-            "DynamicDataTestWithTestCategory (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTestWithTestCategory (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "StackOverflowException_Example (DataSourceTestProject.DynamicDataTests+ExampleTestCase)");
+            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
+            "DynamicDataTest_SourceProperty (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourcePropertyOtherType (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "Custom DynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayName with 2 parameters");
 
         VerifyE2E.FailedTestCount(testResults, 0);
     }
@@ -64,8 +64,8 @@ public class DynamicDataTests : CLITestBase
         // Assert
         VerifyE2E.ContainsTestsPassed(
             testResults,
-            "DynamicDataTestWithTestCategory (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTestWithTestCategory (Jane;Doe,LibProjectReferencedByDataSourceTest.User)");
+            "DynamicDataTestWithTestCategory (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTestWithTestCategory (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)");
 
         VerifyE2E.FailedTestCount(testResults, 0);
     }

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestId.DefaultStrategy.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestId.DefaultStrategy.cs
@@ -67,9 +67,9 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
-            "DynamicDataArraysTests (0,System.Int32[])",
-            "DynamicDataArraysTests (0,System.Int32[])",
-            "DynamicDataArraysTests (0,System.Int32[])");
+            "DynamicDataArraysTests (0,[])",
+            "DynamicDataArraysTests (0,[0])",
+            "DynamicDataArraysTests (0,[0,0,0])");
 
         // We cannot assert the expected ID as it is path dependent
         testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestId.FullyQualifiedStrategy.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestId.FullyQualifiedStrategy.cs
@@ -67,9 +67,9 @@ public partial class TestId : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
         VerifyE2E.TestsPassed(
             testResults,
-            "DynamicDataArraysTests (0,System.Int32[])",
-            "DynamicDataArraysTests (0,System.Int32[])",
-            "DynamicDataArraysTests (0,System.Int32[])");
+            "DynamicDataArraysTests (0,[])",
+            "DynamicDataArraysTests (0,[0])",
+            "DynamicDataArraysTests (0,[0,0,0])");
 
         // We cannot assert the expected ID as it is path dependent
         testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataExtensibilityTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataExtensibilityTests.cs
@@ -20,16 +20,16 @@ public class DataExtensibilityTests : CLITestBase
     {
         InvokeVsTestForExecution([TestAssetName]);
         ValidatePassedTestsContain(
-            "DynamicDataTestMethod1 (string,2,True)",
-            "DynamicDataTestMethod2 (string,4,True)",
-            "DynamicDataTestMethod3 (string,2,True)",
-            "DynamicDataTestMethod3 (string,4,True)");
+            "DynamicDataTestMethod1 (\"string\",2,True)",
+            "DynamicDataTestMethod2 (\"string\",4,True)",
+            "DynamicDataTestMethod3 (\"string\",2,True)",
+            "DynamicDataTestMethod3 (\"string\",4,True)");
 
         ValidatePassedTestsContain(
-            "DynamicDataTestMethod4 (string,2,True)",
-            "DynamicDataTestMethod5 (string,4,True)",
-            "DynamicDataTestMethod6 (string,2,True)",
-            "DynamicDataTestMethod6 (string,4,True)");
+            "DynamicDataTestMethod4 (\"string\",2,True)",
+            "DynamicDataTestMethod5 (\"string\",4,True)",
+            "DynamicDataTestMethod6 (\"string\",2,True)",
+            "DynamicDataTestMethod6 (\"string\",4,True)");
 
         ValidateFailedTestsContain(
             false,

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DynamicDataTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DynamicDataTests.cs
@@ -18,10 +18,10 @@ public class DynamicDataTests : CLITestBase
 
         // Assert
         ValidatePassedTests(
-            "DynamicDataTest_SourceMethod (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceMethod (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceProperty (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceProperty (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceMethod (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceMethod (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceProperty (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceProperty (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayName with 2 parameters",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayName with 2 parameters",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayName with 2 parameters",
@@ -30,20 +30,20 @@ public class DynamicDataTests : CLITestBase
             "UserDynamicDataTestMethod DynamicDataTest_SourceMethod_CustomDisplayNameOtherType with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayNameOtherType with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourceProperty_CustomDisplayNameOtherType with 2 parameters",
-            "DynamicDataTest_SourceMethodOtherType (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourceMethodOtherType (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourcePropertyOtherType (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTest_SourcePropertyOtherType (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceMethodOtherType (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourceMethodOtherType (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourcePropertyOtherType (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTest_SourcePropertyOtherType (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayName with 2 parameters",
             "Custom DynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayName with 2 parameters",
-            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
-            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
             "Custom DynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayName with 2 parameters",
             "Custom DynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayName with 2 parameters",
+            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
+            "UserDynamicDataTestMethod DynamicDataTest_SourceMethodOtherType_CustomDisplayNameOtherType with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayNameOtherType with 2 parameters",
             "UserDynamicDataTestMethod DynamicDataTest_SourcePropertyOtherType_CustomDisplayNameOtherType with 2 parameters",
-            "DynamicDataTestWithTestCategory (John;Doe,LibProjectReferencedByDataSourceTest.User)",
-            "DynamicDataTestWithTestCategory (Jane;Doe,LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTestWithTestCategory (\"John;Doe\",LibProjectReferencedByDataSourceTest.User)",
+            "DynamicDataTestWithTestCategory (\"Jane;Doe\",LibProjectReferencedByDataSourceTest.User)",
             "StackOverflowException_Example (DataSourceTestProject.DynamicDataTests+ExampleTestCase)");
 
         ValidateFailedTestsCount(0);

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/DynamicDataAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/DynamicDataAttributeTests.cs
@@ -22,6 +22,7 @@ public class DynamicDataAttributeTests : TestContainer
         _dummyTestClass = new DummyTestClass();
         _testMethodInfo = _dummyTestClass.GetType().GetTypeInfo().GetDeclaredMethod("TestMethod1");
         _dynamicDataAttribute = new DynamicDataAttribute("ReusableTestDataProperty");
+        DynamicDataAttribute.TestIdGenerationStrategy = TestIdGenerationStrategy.FullyQualified;
     }
 
     public void GetDataShouldThrowExceptionIfInvalidPropertyNameIsSpecifiedOrPropertyDoesNotExist()
@@ -249,13 +250,43 @@ public class DynamicDataAttributeTests : TestContainer
         string[] data2 = ["value1", null, "value2"];
 
         string displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, data);
-        Verify(displayName == "TestMethod1 (value1,value2,)");
+        Verify(displayName == "TestMethod1 (\"value1\",\"value2\",null)");
 
         displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, data1);
-        Verify(displayName == "TestMethod1 (,value1,value2)");
+        Verify(displayName == "TestMethod1 (null,\"value1\",\"value2\")");
 
         displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, data2);
-        Verify(displayName == "TestMethod1 (value1,,value2)");
+        Verify(displayName == "TestMethod1 (\"value1\",null,\"value2\")");
+    }
+
+    public void GetDisplayNameForArrayOfMultipleItems()
+    {
+        string displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, [new[] { "a", "b", "c" }]);
+        Verify(displayName == "TestMethod1 ([\"a\",\"b\",\"c\"])");
+    }
+
+    public void GetDisplayNameForMultipleArraysOfOneItem()
+    {
+        string displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, [new[] { "a" }, new[] { "1" }]);
+        Verify(displayName == "TestMethod1 ([\"a\"],[\"1\"])");
+    }
+
+    public void GetDisplayNameForMultipleArraysOfMultipleItems()
+    {
+        string displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, [new[] { "a", "b", "c" }, new[] { "1", "2", "3" }]);
+        Verify(displayName == "TestMethod1 ([\"a\",\"b\",\"c\"],[\"1\",\"2\",\"3\"])");
+    }
+
+    public void GetDisplayNameForMultipleArraysOfMultipleItemsValueTypes()
+    {
+        string displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, [new[] { 1, 2, 3 }, new[] { 4, 5, 6 }]);
+        Verify(displayName == "TestMethod1 ([1,2,3],[4,5,6])");
+    }
+
+    public void GetDisplayNameForMultipleArraysOfArraysOfMultipleItems()
+    {
+        string displayName = _dynamicDataAttribute.GetDisplayName(_testMethodInfo, [new[] { ["a", "b", "c"], ["d", "e", "f"], new[] { "gh", "ij", "kl" } }, new[] { 'm', 'n', 'o' }, new[] { ["1", "2", "3"], ["4", "5", "6"], new[] { "7", "8", "9" } }]);
+        Verify(displayName == "TestMethod1 ([[\"a\",\"b\",\"c\"],[\"d\",\"e\",\"f\"],[\"gh\",\"ij\",\"kl\"]],['m','n','o'],[[\"1\",\"2\",\"3\"],[\"4\",\"5\",\"6\"],[\"7\",\"8\",\"9\"]])");
     }
 
 #if NETCOREAPP


### PR DESCRIPTION
Copies logic from @MichelZ for `DataRowAttribute` for `DynamicDataAttribute`. This is improving the display for `string`, `char`, `null` and collections.

Before:
![image](https://github.com/user-attachments/assets/dfaf5be7-f8fd-4b92-8010-2629dd946580)

After:
![image](https://github.com/user-attachments/assets/5393e7ea-f947-4445-b401-18931c4647e3)
