### PR TITLE
Fix outputting assembly name in non-ansi progress reporter

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
@@ -202,6 +202,9 @@ internal sealed class NonAnsiTerminal : ITerminal
                 ResetColor();
                 Append(']');
 
+                Append(' ');
+                Append(p.AssemblyName);
+
                 if (p.TargetFramework != null || p.Architecture != null)
                 {
                     Append(" (");


### PR DESCRIPTION
Assembly name was missing when writing progress using the non-ansi progress reporter.