### PR TITLE
Chore: Modulename is never null or empty

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -188,14 +188,7 @@ public sealed class TestApplication : ITestApplication
 #endif
         await logger.LogInformationAsync($"IsDynamicCodeSupported: {isDynamicCodeSupported}");
 
-        string? moduleName = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
-        moduleName = RoslynString.IsNullOrEmpty(moduleName)
-#if !NETCOREAPP
-            ? systemProcessHandler.GetCurrentProcess().MainModule.FileName
-#else
-            ? environment.ProcessPath
-#endif
-            : moduleName;
+        string moduleName = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
         await logger.LogInformationAsync($"Test module: {moduleName}");
         await logger.LogInformationAsync($"Command line arguments: '{(args.Length == 0 ? string.Empty : args.Aggregate((a, b) => $"{a} {b}"))}'");
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/ConsoleDisplayService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/ConsoleDisplayService.cs
@@ -227,19 +227,8 @@ internal class ConsoleOutputDevice : IPlatformOutputDevice,
 #endif
             }
 
-            string? moduleName = _testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
-#if !NETCOREAPP
-            moduleName = RoslynString.IsNullOrEmpty(moduleName)
-                ? _process.GetCurrentProcess().MainModule.FileName
-                : moduleName;
-#else
-            moduleName = RoslynString.IsNullOrEmpty(moduleName)
-                ? _environment.ProcessPath
-                : moduleName;
-#endif
-            string moduleOutput = moduleName is not null
-                ? $" for {moduleName}"
-                : string.Empty;
+            string moduleName = _testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
+            string moduleOutput = $" for {moduleName}";
 
             if (!_firstCallTo_OnSessionStartingAsync)
             {


### PR DESCRIPTION
Getting the application path guarantees to never return null. Remove the unnecessary null checks that duplicate the code done in the method.