### PR TITLE
MSTest.Sdk handles library mode

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Features/Aspire.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Features/Aspire.targets
@@ -2,7 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="$(AspireHostingTestingVersion)" VersionOverride="$(AspireHostingTestingVersion)" Sdk="MSTest" />
+    <PackageReference Include="Aspire.Hosting.Testing" Sdk="MSTest"
+                      Version="$(AspireHostingTestingVersion)" VersionOverride="$(AspireHostingTestingVersion)" />
   </ItemGroup>
 
   <!--

--- a/src/Package/MSTest.Sdk/Sdk/Features/Playwright.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Features/Playwright.targets
@@ -2,7 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright.MSTest" Version="$(MicrosoftPlaywrightVersion)" VersionOverride="$(MicrosoftPlaywrightVersion)" Sdk="MSTest" />
+    <PackageReference Include="Microsoft.Playwright.MSTest" Sdk="MSTest"
+                      Version="$(MicrosoftPlaywrightVersion)" VersionOverride="$(MicrosoftPlaywrightVersion)" />
   </ItemGroup>
 
   <!--

--- a/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
@@ -28,29 +28,50 @@
 
   <!-- Core -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" VersionOverride="$(MicrosoftNETTestSdkVersion)" Sdk="MSTest" />
+    <PackageReference Include="MSTest.TestFramework" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.Analyzers" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)"
+                      Condition=" '$(EnableMSTestAnalyzers)' != 'false' " />
+  </ItemGroup>
+
+  <!-- Core (for test applications - not for test libraries) -->
+  <ItemGroup Condition=" '$(IsTestLibrary)' != 'true' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Sdk="MSTest"
+                      Version="$(MicrosoftNETTestSdkVersion)" VersionOverride="$(MicrosoftNETTestSdkVersion)" />
     <!--
       Most of the times this dependency is not required but we leave the opportunity to align the version of the platform being used.
       At the moment this is mainly used for our acceptance tests because the locally/CI built version ends with -dev or -ci which is
       considered by NuGet resolver as older than any -preview version. Using this property we can ensure the local version is being
       selected.
       -->
-    <PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" VersionOverride="$(MicrosoftTestingPlatformVersion)" Sdk="MSTest"
+    <PackageReference Include="Microsoft.Testing.Platform" Sdk="MSTest"
+                      Version="$(MicrosoftTestingPlatformVersion)" VersionOverride="$(MicrosoftTestingPlatformVersion)"
                       Condition=" '$(EnableMicrosoftTestingPlatform)' == 'true' " />
-    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.Analyzers" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Sdk="MSTest"
-                      Condition=" '$(EnableMSTestAnalyzers)' != 'false' " />
+    <PackageReference Include="MSTest.TestAdapter" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" />
   </ItemGroup>
 
-  <!-- Extensions -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingExtensionsTrxReportVersion)" VersionOverride="$(MicrosoftTestingExtensionsTrxReportVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsTrxReport)' == 'true' " Sdk="MSTest" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingExtensionsCrashDumpVersion)" VersionOverride="$(MicrosoftTestingExtensionsCrashDumpVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsCrashDump)' == 'true' " Sdk="MSTest" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingExtensionsHangDumpVersion)" VersionOverride="$(MicrosoftTestingExtensionsHangDumpVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsHangDump)' == 'true' " Sdk="MSTest" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" VersionOverride="$(MicrosoftTestingExtensionsCodeCoverageVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' " Sdk="MSTest" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HotReload" Version="$(MicrosoftTestingExtensionsHotReloadVersion)" VersionOverride="$(MicrosoftTestingExtensionsHotReloadVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsHotReload)' == 'true' " Sdk="MSTest" />
-    <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$(MicrosoftTestingExtensionsRetryVersion)" VersionOverride="$(MicrosoftTestingExtensionsRetryVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsRetry)' == 'true' " Sdk="MSTest" />
+  <!-- Extensions (for test applications - not for test libraries) -->
+  <ItemGroup Condition=" '$(IsTestLibrary)' != 'true' ">
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsTrxReportVersion)" VersionOverride="$(MicrosoftTestingExtensionsTrxReportVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsTrxReport)' == 'true' " />
+    <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsCrashDumpVersion)" VersionOverride="$(MicrosoftTestingExtensionsCrashDumpVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsCrashDump)' == 'true' " />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsHangDumpVersion)" VersionOverride="$(MicrosoftTestingExtensionsHangDumpVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsHangDump)' == 'true' " />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" VersionOverride="$(MicrosoftTestingExtensionsCodeCoverageVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' " />
+    <PackageReference Include="Microsoft.Testing.Extensions.HotReload" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsHotReloadVersion)" VersionOverride="$(MicrosoftTestingExtensionsHotReloadVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsHotReload)' == 'true' " />
+    <PackageReference Include="Microsoft.Testing.Extensions.Retry" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsRetryVersion)" VersionOverride="$(MicrosoftTestingExtensionsRetryVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsRetry)' == 'true' " />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../Features/Aspire.targets" Condition=" '$(EnableAspireTesting)' == 'true' " />

