### PR TITLE
Save all code files with UTF8BOM

### DIFF
--- a/samples/public/DemoMSTestSdk/ProjectUsingMSTestRunner/UnitTest1.cs
+++ b/samples/public/DemoMSTestSdk/ProjectUsingMSTestRunner/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace ProjectUsingMSTestRunner;

--- a/samples/public/DemoMSTestSdk/ProjectUsingVSTest/UnitTest1.cs
+++ b/samples/public/DemoMSTestSdk/ProjectUsingVSTest/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace ProjectUsingVSTest;

--- a/samples/public/DemoMSTestSdk/ProjectWithNativeAOT/UnitTest1.cs
+++ b/samples/public/DemoMSTestSdk/ProjectWithNativeAOT/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace ProjectWithNativeAOT;

--- a/samples/public/mstest-runner/CustomReportExtension/CustomReportExtension/UnitTest1.cs
+++ b/samples/public/mstest-runner/CustomReportExtension/CustomReportExtension/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace CustomReportExtension;

--- a/samples/public/mstest-runner/NativeAotRunner/TestProject1/UnitTest1.cs
+++ b/samples/public/mstest-runner/NativeAotRunner/TestProject1/UnitTest1.cs
@@ -1,4 +1,4 @@
-using ClassLibrary1;
+﻿using ClassLibrary1;
 
 namespace TestProject1;
 

--- a/samples/public/mstest-runner/RunInDocker/MyServer.Tests/UnitTest1.cs
+++ b/samples/public/mstest-runner/RunInDocker/MyServer.Tests/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/samples/public/mstest-runner/RunInDocker/MyServer/Program.cs
+++ b/samples/public/mstest-runner/RunInDocker/MyServer/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 var builder = WebApplication.CreateBuilder(args);

