### PR TITLE
Fix writing colors to terminal

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -580,7 +580,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
             return;
         }
 
-        terminal.SetColor(TerminalColor.Red);
+        terminal.SetColor(TerminalColor.Blue);
         AppendIndentedMessage(terminal, errorMessage, SingleIndentation);
         terminal.ResetColor();
         terminal.AppendLine();
@@ -683,7 +683,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         _terminalWithProgress.WriteToTerminal(terminal =>
         {
-            terminal.SetColor(TerminalColor.Red);
+            terminal.SetColor(TerminalColor.Blue);
             terminal.AppendLine(text);
             terminal.ResetColor();
         });
@@ -704,6 +704,61 @@ internal sealed partial class TerminalTestReporter : IDisposable
     internal void WriteErrorMessage(string assembly, string? targetFramework, string? architecture, Exception exception)
         => WriteErrorMessage(assembly, targetFramework, architecture, exception.ToString());
 
-    internal void WriteMessage(string text)
-        => _terminalWithProgress.WriteToTerminal(terminal => terminal.AppendLine(text));
+    internal void WriteMessage(string text, SystemConsoleColor? color = null)
+    {
+        if (color != null)
+        {
+            _terminalWithProgress.WriteToTerminal(terminal =>
+            {
+                terminal.SetColor(ToTerminalColor(color.ConsoleColor));
+                terminal.AppendLine(text);
+                terminal.ResetColor();
+            });
+        }
+        else
+        {
+            _terminalWithProgress.WriteToTerminal(terminal => terminal.AppendLine(text));
+        }
+    }
+
+    private TerminalColor ToTerminalColor(ConsoleColor consoleColor)
+    {
+        switch (consoleColor)
+        {
+            case ConsoleColor.Black:
+                return TerminalColor.Black;
+            case ConsoleColor.DarkBlue:
+                return TerminalColor.DarkBlue;
+            case ConsoleColor.DarkGreen:
+                return TerminalColor.DarkGreen;
+            case ConsoleColor.DarkCyan:
+                return TerminalColor.DarkCyan;
+            case ConsoleColor.DarkRed:
+                return TerminalColor.DarkRed;
+            case ConsoleColor.DarkMagenta:
+                return TerminalColor.DarkMagenta;
+            case ConsoleColor.DarkYellow:
+                return TerminalColor.DarkYellow;
+            case ConsoleColor.Gray:
+                return TerminalColor.Gray;
+            case ConsoleColor.DarkGray:
+                return TerminalColor.Gray;
+            case ConsoleColor.Blue:
+                return TerminalColor.Blue;
+            case ConsoleColor.Green:
+                return TerminalColor.Green;
+            case ConsoleColor.Cyan:
+                return TerminalColor.Cyan;
+            case ConsoleColor.Red:
+                return TerminalColor.Red;
+            case ConsoleColor.Magenta:
+                return TerminalColor.Magenta;
+            case ConsoleColor.Yellow:
+                return TerminalColor.Yellow;
+            case ConsoleColor.White:
+                return TerminalColor.White;
+            default:
+                return TerminalColor.Default;
+        }
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -580,7 +580,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
             return;
         }
 
-        terminal.SetColor(TerminalColor.Blue);
+        terminal.SetColor(TerminalColor.Red);
         AppendIndentedMessage(terminal, errorMessage, SingleIndentation);
         terminal.ResetColor();
         terminal.AppendLine();
@@ -683,7 +683,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         _terminalWithProgress.WriteToTerminal(terminal =>
         {
-            terminal.SetColor(TerminalColor.Blue);
+            terminal.SetColor(TerminalColor.Red);
             terminal.AppendLine(text);
             terminal.ResetColor();
         });

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -722,43 +722,24 @@ internal sealed partial class TerminalTestReporter : IDisposable
     }
 
     private TerminalColor ToTerminalColor(ConsoleColor consoleColor)
-    {
-        switch (consoleColor)
+        => consoleColor switch
         {
-            case ConsoleColor.Black:
-                return TerminalColor.Black;
-            case ConsoleColor.DarkBlue:
-                return TerminalColor.DarkBlue;
-            case ConsoleColor.DarkGreen:
-                return TerminalColor.DarkGreen;
-            case ConsoleColor.DarkCyan:
-                return TerminalColor.DarkCyan;
-            case ConsoleColor.DarkRed:
-                return TerminalColor.DarkRed;
-            case ConsoleColor.DarkMagenta:
-                return TerminalColor.DarkMagenta;
-            case ConsoleColor.DarkYellow:
-                return TerminalColor.DarkYellow;
-            case ConsoleColor.Gray:
-                return TerminalColor.Gray;
-            case ConsoleColor.DarkGray:
-                return TerminalColor.Gray;
-            case ConsoleColor.Blue:
-                return TerminalColor.Blue;
-            case ConsoleColor.Green:
-                return TerminalColor.Green;
-            case ConsoleColor.Cyan:
-                return TerminalColor.Cyan;
-            case ConsoleColor.Red:
-                return TerminalColor.Red;
-            case ConsoleColor.Magenta:
-                return TerminalColor.Magenta;
-            case ConsoleColor.Yellow:
-                return TerminalColor.Yellow;
-            case ConsoleColor.White:
-                return TerminalColor.White;
-            default:
-                return TerminalColor.Default;
-        }
-    }
+            ConsoleColor.Black => TerminalColor.Black,
+            ConsoleColor.DarkBlue => TerminalColor.DarkBlue,
+            ConsoleColor.DarkGreen => TerminalColor.DarkGreen,
+            ConsoleColor.DarkCyan => TerminalColor.DarkCyan,
+            ConsoleColor.DarkRed => TerminalColor.DarkRed,
+            ConsoleColor.DarkMagenta => TerminalColor.DarkMagenta,
+            ConsoleColor.DarkYellow => TerminalColor.DarkYellow,
+            ConsoleColor.Gray => TerminalColor.Gray,
+            ConsoleColor.DarkGray => TerminalColor.Gray,
+            ConsoleColor.Blue => TerminalColor.Blue,
+            ConsoleColor.Green => TerminalColor.Green,
+            ConsoleColor.Cyan => TerminalColor.Cyan,
+            ConsoleColor.Red => TerminalColor.Red,
+            ConsoleColor.Magenta => TerminalColor.Magenta,
+            ConsoleColor.Yellow => TerminalColor.Yellow,
+            ConsoleColor.White => TerminalColor.White,
+            _ => TerminalColor.Default,
+        };
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -721,7 +721,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         }
     }
 
-    private TerminalColor ToTerminalColor(ConsoleColor consoleColor)
+    private static TerminalColor ToTerminalColor(ConsoleColor consoleColor)
         => consoleColor switch
         {
             ConsoleColor.Black => TerminalColor.Black,

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -352,7 +352,7 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
                                 _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _architecture, formattedTextOutputDeviceData.Text);
                                 break;
                             default:
-                                _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text);
+                                _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text, color);
                                 break;
                         }
                     }


### PR DESCRIPTION
Allow any system.color to be written by formatted text message, instead of just supporting red and yellow for error and warning.