--- a/src/Package/MSTest.Sdk/Sdk/Runner/Common.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/Common.targets
@@ -3,7 +3,9 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <OutputType>Exe</OutputType>
+    <OutputType Condition=" '$(OutputType)' == '' ">Exe</OutputType>
+    <IsTestLibrary Condition=" '$(OutputType)' == 'Library' ">true</IsTestLibrary>
+    <IsTestLibrary Condition=" '$(OutputType)' != 'Library' ">false</IsTestLibrary>
     <MicrosoftTestingExtensionsCommonVersion Condition=" '$(MicrosoftTestingExtensionsCommonVersion)' == '' " >$(MicrosoftTestingPlatformVersion)</MicrosoftTestingExtensionsCommonVersion>
     <TestingPlatformDotnetTestSupport Condition=" $(TestingPlatformDotnetTestSupport) == '' ">true</TestingPlatformDotnetTestSupport>
     <TestingExtensionsProfile Condition=" $(TestingExtensionsProfile) == '' ">Default</TestingExtensionsProfile>

--- a/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
@@ -13,18 +13,28 @@
 
   <!-- Core -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="$(MicrosoftTestingPlatformVersion)" VersionOverride="$(MicrosoftTestingPlatformVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.Engine" Version="$(MSTestEngineVersion)" VersionOverride="$(MSTestEngineVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.SourceGeneration" Version="$(MSTestEngineVersion)" VersionOverride="$(MSTestEngineVersion)" Sdk="MSTest" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Sdk="MSTest"
+                      Version="$(MicrosoftTestingPlatformVersion)" VersionOverride="$(MicrosoftTestingPlatformVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.Engine" Sdk="MSTest"
+                      Version="$(MSTestEngineVersion)" VersionOverride="$(MSTestEngineVersion)" />
+    <PackageReference Include="MSTest.SourceGeneration" Sdk="MSTest"
+                      Version="$(MSTestEngineVersion)" VersionOverride="$(MSTestEngineVersion)" />
   </ItemGroup>
 
   <!-- Extensions -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingExtensionsTrxReportVersion)" VersionOverride="$(MicrosoftTestingExtensionsTrxReportVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsTrxReport)' == 'true' " Sdk="MSTest" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" VersionOverride="$(MicrosoftTestingExtensionsCodeCoverageVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' " Sdk="MSTest" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsTrxReportVersion)" VersionOverride="$(MicrosoftTestingExtensionsTrxReportVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsTrxReport)' == 'true' " />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" VersionOverride="$(MicrosoftTestingExtensionsCodeCoverageVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' " />
     <!-- Support for -p:AotMsCodeCoverageInstrumentation="true" during dotnet publish for native aot -->
-    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" VersionOverride="$(MicrosoftTestingExtensionsCodeCoverageVersion)" Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' and $(PublishAot) == 'true' " Sdk="MSTest" />
+    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Sdk="MSTest"
+                      Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" VersionOverride="$(MicrosoftTestingExtensionsCodeCoverageVersion)"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' and $(PublishAot) == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/Package/MSTest.Sdk/Sdk/VSTest/VSTest.targets
+++ b/src/Package/MSTest.Sdk/Sdk/VSTest/VSTest.targets
@@ -2,11 +2,26 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" VersionOverride="$(MicrosoftNETTestSdkVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Sdk="MSTest" />
-    <PackageReference Include="MSTest.Analyzers" Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" Condition=" '$(EnableMSTestAnalyzers)' != 'false' " Sdk="MSTest" />
+    <PackageReference Include="MSTest.TestFramework" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.Analyzers" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)"
+                      Condition=" '$(EnableMSTestAnalyzers)' != 'false' " />
   </ItemGroup>
+
+  <!-- If we are a test application (not a test library) -->
+  <ItemGroup Condition=" '$(IsTestLibrary)' != 'true' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Sdk="MSTest"
+                      Version="$(MicrosoftNETTestSdkVersion)" VersionOverride="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="MSTest.TestAdapter" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.Analyzers" Sdk="MSTest"
+                      Version="$(MSTestVersion)" VersionOverride="$(MSTestVersion)"
+                      Condition=" '$(EnableMSTestAnalyzers)' != 'false' " />
+  </ItemGroup>
+
 
   <!--
     Implicit imports

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -7,9 +7,11 @@ using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 using Microsoft.Testing.Platform.Helpers;
 
+using SL = Microsoft.Build.Logging.StructuredLogger;
+
 namespace MSTest.Acceptance.IntegrationTests;
 
-// [TestGroup]
+[TestGroup]
 public sealed class SdkTests : AcceptanceTestBase
 {
     private const string AssetName = "MSTestSdk";
@@ -66,7 +68,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration))]
-    public async Task RunTests_With_VSTest(string multiTfm, BuildConfiguration buildConfiguration)
+    private async Task RunTests_With_VSTest(string multiTfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -103,7 +105,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration))]
-    public async Task RunTests_With_MSTestRunner_DotnetTest(string multiTfm, BuildConfiguration buildConfiguration)
+    private async Task RunTests_With_MSTestRunner_DotnetTest(string multiTfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -140,7 +142,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration))]
-    public async Task RunTests_With_MSTestRunner_Standalone(string multiTfm, BuildConfiguration buildConfiguration)
+    private async Task RunTests_With_MSTestRunner_Standalone(string multiTfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -172,7 +174,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration))]
-    public async Task RunTests_With_CentralPackageManagement_Standalone(string multiTfm, BuildConfiguration buildConfiguration)
+    private async Task RunTests_With_CentralPackageManagement_Standalone(string multiTfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -203,7 +205,7 @@ namespace MSTestSdkTest
         }
     }
 
