### PR TITLE
Feat: allow cooperative timeout

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestAssemblyInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestAssemblyInfo.cs
@@ -58,12 +58,12 @@ public class TestAssemblyInfo
     /// <summary>
     /// Gets or sets the AssemblyInitializeMethod timeout.
     /// </summary>
-    internal int? AssemblyInitializeMethodTimeoutMilliseconds { get; set; }
+    internal TimeoutInfo? AssemblyInitializeMethodTimeoutMilliseconds { get; set; }
 
     /// <summary>
     /// Gets or sets the AssemblyCleanupMethod timeout.
     /// </summary>
-    internal int? AssemblyCleanupMethodTimeoutMilliseconds { get; set; }
+    internal TimeoutInfo? AssemblyCleanupMethodTimeoutMilliseconds { get; set; }
 
     /// <summary>
     /// Gets <c>AssemblyCleanup</c> method for the assembly.

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestClassInfo.cs
@@ -50,12 +50,12 @@ public class TestClassInfo
         TestContextProperty = testContextProperty;
         BaseClassCleanupMethodsStack = new Stack<MethodInfo>();
         BaseClassInitAndCleanupMethods = new Queue<Tuple<MethodInfo?, MethodInfo?>>();
-        ClassInitializeMethodTimeoutMilliseconds = new Dictionary<MethodInfo, int>();
-        ClassCleanupMethodTimeoutMilliseconds = new Dictionary<MethodInfo, int>();
+        ClassInitializeMethodTimeoutMilliseconds = new Dictionary<MethodInfo, TimeoutInfo>();
+        ClassCleanupMethodTimeoutMilliseconds = new Dictionary<MethodInfo, TimeoutInfo>();
         BaseTestInitializeMethodsQueue = new Queue<MethodInfo>();
         BaseTestCleanupMethodsQueue = new Queue<MethodInfo>();
-        TestInitializeMethodTimeoutMilliseconds = new Dictionary<MethodInfo, int>();
-        TestCleanupMethodTimeoutMilliseconds = new Dictionary<MethodInfo, int>();
+        TestInitializeMethodTimeoutMilliseconds = new Dictionary<MethodInfo, TimeoutInfo>();
+        TestCleanupMethodTimeoutMilliseconds = new Dictionary<MethodInfo, TimeoutInfo>();
         Parent = parent;
         ClassAttribute = classAttribute;
         _testClassExecuteSyncObject = new object();
@@ -111,25 +111,25 @@ public class TestClassInfo
     /// Gets the timeout for the class initialize methods.
     /// We can use a dictionary because the MethodInfo is unique in an inheritance hierarchy.
     /// </summary>
-    internal Dictionary<MethodInfo, int> ClassInitializeMethodTimeoutMilliseconds { get; }
+    internal Dictionary<MethodInfo, TimeoutInfo> ClassInitializeMethodTimeoutMilliseconds { get; }
 
     /// <summary>
     /// Gets the timeout for the class cleanup methods.
     /// We can use a dictionary because the MethodInfo is unique in an inheritance hierarchy.
     /// </summary>
-    internal Dictionary<MethodInfo, int> ClassCleanupMethodTimeoutMilliseconds { get; }
+    internal Dictionary<MethodInfo, TimeoutInfo> ClassCleanupMethodTimeoutMilliseconds { get; }
 
     /// <summary>
     /// Gets the timeout for the test initialize methods.
     /// We can use a dictionary because the MethodInfo is unique in an inheritance hierarchy.
     /// </summary>
-    internal Dictionary<MethodInfo, int> TestInitializeMethodTimeoutMilliseconds { get; }
+    internal Dictionary<MethodInfo, TimeoutInfo> TestInitializeMethodTimeoutMilliseconds { get; }
 
     /// <summary>
     /// Gets the timeout for the test cleanup methods.
     /// We can use a dictionary because the MethodInfo is unique in an inheritance hierarchy.
     /// </summary>
-    internal Dictionary<MethodInfo, int> TestCleanupMethodTimeoutMilliseconds { get; }
+    internal Dictionary<MethodInfo, TimeoutInfo> TestCleanupMethodTimeoutMilliseconds { get; }
 
     /// <summary>
     /// Gets a value indicating whether class initialize has executed.
