### PR TITLE
Fix shutdown order for server mode

### DIFF
--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -21,6 +21,7 @@
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer" />
     <PackageReference Include="StreamJsonRpc" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Playground/Program.cs
+++ b/samples/Playground/Program.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 
-using Microsoft.Testing.Extensions;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.ServerMode.IntegrationTests.Messages.V100;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -17,7 +16,7 @@ public class Program
     public static async Task<int> Main(string[] args)
     {
         // Opt-out telemetry
-        // Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+        Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
 
         if (Environment.GetEnvironmentVariable("TESTSERVERMODE") != "1")
         {

--- a/samples/Playground/Program.cs
+++ b/samples/Playground/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 
+using Microsoft.Testing.Extensions;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.ServerMode.IntegrationTests.Messages.V100;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -16,7 +17,7 @@ public class Program
     public static async Task<int> Main(string[] args)
     {
         // Opt-out telemetry
-        Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+        // Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
 
         if (Environment.GetEnvironmentVariable("TESTSERVERMODE") != "1")
         {
@@ -27,6 +28,9 @@ public class Program
 
             // Enable Trx
             // testApplicationBuilder.AddTrxReportProvider();
+
+            // Enable Telemetry
+            // testApplicationBuilder.AddAppInsightsTelemetryProvider();
             using ITestApplication testApplication = await testApplicationBuilder.BuildAsync();
             return await testApplication.RunAsync();
         }
@@ -49,6 +53,8 @@ public class Program
                 return Task.CompletedTask;
             });
             await runRequest.WaitCompletionAsync();
+
+            await client.ExitAsync();
 
             return 0;
         }

--- a/samples/Playground/ServerMode/TestingPlatformClientFactory.cs
+++ b/samples/Playground/ServerMode/TestingPlatformClientFactory.cs
@@ -138,8 +138,8 @@ public partial /* for codegen regx */ class TestingPlatformClientFactory
             },
 
             // OnExit = (_, exitCode) => NotepadWindow.WriteLine($"[OnExit] Process exit code '{exitCode}'"),
-            // Arguments = "--server --diagnostic --diagnostic-verbosity error",
-            Arguments = "--server",
+            Arguments = "--server --diagnostic --diagnostic-verbosity trace",
+            // Arguments = "--server",
             EnvironmentVariables = environmentVariables,
         };
 
@@ -199,6 +199,8 @@ public interface IProcessHandle
     Task<int> StopAsync();
 
     Task<int> WaitForExitAsync();
+
+    void WaitForExit();
 
     Task WriteInputAsync(string input);
 }
@@ -354,6 +356,8 @@ public sealed class ProcessHandle : IProcessHandle, IDisposable
 #endif
         return await Task.FromResult(_process.ExitCode);
     }
+
+    public void WaitForExit() => _process.WaitForExit();
 
     public async Task<int> StopAsync()
     {

--- a/samples/Playground/ServerMode/v1.0.0/TestingPlatformClient.cs
+++ b/samples/Playground/ServerMode/v1.0.0/TestingPlatformClient.cs
@@ -163,6 +163,7 @@ public sealed class TestingPlatformClient : IDisposable
     {
         JsonRpcClient.Dispose();
         _tcpClient.Dispose();
+        _processHandler.WaitForExit();
         _processHandler.Dispose();
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -682,6 +682,9 @@ internal sealed partial class ServerTestHost : CommonTestHost, IServerTestHost, 
                     method: JsonRpcMethods.ClientLog,
                     @params: new LogEventArgs(logMessage),
                     _testApplicationCancellationTokenSource.CancellationToken,
+
+                    // We could receive some log messages after the exit, a real sample is if telemetry provider is too slow and we log a warning.
+                    checkServerExit: true,
                     rethrowException: false);
                 break;
         }


### PR DESCRIPTION
In server mode we cannot send back logging information to VS after the "exit". 

cc: @drognanar 