-    public static IEnumerable<TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration, string MSBuildExtensionEnableFragment, string EnableCommandLineArg, string InvalidCommandLineArg)>> RunTests_With_MSTestRunner_Standalone_Plus_Extensions_Data()
+    private static IEnumerable<TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration, string MSBuildExtensionEnableFragment, string EnableCommandLineArg, string InvalidCommandLineArg)>> RunTests_With_MSTestRunner_Standalone_Plus_Extensions_Data()
     {
         foreach (TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration)> buildConfig in GetBuildMatrixMultiTfmFoldedBuildConfiguration())
         {
@@ -245,7 +247,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(RunTests_With_MSTestRunner_Standalone_Plus_Extensions_Data))]
-    public async Task RunTests_With_MSTestRunner_Standalone_Selectively_Enabled_Extensions(string multiTfm, BuildConfiguration buildConfiguration,
+    private async Task RunTests_With_MSTestRunner_Standalone_Selectively_Enabled_Extensions(string multiTfm, BuildConfiguration buildConfiguration,
         string msbuildExtensionEnableFragment,
         string enableCommandLineArg,
         string invalidCommandLineArg)
@@ -283,7 +285,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration))]
-    public async Task RunTests_With_MSTestRunner_Standalone_EnableAll_Extensions(string multiTfm, BuildConfiguration buildConfiguration)
+    private async Task RunTests_With_MSTestRunner_Standalone_EnableAll_Extensions(string multiTfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -314,7 +316,7 @@ namespace MSTestSdkTest
         }
     }
 
-    public static IEnumerable<TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration, bool EnableDefaultExtensions)>> RunTests_With_MSTestRunner_Standalone_Default_Extensions_Data()
+    private static IEnumerable<TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration, bool EnableDefaultExtensions)>> RunTests_With_MSTestRunner_Standalone_Default_Extensions_Data()
     {
         foreach (TestArgumentsEntry<(string MultiTfm, BuildConfiguration BuildConfiguration)> buildConfig in GetBuildMatrixMultiTfmFoldedBuildConfiguration())
         {
@@ -329,7 +331,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(RunTests_With_MSTestRunner_Standalone_Default_Extensions_Data))]
-    public async Task RunTests_With_MSTestRunner_Standalone_Enable_Default_Extensions(string multiTfm, BuildConfiguration buildConfiguration, bool enableDefaultExtensions)
+    private async Task RunTests_With_MSTestRunner_Standalone_Enable_Default_Extensions(string multiTfm, BuildConfiguration buildConfiguration, bool enableDefaultExtensions)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -368,7 +370,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration))]
-    public async Task Invalid_TestingProfile_Name_Should_Fail(string multiTfm, BuildConfiguration buildConfiguration)
+    private async Task Invalid_TestingProfile_Name_Should_Fail(string multiTfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
                AssetName,
@@ -394,7 +396,7 @@ namespace MSTestSdkTest
         compilationResult.AssertOutputContains("Invalid value for property TestingExtensionsProfile. Valid values are 'Default', 'AllMicrosoft' and 'None'.");
     }
 
