### PR TITLE
Refactor TestMethod DisplayName

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
@@ -14,8 +14,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using FrameworkITestDataSource = Microsoft.VisualStudio.TestTools.UnitTesting.ITestDataSource;
-
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
 
 /// <summary>
@@ -373,9 +371,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
 
         static UnitTestElement GetFixtureTest(string classFullName, string assemblyLocation, string fixtureType, string methodName, string[] hierarchy)
         {
-            var method = new TestMethod(classFullName, methodName,
-                hierarchy, methodName, classFullName, assemblyLocation, false,
-                TestIdGenerationStrategy.FullyQualified);
+            var method = new TestMethod(classFullName, methodName, hierarchy, methodName, classFullName, assemblyLocation, false, null, TestIdGenerationStrategy.FullyQualified);
             return new UnitTestElement(method)
             {
                 DisplayName = $"[{fixtureType}] {methodName}",
@@ -392,7 +388,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
         // We don't have a special method to filter attributes that are not derived from Attribute, so we take all
         // attributes and filter them. We don't have to care if there is one, because this method is only entered when
         // there is at least one (we determine this in TypeEnumerator.GetTestFromMethod.
-        IEnumerable<FrameworkITestDataSource>? testDataSources = ReflectHelper.Instance.GetDerivedAttributes<Attribute>(methodInfo, inherit: false).OfType<FrameworkITestDataSource>();
+        IEnumerable<ITestDataSource>? testDataSources = ReflectHelper.Instance.GetDerivedAttributes<Attribute>(methodInfo, inherit: false).OfType<ITestDataSource>();
 
         try
         {
@@ -406,10 +402,10 @@ internal class AssemblyEnumerator : MarshalByRefObject
         }
     }
 
-    private static bool ProcessTestDataSourceTests(UnitTestElement test, MethodInfo methodInfo, IEnumerable<FrameworkITestDataSource> testDataSources,
+    private static bool ProcessTestDataSourceTests(UnitTestElement test, MethodInfo methodInfo, IEnumerable<ITestDataSource> testDataSources,
         List<UnitTestElement> tests)
     {
-        foreach (FrameworkITestDataSource dataSource in testDataSources)
+        foreach (ITestDataSource dataSource in testDataSources)
         {
             IEnumerable<object?[]>? data;
 

--- a/src/Adapter/MSTest.TestAdapter/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/TypeEnumerator.cs
@@ -5,6 +5,8 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Reflection;
 
+using Microsoft.TestPlatform.AdapterUtilities;
+using Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
@@ -138,7 +140,9 @@ internal class TypeEnumerator
         // This allows void returning async test method to be valid test method. Though they will be executed similar to non-async test method.
         bool isAsync = ReflectHelper.MatchReturnType(method, typeof(Task));
 
-        var testMethod = new TestMethod(method, method.Name, _type.FullName!, _assemblyFilePath, isAsync, _testIdGenerationStrategy);
+        ManagedNameHelper.GetManagedName(method, out string managedType, out string managedMethod, out string?[]? hierarchyValues);
+        hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = null; // This one will be set by test windows to current test project name.
+        var testMethod = new TestMethod(managedType, managedMethod, hierarchyValues, method.Name, _type.FullName!, _assemblyFilePath, isAsync, null, _testIdGenerationStrategy);
 
         if (!string.Equals(method.DeclaringType!.FullName, _type.FullName, StringComparison.Ordinal))
         {

--- a/src/Adapter/MSTest.TestAdapter/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/TestCaseExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.TestPlatform.AdapterUtilities;
@@ -77,8 +77,8 @@ internal static class TestCaseExtensions
             (int)TestIdGenerationStrategy.FullyQualified);
 
         TestMethod testMethod = testCase.ContainsManagedMethodAndType()
-            ? new(testCase.GetManagedType(), testCase.GetManagedMethod(), testCase.GetHierarchy()!, name, testClassName!, source, isAsync, testIdGenerationStrategy)
-            : new(name, testClassName!, source, isAsync, testIdGenerationStrategy);
+            ? new(testCase.GetManagedType(), testCase.GetManagedMethod(), testCase.GetHierarchy()!, name, testClassName!, source, isAsync, testCase.DisplayName, testIdGenerationStrategy)
+            : new(name, testClassName!, source, isAsync, testCase.DisplayName, testIdGenerationStrategy);
         var dataType = (DynamicDataType)testCase.GetPropertyValue(Constants.TestDynamicDataTypeProperty, (int)DynamicDataType.None);
         if (dataType != DynamicDataType.None)
         {
@@ -87,8 +87,6 @@ internal static class TestCaseExtensions
             testMethod.DataType = dataType;
             testMethod.SerializedData = data;
         }
-
-        testMethod.DisplayName = testCase.DisplayName;
 
         if (testCase.GetPropertyValue(Constants.DeclaringClassNameProperty) is string declaringClassName && declaringClassName != testClassName)
         {

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethod.cs
@@ -1,12 +1,10 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 using Microsoft.TestPlatform.AdapterUtilities;
-using Microsoft.TestPlatform.AdapterUtilities.ManagedNameUtilities;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -31,63 +29,44 @@ public sealed class TestMethod : ITestMethod
     private string? _declaringAssemblyName;
 
     public TestMethod(string name, string fullClassName, string assemblyName, bool isAsync)
+        : this(null, null, null, name, fullClassName, assemblyName, isAsync, null, TestIdGenerationStrategy.FullyQualified)
+    {
+    }
+
+    internal TestMethod(string name, string fullClassName, string assemblyName, bool isAsync, string? displayName,
+        TestIdGenerationStrategy testIdGenerationStrategy)
+        : this(null, null, null, name, fullClassName, assemblyName, isAsync, displayName, testIdGenerationStrategy)
+    {
+    }
+
+    internal TestMethod(string? managedTypeName, string? managedMethodName, string?[]? hierarchyValues, string name,
+        string fullClassName, string assemblyName, bool isAsync, string? displayName,
+        TestIdGenerationStrategy testIdGenerationStrategy)
     {
         if (StringEx.IsNullOrEmpty(assemblyName))
         {
             throw new ArgumentNullException(nameof(assemblyName));
         }
 
-        DebugEx.Assert(!StringEx.IsNullOrEmpty(name), "TestName cannot be empty");
-        DebugEx.Assert(!StringEx.IsNullOrEmpty(fullClassName), "Full className cannot be empty");
-
         Name = name;
+        DisplayName = displayName ?? name;
         FullClassName = fullClassName;
         AssemblyName = assemblyName;
         IsAsync = isAsync;
 
-        string?[] hierarchy = new string?[HierarchyConstants.Levels.TotalLevelCount];
-        hierarchy[HierarchyConstants.Levels.ContainerIndex] = null;
-        hierarchy[HierarchyConstants.Levels.NamespaceIndex] = fullClassName;
-        hierarchy[HierarchyConstants.Levels.ClassIndex] = name;
-        hierarchy[HierarchyConstants.Levels.TestGroupIndex] = name;
-
-        _hierarchy = new ReadOnlyCollection<string?>(hierarchy);
-        TestIdGenerationStrategy = TestIdGenerationStrategy.FullyQualified;
-    }
-
-    internal TestMethod(string name, string fullClassName, string assemblyName, bool isAsync,
-        TestIdGenerationStrategy testIdGenerationStrategy)
-        : this(name, fullClassName, assemblyName, isAsync)
-    {
-        TestIdGenerationStrategy = testIdGenerationStrategy;
-    }
-
-    internal TestMethod(MethodBase method, string name, string fullClassName, string assemblyName, bool isAsync,
-        TestIdGenerationStrategy testIdGenerationStrategy)
-        : this(name, fullClassName, assemblyName, isAsync)
-    {
-        if (method == null)
+        if (hierarchyValues is null)
         {
-            throw new ArgumentNullException(nameof(method));
+            hierarchyValues = new string?[HierarchyConstants.Levels.TotalLevelCount];
+            hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = null;
+            hierarchyValues[HierarchyConstants.Levels.NamespaceIndex] = fullClassName;
+            hierarchyValues[HierarchyConstants.Levels.ClassIndex] = name;
+            hierarchyValues[HierarchyConstants.Levels.TestGroupIndex] = name;
         }
 
-        ManagedNameHelper.GetManagedName(method, out string managedType, out string managedMethod, out string?[]? hierarchyValues);
-        hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = null; // This one will be set by test windows to current test project name.
-
-        ManagedTypeName = managedType;
-        ManagedMethodName = managedMethod;
-        TestIdGenerationStrategy = testIdGenerationStrategy;
         _hierarchy = new ReadOnlyCollection<string?>(hierarchyValues);
-    }
-
-    internal TestMethod(string? managedTypeName, string? managedMethodName, string[] hierarchyValues, string name,
-        string fullClassName, string assemblyName, bool isAsync, TestIdGenerationStrategy testIdGenerationStrategy)
-        : this(name, fullClassName, assemblyName, isAsync)
-    {
         ManagedTypeName = managedTypeName;
         ManagedMethodName = managedMethodName;
         TestIdGenerationStrategy = testIdGenerationStrategy;
-        _hierarchy = new ReadOnlyCollection<string?>(hierarchyValues);
     }
 
     /// <inheritdoc />
@@ -167,9 +146,9 @@ public sealed class TestMethod : ITestMethod
     internal string? TestGroup { get; set; }
 
     /// <summary>
-    /// Gets or sets the display name set during discovery.
+    /// Gets the display name set during discovery.
     /// </summary>
-    internal string? DisplayName { get; set; }
+    internal string DisplayName { get; }
 
     internal string UniqueName
         => HasManagedMethodAndTypeProperties

--- a/test/UnitTests/MSTestAdapter.UnitTests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/ObjectModel/UnitTestElementTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
@@ -190,7 +190,7 @@ public class UnitTestElementTests : TestContainer
     {
         foreach (DynamicDataType dataType in Enum.GetValues(typeof(DynamicDataType)))
         {
-            var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, TestIdGenerationStrategy.Legacy) { DataType = dataType }).ToTestCase();
+            var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, TestIdGenerationStrategy.Legacy) { DataType = dataType }).ToTestCase();
             var expectedTestCase = new TestCase(testCase.FullyQualifiedName, testCase.ExecutorUri, testCase.Source);
             Verify(expectedTestCase.Id == testCase.Id);
             Verify(testCase.GetPropertyValue(Constants.TestIdGenerationStrategyProperty).Equals((int)TestIdGenerationStrategy.Legacy));
@@ -202,7 +202,7 @@ public class UnitTestElementTests : TestContainer
     {
         foreach (DynamicDataType dataType in Enum.GetValues(typeof(DynamicDataType)))
         {
-            var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, TestIdGenerationStrategy.DisplayName) { DataType = dataType }).ToTestCase();
+            var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, TestIdGenerationStrategy.DisplayName) { DataType = dataType }).ToTestCase();
             var expectedTestCase = new TestCase(testCase.FullyQualifiedName, testCase.ExecutorUri, testCase.Source);
             if (dataType == DynamicDataType.None)
             {
@@ -221,7 +221,7 @@ public class UnitTestElementTests : TestContainer
     {
         foreach (DynamicDataType dataType in Enum.GetValues(typeof(DynamicDataType)))
         {
-            var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, TestIdGenerationStrategy.FullyQualified) { DataType = dataType }).ToTestCase();
+            var testCase = new UnitTestElement(new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, TestIdGenerationStrategy.FullyQualified) { DataType = dataType }).ToTestCase();
             var expectedTestCase = new TestCase(testCase.FullyQualifiedName, testCase.ExecutorUri, testCase.Source);
             Verify(expectedTestCase.Id != testCase.Id);
             Verify(testCase.GetPropertyValue(Constants.TestIdGenerationStrategyProperty).Equals((int)TestIdGenerationStrategy.FullyQualified));
@@ -235,19 +235,19 @@ public class UnitTestElementTests : TestContainer
         TestCase[] testCases =
         [
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy))
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyOtherMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy))
+                new("MyOtherMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyOtherProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy))
+                new("MyMethod", "MyOtherProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyOtherAssembly", false, testIdStrategy))
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyOtherAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.DataSourceAttribute,
                 })
