### PR TITLE
improve perf of PropertyBag.SingleOrDefault

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
@@ -167,13 +167,28 @@ public sealed partial class PropertyBag
             return default;
         }
 
-        IEnumerable<TProperty> matchingValues = _property is null ? Array.Empty<TProperty>() : _property.OfType<TProperty>();
+        if (_property is null)
+        {
+            return default;
+        }
 
-        return !matchingValues.Any()
-            ? default
-            : matchingValues.Skip(1).Any()
-                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
-                : matchingValues.First();
+        if (_property.Count == 0)
+        {
+            return default;
+        }
+
+        IEnumerable<TProperty> matchingValues = _property.OfType<TProperty>();
+
+        using IEnumerator<TProperty> enumerator = matchingValues.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            return default;
+        }
+
+        TProperty property = enumerator.Current!;
+        return enumerator.MoveNext()
+            ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+            : property;
     }
 
     [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "No interop")]

--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
@@ -167,12 +167,7 @@ public sealed partial class PropertyBag
             return default;
         }
 
-        if (_property is null)
-        {
-            return default;
-        }
-
-        if (_property.Count == 0)
+        if (_property is null || _property.Count == 0)
         {
             return default;
         }


### PR DESCRIPTION
 * dont do linq if _property is null or _property is empty
 * avoid multiple enumeration of matchingValues