### PR TITLE
Add --output option

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
@@ -14,6 +14,8 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : ICommandL
     public const string NoProgressOption = "no-progress";
     public const string NoAnsiOption = "no-ansi";
     public const string OutputOption = "output";
+    public const string OutputOptionNormalArgument = "normal";
+    public const string OutputOptionDetailedArgument = "detailed"
 
     /// <inheritdoc />
     public string Uid { get; } = nameof(TerminalTestReporterCommandLineOptionsProvider);
@@ -43,10 +45,10 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : ICommandL
         {
             NoProgressOption => ValidationResult.ValidTask,
             NoAnsiOption => ValidationResult.ValidTask,
-            OutputOption => "normal".Equals(arguments[0], StringComparison.OrdinalIgnoreCase) || "detailed".Equals(arguments[0], StringComparison.OrdinalIgnoreCase)
+            OutputOption => OutputOptionNormalArgument.Equals(arguments[0], StringComparison.OrdinalIgnoreCase) || OutputOptionDetailedArgument.Equals(arguments[0], StringComparison.OrdinalIgnoreCase)
                 ? ValidationResult.ValidTask
                 : ValidationResult.InvalidTask(PlatformResources.TerminalOutputOptionInvalidArgument),
-            _ => throw new NotSupportedException(),
+            _ => throw ApplicationStateGuard.Unreachable(),
         };
 
     public Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
@@ -15,7 +15,7 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : ICommandL
     public const string NoAnsiOption = "no-ansi";
     public const string OutputOption = "output";
     public const string OutputOptionNormalArgument = "normal";