@@ -448,8 +448,8 @@ public class TestClassInfo
 
     private TestFailedException? InvokeInitializeMethod(MethodInfo methodInfo, TestContext testContext)
     {
-        int? timeout = null;
-        if (ClassInitializeMethodTimeoutMilliseconds.TryGetValue(methodInfo, out int localTimeout))
+        TimeoutInfo? timeout = null;
+        if (ClassInitializeMethodTimeoutMilliseconds.TryGetValue(methodInfo, out TimeoutInfo localTimeout))
         {
             timeout = localTimeout;
         }
@@ -732,8 +732,8 @@ public class TestClassInfo
 
     private TestFailedException? InvokeCleanupMethod(MethodInfo methodInfo, int remainingCleanupCount)
     {
-        int? timeout = null;
-        if (ClassCleanupMethodTimeoutMilliseconds.TryGetValue(methodInfo, out int localTimeout))
+        TimeoutInfo? timeout = null;
+        if (ClassCleanupMethodTimeoutMilliseconds.TryGetValue(methodInfo, out TimeoutInfo localTimeout))
         {
             timeout = localTimeout;
         }

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -644,8 +644,8 @@ public class TestMethodInfo : ITestMethod
 
     private TestFailedException? InvokeInitializeMethod(MethodInfo methodInfo, object classInstance)
     {
-        int? timeout = null;
-        if (Parent.TestInitializeMethodTimeoutMilliseconds.TryGetValue(methodInfo, out int localTimeout))
+        TimeoutInfo? timeout = null;
+        if (Parent.TestInitializeMethodTimeoutMilliseconds.TryGetValue(methodInfo, out TimeoutInfo localTimeout))
         {
             timeout = localTimeout;
         }
@@ -662,8 +662,8 @@ public class TestMethodInfo : ITestMethod
 
     private TestFailedException? InvokeCleanupMethod(MethodInfo methodInfo, object classInstance, int remainingCleanupCount)
     {
-        int? timeout = null;
-        if (Parent.TestCleanupMethodTimeoutMilliseconds.TryGetValue(methodInfo, out int localTimeout))
+        TimeoutInfo? timeout = null;
+        if (Parent.TestCleanupMethodTimeoutMilliseconds.TryGetValue(methodInfo, out TimeoutInfo localTimeout))
         {
             timeout = localTimeout;
         }

--- a/src/Adapter/MSTest.TestAdapter/Execution/TimeoutInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TimeoutInfo.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+
+internal readonly struct TimeoutInfo
+{
+    public TimeoutInfo(TimeoutAttribute timeoutAttribute)
+    {
+        Timeout = timeoutAttribute.Timeout;
+        CooperativeCancellation = timeoutAttribute.IsCooperativeCancellationSet
+            ? timeoutAttribute.CooperativeCancellation
+            : MSTestSettings.CurrentSettings.CooperativeCancellationTimeout;
+    }
+
+    public TimeoutInfo(FixtureKind fixtureKind)
+    {
+        Timeout = fixtureKind switch
+        {
+            FixtureKind.AssemblyInitialize => MSTestSettings.CurrentSettings.AssemblyInitializeTimeout,
+            FixtureKind.AssemblyCleanup => MSTestSettings.CurrentSettings.AssemblyCleanupTimeout,
+            FixtureKind.ClassInitialize => MSTestSettings.CurrentSettings.ClassInitializeTimeout,
+            FixtureKind.ClassCleanup => MSTestSettings.CurrentSettings.ClassCleanupTimeout,
+            FixtureKind.TestInitialize => MSTestSettings.CurrentSettings.TestInitializeTimeout,
+            FixtureKind.TestCleanup => MSTestSettings.CurrentSettings.TestCleanupTimeout,
+            _ => throw new NotSupportedException("Unsupported fixture kind " + fixtureKind),
+        };
+        CooperativeCancellation = MSTestSettings.CurrentSettings.CooperativeCancellationTimeout;
+    }
+
+    public int Timeout { get; }
+
+    public bool CooperativeCancellation { get; }
+}

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -434,11 +434,11 @@ internal class TypeCache : MarshalByRefObject
                             throw new TypeInspectionException(message);
                         }
 
-                        assemblyInfo.AssemblyInitializeMethodTimeoutMilliseconds = timeoutAttribute.Timeout;
+                        assemblyInfo.AssemblyInitializeMethodTimeoutMilliseconds = new(timeoutAttribute);
                     }
                     else if (MSTestSettings.CurrentSettings.AssemblyInitializeTimeout > 0)
                     {
-                        assemblyInfo.AssemblyInitializeMethodTimeoutMilliseconds = MSTestSettings.CurrentSettings.AssemblyInitializeTimeout;
+                        assemblyInfo.AssemblyInitializeMethodTimeoutMilliseconds = new(FixtureKind.AssemblyInitialize);
                     }
                 }
                 else if (IsAssemblyOrClassCleanupMethod<AssemblyCleanupAttribute>(methodInfo))
@@ -453,11 +453,11 @@ internal class TypeCache : MarshalByRefObject
                             throw new TypeInspectionException(message);
                         }
 
-                        assemblyInfo.AssemblyCleanupMethodTimeoutMilliseconds = timeoutAttribute.Timeout;
+                        assemblyInfo.AssemblyCleanupMethodTimeoutMilliseconds = new(timeoutAttribute);
                     }
                     else if (MSTestSettings.CurrentSettings.AssemblyCleanupTimeout > 0)
                     {
-                        assemblyInfo.AssemblyCleanupMethodTimeoutMilliseconds = MSTestSettings.CurrentSettings.AssemblyCleanupTimeout;
+                        assemblyInfo.AssemblyCleanupMethodTimeoutMilliseconds = new(FixtureKind.AssemblyCleanup);
                     }
                 }
             }
@@ -573,11 +573,11 @@ internal class TypeCache : MarshalByRefObject
                     throw new TypeInspectionException(message);
                 }
 
-                classInfo.ClassInitializeMethodTimeoutMilliseconds.Add(methodInfo, timeoutAttribute.Timeout);
+                classInfo.ClassInitializeMethodTimeoutMilliseconds.Add(methodInfo, new(timeoutAttribute));
             }
             else if (MSTestSettings.CurrentSettings.ClassInitializeTimeout > 0)
             {
-                classInfo.ClassInitializeMethodTimeoutMilliseconds.Add(methodInfo, MSTestSettings.CurrentSettings.ClassInitializeTimeout);
+                classInfo.ClassInitializeMethodTimeoutMilliseconds.Add(methodInfo, new(FixtureKind.ClassInitialize));
             }
 
             if (isBase)
