### PR TITLE
Change non-ansi progress indicators to ascii

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
@@ -177,10 +177,12 @@ internal sealed class NonAnsiTerminal : ITerminal
             int failed = p.Failed;
             int skipped = p.Skipped;
 
+            // Use just ascii here, so we don't put too many restrictions on fonts needing to
+            // properly show unicode, or logs being saved in particular encoding.
             string? detail = !RoslynString.IsNullOrWhiteSpace(p.Detail) ? $"- {p.Detail}" : null;
             Append('[');
             SetColor(TerminalColor.DarkGreen);
-            Append('✓');
+            Append('+');
             Append(passed.ToString(CultureInfo.CurrentCulture));
             ResetColor();
 
@@ -194,7 +196,7 @@ internal sealed class NonAnsiTerminal : ITerminal
             Append('/');
 
             SetColor(TerminalColor.DarkYellow);
-            Append('↓');
+            Append('?');
             Append(skipped.ToString(CultureInfo.CurrentCulture));
             ResetColor();
             Append(']');


### PR DESCRIPTION
Change to using just ascii to avoid breaking the progress in text, when saved in non-unicode encoding, or not having the right font: 

![image](https://github.com/user-attachments/assets/c2ea770f-04ac-4501-9f7f-8153f5632c84)


also easier to find: 

`[+0/x0/?0]`