### PR TITLE
Remove useless check during `--list-tests`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/ListTestsMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/ListTestsMessageBus.cs
@@ -59,8 +59,7 @@ internal sealed class ListTestsMessageBus(
             return;
         }
 
-        if (_testFramework.Uid != dataProducer.Uid
-            || data is not TestNodeUpdateMessage testNodeUpdatedMessage
+        if (data is not TestNodeUpdateMessage testNodeUpdatedMessage
             || testNodeUpdatedMessage.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>() is not DiscoveredTestNodeStateProperty)
         {
             if (_logger.IsEnabled(LogLevel.Trace))


### PR DESCRIPTION
Originally we want to check that the producer and the test framework were the same but actually there's no need for it.