@@ -606,11 +606,11 @@ internal class TypeCache : MarshalByRefObject
                     throw new TypeInspectionException(message);
                 }
 
-                classInfo.ClassCleanupMethodTimeoutMilliseconds.Add(methodInfo, timeoutAttribute.Timeout);
+                classInfo.ClassCleanupMethodTimeoutMilliseconds.Add(methodInfo, new(timeoutAttribute));
             }
             else if (MSTestSettings.CurrentSettings.ClassCleanupTimeout > 0)
             {
-                classInfo.ClassCleanupMethodTimeoutMilliseconds.Add(methodInfo, MSTestSettings.CurrentSettings.ClassCleanupTimeout);
+                classInfo.ClassCleanupMethodTimeoutMilliseconds.Add(methodInfo, new(FixtureKind.ClassCleanup));
             }
 
             if (isBase)
@@ -672,11 +672,11 @@ internal class TypeCache : MarshalByRefObject
                     throw new TypeInspectionException(message);
                 }
 
-                classInfo.TestInitializeMethodTimeoutMilliseconds.Add(methodInfo, timeoutAttribute.Timeout);
+                classInfo.TestInitializeMethodTimeoutMilliseconds.Add(methodInfo, new(timeoutAttribute));
             }
             else if (MSTestSettings.CurrentSettings.TestInitializeTimeout > 0)
             {
-                classInfo.TestInitializeMethodTimeoutMilliseconds.Add(methodInfo, MSTestSettings.CurrentSettings.TestInitializeTimeout);
+                classInfo.TestInitializeMethodTimeoutMilliseconds.Add(methodInfo, new(FixtureKind.TestInitialize));
             }
 
             if (!isBase)
@@ -703,11 +703,11 @@ internal class TypeCache : MarshalByRefObject
                     throw new TypeInspectionException(message);
                 }
 
-                classInfo.TestCleanupMethodTimeoutMilliseconds.Add(methodInfo, timeoutAttribute.Timeout);
+                classInfo.TestCleanupMethodTimeoutMilliseconds.Add(methodInfo, new(timeoutAttribute));
             }
             else if (MSTestSettings.CurrentSettings.TestCleanupTimeout > 0)
             {
-                classInfo.TestCleanupMethodTimeoutMilliseconds.Add(methodInfo, MSTestSettings.CurrentSettings.TestCleanupTimeout);
+                classInfo.TestCleanupMethodTimeoutMilliseconds.Add(methodInfo, new(FixtureKind.TestCleanup));
             }
 
             if (!isBase)

--- a/src/Adapter/MSTest.TestAdapter/Helpers/FixtureKind.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/FixtureKind.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:Enumeration items should be documented", Justification = "Internal and self-explanatory")]
+internal enum FixtureKind
+{
+    AssemblyInitialize,
+    AssemblyCleanup,
+    ClassInitialize,
+    ClassCleanup,
+    TestInitialize,
+    TestCleanup,
+}

--- a/src/Adapter/MSTest.TestAdapter/Helpers/FixtureMethodRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/FixtureMethodRunner.cs
@@ -62,8 +62,10 @@ internal static class FixtureMethodRunner
                 action();
                 return null;
             }
