### PR TITLE
Add known report files

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -16,15 +16,27 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 /// </summary>
 internal sealed class AnsiTerminal : ITerminal
 {
+    /// <summary>
+    /// File extensions that we will link to directly, all other files
+    /// are linked to their directory, to avoid opening dlls, or executables.
+    /// </summary>
     private static readonly string[] KnownFileExtensions = new string[]
     {
+        // code files
         ".cs",
         ".vb",
         ".fs",
-        ".trx",
-        ".coverage",
+        // logs
         ".log",
         ".txt",
+        // reports
+        ".coverage",
+        ".ctrf",
+        ".html",
+        ".junit",
+        ".nunit",
+        ".trx",
+        ".xml",
     };
 
     private readonly IConsole _console;


### PR DESCRIPTION
Add extensions for report files used by xunit.

![image](https://github.com/user-attachments/assets/457b69ab-be02-4a37-9bd4-24c5f316d52a)
