### PR TITLE
Fix possible deadlock inside MSBuild task

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -238,7 +238,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     }
 
     protected override void ProcessStarted()
-        => _connectionLoopTask = Task.Run(() =>
+        => _connectionLoopTask = Task.Run(async () =>
         {
             try
             {
@@ -249,7 +249,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
                     pipeServer.RegisterSerializer(new VoidResponseSerializer(), typeof(VoidResponse));
                     pipeServer.RegisterSerializer(new FailedTestInfoRequestSerializer(), typeof(FailedTestInfoRequest));
                     pipeServer.RegisterSerializer(new RunSummaryInfoRequestSerializer(), typeof(RunSummaryInfoRequest));
-                    pipeServer.WaitConnectionAsync(_waitForConnections.Token).GetAwaiter().GetResult();
+                    await pipeServer.WaitConnectionAsync(_waitForConnections.Token);
                     _connections.Add(pipeServer);
                     Log.LogMessage(MessageImportance.Low, $"Client connected to '{_pipeNameDescription.Name}'");
                 }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -258,6 +258,10 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
             {
                 // Do nothing we're cancelling
             }
+            catch (Exception ex)
+            {
+                Log.LogError(ex.ToString());
+            }
         });
 
     public override bool Execute()

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -63,7 +63,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
         CancellationToken cancellationToken)
     {
         ArgumentGuard.IsNotNull(pipeNameDescription);
-        _namedPipeServerStream = new((PipeName = pipeNameDescription).Name, PipeDirection.InOut, maxNumberOfServerInstances);
+        _namedPipeServerStream = new((PipeName = pipeNameDescription).Name, PipeDirection.InOut, maxNumberOfServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
         _callback = callback;
         _environment = environment;
         _logger = logger;


### PR DESCRIPTION
* I don't recall why we went for a blocking wait. We have and hang on this line only for 6.0 so it could be a deadlock due to the blocking wait. Token is correctly signaled.
* Setup the pipe to be async

Fixes #3295 