-            catch (OperationCanceledException) // Ideally we would like to check that the token of the exception matches cancellationTokenSource but TestContext instances are not well defined so we have to handle the exception entirely.
+            catch (OperationCanceledException)
             {
+                // Ideally we would like to check that the token of the exception matches cancellationTokenSource but TestContext
+                // instances are not well defined so we have to handle the exception entirely.
                 return new(
                     UnitTestOutcome.Timeout,
                     timeoutTokenSource.Token.IsCancellationRequested

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -65,6 +65,7 @@ public class MSTestSettings
         TestInitializeTimeout = 0;
         TestCleanupTimeout = 0;
         TreatClassAndAssemblyCleanupWarningsAsErrors = false;
+        CooperativeCancellationTimeout = false;
     }
 
     /// <summary>
@@ -199,6 +200,11 @@ public class MSTestSettings
     internal bool ConsiderFixturesAsSpecialTests { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether all timeouts should be cooperative.
+    /// </summary>
+    internal bool CooperativeCancellationTimeout { get; private set; }
+
+    /// <summary>
     /// Populate settings based on existing settings object.
     /// </summary>
     /// <param name="settings">The existing settings object.</param>
@@ -230,6 +236,7 @@ public class MSTestSettings
         CurrentSettings.TestInitializeTimeout = settings.TestInitializeTimeout;
         CurrentSettings.TestCleanupTimeout = settings.TestCleanupTimeout;
         CurrentSettings.ConsiderFixturesAsSpecialTests = settings.ConsiderFixturesAsSpecialTests;
+        CurrentSettings.CooperativeCancellationTimeout = settings.CooperativeCancellationTimeout;
     }
 
     /// <summary>
@@ -566,6 +573,16 @@ public class MSTestSettings
                             if (bool.TryParse(reader.ReadInnerXml(), out result))
                             {
                                 settings.ConsiderFixturesAsSpecialTests = result;
+                            }
+
+                            break;
+                        }
+
+                    case "COOPERATIVECANCELLATIONTIMEOUT":
+                        {
+                            if (bool.TryParse(reader.ReadInnerXml(), out result))
+                            {
+                                settings.CooperativeCancellationTimeout = result;
                             }
 
                             break;

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -9,6 +9,8 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class TimeoutAttribute : Attribute
 {
+    private bool _isCooperativeCancellation;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TimeoutAttribute"/> class.
     /// </summary>
@@ -35,4 +37,21 @@ public sealed class TimeoutAttribute : Attribute
     /// Gets the timeout in milliseconds.
     /// </summary>
     public int Timeout { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the method should be cooperatively cancelled on timeout.
+    /// When set to <see langword="true"/>, the method should be designed to cooperatively cancel itself when the timeout is reached.
+    /// Otherwise, when set to <see langword="false"/>, the task method will be unobserved.
+    /// </summary>
+    public bool CooperativeCancellation
+    {
+        get => _isCooperativeCancellation;
+        set
+        {
+            IsCooperativeCancellationSet = true;
+            _isCooperativeCancellation = value;
+        }
+    }
+
+    internal bool IsCooperativeCancellationSet { get; private set; }
 }

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -39,9 +39,13 @@ public sealed class TimeoutAttribute : Attribute
     public int Timeout { get; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the test method should be cooperatively cancelled on timeout. 
-    /// When set to <see langword="true"/>, the cancellation token is cancelled on timeout, and the method completion is awaited. The test method and all the code it calls, must be designed in a way that it observes the cancellation and cancels cooperatively. If the test method does not complete, the timeout does not force it to complete.
-    /// When set to <see langword="false"/>, the cancellation token is cancelled on timeout, timeout result is reported and the method task will continue running on background. This may lead to conflicts in file access on test cleanup, unobserved exceptions, and memory leaks.
+    /// Gets or sets a value indicating whether the test method should be cooperatively cancelled on timeout.
+    /// When set to <see langword="true"/>, the cancellation token is cancelled on timeout, and the method completion is awaited.
+    /// The test method and all the code it calls, must be designed in a way that it observes the cancellation and cancels
+    /// cooperatively. If the test method does not complete, the timeout does not force it to complete.
+    /// When set to <see langword="false"/>, the cancellation token is cancelled on timeout, timeout result is reported and the
+    /// method task will continue running on background. This may lead to conflicts in file access on test cleanup, unobserved
+    /// exceptions, and memory leaks.
     /// </summary>
     public bool CooperativeCancellation
     {

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -39,9 +39,9 @@ public sealed class TimeoutAttribute : Attribute
     public int Timeout { get; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the method should be cooperatively cancelled on timeout.
-    /// When set to <see langword="true"/>, the method should be designed to cooperatively cancel itself when the timeout is reached.
-    /// Otherwise, when set to <see langword="false"/>, the task method will be unobserved.
+    /// Gets or sets a value indicating whether the test method should be cooperatively cancelled on timeout. 
+    /// When set to <see langword="true"/>, the cancellation token is cancelled on timeout, and the method completion is awaited. The test method and all the code it calls, must be designed in a way that it observes the cancellation and cancels cooperatively. If the test method does not complete, the timeout does not force it to complete.
+    /// When set to <see langword="false"/>, the cancellation token is cancelled on timeout, timeout result is reported and the method task will continue running on background. This may lead to conflicts in file access on test cleanup, unobserved exceptions, and memory leaks.
     /// </summary>
     public bool CooperativeCancellation
     {

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -48,6 +48,7 @@ public sealed class TimeoutAttribute : Attribute
         get => _isCooperativeCancellation;
         set
         {
+            // Attributes don't allow nullable boolean, so we need this to know that the value was set explicitly.
             IsCooperativeCancellationSet = true;
             _isCooperativeCancellation = value;
         }

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ Microsoft.VisualStudio.TestTools.UnitTesting.STATestClassAttribute.STATestClassA
 Microsoft.VisualStudio.TestTools.UnitTesting.STATestMethodAttribute
 Microsoft.VisualStudio.TestTools.UnitTesting.STATestMethodAttribute.STATestMethodAttribute() -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.STATestMethodAttribute.STATestMethodAttribute(string? displayName) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.TimeoutAttribute.CooperativeCancellation.get -> bool
+Microsoft.VisualStudio.TestTools.UnitTesting.TimeoutAttribute.CooperativeCancellation.set -> void

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InitializeAndCleanupTimeoutTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InitializeAndCleanupTimeoutTests.cs
@@ -167,6 +167,190 @@ public class InitializeAndCleanupTimeout : AcceptanceTestBase
     public async Task TestCleanup_WhenTimeoutExpires_TestCleanupIsCancelled_AttributeTakesPrecedence(string tfm)
        => await RunAndAssertWithRunSettingsAsync(tfm, 25000, true, "testCleanup");
 
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenAssemblyInitTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_ASSEMBLYINIT"] = "1" });
+
+        testHostResult.AssertOutputContains("AssemblyInit started");
+        testHostResult.AssertOutputContains("Assembly initialize method 'TestClass.AssemblyInit' timed out");
+        testHostResult.AssertOutputDoesNotContain("AssemblyInit Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("AssemblyInit completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenAssemblyCleanupTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_ASSEMBLYCLEANUP"] = "1" });
+
+        testHostResult.AssertOutputContains("AssemblyCleanup started");
+        testHostResult.AssertOutputContains("Assembly cleanup method 'TestClass.AssemblyCleanup' was cancelled");
+        testHostResult.AssertOutputDoesNotContain("AssemblyCleanup Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("AssemblyCleanup completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenClassInitTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_CLASSINIT"] = "1" });
+
+        testHostResult.AssertOutputContains("ClassInit started");
+        testHostResult.AssertOutputContains("Class initialize method 'TestClass.ClassInit' was cancelled");
+        testHostResult.AssertOutputDoesNotContain("ClassInit Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("ClassInit completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenClassCleanupTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_CLASSCLEANUP"] = "1" });
+
+        testHostResult.AssertOutputContains("ClassCleanup started");
+        testHostResult.AssertOutputContains("Class cleanup method 'TestClass.ClassCleanup' was cancelled");
+        testHostResult.AssertOutputDoesNotContain("ClassCleanup Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("ClassCleanup completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenTestInitTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_TESTINIT"] = "1" });
+
+        testHostResult.AssertOutputDoesNotContain("TestInit started");
+        testHostResult.AssertOutputContains("Test 'TestMethod' execution has been aborted");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenTestCleanupTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_TESTCLEANUP"] = "1" });
+
+        testHostResult.AssertOutputDoesNotContain("TestInit started");
+        testHostResult.AssertOutputContains("Test 'TestMethod' execution has been aborted");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenTestMethodTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_TESTMETHOD"] = "1" });
+
+        testHostResult.AssertOutputDoesNotContain("TestMethod started");
+        testHostResult.AssertOutputContains("Test 'TestMethod' execution has been aborted");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenAssemblyInitTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_ASSEMBLYINIT"] = "1" });
+
+        testHostResult.AssertOutputContains("AssemblyInit started");
+        testHostResult.AssertOutputContains("Assembly initialize method 'TestClass.AssemblyInit' timed out");
+        testHostResult.AssertOutputContains("AssemblyInit Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("AssemblyInit completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenAssemblyCleanupTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_ASSEMBLYCLEANUP"] = "1" });
+
+        testHostResult.AssertOutputContains("AssemblyCleanup started");
+        testHostResult.AssertOutputContains("Assembly cleanup method 'TestClass.AssemblyCleanup' timed out");
+        testHostResult.AssertOutputContains("AssemblyCleanup Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("AssemblyCleanup completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenClassInitTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_CLASSINIT"] = "1" });
+
+        testHostResult.AssertOutputContains("ClassInit started");
+        testHostResult.AssertOutputContains("Class initialize method 'TestClass.ClassInit' timed out");
+        testHostResult.AssertOutputContains("ClassInit Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("ClassInit completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenClassCleanupTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_CLASSCLEANUP"] = "1" });
+
+        testHostResult.AssertOutputContains("ClassCleanup started");
+        testHostResult.AssertOutputContains("Class cleanup method 'TestClass.ClassCleanup' timed out ");
+        testHostResult.AssertOutputContains("ClassCleanup Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("ClassCleanup completed");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenTestInitTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_TESTINIT"] = "1" });
+
+        testHostResult.AssertOutputDoesNotContain("TestInit started");
+        testHostResult.AssertOutputContains("Test 'TestMethod' execution has been aborted");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenTestCleanupTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_TESTCLEANUP"] = "1" });
+
+        testHostResult.AssertOutputDoesNotContain("TestCleanup started");
+        testHostResult.AssertOutputContains("Test 'TestMethod' execution has been aborted");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenTestMethodTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(_testAssetFixture.CooperativeTimeoutAssetPath, TestAssetFixture.CooperativeTimeout, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_TESTMETHOD"] = "1" });
+
+        testHostResult.AssertOutputDoesNotContain("TestMethod started");
+        testHostResult.AssertOutputContains("Test 'TestMethod' execution has been aborted");
+    }
+
     private async Task RunAndAssertTestWasCancelledAsync(string rootFolder, string assetName, string tfm, string envVarPrefix, string entryKind)
     {
         var testHost = TestHost.LocateFrom(rootFolder, assetName, tfm);
@@ -222,39 +406,115 @@ public class InitializeAndCleanupTimeout : AcceptanceTestBase
         public const string CodeWithOneSecTimeout = nameof(CodeWithOneSecTimeout);
         public const string CodeWithSixtySecTimeout = nameof(CodeWithSixtySecTimeout);
         public const string CodeWithNoTimeout = nameof(CodeWithNoTimeout);
+        public const string CooperativeTimeout = nameof(CooperativeTimeout);
 
-        public string CodeWithOneSecTimeoutAssetPath => GetAssetPath(CodeWithOneSecTimeout);
+        private const string CooperativeTimeoutSourceCode = """
+#file $ProjectName$.csproj
+<Project Sdk="Microsoft.NET.Sdk">
 
-        public string CodeWithSixtySecTimeoutAssetPath => GetAssetPath(CodeWithSixtySecTimeout);
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
 
-        public string CodeWithNoTimeoutAssetPath => GetAssetPath(CodeWithNoTimeout);
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
 
-        public override IEnumerable<(string ID, string Name, string Code)> GetAssetsToGenerate()
+  <ItemGroup>
+    <None Update="*.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>
+
+#file my.runsettings
+<RunSettings>
+  <MSTest>
+    <CaptureTraceOutput>false</CaptureTraceOutput>
+  </MSTest>
+</RunSettings>
+
+#file UnitTest1.cs
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class TestClass
+{
+    private static TestContext _assemblyTestContext;
+    private static TestContext _classTestContext;
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [AssemblyInitialize]
+    public static async Task AssemblyInit(TestContext testContext)
+    {
+        _assemblyTestContext = testContext;
+        await DoWork("ASSEMBLYINIT", "AssemblyInit", testContext);
+    }
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [AssemblyCleanup]
+    public static async Task AssemblyCleanup()
+        => await DoWork("ASSEMBLYCLEANUP", "AssemblyCleanup", _assemblyTestContext);
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext testContext)
+    {
+        _classTestContext = testContext;
+        await DoWork("CLASSINIT", "ClassInit", testContext);
+    }
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
+    public static async Task ClassCleanup()
+        => await DoWork("CLASSCLEANUP", "ClassCleanup", _classTestContext);
+
+    public TestContext TestContext { get; set; }
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [TestInitialize]
+    public async Task TestInit()
+        => await DoWork("TESTINIT", "TestInit", TestContext);
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [TestCleanup]
+    public async Task TestCleanup()
+        => await DoWork("TESTCLEANUP", "TestCleanup", TestContext);
+
+    [Timeout(100, CooperativeCancellation = true)]
+    [TestMethod]
+    public async Task TestMethod()
+        => await DoWork("TESTMETHOD", "TestMethod", TestContext);
+
+    private static async Task DoWork(string envVarSuffix, string stepName, TestContext testContext)
+    {
+        Console.WriteLine($"{stepName} started");
+
+        if (Environment.GetEnvironmentVariable($"TASKDELAY_{envVarSuffix}") == "1")
         {
-            yield return (CodeWithNoTimeout, CodeWithNoTimeout,
-                SourceCode
-                .PatchCodeWithReplace("$TimeoutAttribute$", string.Empty)
-                .PatchCodeWithReplace("$ProjectName$", CodeWithNoTimeout)
-                .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
-                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
-
-            yield return (CodeWithOneSecTimeout, CodeWithOneSecTimeout,
-                SourceCode
-                .PatchCodeWithReplace("$TimeoutAttribute$", "[Timeout(1000)]")
-                .PatchCodeWithReplace("$ProjectName$", CodeWithOneSecTimeout)
-                .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
-                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
-
-            yield return (CodeWithSixtySecTimeout, CodeWithSixtySecTimeout,
-                SourceCode
-                .PatchCodeWithReplace("$TimeoutAttribute$", "[Timeout(60000)]")
-                .PatchCodeWithReplace("$ProjectName$", CodeWithSixtySecTimeout)
-                .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
-                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+            await Task.Delay(10_000, testContext.CancellationTokenSource.Token);
         }
+        else
+        {
+            System.Threading.Thread.Sleep(200);
+            Console.WriteLine($"{stepName} Thread.Sleep completed");
+            if (Environment.GetEnvironmentVariable($"CHECKTOKEN_{envVarSuffix}") == "1")
+            {
+                testContext.CancellationTokenSource.Token.ThrowIfCancellationRequested();
+            }
+
+        }
+
+        Console.WriteLine($"{stepName} completed");
+    }
+}
+""";
 
         private const string SourceCode = """
 #file $ProjectName$.csproj
@@ -429,5 +689,43 @@ public class TestClass : TestClassBase
     public Task Test1() => Task.CompletedTask;
 }
 """;
+
+        public string CodeWithOneSecTimeoutAssetPath => GetAssetPath(CodeWithOneSecTimeout);
+
+        public string CodeWithSixtySecTimeoutAssetPath => GetAssetPath(CodeWithSixtySecTimeout);
+
+        public string CodeWithNoTimeoutAssetPath => GetAssetPath(CodeWithNoTimeout);
+
+        public string CooperativeTimeoutAssetPath => GetAssetPath(CooperativeTimeout);
+
+        public override IEnumerable<(string ID, string Name, string Code)> GetAssetsToGenerate()
+        {
+            yield return (CodeWithNoTimeout, CodeWithNoTimeout,
+                SourceCode
+                .PatchCodeWithReplace("$TimeoutAttribute$", string.Empty)
+                .PatchCodeWithReplace("$ProjectName$", CodeWithNoTimeout)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+            yield return (CodeWithOneSecTimeout, CodeWithOneSecTimeout,
+                SourceCode
+                .PatchCodeWithReplace("$TimeoutAttribute$", "[Timeout(1000)]")
+                .PatchCodeWithReplace("$ProjectName$", CodeWithOneSecTimeout)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+            yield return (CodeWithSixtySecTimeout, CodeWithSixtySecTimeout,
+                SourceCode
+                .PatchCodeWithReplace("$TimeoutAttribute$", "[Timeout(60000)]")
+                .PatchCodeWithReplace("$ProjectName$", CodeWithSixtySecTimeout)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+            yield return (CooperativeTimeout, CooperativeTimeout,
+                CooperativeTimeoutSourceCode
+                .PatchCodeWithReplace("$ProjectName$", CooperativeTimeout)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+        }
     }
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Properties/launchSettings.json
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "MSTest.Acceptance.IntegrationTests": {
       "commandName": "Project",
-      "commandLineArgs": "--treenode-filter /*/*/InitializeAndCleanupTimeout/CooperativeCancellation*/**"
+      "commandLineArgs": "--treenode-filter /*/*/*/**"
     }
   }
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Properties/launchSettings.json
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "MSTest.Acceptance.IntegrationTests": {
       "commandName": "Project",
-      "commandLineArgs": "--treenode-filter /*/*/*/**"
+      "commandLineArgs": "--treenode-filter /*/*/InitializeAndCleanupTimeout/CooperativeCancellation*/**"
     }
   }
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/STATestClassTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/STATestClassTests.cs
@@ -13,6 +13,8 @@ public sealed class STATestClassTests : AcceptanceTestBase
 {
     private readonly TestAssetFixture _testAssetFixture;
     private const string AssetName = "STATestClass";
+    private const string TimeoutAssetName = "TimeoutSTATestClass";
+    private const string CooperativeTimeoutAssetName = "CooperativeTimeoutSTATestClass";
 
     // There's a bug in TAFX where we need to use it at least one time somewhere to use it inside the fixture self (AcceptanceFixture).
     public STATestClassTests(ITestExecutionContext testExecutionContext, TestAssetFixture testAssetFixture,
@@ -73,6 +75,106 @@ public sealed class STATestClassTests : AcceptanceTestBase
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task STATestClass_OnWindows_OnLifeCycleTestClass_WithTimeout_FixturesAndMethodsAreOnExpectedApartmentState(string currentTfm)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var testHost = TestHost.LocateFrom(_testAssetFixture.TargetTimeoutAssetPath, TimeoutAssetName, currentTfm);
+        string runSettingsFilePath = Path.Combine(testHost.DirectoryName, "mta.runsettings");
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath} --filter className=LifeCycleTestClass");
+
+        testHostResult.AssertExitCodeIs(0);
+        testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.ClassInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.Constructor");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.TestInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.TestMethod1");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.TestCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.Dispose");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.ClassCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyCleanup");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task STATestClass_OnWindows_OnLifeCycleTestClassWithLastTestSkipped_WithTimeout_FixturesAndMethodsAreOnExpectedApartmentState(string currentTfm)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var testHost = TestHost.LocateFrom(_testAssetFixture.TargetTimeoutAssetPath, TimeoutAssetName, currentTfm);
+        string runSettingsFilePath = Path.Combine(testHost.DirectoryName, "mta.runsettings");
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath} --filter className=LifeCycleTestClassWithLastTestSkipped");
+
+        testHostResult.AssertExitCodeIs(0);
+        testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 1, Total: 2");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.ClassInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.Constructor");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.TestInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.TestMethod1");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.TestCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.Dispose");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.ClassCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyCleanup");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task STATestClass_OnWindows_OnLifeCycleTestClass_WithCooperativeTimeout_FixturesAndMethodsAreOnExpectedApartmentState(string currentTfm)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var testHost = TestHost.LocateFrom(_testAssetFixture.TargetCooperativeTimeoutAssetPath, CooperativeTimeoutAssetName, currentTfm);
+        string runSettingsFilePath = Path.Combine(testHost.DirectoryName, "mta.runsettings");
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath} --filter className=LifeCycleTestClass");
+
+        testHostResult.AssertExitCodeIs(0);
+        testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.ClassInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.Constructor");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.TestInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.TestMethod1");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.TestCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.Dispose");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.ClassCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyCleanup");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
+    public async Task STATestClass_OnWindows_OnLifeCycleTestClassWithLastTestSkipped_WithCooperativeTimeout_FixturesAndMethodsAreOnExpectedApartmentState(string currentTfm)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var testHost = TestHost.LocateFrom(_testAssetFixture.TargetCooperativeTimeoutAssetPath, CooperativeTimeoutAssetName, currentTfm);
+        string runSettingsFilePath = Path.Combine(testHost.DirectoryName, "mta.runsettings");
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath} --filter className=LifeCycleTestClassWithLastTestSkipped");
+
+        testHostResult.AssertExitCodeIs(0);
+        testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 1, Total: 2");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.ClassInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.Constructor");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.TestInitialize");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.TestMethod1");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.TestCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.Dispose");
+        testHostResult.AssertOutputContains("LifeCycleTestClassWithLastTestSkipped.ClassCleanup");
+        testHostResult.AssertOutputContains("LifeCycleTestClass.AssemblyCleanup");
+    }
+
+    [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
     public async Task DerivedSTATestClass_OnWindows_OnTestClassWithClassCleanupEndOfAssembly_ClassCleanupIsMTA(string currentTfm)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -102,12 +204,31 @@ public sealed class STATestClassTests : AcceptanceTestBase
     {
         public string TargetAssetPath => GetAssetPath(AssetName);
 
+        public string TargetTimeoutAssetPath => GetAssetPath(TimeoutAssetName);
+
+        public string TargetCooperativeTimeoutAssetPath => GetAssetPath(CooperativeTimeoutAssetName);
+
         public override IEnumerable<(string ID, string Name, string Code)> GetAssetsToGenerate()
         {
             yield return (AssetName, AssetName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$ProjectName$", AssetName)
+                .PatchCodeWithReplace("$TimeoutAttribute$", string.Empty)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+            yield return (TimeoutAssetName, TimeoutAssetName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$ProjectName$", TimeoutAssetName)
+                .PatchCodeWithReplace("$TimeoutAttribute$", ", Timeout(5000)")
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+            yield return (CooperativeTimeoutAssetName, CooperativeTimeoutAssetName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$ProjectName$", CooperativeTimeoutAssetName)
+                .PatchCodeWithReplace("$TimeoutAttribute$", ", Timeout(5000, CooperativeCancellation = true)")
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 
@@ -123,7 +244,7 @@ public sealed class STATestClassTests : AcceptanceTestBase
     </MSTest>
 </RunSettings>
 
-#file STATestClass.csproj
+#file $ProjectName$.csproj
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -155,14 +276,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [STATestClass]
 public class LifeCycleTestClass : IDisposable
 {
-    [AssemblyInitialize]
+    [AssemblyInitialize$TimeoutAttribute$]
     public static void AssemblyInitialize(TestContext context)
     {
         Console.WriteLine("LifeCycleTestClass.AssemblyInitialize");
         ThreadAssert.AssertApartmentStateIsMTA();
     }
 
-    [AssemblyCleanup]
+    [AssemblyCleanup$TimeoutAttribute$]
     public static void AssemblyCleanup()
     {
         Console.WriteLine("LifeCycleTestClass.AssemblyCleanup");
@@ -175,35 +296,35 @@ public class LifeCycleTestClass : IDisposable
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [ClassInitialize]
+    [ClassInitialize$TimeoutAttribute$]
     public static void ClassInitialize(TestContext context)
     {
         Console.WriteLine("LifeCycleTestClass.ClassInitialize");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)$TimeoutAttribute$]
     public static void ClassCleanup()
     {
         Console.WriteLine("LifeCycleTestClass.ClassCleanup");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestInitialize]
+    [TestInitialize$TimeoutAttribute$]
     public void TestInitialize()
     {
         Console.WriteLine("LifeCycleTestClass.TestInitialize");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestCleanup]
+    [TestCleanup$TimeoutAttribute$]
     public void TestCleanup()
     {
         Console.WriteLine("LifeCycleTestClass.TestCleanup");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestMethod]
+    [TestMethod$TimeoutAttribute$]
     public void TestMethod1()
     {
         Console.WriteLine("LifeCycleTestClass.TestMethod1");
@@ -226,35 +347,35 @@ public class LifeCycleTestClassWithLastTestSkipped : IDisposable
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [ClassInitialize]
+    [ClassInitialize$TimeoutAttribute$]
     public static void ClassInitialize(TestContext context)
     {
         Console.WriteLine("LifeCycleTestClassWithLastTestSkipped.ClassInitialize");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)$TimeoutAttribute$]
     public static void ClassCleanup()
     {
         Console.WriteLine("LifeCycleTestClassWithLastTestSkipped.ClassCleanup");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestInitialize]
+    [TestInitialize$TimeoutAttribute$]
     public void TestInitialize()
     {
         Console.WriteLine("LifeCycleTestClassWithLastTestSkipped.TestInitialize");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestCleanup]
+    [TestCleanup$TimeoutAttribute$]
     public void TestCleanup()
     {
         Console.WriteLine("LifeCycleTestClassWithLastTestSkipped.TestCleanup");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestMethod]
+    [TestMethod$TimeoutAttribute$]
     public void TestMethod1()
     {
         Console.WriteLine("LifeCycleTestClassWithLastTestSkipped.TestMethod1");
@@ -288,35 +409,35 @@ public class TestClassWithClassCleanupEndOfAssembly : IDisposable
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [ClassInitialize]
+    [ClassInitialize$TimeoutAttribute$]
     public static void ClassInitialize(TestContext context)
     {
         Console.WriteLine("TestClassWithClassCleanupEndOfAssembly.ClassInitialize");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [ClassCleanup(ClassCleanupBehavior.EndOfAssembly)]
+    [ClassCleanup(ClassCleanupBehavior.EndOfAssembly)$TimeoutAttribute$]
     public static void ClassCleanup()
     {
         Console.WriteLine("TestClassWithClassCleanupEndOfAssembly.ClassCleanup");
         ThreadAssert.AssertApartmentStateIsMTA();
     }
 
-    [TestInitialize]
+    [TestInitialize$TimeoutAttribute$]
     public void TestInitialize()
     {
         Console.WriteLine("TestClassWithClassCleanupEndOfAssembly.TestInitialize");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestCleanup]
+    [TestCleanup$TimeoutAttribute$]
     public void TestCleanup()
     {
         Console.WriteLine("TestClassWithClassCleanupEndOfAssembly.TestCleanup");
         ThreadAssert.AssertApartmentStateIsSTA();
     }
 
-    [TestMethod]
+    [TestMethod$TimeoutAttribute$]
     public void TestMethod1()
     {
         Console.WriteLine("TestClassWithClassCleanupEndOfAssembly.TestMethod1");


### PR DESCRIPTION
The current implementation of the timeout will create a "thread" that will observe the execution of the step (fixture or test method) for a given time (timeout value) and will stop observing after that. This means that we are producing dangling tasks where code continues to execute and possibly mutate state when we move to the next step which can have many unwanted consequences.

With this PR, we introduce a virtuous mode that ressemble what user has to do when implementing cooperative cancellation in their production code. 

/!\ It's important to note that when opting-in to this mode, if the method (fixture or test) is ignoring the token then the method will continue.

Fixes #2432