### PR TITLE
Humanize progress time, and reduce update to 500ms

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/AnsiTerminal.cs
@@ -32,7 +32,7 @@ internal class AnsiTerminal : ITerminal
     private readonly bool _useBusyIndicator;
     private readonly StringBuilder _stringBuilder = new();
     private bool _isBatching;
-    private TestProgressFrame _currentFrame = new(Array.Empty<TestProgressState>(), 0, 0);
+    private AnsiTerminalTestProgressFrame _currentFrame = new(Array.Empty<TestProgressState>(), 0, 0);
 
     public AnsiTerminal(IConsole console, string? baseDirectory)
     {
@@ -274,7 +274,7 @@ internal class AnsiTerminal : ITerminal
 
     public void RenderProgress(TestProgressState?[] progress)
     {
-        TestProgressFrame newFrame = new(progress, Width, Height);
+        AnsiTerminalTestProgressFrame newFrame = new(progress, Width, Height);
 
         // Do not render delta but clear everything if Terminal width or height have changed.
         if (newFrame.Width != _currentFrame.Width || newFrame.Height != _currentFrame.Height)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/AnsiTerminalTestProgressFrame.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Testing.Platform.OutputDevice.Console;
 /// </summary>
 internal sealed class AnsiTerminalTestProgressFrame
 {
-    private const int MaxColumn = 120;
+    private const int MaxColumn = 250;
 
     private readonly (TestProgressState TestWorkerProgress, int DurationLength)[] _progressItems;
 
@@ -120,15 +120,16 @@ internal sealed class AnsiTerminalTestProgressFrame
             // rather than deleting whole line and have the line flicker. Most commonly this will rewrite just the time part of the line.
             if (previousFrame.ProgressCount > i)
             {
-                if (previousFrame._progressItems[i] == _progressItems[i])
+                if (previousFrame._progressItems[i].TestWorkerProgress == _progressItems[i].TestWorkerProgress)
                 {
                     // Same everything except time, AND same number of digits in time
                     string durationString = HumanReadableDurationFormatter.Render(_progressItems[i].TestWorkerProgress.Stopwatch.Elapsed);
 
-                    if (_progressItems[i].DurationLength == durationString.Length)
+                    if (previousFrame._progressItems[i].DurationLength == durationString.Length)
                     {
                         terminal.SetCursorHorizontal(MaxColumn);
                         terminal.Append($"{AnsiCodes.SetCursorHorizontal(MaxColumn)}{AnsiCodes.MoveCursorBackward(durationString.Length)}{durationString}");
+                        _progressItems[i].DurationLength = durationString.Length;
                     }
                     else
                     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/ConsoleLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/ConsoleLogger.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 #endif
 
 using System.Globalization;
-using System.Text;
 using System.Text.RegularExpressions;
 
 using Microsoft.Testing.Platform.Helpers;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/ConsoleLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/ConsoleLogger.cs
@@ -3,13 +3,11 @@
 
 #if !NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
-using System.Globalization;
-#if !NET7_0_OR_GREATER
 using System.Reflection;
-
 #endif
 
+using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Microsoft.Testing.Platform.Helpers;
@@ -116,8 +114,8 @@ internal partial class ConsoleLogger : IDisposable
 
         // When not writing to ANSI we write the progress to screen and leave it there so we don't want to write it more often than every few seconds.
         int nonAnsiUpdateCadenceInMs = 3_000;
-        // When writing to ANSI we update the progress in place and it should look responsive so we update every few ms, roughly 30 FPS.
-        int ansiUpdateCadenceInMs = 33;
+        // When writing to ANSI we update the progress in place and it should look responsive so we update every half second, because we only show seconds on the screen, so it is good enough.
+        int ansiUpdateCadenceInMs = 500;
         if (!_options.UseAnsi)
         {
             consoleWithProgress = new ConsoleWithProgress(new NonAnsiTerminal(console), showProgress, updateEvery: nonAnsiUpdateCadenceInMs);
@@ -652,46 +650,7 @@ internal partial class ConsoleLogger : IDisposable
             terminal.SetColor(TerminalColor.Gray);
         }
 
-        if (wrapInParentheses)
-        {
-            terminal.Append('(');
-        }
-
-        bool hasParentValue = false;
-
-        if (duration.Days > 0)
-        {
-            terminal.Append($"{duration.Days}d");
-            hasParentValue = true;
-        }
-
-        if (duration.Hours > 0 || hasParentValue)
-        {
-            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Hours.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Hours.ToString(CultureInfo.InvariantCulture))}h");
-            hasParentValue = true;
-        }
-
-        if (duration.Minutes > 0 || hasParentValue)
-        {
-            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Minutes.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Minutes.ToString(CultureInfo.InvariantCulture))}m");
-            hasParentValue = true;
-        }
-
-        if (duration.Seconds > 0 || hasParentValue)
-        {
-            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Seconds.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Seconds.ToString(CultureInfo.InvariantCulture))}s");
-            hasParentValue = true;
-        }
-
-        if (duration.Milliseconds >= 0 || hasParentValue)
-        {
-            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Milliseconds.ToString(CultureInfo.InvariantCulture).PadLeft(3, '0') : duration.Milliseconds.ToString(CultureInfo.InvariantCulture))}ms");
-        }
-
-        if (wrapInParentheses)
-        {
-            terminal.Append(')');
-        }
+        HumanReadableDurationFormatter.Append(terminal, duration, wrapInParentheses);
 
         if (colorize)
         {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/HumanReadableDurationFormatter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/HumanReadableDurationFormatter.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !NET7_0_OR_GREATER
-#endif
-
 using System.Globalization;
 using System.Text;
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/HumanReadableDurationFormatter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/HumanReadableDurationFormatter.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !NET7_0_OR_GREATER
+#endif
+
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Testing.Platform.OutputDevice.Console;
+
+internal static class HumanReadableDurationFormatter
+{
+    public static void Append(ITerminal terminal, TimeSpan duration, bool wrapInParentheses = true)
+    {
+        bool hasParentValue = false;
+
+        if (wrapInParentheses)
+        {
+            terminal.Append('(');
+        }
+
+        if (duration.Days > 0)
+        {
+            terminal.Append($"{duration.Days}d");
+            hasParentValue = true;
+        }
+
+        if (duration.Hours > 0 || hasParentValue)
+        {
+            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Hours.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Hours.ToString(CultureInfo.InvariantCulture))}h");
+            hasParentValue = true;
+        }
+
+        if (duration.Minutes > 0 || hasParentValue)
+        {
+            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Minutes.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Minutes.ToString(CultureInfo.InvariantCulture))}m");
+            hasParentValue = true;
+        }
+
+        if (duration.Seconds > 0 || hasParentValue)
+        {
+            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Seconds.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Seconds.ToString(CultureInfo.InvariantCulture))}s");
+            hasParentValue = true;
+        }
+
+        if (duration.Milliseconds >= 0 || hasParentValue)
+        {
+            terminal.Append($"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Milliseconds.ToString(CultureInfo.InvariantCulture).PadLeft(3, '0') : duration.Milliseconds.ToString(CultureInfo.InvariantCulture))}ms");
+        }
+
+        if (wrapInParentheses)
+        {
+            terminal.Append(')');
+        }
+    }
+
+    public static string Render(TimeSpan duration, bool wrapInParentheses = true, bool showMilliseconds = false)
+    {
+        bool hasParentValue = false;
+
+        var stringBuilder = new StringBuilder();
+
+        if (wrapInParentheses)
+        {
+            stringBuilder.Append('(');
+        }
+
+        if (duration.Days > 0)
+        {
+            stringBuilder.Append(CultureInfo.CurrentCulture, $"{duration.Days}d");
+            hasParentValue = true;
+        }
+
+        if (duration.Hours > 0 || hasParentValue)
+        {
+            stringBuilder.Append(CultureInfo.CurrentCulture, $"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Hours.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Hours.ToString(CultureInfo.InvariantCulture))}h");
+            hasParentValue = true;
+        }
+
+        if (duration.Minutes > 0 || hasParentValue)
+        {
+            stringBuilder.Append(CultureInfo.CurrentCulture, $"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Minutes.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Minutes.ToString(CultureInfo.InvariantCulture))}m");
+            hasParentValue = true;
+        }
+
+        if (duration.Seconds > 0 || hasParentValue || !showMilliseconds)
+        {
+            stringBuilder.Append(CultureInfo.CurrentCulture, $"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Seconds.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0') : duration.Seconds.ToString(CultureInfo.InvariantCulture))}s");
+            hasParentValue = true;
+        }
+
+        if (showMilliseconds)
+        {
+            if (duration.Milliseconds >= 0 || hasParentValue)
+            {
+                stringBuilder.Append(CultureInfo.CurrentCulture, $"{(hasParentValue ? " " : string.Empty)}{(hasParentValue ? duration.Milliseconds.ToString(CultureInfo.InvariantCulture).PadLeft(3, '0') : duration.Milliseconds.ToString(CultureInfo.InvariantCulture))}ms");
+            }
+        }
+
+        if (wrapInParentheses)
+        {
+            stringBuilder.Append(')');
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/NonAnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Console/NonAnsiTerminal.cs
@@ -174,7 +174,7 @@ internal class NonAnsiTerminal : ITerminal
                     continue;
                 }
 
-                string durationString = $" ({p.Stopwatch.Elapsed.TotalSeconds:F1}s)";
+                string durationString = HumanReadableDurationFormatter.Render(p.Stopwatch.Elapsed);
 
                 int passed = p.Passed;
                 int failed = p.Failed;


### PR DESCRIPTION
Humanize the time in the progress to show minutes and hours, and reduce the precision to whole seconds. This change reduces the update frequency of the progress to 500ms to reduce flickering and improve performance.


![m-in-time-RDESKTOP](https://github.com/user-attachments/assets/aea91927-a3af-4c57-a37c-0f5d9819baa0)

Fix #3532