-    public const string OutputOptionDetailedArgument = "detailed"
+    public const string OutputOptionDetailedArgument = "detailed";
 
     /// <inheritdoc />
     public string Uid { get; } = nameof(TerminalTestReporterCommandLineOptionsProvider);

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
@@ -13,6 +13,7 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : ICommandL
 {
     public const string NoProgressOption = "no-progress";
     public const string NoAnsiOption = "no-ansi";
+    public const string OutputOption = "output";
 
     /// <inheritdoc />
     public string Uid { get; } = nameof(TerminalTestReporterCommandLineOptionsProvider);
@@ -32,12 +33,21 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : ICommandL
     public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions()
         =>
         [
-            new(NoProgressOption, PlatformResources.TerminalNoProgressOptionDescription, ArgumentArity.Zero, false),
-            new(NoAnsiOption, PlatformResources.TerminalNoAnsiOptionDescription, ArgumentArity.Zero, false)
+            new(NoProgressOption, PlatformResources.TerminalNoProgressOptionDescription, ArgumentArity.Zero, isHidden: false),
+            new(NoAnsiOption, PlatformResources.TerminalNoAnsiOptionDescription, ArgumentArity.Zero, isHidden: false),
+            new(OutputOption, PlatformResources.TerminalOutputOptionDescription, ArgumentArity.ExactlyOne, isHidden: false),
         ];
 
     public Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
-        => ValidationResult.ValidTask;
+        => commandOption.Name switch
+        {
+            NoProgressOption => ValidationResult.ValidTask,
+            NoAnsiOption => ValidationResult.ValidTask,
+            OutputOption => "normal".Equals(arguments[0], StringComparison.OrdinalIgnoreCase) || "detailed".Equals(arguments[0], StringComparison.OrdinalIgnoreCase)
+                ? ValidationResult.ValidTask
+                : ValidationResult.InvalidTask(PlatformResources.TerminalOutputOptionInvalidArgument),
+            _ => throw new NotSupportedException(),
+        };
 
     public Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
         => // No problem found

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -98,6 +98,13 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
         bool noAnsi = parseResult.IsOptionSet(TerminalTestReporterCommandLineOptionsProvider.NoAnsiOption);
         bool noProgress = parseResult.IsOptionSet(TerminalTestReporterCommandLineOptionsProvider.NoProgressOption);
 
+        bool showPassed = false;
+        OptionRecord? output = parseResult.Options.FirstOrDefault(o => o.Option == TerminalTestReporterCommandLineOptionsProvider.OutputOption);
+        if (output != null && output.Arguments.Length > 0 && "Detailed".Equals(output.Arguments[0], StringComparison.OrdinalIgnoreCase))
+        {
+            showPassed = true;
+        }
+
         Func<bool?> shouldShowProgress = noProgress
             // User preference is to not show progress.
             ? () => false
@@ -110,15 +117,13 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
             // func.
             : () => testHostControllerInfo.IsCurrentProcessTestHostController == null ? null : !testHostControllerInfo.IsCurrentProcessTestHostController;
 
-        // This is single exe run, don't show all the details of assemblies and their summaries
-        // and don't show passed tests.
-        bool verbose = false;
+        // This is single exe run, don't show all the details of assemblies and their summaries.
         _terminalTestReporter = new TerminalTestReporter(console, new()
         {
             BaseDirectory = null,
-            ShowAssembly = verbose,
-            ShowAssemblyStartAndComplete = verbose,
-            ShowPassedTests = verbose,
+            ShowAssembly = false,
+            ShowAssemblyStartAndComplete = false,
+            ShowPassedTests = showPassed,
             MinimumExpectedTests = minimumExpectedTest,
             UseAnsi = !noAnsi,
             ShowProgress = shouldShowProgress,

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -100,7 +100,7 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
 
         bool showPassed = false;
         OptionRecord? output = parseResult.Options.FirstOrDefault(o => o.Option == TerminalTestReporterCommandLineOptionsProvider.OutputOption);
-        if (output != null && output.Arguments.Length > 0 && "Detailed".Equals(output.Arguments[0], StringComparison.OrdinalIgnoreCase))
+        if (output != null && output.Arguments.Length > 0 && TerminalTestReporterCommandLineOptionsProvider.OutputOptionDetailedArgument.Equals(output.Arguments[0], StringComparison.OrdinalIgnoreCase))
         {
             showPassed = true;
         }

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
@@ -1148,6 +1148,24 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Output verbosity when reporting tests. Valid values are &apos;Normal&apos;, &apos;Detailed&apos;. Default is &apos;Normal&apos;..
+        /// </summary>
+        internal static string TerminalOutputOptionDescription {
+            get {
+                return ResourceManager.GetString("TerminalOutputOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to --output expects a single parameter with value &apos;Normal&apos; or &apos;Detailed&apos;..
+        /// </summary>
+        internal static string TerminalOutputOptionInvalidArgument {
+            get {
+                return ResourceManager.GetString("TerminalOutputOptionInvalidArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Writes test results to terminal..
         /// </summary>
         internal static string TerminalTestReporterDescription {

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -596,4 +596,10 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
   <data name="TerminalTestReporterDisplayName" xml:space="preserve">
     <value>Terminal test reporter</value>
   </data>
+  <data name="TerminalOutputOptionDescription" xml:space="preserve">
+    <value>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</value>
+  </data>
+  <data name="TerminalOutputOptionInvalidArgument" xml:space="preserve">
+    <value>--output expects a single parameter with value 'Normal' or 'Detailed'.</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -623,6 +623,16 @@ Přečtěte si další informace o telemetrii Microsoft Testing Platform: https:
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -623,6 +623,16 @@ Weitere Informationen zu Microsoft Testing Platform-Telemetriedaten: https://aka
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -623,6 +623,16 @@ Más información sobre la telemetría de la Plataforma de pruebas de Microsoft:
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -623,6 +623,16 @@ En savoir plus sur la télémétrie de la plateforme de tests Microsoft : https:
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -623,6 +623,16 @@ Altre informazioni sulla telemetria della piattaforma di test Microsoft: https:/
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -624,6 +624,16 @@ Microsoft Testing Platform テレメトリの詳細: https://aka.ms/testingplatf
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -623,6 +623,16 @@ Microsoft 테스트 플랫폼 원격 분석에 대해 자세히 알아보기: ht
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -623,6 +623,16 @@ Więcej informacji o telemetrii platformy testowej firmy Microsoft: https://aka.
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -623,6 +623,16 @@ Leia mais sobre a telemetria da Plataforma de Testes da Microsoft: https://aka.m
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -623,6 +623,16 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -623,6 +623,16 @@ Microsoft Test Platformu telemetrisi hakkında daha fazla bilgi edinin: https://
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -623,6 +623,16 @@ Microsoft 测试平台会收集使用数据，帮助我们改善体验。该数�
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -623,6 +623,16 @@ Microsoft 測試平台會收集使用量資料，以協助我們改善您的體�
         <target state="new">Disable reporting progress to screen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TerminalOutputOptionDescription">
+        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="new">Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TerminalOutputOptionInvalidArgument">
+        <source>--output expects a single parameter with value 'Normal' or 'Detailed'.</source>
+        <target state="new">--output expects a single parameter with value 'Normal' or 'Detailed'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>
         <target state="new">Writes test results to terminal.</target>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -47,6 +47,7 @@ Extension options:
   --filter         Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.
   --no-ansi        Disable outputting ANSI escape characters to screen.
   --no-progress    Disable reporting progress to screen.
+  --output         Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   --settings       The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file
   --test-parameter Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
 """;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -42,6 +42,7 @@ Options:
 Extension options:
   --no-ansi         Disable outputting ANSI escape characters to screen.
   --no-progress     Disable reporting progress to screen.
+  --output          Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   --treenode-filter Use a tree filter to filter down the tests to execute
 """;
 
@@ -76,6 +77,7 @@ Options:
 Extension options:
   --no-ansi         Disable outputting ANSI escape characters to screen.
   --no-progress     Disable reporting progress to screen.
+  --output          Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   --treenode-filter Use a tree filter to filter down the tests to execute
 """;
 
@@ -113,6 +115,7 @@ Options:
 Extension options:
   --no-ansi         Disable outputting ANSI escape characters to screen.
   --no-progress     Disable reporting progress to screen.
+  --output          Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   --treenode-filter Use a tree filter to filter down the tests to execute
 """;
 
@@ -242,6 +245,10 @@ Registered command line providers:
         Arity: 0
         Hidden: False
         Description: Disable reporting progress to screen.
+      --output
+        Arity: 1
+        Hidden: False
+        Description: Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   TestingFrameworkExtension
     Name: Microsoft Testing Framework
     Version: .+
@@ -296,6 +303,7 @@ Extension options:
   --hangdump-type       Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'
   --no-ansi             Disable outputting ANSI escape characters to screen.
   --no-progress         Disable reporting progress to screen.
+  --output              Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   --report-trx          Enable generating TRX report
   --report-trx-filename The name of the generated TRX report
   --treenode-filter     Use a tree filter to filter down the tests to execute
@@ -342,6 +350,7 @@ Extension options:
   --hangdump-type       Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'
   --no-ansi             Disable outputting ANSI escape characters to screen.
   --no-progress         Disable reporting progress to screen.
+  --output              Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   --report-trx          Enable generating TRX report
   --report-trx-filename The name of the generated TRX report
   --treenode-filter     Use a tree filter to filter down the tests to execute
@@ -532,6 +541,10 @@ Registered command line providers:
         Arity: 0
         Hidden: False
         Description: Disable reporting progress to screen.
+      --output
+        Arity: 1
+        Hidden: False
+        Description: Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   TestingFrameworkExtension
     Name: Microsoft Testing Framework
     Version: *


### PR DESCRIPTION
Add option to allow outputting normal, or detailed, so we can output without or with passed tests.