--- a/samples/public/mstest-runner/Simple1/TestConfiguration.cs
+++ b/samples/public/mstest-runner/Simple1/TestConfiguration.cs
@@ -1,1 +1,1 @@
-[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/samples/public/mstest-runner/Simple1/UnitTest1.cs
+++ b/samples/public/mstest-runner/Simple1/UnitTest1.cs
@@ -1,4 +1,4 @@
-namespace Simple1;
+﻿namespace Simple1;
 
 [TestClass]
 public class UnitTest1

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MSTestConfiguration.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MSTestConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0001.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0001.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0002.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0002.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0003.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0003.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0004.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0004.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0005.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0005.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0006.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0006.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0007.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0007.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0008.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0008.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0009.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0009.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0010.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0010.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0011.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0011.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0012.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0012.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0013.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0013.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0014.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0014.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0015.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0015.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0016.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0016.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0017.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0017.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0018.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0018.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0019.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0019.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0020.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0020.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0021.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0021.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0022.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0022.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0023.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0023.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0024.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0024.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0025.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0025.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0026.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0026.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0027.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0027.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0028.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0028.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0029.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0029.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0030.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0030.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0031.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0031.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0032.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0032.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0033.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0033.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0034.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0034.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0035.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0035.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0036.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0036.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0037.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0037.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0038.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0038.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0039.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0039.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0040.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0040.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0041.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0041.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0042.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0042.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0043.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0043.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0044.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0044.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0045.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0045.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0046.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0046.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0047.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0047.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0048.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0048.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0049.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0049.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0050.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0050.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0051.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0051.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0052.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0052.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0053.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0053.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0054.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0054.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0055.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0055.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0056.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0056.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0057.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0057.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0058.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0058.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0059.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0059.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0060.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0060.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0061.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0061.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0062.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0062.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0063.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0063.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0064.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0064.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0065.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0065.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0066.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0066.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0067.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0067.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0068.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0068.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0069.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0069.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0070.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0070.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0071.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0071.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0072.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0072.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0073.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0073.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0074.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0074.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0075.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0075.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0076.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0076.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0077.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0077.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0078.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0078.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0079.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0079.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0080.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0080.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0081.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0081.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0082.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0082.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0083.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0083.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0084.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0084.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0085.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0085.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0086.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0086.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0087.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0087.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0088.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0088.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0089.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0089.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0090.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0090.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0091.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0091.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0092.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0092.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0093.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0093.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0094.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0094.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0095.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0095.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0096.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0096.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0097.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0097.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0098.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0098.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0099.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0099.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0100.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0100.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0101.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0101.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0102.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0102.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0103.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0103.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0104.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0104.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0105.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0105.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0106.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0106.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0107.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0107.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0108.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0108.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0109.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0109.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0110.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0110.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0111.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0111.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0112.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0112.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0113.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0113.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0114.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0114.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0115.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0115.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0116.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0116.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0117.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0117.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0118.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0118.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0119.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0119.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0120.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0120.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0121.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0121.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0122.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0122.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0123.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0123.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0124.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0124.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0125.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0125.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0126.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0126.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0127.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0127.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0128.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0128.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0129.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0129.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0130.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0130.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0131.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0131.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0132.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0132.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0133.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0133.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0134.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0134.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0135.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0135.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0136.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0136.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0137.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0137.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0138.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0138.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0139.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0139.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0140.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0140.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0141.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0141.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0142.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0142.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0143.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0143.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0144.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0144.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0145.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0145.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0146.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0146.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0147.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0147.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0148.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0148.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0149.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0149.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0150.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0150.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0151.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0151.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0152.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0152.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0153.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0153.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0154.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0154.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0155.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0155.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0156.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0156.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0157.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0157.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0158.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0158.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0159.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0159.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0160.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0160.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0161.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0161.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0162.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0162.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0163.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0163.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0164.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0164.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0165.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0165.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0166.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0166.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0167.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0167.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0168.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0168.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0169.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0169.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0170.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0170.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0171.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0171.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0172.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0172.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0173.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0173.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0174.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0174.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0175.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0175.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0176.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0176.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0177.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0177.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0178.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0178.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0179.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0179.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0180.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0180.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0181.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0181.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0182.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0182.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0183.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0183.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0184.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0184.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0185.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0185.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0186.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0186.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0187.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0187.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0188.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0188.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0189.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0189.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0190.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0190.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0191.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0191.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0192.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0192.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0193.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0193.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0194.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0194.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0195.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0195.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0196.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0196.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0197.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0197.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0198.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0198.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0199.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0199.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0200.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0200.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0201.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0201.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0202.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0202.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0203.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0203.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0204.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0204.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0205.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0205.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0206.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0206.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0207.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0207.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0208.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0208.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0209.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0209.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0210.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0210.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0211.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0211.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0212.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0212.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0213.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0213.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0214.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0214.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0215.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0215.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0216.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0216.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0217.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0217.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0218.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0218.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0219.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0219.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0220.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0220.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0221.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0221.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0222.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0222.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0223.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0223.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0224.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0224.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0225.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0225.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0226.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0226.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0227.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0227.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0228.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0228.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0229.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0229.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0230.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0230.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0231.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0231.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0232.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0232.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0233.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0233.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0234.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0234.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0235.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0235.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0236.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0236.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0237.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0237.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0238.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0238.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0239.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0239.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0240.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0240.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0241.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0241.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0242.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0242.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0243.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0243.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0244.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0244.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0245.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0245.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0246.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0246.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0247.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0247.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0248.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0248.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0249.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0249.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0250.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0250.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0251.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0251.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0252.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0252.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0253.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0253.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0254.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0254.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0255.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0255.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0256.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0256.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0257.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0257.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0258.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0258.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0259.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0259.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0260.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0260.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0261.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0261.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0262.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0262.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0263.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0263.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0264.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0264.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0265.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0265.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0266.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0266.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0267.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0267.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0268.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0268.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0269.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0269.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0270.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0270.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0271.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0271.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0272.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0272.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0273.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0273.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0274.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0274.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0275.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0275.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0276.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0276.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0277.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0277.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0278.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0278.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0279.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0279.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0280.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0280.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0281.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0281.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0282.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0282.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0283.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0283.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0284.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0284.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0285.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0285.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0286.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0286.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0287.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0287.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0288.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0288.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0289.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0289.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0290.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0290.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0291.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0291.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0292.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0292.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0293.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0293.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0294.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0294.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0295.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0295.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0296.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0296.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0297.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0297.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0298.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0298.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0299.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0299.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0300.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0300.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0301.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0301.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0302.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0302.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0303.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0303.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0304.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0304.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0305.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0305.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0306.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0306.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0307.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0307.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0308.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0308.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0309.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0309.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0310.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0310.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0311.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0311.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0312.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0312.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0313.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0313.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0314.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0314.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0315.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0315.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0316.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0316.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0317.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0317.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0318.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0318.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0319.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0319.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0320.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0320.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0321.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0321.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0322.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0322.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0323.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0323.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0324.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0324.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0325.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0325.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0326.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0326.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0327.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0327.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0328.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0328.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0329.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0329.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0330.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0330.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0331.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0331.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0332.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0332.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0333.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0333.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0334.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0334.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0335.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0335.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0336.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0336.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0337.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0337.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0338.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0338.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0339.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0339.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0340.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0340.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0341.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0341.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0342.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0342.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0343.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0343.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0344.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0344.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0345.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0345.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0346.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0346.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0347.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0347.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0348.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0348.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0349.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0349.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0350.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0350.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0351.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0351.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0352.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0352.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0353.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0353.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0354.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0354.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0355.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0355.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0356.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0356.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0357.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0357.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0358.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0358.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0359.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0359.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0360.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0360.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0361.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0361.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0362.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0362.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0363.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0363.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0364.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0364.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0365.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0365.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0366.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0366.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0367.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0367.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0368.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0368.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0369.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0369.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0370.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0370.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0371.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0371.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0372.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0372.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0373.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0373.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0374.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0374.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0375.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0375.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0376.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0376.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0377.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0377.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0378.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0378.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0379.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0379.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0380.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0380.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0381.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0381.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0382.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0382.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0383.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0383.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0384.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0384.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0385.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0385.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0386.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0386.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0387.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0387.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0388.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0388.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0389.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0389.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0390.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0390.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0391.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0391.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0392.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0392.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0393.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0393.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0394.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0394.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0395.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0395.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0396.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0396.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0397.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0397.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0398.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0398.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0399.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0399.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0400.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0400.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0401.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0401.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0402.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0402.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0403.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0403.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0404.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0404.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0405.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0405.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0406.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0406.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0407.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0407.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0408.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0408.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0409.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0409.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0410.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0410.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0411.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0411.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0412.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0412.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0413.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0413.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0414.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0414.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0415.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0415.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0416.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0416.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0417.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0417.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0418.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0418.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0419.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0419.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0420.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0420.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0421.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0421.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0422.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0422.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0423.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0423.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0424.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0424.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0425.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0425.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0426.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0426.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0427.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0427.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0428.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0428.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0429.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0429.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0430.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0430.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0431.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0431.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0432.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0432.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0433.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0433.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0434.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0434.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0435.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0435.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0436.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0436.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0437.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0437.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0438.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0438.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0439.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0439.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0440.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0440.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0441.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0441.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0442.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0442.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0443.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0443.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0444.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0444.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0445.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0445.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0446.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0446.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0447.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0447.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0448.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0448.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0449.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0449.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0450.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0450.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0451.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0451.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0452.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0452.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0453.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0453.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0454.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0454.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0455.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0455.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0456.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0456.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0457.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0457.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0458.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0458.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0459.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0459.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0460.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0460.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0461.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0461.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0462.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0462.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0463.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0463.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0464.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0464.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0465.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0465.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0466.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0466.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0467.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0467.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0468.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0468.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0469.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0469.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0470.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0470.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0471.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0471.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0472.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0472.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0473.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0473.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0474.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0474.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0475.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0475.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0476.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0476.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0477.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0477.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0478.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0478.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0479.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0479.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0480.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0480.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0481.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0481.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0482.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0482.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0483.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0483.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0484.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0484.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0485.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0485.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0486.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0486.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0487.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0487.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0488.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0488.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0489.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0489.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0490.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0490.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0491.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0491.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0492.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0492.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0493.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0493.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0494.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0494.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0495.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0495.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0496.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0496.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0497.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0497.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0498.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0498.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0499.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0499.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0500.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0500.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0501.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0501.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0502.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0502.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0503.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0503.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0504.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0504.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0505.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0505.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0506.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0506.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0507.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0507.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0508.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0508.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0509.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0509.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0510.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0510.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0511.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0511.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0512.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0512.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0513.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0513.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0514.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0514.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0515.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0515.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0516.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0516.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0517.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0517.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0518.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0518.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0519.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0519.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0520.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0520.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0521.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0521.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0522.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0522.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0523.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0523.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0524.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0524.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0525.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0525.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0526.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0526.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0527.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0527.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0528.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0528.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0529.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0529.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0530.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0530.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0531.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0531.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0532.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0532.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0533.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0533.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0534.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0534.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0535.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0535.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0536.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0536.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0537.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0537.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0538.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0538.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0539.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0539.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0540.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0540.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0541.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0541.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0542.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0542.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0543.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0543.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0544.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0544.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0545.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0545.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0546.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0546.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0547.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0547.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0548.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0548.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0549.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0549.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0550.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0550.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0551.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0551.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0552.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0552.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0553.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0553.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0554.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0554.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0555.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0555.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0556.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0556.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0557.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0557.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0558.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0558.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0559.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0559.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0560.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0560.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0561.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0561.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0562.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0562.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0563.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0563.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0564.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0564.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0565.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0565.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0566.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0566.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0567.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0567.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0568.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0568.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0569.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0569.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0570.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0570.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0571.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0571.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0572.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0572.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0573.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0573.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0574.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0574.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0575.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0575.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0576.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0576.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0577.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0577.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0578.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0578.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0579.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0579.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0580.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0580.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0581.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0581.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0582.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0582.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0583.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0583.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0584.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0584.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0585.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0585.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0586.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0586.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0587.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0587.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0588.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0588.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0589.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0589.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0590.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0590.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0591.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0591.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0592.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0592.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0593.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0593.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0594.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0594.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0595.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0595.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0596.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0596.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0597.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0597.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0598.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0598.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0599.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0599.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0600.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0600.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0601.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0601.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0602.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0602.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0603.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0603.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0604.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0604.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0605.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0605.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0606.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0606.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0607.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0607.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0608.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0608.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0609.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0609.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0610.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0610.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0611.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0611.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0612.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0612.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0613.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0613.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0614.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0614.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0615.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0615.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0616.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0616.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0617.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0617.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0618.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0618.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0619.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0619.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0620.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0620.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0621.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0621.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0622.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0622.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0623.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0623.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0624.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0624.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0625.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0625.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0626.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0626.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0627.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0627.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0628.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0628.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0629.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0629.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0630.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0630.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0631.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0631.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0632.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0632.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0633.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0633.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0634.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0634.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0635.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0635.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0636.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0636.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0637.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0637.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0638.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0638.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0639.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0639.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0640.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0640.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0641.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0641.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0642.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0642.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0643.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0643.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0644.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0644.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0645.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0645.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0646.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0646.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0647.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0647.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0648.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0648.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0649.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0649.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0650.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0650.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0651.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0651.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0652.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0652.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0653.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0653.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0654.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0654.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0655.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0655.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0656.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0656.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0657.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0657.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0658.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0658.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0659.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0659.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0660.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0660.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0661.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0661.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0662.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0662.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0663.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0663.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0664.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0664.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0665.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0665.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0666.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0666.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0667.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0667.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0668.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0668.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0669.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0669.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0670.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0670.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0671.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0671.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0672.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0672.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0673.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0673.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0674.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0674.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0675.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0675.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0676.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0676.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0677.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0677.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0678.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0678.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0679.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0679.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0680.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0680.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0681.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0681.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0682.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0682.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0683.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0683.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0684.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0684.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0685.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0685.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0686.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0686.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0687.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0687.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0688.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0688.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0689.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0689.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0690.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0690.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0691.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0691.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0692.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0692.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0693.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0693.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0694.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0694.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0695.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0695.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0696.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0696.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0697.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0697.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0698.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0698.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0699.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0699.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0700.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0700.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0701.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0701.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0702.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0702.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0703.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0703.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0704.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0704.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0705.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0705.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0706.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0706.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0707.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0707.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0708.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0708.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0709.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0709.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0710.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0710.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0711.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0711.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0712.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0712.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0713.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0713.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0714.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0714.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0715.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0715.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0716.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0716.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0717.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0717.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0718.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0718.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0719.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0719.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0720.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0720.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0721.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0721.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0722.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0722.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0723.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0723.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0724.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0724.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0725.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0725.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0726.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0726.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0727.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0727.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0728.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0728.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0729.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0729.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0730.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0730.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0731.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0731.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0732.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0732.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0733.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0733.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0734.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0734.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0735.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0735.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0736.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0736.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0737.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0737.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0738.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0738.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0739.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0739.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0740.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0740.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0741.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0741.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0742.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0742.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0743.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0743.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0744.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0744.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0745.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0745.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0746.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0746.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0747.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0747.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0748.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0748.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0749.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0749.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0750.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0750.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0751.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0751.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0752.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0752.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0753.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0753.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0754.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0754.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0755.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0755.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0756.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0756.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0757.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0757.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0758.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0758.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0759.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0759.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0760.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0760.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0761.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0761.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0762.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0762.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0763.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0763.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0764.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0764.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0765.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0765.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0766.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0766.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0767.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0767.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0768.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0768.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0769.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0769.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0770.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0770.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0771.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0771.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0772.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0772.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0773.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0773.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0774.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0774.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0775.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0775.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0776.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0776.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0777.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0777.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0778.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0778.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0779.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0779.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0780.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0780.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0781.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0781.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0782.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0782.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0783.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0783.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0784.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0784.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0785.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0785.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0786.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0786.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0787.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0787.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0788.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0788.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0789.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0789.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0790.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0790.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0791.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0791.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0792.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0792.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0793.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0793.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0794.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0794.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0795.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0795.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0796.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0796.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0797.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0797.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0798.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0798.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0799.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0799.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0800.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0800.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0801.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0801.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0802.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0802.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0803.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0803.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0804.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0804.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0805.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0805.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0806.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0806.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0807.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0807.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0808.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0808.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0809.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0809.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0810.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0810.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0811.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0811.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0812.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0812.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0813.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0813.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0814.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0814.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0815.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0815.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0816.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0816.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0817.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0817.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0818.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0818.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0819.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0819.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0820.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0820.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0821.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0821.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0822.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0822.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0823.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0823.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0824.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0824.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0825.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0825.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0826.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0826.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0827.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0827.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0828.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0828.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0829.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0829.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0830.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0830.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0831.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0831.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0832.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0832.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0833.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0833.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0834.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0834.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0835.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0835.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0836.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0836.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0837.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0837.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0838.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0838.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0839.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0839.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0840.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0840.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0841.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0841.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0842.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0842.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0843.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0843.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0844.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0844.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0845.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0845.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0846.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0846.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0847.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0847.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0848.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0848.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0849.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0849.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0850.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0850.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0851.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0851.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0852.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0852.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0853.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0853.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0854.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0854.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0855.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0855.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0856.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0856.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0857.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0857.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0858.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0858.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0859.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0859.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0860.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0860.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0861.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0861.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0862.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0862.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0863.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0863.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0864.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0864.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0865.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0865.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0866.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0866.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0867.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0867.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0868.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0868.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0869.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0869.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0870.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0870.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0871.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0871.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0872.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0872.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0873.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0873.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0874.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0874.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0875.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0875.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0876.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0876.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0877.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0877.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0878.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0878.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0879.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0879.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0880.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0880.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0881.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0881.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0882.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0882.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0883.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0883.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0884.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0884.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0885.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0885.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0886.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0886.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0887.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0887.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0888.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0888.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0889.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0889.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0890.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0890.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0891.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0891.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0892.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0892.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0893.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0893.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0894.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0894.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0895.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0895.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0896.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0896.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0897.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0897.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0898.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0898.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0899.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0899.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0900.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0900.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0901.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0901.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0902.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0902.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0903.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0903.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0904.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0904.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0905.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0905.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0906.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0906.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0907.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0907.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0908.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0908.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0909.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0909.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0910.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0910.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0911.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0911.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0912.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0912.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0913.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0913.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0914.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0914.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0915.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0915.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0916.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0916.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0917.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0917.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0918.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0918.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0919.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0919.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0920.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0920.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0921.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0921.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0922.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0922.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0923.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0923.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0924.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0924.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0925.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0925.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0926.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0926.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0927.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0927.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0928.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0928.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0929.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0929.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0930.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0930.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0931.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0931.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0932.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0932.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0933.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0933.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0934.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0934.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0935.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0935.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0936.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0936.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0937.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0937.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0938.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0938.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0939.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0939.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0940.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0940.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0941.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0941.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0942.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0942.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0943.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0943.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0944.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0944.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0945.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0945.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0946.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0946.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0947.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0947.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0948.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0948.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0949.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0949.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0950.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0950.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0951.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0951.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0952.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0952.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0953.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0953.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0954.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0954.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0955.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0955.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0956.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0956.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0957.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0957.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0958.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0958.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0959.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0959.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0960.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0960.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0961.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0961.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0962.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0962.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0963.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0963.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0964.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0964.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0965.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0965.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0966.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0966.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0967.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0967.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0968.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0968.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0969.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0969.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0970.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0970.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0971.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0971.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0972.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0972.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0973.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0973.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0974.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0974.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0975.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0975.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0976.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0976.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0977.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0977.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0978.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0978.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0979.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0979.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0980.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0980.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0981.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0981.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0982.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0982.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0983.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0983.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0984.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0984.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0985.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0985.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0986.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0986.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0987.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0987.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0988.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0988.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0989.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0989.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0990.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0990.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0991.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0991.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0992.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0992.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0993.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0993.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0994.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0994.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0995.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0995.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0996.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0996.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0997.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0997.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0998.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0998.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0999.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass0999.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass1000.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/1000C_100M/MyTestClass1000.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MSTestConfiguration.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MSTestConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass001.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass001.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass002.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass002.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass003.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass003.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass004.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass004.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass005.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass005.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass006.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass006.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass007.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass007.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass008.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass008.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass009.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass009.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass010.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass010.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass011.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass011.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass012.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass012.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass013.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass013.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass014.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass014.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass015.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass015.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass016.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass016.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass017.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass017.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass018.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass018.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass019.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass019.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass020.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass020.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass021.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass021.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass022.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass022.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass023.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass023.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass024.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass024.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass025.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass025.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass026.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass026.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass027.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass027.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass028.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass028.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass029.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass029.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass030.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass030.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass031.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass031.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass032.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass032.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass033.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass033.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass034.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass034.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass035.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass035.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass036.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass036.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass037.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass037.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass038.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass038.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass039.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass039.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass040.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass040.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass041.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass041.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass042.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass042.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass043.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass043.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass044.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass044.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass045.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass045.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass046.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass046.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass047.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass047.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass048.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass048.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass049.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass049.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass050.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass050.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass051.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass051.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass052.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass052.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass053.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass053.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass054.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass054.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass055.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass055.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass056.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass056.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass057.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass057.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass058.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass058.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass059.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass059.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass060.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass060.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass061.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass061.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass062.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass062.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass063.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass063.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass064.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass064.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass065.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass065.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass066.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass066.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass067.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass067.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass068.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass068.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass069.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass069.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass070.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass070.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass071.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass071.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass072.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass072.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass073.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass073.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass074.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass074.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass075.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass075.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass076.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass076.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass077.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass077.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass078.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass078.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass079.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass079.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass080.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass080.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass081.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass081.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass082.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass082.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass083.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass083.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass084.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass084.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass085.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass085.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass086.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass086.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass087.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass087.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass088.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass088.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass089.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass089.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass090.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass090.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass091.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass091.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass092.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass092.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass093.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass093.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass094.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass094.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass095.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass095.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass096.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass096.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass097.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass097.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass098.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass098.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass099.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass099.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass100.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/100C_100M/MyTestClass100.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MSTestConfiguration.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MSTestConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass01.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass01.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass02.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass02.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass03.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass03.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass04.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass04.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass05.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass05.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass06.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass06.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass07.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass07.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass08.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass08.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass09.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass09.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass10.cs
+++ b/samples/public/mstest-runner/runner_vs_vstest/10C_100M/MyTestClass10.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumeratorWrapper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumeratorWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/src/Adapter/MSTest.TestAdapter/Execution/LogMessageListener.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/LogMessageListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/Adapter/MSTest.TestAdapter/Execution/RunCleanupResult.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/RunCleanupResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestCaseDiscoverySink.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestCaseDiscoverySink.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;

--- a/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/Adapter/MSTest.TestAdapter/Friends.cs
+++ b/src/Adapter/MSTest.TestAdapter/Friends.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Friend assemblies

--- a/src/Adapter/MSTest.TestAdapter/IPlatformServiceProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/IPlatformServiceProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/StackTraceInformation.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/StackTraceInformation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/TestFailedException.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/TestFailedException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/TypeInspectionException.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/TypeInspectionException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestResult.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;

--- a/src/Adapter/MSTest.TestAdapter/Properties/AssemblyInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform;

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Constants.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Constants.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/CsvDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/CsvDataConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/OdbcDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/OdbcDataConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/OleDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/OleDataConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/SqlDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/SqlDataConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionFactory.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Deployment/AssemblyLoadWorker.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Deployment/AssemblyLoadWorker.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Deployment/DeploymentItem.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Deployment/DeploymentItem.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Deployment/TestRunDirectories.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Deployment/TestRunDirectories.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IAdapterTraceLogger.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IAdapterTraceLogger.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #pragma warning disable CA1716 // Do not use reserved keywords

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IFileOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IFileOperations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ISettingsProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ISettingsProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Xml;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestContext.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestDataSource.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestDataSource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using UTF = Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestDeployment.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestDeployment.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestSource.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestSource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestSourceHost.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestSourceHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ObjectModel/ITestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ObjectModel/ITestMethod.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Properties/AssemblyInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK || WIN_UI

--- a/src/Adapter/MSTestAdapter.PlatformServices/RecursiveDirectoryPath.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/RecursiveDirectoryPath.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDataSource.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDataSource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSource.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadSafeStringWriter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ThreadSafeStringWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AssemblyUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AssemblyUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/FileUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/FileUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/RandomIntPermutation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/RandomIntPermutation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/ReflectionUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/ReflectionUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/SequentialIntPermutation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/SequentialIntPermutation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/VSInstallationUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/VSInstallationUtilities.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/TestFramework/TestFramework.Extensions/Attributes/DeploymentItemAttribute.cs
+++ b/src/TestFramework/TestFramework.Extensions/Attributes/DeploymentItemAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework.Extensions/ConfigurationSettings/TestConfiguration.cs
+++ b/src/TestFramework/TestFramework.Extensions/ConfigurationSettings/TestConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/TestFramework/TestFramework.Extensions/PrivateObject.cs
+++ b/src/TestFramework/TestFramework.Extensions/PrivateObject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/TestFramework/TestFramework.Extensions/PrivateType.cs
+++ b/src/TestFramework/TestFramework.Extensions/PrivateType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/TestFramework/TestFramework.Extensions/RuntimeTypeHelper.cs
+++ b/src/TestFramework/TestFramework.Extensions/RuntimeTypeHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;

--- a/src/TestFramework/TestFramework/Assertions/Assert.Fail.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Fail.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Assertions/Assert.Inconclusive.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Inconclusive.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Assertions/StringAssert.cs
+++ b/src/TestFramework/TestFramework/Assertions/StringAssert.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DataSourceAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DataSourceAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Attributes/DataSource/TestIdGenerationStrategy.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/TestIdGenerationStrategy.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Attributes/DataSource/TestIdGenerationStrategyAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/TestIdGenerationStrategyAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/ExpectedExceptionBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/ExpectedExceptionBaseAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TestCategoryAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TestCategoryAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TestCategoryBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TestCategoryBaseAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/DataAccessMethod.cs
+++ b/src/TestFramework/TestFramework/DataAccessMethod.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Exceptions/AssertFailedException.cs
+++ b/src/TestFramework/TestFramework/Exceptions/AssertFailedException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Exceptions/AssertInconclusiveException.cs
+++ b/src/TestFramework/TestFramework/Exceptions/AssertInconclusiveException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Exceptions/InternalTestFailureException.cs
+++ b/src/TestFramework/TestFramework/Exceptions/InternalTestFailureException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Exceptions/UnitTestAssertException.cs
+++ b/src/TestFramework/TestFramework/Exceptions/UnitTestAssertException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Friends.cs
+++ b/src/TestFramework/TestFramework/Friends.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;

--- a/src/TestFramework/TestFramework/GenericParameterHelper.cs
+++ b/src/TestFramework/TestFramework/GenericParameterHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;

--- a/src/TestFramework/TestFramework/Interfaces/ITestMethod.cs
+++ b/src/TestFramework/TestFramework/Interfaces/ITestMethod.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/src/TestFramework/TestFramework/Internal/UtfHelper.cs
+++ b/src/TestFramework/TestFramework/Internal/UtfHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/TestFramework/TestFramework/Properties/AssemblyInfo.cs
+++ b/src/TestFramework/TestFramework/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 [assembly: CLSCompliant(true)]

--- a/src/TestFramework/TestFramework/UnitTestOutcome.cs
+++ b/src/TestFramework/TestFramework/UnitTestOutcome.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;

--- a/test/IntegrationTests/TestAssets/DataRowTestProject/DataRowTests_BaseClass.cs
+++ b/test/IntegrationTests/TestAssets/DataRowTestProject/DataRowTests_BaseClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/IntegrationTests/TestAssets/DiscoverInternalsProject/UnitTest1.cs
+++ b/test/IntegrationTests/TestAssets/DiscoverInternalsProject/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;

--- a/test/IntegrationTests/TestAssets/DoNotParallelizeTestProject/UnitTest1.cs
+++ b/test/IntegrationTests/TestAssets/DoNotParallelizeTestProject/UnitTest1.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/IntegrationTests/TestAssets/FSharpTestProject/Tests.fs
+++ b/test/IntegrationTests/TestAssets/FSharpTestProject/Tests.fs
@@ -1,4 +1,4 @@
-namespace FSharpTestProject
+﻿namespace FSharpTestProject
 
 open System
 open Microsoft.VisualStudio.TestTools.UnitTesting

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanup.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfAssembly.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfAssembly.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfAssemblyAndNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfAssemblyAndNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfClassAndNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassCleanupEndOfClassAndNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeAndCleanupNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeAndCleanupNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfClassAndNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassCleanupEndOfClassAndNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeAndCleanupNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeAndCleanupNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.cs
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/AssemblyResolverTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/AssemblyResolverTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Deployment/DeploymentItemTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Deployment/DeploymentItemTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Deployment/TestRunDirectoriesTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Deployment/TestRunDirectoriesTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Extensions/ExceptionExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Extensions;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Properties/AssemblyInfo.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopFileOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopFileOperationsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestDataSourceTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestDataSourceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestDeploymentTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestDeploymentTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestSourceHostTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestSourceTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestSourceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DiaSessionOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DiaSessionOperationsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/FileOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/FileOperationsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Xml;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestSettingsProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestSettingsProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Xml;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestSourceHostTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestSourceHostTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/DeploymentUtilityTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/DeploymentUtilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/VSInstallationUtilitiesTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/VSInstallationUtilitiesTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NET462

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/ns10FileUtilityTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/ns10FileUtilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/ns13DeploymentItemUtilityTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/ns13DeploymentItemUtilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ns10TestSourceTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ns10TestSourceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorWrapperTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorWrapperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/LogMessageListenerTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/LogMessageListenerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestCaseDiscoverySinkTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestCaseDiscoverySinkTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodFilterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/ExceptionExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/TestCaseExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/TestCaseExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestDiscovererTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestDiscovererTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestExecutorTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestExecutorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;

--- a/test/UnitTests/MSTestAdapter.UnitTests/PlatformServiceProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/PlatformServiceProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;

--- a/test/UnitTests/MSTestAdapter.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInstanceOfTypeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInstanceOfTypeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #nullable enable

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsTrueTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsTrueTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/ExpectedExceptionAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/ExpectedExceptionAttributeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/ExpectedExceptionBaseAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/ExpectedExceptionBaseAttributeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/UnitTests/TestFramework.UnitTests/GenericParameterHelperTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/GenericParameterHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/Utilities/TestFramework.ForTestingMSTest/DoesNotReturnIfAttribute.cs
+++ b/test/Utilities/TestFramework.ForTestingMSTest/DoesNotReturnIfAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETSTANDARD2_0 || NETFRAMEWORK


### PR DESCRIPTION
Save all code files with BOM as defined in .editorconfig, so we don't get additional changes in PRs when editing files that don't have the correct encoding yet.