-    public async Task NativeAot_Smoke_Test_On_Windows() =>
+    private async Task NativeAot_Smoke_Test_On_Windows() =>
         // Sometimes we got strange error from the compilers like "fatal error LNK1136: invalid or corrupt file"
         // I suppose due to the load on the build machines. So, we retry the test a few times.
         await RetryHelper.RetryAsync(
@@ -437,7 +439,7 @@ namespace MSTestSdkTest
             }, 3, TimeSpan.FromSeconds(5));
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
-    public async Task EnablePlaywrightProperty_WhenUsingRunner_AllowsToRunPlaywrightTests(string tfm)
+    private async Task EnablePlaywrightProperty_WhenUsingRunner_AllowsToRunPlaywrightTests(string tfm)
     {
         var testHost = TestHost.LocateFrom(_testAssetFixture.PlaywrightProjectPath, TestAssetFixture.PlaywrightProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync();
@@ -461,7 +463,7 @@ namespace MSTestSdkTest
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
-    public async Task EnablePlaywrightProperty_WhenUsingVSTest_AllowsToRunPlaywrightTests(string tfm)
+    private async Task EnablePlaywrightProperty_WhenUsingVSTest_AllowsToRunPlaywrightTests(string tfm)
     {
         var testHost = TestHost.LocateFrom(_testAssetFixture.PlaywrightProjectPath, TestAssetFixture.PlaywrightProjectName, tfm);
         string exeOrDllName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -490,14 +492,14 @@ namespace MSTestSdkTest
         }
     }
 
-    public async Task EnableAspireProperty_WhenUsingRunner_AllowsToRunAspireTests()
+    private async Task EnableAspireProperty_WhenUsingRunner_AllowsToRunAspireTests()
     {
         var testHost = TestHost.LocateFrom(_testAssetFixture.AspireProjectPath, TestAssetFixture.AspireProjectName, TargetFrameworks.NetCurrent.UidFragment);
         TestHostResult testHostResult = await testHost.ExecuteAsync();
         testHostResult.AssertOutputContains("Passed! - Failed: 0, Passed: 1, Skipped: 0, Total: 1");
     }
 
-    public async Task EnableAspireProperty_WhenUsingVSTest_AllowsToRunAspireTests()
+    private async Task EnableAspireProperty_WhenUsingVSTest_AllowsToRunAspireTests()
     {
         var testHost = TestHost.LocateFrom(_testAssetFixture.AspireProjectPath, TestAssetFixture.AspireProjectName, TargetFrameworks.NetCurrent.UidFragment);
         string exeOrDllName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -508,6 +510,37 @@ namespace MSTestSdkTest
         // Ensure output contains the right platform banner
         dotnetTestResult.AssertOutputContains("Test Execution Command Line Tool");
         dotnetTestResult.AssertOutputContains("Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1");
+    }
+
+    public async Task SettingOutputTypeToLibraryReducesAddedExtensions()
+    {
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+               AssetName,
+               SingleTestSourceCode
+               .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+               .PatchCodeWithReplace("$OutputType$", "<OutputType>Library</OutputType>")
+               .PatchCodeWithReplace("$TargetFramework$", $"<TargetFrameworks>{TargetFrameworks.NetCurrent.UidFragment}</TargetFrameworks>")
+               .PatchCodeWithReplace("$EnableMSTestRunner$", string.Empty)
+               .PatchCodeWithReplace("$TestingPlatformDotnetTestSupport$", string.Empty)
+               .PatchCodeWithReplace("$ExtraProperties$", string.Empty)
+               .PatchCodeWithReplace("$Extensions$", string.Empty));
+        string binlogFile = Path.Combine(testAsset.TargetAssetPath, Guid.NewGuid().ToString("N"), "msbuild.binlog");
+
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"test {testAsset.TargetAssetPath} -bl:{binlogFile}", _acceptanceFixture.NuGetGlobalPackagesFolder.Path);
+
+        Assert.AreEqual(0, compilationResult.ExitCode);
+
+        SL.Build binLog = SL.Serialization.Read(binlogFile);
+        SL.Task cscTask = binLog.FindChildrenRecursive<SL.Task>(task => task.Name == "Csc").Single();
+        SL.Item[] references = cscTask.FindChildrenRecursive<SL.Parameter>(p => p.Name == "References").Single().Children.OfType<SL.Item>().ToArray();
+
+        // Ensure that MSTest.Framework is referenced
+        Assert.IsTrue(references.Any(r => r.Text.EndsWith("Microsoft.VisualStudio.TestPlatform.TestFramework.dll", StringComparison.OrdinalIgnoreCase)));
+        Assert.IsTrue(references.Any(r => r.Text.EndsWith("Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll", StringComparison.OrdinalIgnoreCase)));
+
+        // No adapter, no extensions, no vstest sdk
+        Assert.IsFalse(references.Any(r => r.Text.EndsWith("Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll", StringComparison.OrdinalIgnoreCase)));
+        Assert.IsFalse(references.Any(r => r.Text.Contains("Microsoft.Testing.Extensions.", StringComparison.OrdinalIgnoreCase)));
     }
 
     [TestFixture(TestFixtureSharingStrategy.PerTestGroup)]


### PR DESCRIPTION
This pull request includes several changes to allow MSTest.Sdk to be used on infra/shared testing libraries. For these libraries, `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter` and all `Microsoft.Testing.Extensions.*` packages are not required.

Fixes #3567 