### PR TITLE
Chore: remove unused patching in MSTest acceptance tests

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyResolverTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyResolverTests.cs
@@ -46,7 +46,6 @@ public class AssemblyResolverTests : AcceptanceTestBase
             yield return (AssetName, AssetName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.NetFramework)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InitializeAndCleanupTimeoutTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InitializeAndCleanupTimeoutTests.cs
@@ -236,7 +236,6 @@ public class InitializeAndCleanupTimeout : AcceptanceTestBase
                 .PatchCodeWithReplace("$TimeoutAttribute$", string.Empty)
                 .PatchCodeWithReplace("$ProjectName$", CodeWithNoTimeout)
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (CodeWithOneSecTimeout, CodeWithOneSecTimeout,
@@ -244,7 +243,6 @@ public class InitializeAndCleanupTimeout : AcceptanceTestBase
                 .PatchCodeWithReplace("$TimeoutAttribute$", "[Timeout(1000)]")
                 .PatchCodeWithReplace("$ProjectName$", CodeWithOneSecTimeout)
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (CodeWithSixtySecTimeout, CodeWithSixtySecTimeout,
@@ -252,7 +250,6 @@ public class InitializeAndCleanupTimeout : AcceptanceTestBase
                 .PatchCodeWithReplace("$TimeoutAttribute$", "[Timeout(60000)]")
                 .PatchCodeWithReplace("$ProjectName$", CodeWithSixtySecTimeout)
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedTestTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedTestTests.cs
@@ -94,12 +94,10 @@ public class ParameterizedTestTests : AcceptanceTestBase
             yield return (DynamicDataAssetName, DynamicDataAssetName,
                 SourceCodeDynamicData
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
             yield return (DataSourceAssetName, DataSourceAssetName,
                 SourceCodeDataSource
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/STATestClassTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/STATestClassTests.cs
@@ -107,7 +107,6 @@ public sealed class STATestClassTests : AcceptanceTestBase
             yield return (AssetName, AssetName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/STATestMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/STATestMethodTests.cs
@@ -110,7 +110,6 @@ public sealed class STATestMethodTests : AcceptanceTestBase
             yield return (AssetName, AssetName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestDiscoveryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestDiscoveryTests.cs
@@ -55,7 +55,6 @@ public class TestDiscoveryTests : AcceptanceTestBase
             yield return (AssetName, AssetName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestFilterTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestFilterTests.cs
@@ -97,7 +97,6 @@ UTA023: TestClass: Cannot define predefined property Owner on method OwnerTest.
             yield return (AssetName, AssetName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
@@ -51,7 +51,6 @@ public sealed class TestRunParametersTests : AcceptanceTestBase
             yield return (ProjectName, ProjectName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
@@ -759,19 +759,16 @@ public class DerivedClassIntermediateClassWithoutTestInitCleanupBaseClassWithout
             yield return (InitToTestProjectName, InitToTestProjectName,
                 InitToTestSourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (CultureFlowsProjectName, CultureFlowsProjectName,
                 CultureFlowsSourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (CultureFlowsInheritanceProjectName, CultureFlowsInheritanceProjectName,
                 CultureFlowsInheritanceSourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
@@ -248,7 +248,6 @@ public sealed class ThreadingTests : AcceptanceTestBase
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$ProjectName$", ProjectName)
                 .PatchCodeWithReplace("$GenerateEntryPoint$", "true")
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (STAThreadProjectName, STAThreadProjectName,
@@ -256,33 +255,28 @@ public sealed class ThreadingTests : AcceptanceTestBase
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$ProjectName$", STAThreadProjectName)
                 .PatchCodeWithReplace("$GenerateEntryPoint$", "false")
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (LifecycleAttributesVoidProjectName, LifecycleAttributesVoidProjectName,
                 LifecycleAttributesVoidSource
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (LifecycleAttributesTaskProjectName, LifecycleAttributesTaskProjectName,
                 LifecycleAttributesTaskSource
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$ParallelAttribute$", string.Empty)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (LifecycleWithParallelAttributesTaskProjectName, LifecycleWithParallelAttributesTaskProjectName,
                 LifecycleAttributesTaskSource
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$ParallelAttribute$", "[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]")
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
             yield return (LifecycleAttributesValueTaskProjectName, LifecycleAttributesValueTaskProjectName,
                 LifecycleAttributesValueTaskSource
                 .PatchTargetFrameworks(TargetFrameworks.Net)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ValueTaskTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ValueTaskTests.cs
@@ -39,7 +39,6 @@ public sealed class ValueTaskTests : AcceptanceTestBase
             yield return (ProjectName, ProjectName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
 


### PR DESCRIPTION
These patching are no longer required as we create the platform packages locally now.