@@ -256,7 +256,7 @@ public class UnitTestElementTests : TestContainer
             }
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.ITestDataSource,
                 })
@@ -276,34 +276,34 @@ public class UnitTestElementTests : TestContainer
         TestCase[] testCases =
         [
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.DataSourceAttribute,
                 })
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.DataSourceAttribute,
                     SerializedData = ["1"],
                 })
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.DataSourceAttribute,
                     SerializedData = ["2"],
                 })
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.ITestDataSource,
                     SerializedData = ["1"],
                 })
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     DataType = DynamicDataType.ITestDataSource,
                     SerializedData = ["2"],
@@ -320,31 +320,31 @@ public class UnitTestElementTests : TestContainer
         TestCase[] testCases =
         [
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy))
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyOtherMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy))
+                new("MyOtherMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyOtherProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy))
+                new("MyMethod", "MyOtherProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyOtherAssembly", false, testIdStrategy))
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyOtherAssembly", false, null, testIdStrategy))
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     SerializedData = ["System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "[]"],
                 })
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     SerializedData = ["System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "[1]"],
                 })
             .ToTestCase(),
             new UnitTestElement(
-                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, testIdStrategy)
+                new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", false, null, testIdStrategy)
                 {
                     SerializedData = ["System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "[1,1]"],
                 })


### PR DESCRIPTION
Refactor `TestMethod.DisplayName` to be readonly has it never needs to be updated.