### PR TITLE
Handle `--` for msbuild dotnet test integration

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -208,7 +208,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
             builder.AppendTextUnquoted($" {TestingPlatformCommandLineArguments!.ItemSpec} ");
         }
 
-        if (VSTestCLIRunSettings is not null && VSTestCLIRunSettings.Length > 0)
+        if (VSTestCLIRunSettings?.Length > 0)
         {
             foreach (ITaskItem taskItem in VSTestCLIRunSettings)
             {

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -83,6 +83,8 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
     public ITaskItem? TestingPlatformCommandLineArguments { get; set; }
 
+    public ITaskItem[]? VSTestCLIRunSettings { get; set; }
+
     private bool IsNetCoreApp => TargetFrameworkIdentifier.ItemSpec == ".NETCoreApp";
 
     protected override string ToolName
@@ -204,6 +206,14 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
         if (!string.IsNullOrEmpty(TestingPlatformCommandLineArguments?.ItemSpec))
         {
             builder.AppendTextUnquoted($" {TestingPlatformCommandLineArguments!.ItemSpec} ");
+        }
+
+        if (VSTestCLIRunSettings is not null && VSTestCLIRunSettings.Length > 0)
+        {
+            foreach (ITaskItem taskItem in VSTestCLIRunSettings)
+            {
+                builder.AppendTextUnquoted($" {taskItem.ItemSpec}");
+            }
         }
 
         return builder.ToString();

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -252,6 +252,7 @@
                                ProjectFullPath="$(MSBuildProjectFullPath)"
                                TestingPlatformShowTestsFailure="$(TestingPlatformShowTestsFailure)"
                                TestingPlatformCommandLineArguments="$(TestingPlatformCommandLineArguments)"
+                               VSTestCLIRunSettings="$(VSTestCLIRunSettings)"
                                TestingPlatformCaptureOutput="$(TestingPlatformCaptureOutput)"
                                DotnetHostPath="$(DOTNET_HOST_PATH)" />
   </Target>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -124,7 +124,10 @@ public class MSBuildTests_Test : AcceptanceTestBase
                     .PatchCodeWithReplace("$MicrosoftTestingEnterpriseExtensionsVersion$", MicrosoftTestingEnterpriseExtensionsVersion));
                 string binlogFile = Path.Combine(testAsset.TargetAssetPath, Guid.NewGuid().ToString("N"), "msbuild.binlog");
                 string testResultFolder = Path.Combine(testAsset.TargetAssetPath, Guid.NewGuid().ToString("N"));
-                DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{testCommand} -p:TestingPlatformCommandLineArguments=\"--treenode-filter /*/*/*/TestMethod1 --results-directory %22{testResultFolder}%22\" -p:Configuration={compilationMode} -p:nodeReuse=false -bl:{binlogFile} /warnAsError \"{testAsset.TargetAssetPath}\"", _acceptanceFixture.NuGetGlobalPackagesFolder.Path, failIfReturnValueIsNotZero: true);
+
+                DotnetMuxerResult compilationResult = testCommand.StartsWith("test", StringComparison.OrdinalIgnoreCase)
+                    ? await DotnetCli.RunAsync($"{testCommand} -p:Configuration={compilationMode} -p:nodeReuse=false -bl:{binlogFile} /warnAsError \"{testAsset.TargetAssetPath}\" -- --treenode-filter /*/*/*/TestMethod1 --results-directory \"{testResultFolder}\"", _acceptanceFixture.NuGetGlobalPackagesFolder.Path, failIfReturnValueIsNotZero: true)
+                    : await DotnetCli.RunAsync($"{testCommand} -p:TestingPlatformCommandLineArguments=\"--treenode-filter /*/*/*/TestMethod1 --results-directory %22{testResultFolder}%22\" -p:Configuration={compilationMode} -p:nodeReuse=false -bl:{binlogFile} /warnAsError \"{testAsset.TargetAssetPath}\"", _acceptanceFixture.NuGetGlobalPackagesFolder.Path, failIfReturnValueIsNotZero: true);
 
                 foreach (string tfmToAssert in tfmsToAssert)
                 {


### PR DESCRIPTION
closes https://github.com/microsoft/testfx/issues/3268

New available syntax 

```bash
dotnet test -- --treenode-filter /*/*/*/TestMethod1 --results-directory "C:\\git\\testfx\\artifacts\\tmp\\Debug\\testsuite\\IDdwQ\\MSBuildTests\\45c8381577bc4a8f8fc63fc9575c3ae9" 
```