### PR TITLE
Change --help formatting (and fix --info)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.Designer.cs
@@ -151,8 +151,8 @@ namespace Microsoft.Testing.Extensions.Diagnostics.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the type of the dump. 
-        ///Valid values are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; or &apos;Full&apos;. Default type is &apos;Full&apos;. 
+        ///   Looks up a localized string similar to Specify the type of the dump.
+        ///Valid values are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; or &apos;Full&apos;. Default type is &apos;Full&apos;.
         ///For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps.
         /// </summary>
         internal static string CrashDumpTypeOptionDescription {

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.Designer.cs
@@ -151,7 +151,9 @@ namespace Microsoft.Testing.Extensions.Diagnostics.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the type of the dump. Valid values are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; or &apos;Full&apos;. Default type is &apos;Full&apos;. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps.
+        ///   Looks up a localized string similar to Specify the type of the dump. 
+        ///Valid values are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; or &apos;Full&apos;. Default type is &apos;Full&apos;. 
+        ///For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps.
         /// </summary>
         internal static string CrashDumpTypeOptionDescription {
             get {

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
@@ -148,7 +148,9 @@
     <value>Test host process with PID '{0}' crashed, a dump file was generated</value>
   </data>
   <data name="CrashDumpTypeOptionDescription" xml:space="preserve">
-    <value>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</value>
+    <value>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</value>
   </data>
   <data name="CrashDumpTypeOptionInvalidType" xml:space="preserve">
     <value>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' and 'Full'</value>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
@@ -148,8 +148,8 @@
     <value>Test host process with PID '{0}' crashed, a dump file was generated</value>
   </data>
   <data name="CrashDumpTypeOptionDescription" xml:space="preserve">
-    <value>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+    <value>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</value>
   </data>
   <data name="CrashDumpTypeOptionInvalidType" xml:space="preserve">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Zadejte typ výpisu paměti. Platné hodnoty jsou Mini, Heap, Triage nebo Full. Výchozí typ je Full. Další informace najdete na https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Zadejte typ výpisu paměti. Platné hodnoty jsou Mini, Heap, Triage nebo Full. Výchozí typ je Full. Další informace najdete na https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Zadejte typ výpisu paměti. Platné hodnoty jsou Mini, Heap, Triage nebo Full. Výchozí typ je Full. Další informace najdete na https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Geben Sie den Typ des Speicherabbilds an. Gültige Werte sind „Mini“, „Heap“, „Triage“ oder „Full“. Der Standardtyp ist „Full“. Weitere Informationen finden Sie unter https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Geben Sie den Typ des Speicherabbilds an. Gültige Werte sind „Mini“, „Heap“, „Triage“ oder „Full“. Der Standardtyp ist „Full“. Weitere Informationen finden Sie unter https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Geben Sie den Typ des Speicherabbilds an. Gültige Werte sind „Mini“, „Heap“, „Triage“ oder „Full“. Der Standardtyp ist „Full“. Weitere Informationen finden Sie unter https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Especifique el tipo de volcado. Los valores válidos son "Mini", "Heap", "Evaluación de prioridades" o "Completo". El tipo predeterminado es 'Completo'. Para obtener más información, visite https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Especifique el tipo de volcado. Los valores válidos son "Mini", "Heap", "Evaluación de prioridades" o "Completo". El tipo predeterminado es 'Completo'. Para obtener más información, visite https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Especifique el tipo de volcado. Los valores válidos son "Mini", "Heap", "Evaluación de prioridades" o "Completo". El tipo predeterminado es 'Completo'. Para obtener más información, visite https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Spécifiez le type de l’image mémoire. Les valeurs valides sont « Mini », « Heap », « Triage » ou « Full ». Le type par défaut est « Full ». Pour plus d’informations, visitez https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Spécifiez le type de l’image mémoire. Les valeurs valides sont « Mini », « Heap », « Triage » ou « Full ». Le type par défaut est « Full ». Pour plus d’informations, visitez https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Spécifiez le type de l’image mémoire. Les valeurs valides sont « Mini », « Heap », « Triage » ou « Full ». Le type par défaut est « Full ». Pour plus d’informations, visitez https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Specificare il tipo di dump. I valori validi sono "Mini", "Heap", "Valutazione" o "Completo". Il tipo predefinito è "Completo". Per altre informazioni, visitare https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Specificare il tipo di dump. I valori validi sono "Mini", "Heap", "Valutazione" o "Completo". Il tipo predefinito è "Completo". Per altre informazioni, visitare https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Specificare il tipo di dump. I valori validi sono "Mini", "Heap", "Valutazione" o "Completo". Il tipo predefinito è "Completo". Per altre informazioni, visitare https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">ダンプの型を指定します。有効な値は、'Mini'、'Heap'、'Triage'、または 'Full' です。既定の型は 'Full' です。詳細については、https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps を参照してください</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">ダンプの型を指定します。有効な値は、'Mini'、'Heap'、'Triage'、または 'Full' です。既定の型は 'Full' です。詳細については、https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps を参照してください</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">ダンプの型を指定します。有効な値は、'Mini'、'Heap'、'Triage'、または 'Full' です。既定の型は 'Full' です。詳細については、https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps を参照してください</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">덤프 유형을 지정합니다. 유효한 값은 'Mini', 'Heap', 'Triage' 또는 'Full'입니다. 기본 유형은 'Full'입니다. 자세한 내용은 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps를 방문하세요.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">덤프 유형을 지정합니다. 유효한 값은 'Mini', 'Heap', 'Triage' 또는 'Full'입니다. 기본 유형은 'Full'입니다. 자세한 내용은 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps를 방문하세요.</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">덤프 유형을 지정합니다. 유효한 값은 'Mini', 'Heap', 'Triage' 또는 'Full'입니다. 기본 유형은 'Full'입니다. 자세한 내용은 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps를 방문하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Określ typ zrzutu. Prawidłowe wartości to „Mini”, „Sterta”, „Klasyfikacja” i „Pełne”. Typ domyślny to „Pełne”. Aby uzyskać więcej informacji, odwiedź stronę https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Określ typ zrzutu. Prawidłowe wartości to „Mini”, „Sterta”, „Klasyfikacja” i „Pełne”. Typ domyślny to „Pełne”. Aby uzyskać więcej informacji, odwiedź stronę https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Określ typ zrzutu. Prawidłowe wartości to „Mini”, „Sterta”, „Klasyfikacja” i „Pełne”. Typ domyślny to „Pełne”. Aby uzyskać więcej informacji, odwiedź stronę https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Especifique o tipo de despejo. Os valores válidos são ''Mini'', ''Heap'', ''Triage'' ou ''Full''. O tipo padrão é ''Full''. Para obter mais informações, visite https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Especifique o tipo de despejo. Os valores válidos são ''Mini'', ''Heap'', ''Triage'' ou ''Full''. O tipo padrão é ''Full''. Para obter mais informações, visite https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Especifique o tipo de despejo. Os valores válidos são ''Mini'', ''Heap'', ''Triage'' ou ''Full''. O tipo padrão é ''Full''. Para obter mais informações, visite https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Укажите тип дампа. Допустимые значения: "Mini", "Heap", "Triage" или "Full". Тип по умолчанию — "Full". Дополнительные сведения см. на странице https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Укажите тип дампа. Допустимые значения: "Mini", "Heap", "Triage" или "Full". Тип по умолчанию — "Full". Дополнительные сведения см. на странице https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Укажите тип дампа. Допустимые значения: "Mini", "Heap", "Triage" или "Full". Тип по умолчанию — "Full". Дополнительные сведения см. на странице https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">Dökümün türünü belirtin. Geçerli değerler: 'Mini', 'Heap', 'Triage' veya 'Full'. Varsayılan tür: 'Full'. Daha fazla bilgi için https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps adresini ziyaret edin</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">Dökümün türünü belirtin. Geçerli değerler: 'Mini', 'Heap', 'Triage' veya 'Full'. Varsayılan tür: 'Full'. Daha fazla bilgi için https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps adresini ziyaret edin</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">Dökümün türünü belirtin. Geçerli değerler: 'Mini', 'Heap', 'Triage' veya 'Full'. Varsayılan tür: 'Full'. Daha fazla bilgi için https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps adresini ziyaret edin</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">指定转储的类型。有效值为 "Mini"、"Heap"、"Triage" 或 "Full"。默认类型为 "Full"。有关详细信息，请访问 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">指定转储的类型。有效值为 "Mini"、"Heap"、"Triage" 或 "Full"。默认类型为 "Full"。有关详细信息，请访问 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">指定转储的类型。有效值为 "Mini"、"Heap"、"Triage" 或 "Full"。默认类型为 "Full"。有关详细信息，请访问 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. 
-Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
 For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
         <target state="needs-review-translation">指定傾印的類型。有效值為 'Mini'、'Heap'、'Triage' 或 'Full'。預設類型為 'Full'。如需詳細資訊，請瀏覽 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
@@ -53,8 +53,10 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
-        <target state="translated">指定傾印的類型。有效值為 'Mini'、'Heap'、'Triage' 或 'Full'。預設類型為 'Full'。如需詳細資訊，請瀏覽 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
+        <source>Specify the type of the dump. 
+Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. 
+For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</source>
+        <target state="needs-review-translation">指定傾印的類型。有效值為 'Mini'、'Heap'、'Triage' 或 'Full'。預設類型為 'Full'。如需詳細資訊，請瀏覽 https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpTypeOptionInvalidType">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.Designer.cs
@@ -152,10 +152,10 @@ namespace Microsoft.Testing.Extensions.Diagnostics.Resources {
         
         /// <summary>
         ///   Looks up a localized string similar to Specify the timeout after which the dump will be generated.
-        ///The timeout value is specified in one of the following formats: 
-        ///    1.5h, 1.5hour, 1.5hours, 
-        ///    90m, 90min, 90minute, 90minutes, 
-        ///    5400s, 5400sec, 5400second, 5400seconds. 
+        ///The timeout value is specified in one of the following formats:
+        ///    1.5h, 1.5hour, 1.5hours,
+        ///    90m, 90min, 90minute, 90minutes,
+        ///    5400s, 5400sec, 5400second, 5400seconds.
         ///    Default is 30m..
         /// </summary>
         internal static string HangDumpTimeoutOptionDescription {

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.Designer.cs
@@ -151,7 +151,12 @@ namespace Microsoft.Testing.Extensions.Diagnostics.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m..
+        ///   Looks up a localized string similar to Specify the timeout after which the dump will be generated.
+        ///The timeout value is specified in one of the following formats: 
+        ///    1.5h, 1.5hour, 1.5hours, 
+        ///    90m, 90min, 90minute, 90minutes, 
+        ///    5400s, 5400sec, 5400second, 5400seconds. 
+        ///    Default is 30m..
         /// </summary>
         internal static string HangDumpTimeoutOptionDescription {
             get {
@@ -169,7 +174,9 @@ namespace Microsoft.Testing.Extensions.Diagnostics.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the type of the dump. Valid values are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; (only available in .NET 6+) or &apos;Full&apos;. Default type is &apos;Full&apos;.
+        ///   Looks up a localized string similar to Specify the type of the dump.
+        ///Valid values are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; (only available in .NET 6+) or &apos;Full&apos;.
+        ///Default type is &apos;Full&apos;.
         /// </summary>
         internal static string HangDumpTypeOptionDescription {
             get {
@@ -178,7 +185,8 @@ namespace Microsoft.Testing.Extensions.Diagnostics.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid dump type. Valid options are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; (only available in .NET 6+) and &apos;Full&apos;.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid dump type.
+        ///Valid options are &apos;Mini&apos;, &apos;Heap&apos;, &apos;Triage&apos; (only available in .NET 6+) and &apos;Full&apos;.
         /// </summary>
         internal static string HangDumpTypeOptionInvalidType {
             get {

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.resx
@@ -149,10 +149,10 @@
   </data>
   <data name="HangDumpTimeoutOptionDescription" xml:space="preserve">
     <value>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</value>
   </data>
   <data name="HangDumpTimeoutOptionInvalidArgument" xml:space="preserve">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.resx
@@ -148,16 +148,24 @@
     <value>Hang dump timeout of '{0}' expired</value>
   </data>
   <data name="HangDumpTimeoutOptionDescription" xml:space="preserve">
-    <value>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</value>
+    <value>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</value>
   </data>
   <data name="HangDumpTimeoutOptionInvalidArgument" xml:space="preserve">
     <value>'--hangdump-timeout' expects a single timeout argument</value>
   </data>
   <data name="HangDumpTypeOptionDescription" xml:space="preserve">
-    <value>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</value>
+    <value>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</value>
   </data>
   <data name="HangDumpTypeOptionInvalidType" xml:space="preserve">
-    <value>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</value>
+    <value>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</value>
   </data>
   <data name="HangDumpUnsupportedRequestTypeErrorMessage" xml:space="preserve">
     <value>Request of type '{0}' is not supported</value>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.cs.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Zadejte časový limit, po kterém bude vygenerován výpis paměti. Hodnota časového limitu se zadává v jednom z následujících formátů: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Výchozí hodnota je 30m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Zadejte časový limit, po kterém bude vygenerován výpis paměti. Hodnota časového limitu se zadává v jednom z následujících formátů: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Výchozí hodnota je 30m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Zadejte typ výpisu paměti. Platné hodnoty jsou Mini, Heap, Triage (dostupné pouze v .NET 6+) nebo Full. Výchozí typ je Full.</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Zadejte typ výpisu paměti. Platné hodnoty jsou Mini, Heap, Triage (dostupné pouze v .NET 6+) nebo Full. Výchozí typ je Full.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">{0} není platný typ výpisu paměti. Platné možnosti jsou Mini, Heap, Triage (k dispozici pouze v .NET 6+) a Full.</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">{0} není platný typ výpisu paměti. Platné možnosti jsou Mini, Heap, Triage (k dispozici pouze v .NET 6+) a Full.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.cs.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Zadejte časový limit, po kterém bude vygenerován výpis paměti. Hodnota časového limitu se zadává v jednom z následujících formátů: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Výchozí hodnota je 30m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.de.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Geben Sie das Timeout an, nach dem das Speicherabbild generiert wird. Der Timeoutwert wird in einem der folgenden Formate angegeben: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Der Standardwert ist 30m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Geben Sie das Timeout an, nach dem das Speicherabbild generiert wird. Der Timeoutwert wird in einem der folgenden Formate angegeben: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Der Standardwert ist 30m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Geben Sie den Typ des Speicherabbilds an. Gültige Werte sind "Mini", "Heap", "Triage" (nur in .NET 6 und höher verfügbar) oder "Full". Der Standardtyp ist "Full".</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Geben Sie den Typ des Speicherabbilds an. Gültige Werte sind "Mini", "Heap", "Triage" (nur in .NET 6 und höher verfügbar) oder "Full". Der Standardtyp ist "Full".</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">"{0}" ist kein gültiger Speicherabbildtyp. Gültige Optionen sind "Mini", "Heap", "Triage" (nur in .NET 6 und höher verfügbar) und "Full".</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">"{0}" ist kein gültiger Speicherabbildtyp. Gültige Optionen sind "Mini", "Heap", "Triage" (nur in .NET 6 und höher verfügbar) und "Full".</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.de.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Geben Sie das Timeout an, nach dem das Speicherabbild generiert wird. Der Timeoutwert wird in einem der folgenden Formate angegeben: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Der Standardwert ist 30m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.es.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Especifique el tiempo de espera después del cual se generará el volcado. El valor de tiempo de espera se especifica en uno de los formatos siguientes: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. El valor predeterminado es 30 m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.es.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Especifique el tiempo de espera después del cual se generará el volcado. El valor de tiempo de espera se especifica en uno de los formatos siguientes: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. El valor predeterminado es 30 m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Especifique el tiempo de espera después del cual se generará el volcado. El valor de tiempo de espera se especifica en uno de los formatos siguientes: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. El valor predeterminado es 30 m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Especifique el tipo de volcado. Los valores válidos son "Mini", "Heap", "Triage" (solo disponible en .NET 6+) o "Full". El tipo predeterminado es 'Full'</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Especifique el tipo de volcado. Los valores válidos son "Mini", "Heap", "Triage" (solo disponible en .NET 6+) o "Full". El tipo predeterminado es 'Full'</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}' no es un tipo de volcado válido. Las opciones válidas son "Mini", "Montón", "Evaluación de prioridades" (solo disponible en .NET 6+) y "Full"</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}' no es un tipo de volcado válido. Las opciones válidas son "Mini", "Montón", "Evaluación de prioridades" (solo disponible en .NET 6+) y "Full"</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.fr.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Spécifiez le délai d’expiration après lequel le vidage sera généré. La valeur du délai d'attente est spécifiée dans l'un des formats suivants : 1,5 h, 1,5 heure, 1,5 heure, 90 m, 90 min, 90 minutes, 90 minutes 5 400 s, 5 400 s, 5 400 secondes, 5 400 secondes. La valeur par défaut est 30 m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.fr.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Spécifiez le délai d’expiration après lequel le vidage sera généré. La valeur du délai d'attente est spécifiée dans l'un des formats suivants : 1,5 h, 1,5 heure, 1,5 heure, 90 m, 90 min, 90 minutes, 90 minutes 5 400 s, 5 400 s, 5 400 secondes, 5 400 secondes. La valeur par défaut est 30 m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Spécifiez le délai d’expiration après lequel le vidage sera généré. La valeur du délai d'attente est spécifiée dans l'un des formats suivants : 1,5 h, 1,5 heure, 1,5 heure, 90 m, 90 min, 90 minutes, 90 minutes 5 400 s, 5 400 s, 5 400 secondes, 5 400 secondes. La valeur par défaut est 30 m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Spécifiez le type de l’image mémoire. Les valeurs valides sont « Mini », « Heap », « Triage » (uniquement disponible dans .NET 6+) ou « Full ». Le type par défaut est ' Full'</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Spécifiez le type de l’image mémoire. Les valeurs valides sont « Mini », « Heap », « Triage » (uniquement disponible dans .NET 6+) ou « Full ». Le type par défaut est ' Full'</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}' n’est pas un type de vidage valide. Les options valides sont « Mini », « Heap », « Triage » (uniquement disponible dans .NET 6+) et « Full »</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}' n’est pas un type de vidage valide. Les options valides sont « Mini », « Heap », « Triage » (uniquement disponible dans .NET 6+) et « Full »</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.it.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Specificare il timeout dopo il quale verrà generato il dump. Il valore di timeout è specificato in uno dei seguenti formati: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Il valore predefinito è 30m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.it.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Specificare il timeout dopo il quale verrà generato il dump. Il valore di timeout è specificato in uno dei seguenti formati: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Il valore predefinito è 30m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Specificare il timeout dopo il quale verrà generato il dump. Il valore di timeout è specificato in uno dei seguenti formati: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Il valore predefinito è 30m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Specificare il tipo di dump. I valori ammessi sono 'Mini', 'Heap', 'Triage' (disponibile solo in .NET 6+) o 'Full'. Il tipo predefinito è 'Full'</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Specificare il tipo di dump. I valori ammessi sono 'Mini', 'Heap', 'Triage' (disponibile solo in .NET 6+) o 'Full'. Il tipo predefinito è 'Full'</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}' non è un tipo di dump valido. Le opzioni valide sono 'Mini', 'Heap', 'Triage' (disponibile solo in .NET 6+) e 'Full'.</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}' non è un tipo di dump valido. Le opzioni valide sono 'Mini', 'Heap', 'Triage' (disponibile solo in .NET 6+) e 'Full'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ja.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">ダンプが生成されるまでのタイムアウトを指定します。タイムアウト値は、次のいずれかの形式で指定されます 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes、5400s、5400sec、5400second、5400seconds.。既定値は 30m です。</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">ダンプが生成されるまでのタイムアウトを指定します。タイムアウト値は、次のいずれかの形式で指定されます 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes、5400s、5400sec、5400second、5400seconds.。既定値は 30m です。</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">ダンプの型を指定します。有効な値は、'Mini'、'Heap'、'Triage' (.NET 6 以降でのみ利用可能)、または 'Full' です。既定の型は 'Full' です</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">ダンプの型を指定します。有効な値は、'Mini'、'Heap'、'Triage' (.NET 6 以降でのみ利用可能)、または 'Full' です。既定の型は 'Full' です</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}' は有効なダンプの種類ではありません。有効なオプションは、'Mini'、'Heap'、'Triage' (.NET 6 以降でのみ利用可能)、'Full' です</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}' は有効なダンプの種類ではありません。有効なオプションは、'Mini'、'Heap'、'Triage' (.NET 6 以降でのみ利用可能)、'Full' です</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ja.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">ダンプが生成されるまでのタイムアウトを指定します。タイムアウト値は、次のいずれかの形式で指定されます 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes、5400s、5400sec、5400second、5400seconds.。既定値は 30m です。</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ko.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">덤프가 생성되기 전까지의 시간 제한을 지정합니다. 시간 제한 값은 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds 형식 중 하나로 지정됩니다. 기본값은 30m입니다.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ko.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">덤프가 생성되기 전까지의 시간 제한을 지정합니다. 시간 제한 값은 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds 형식 중 하나로 지정됩니다. 기본값은 30m입니다.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">덤프가 생성되기 전까지의 시간 제한을 지정합니다. 시간 제한 값은 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds 형식 중 하나로 지정됩니다. 기본값은 30m입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">덤프 유형을 지정하십시오. 유효한 값은 'Mini', 'Heap', 'Triage'(.NET 6 이상에서만 사용 가능) 또는 'Full'입니다. 기본 유형은 'Full'입니다.</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">덤프 유형을 지정하십시오. 유효한 값은 'Mini', 'Heap', 'Triage'(.NET 6 이상에서만 사용 가능) 또는 'Full'입니다. 기본 유형은 'Full'입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}'은(는) 올바른 덤프 유형이 아닙니다. 유효한 옵션은 'Mini', 'Heap', 'Triage'(.NET 6 이상에서만 사용 가능) 및 'Full'입니다.</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}'은(는) 올바른 덤프 유형이 아닙니다. 유효한 옵션은 'Mini', 'Heap', 'Triage'(.NET 6 이상에서만 사용 가능) 및 'Full'입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pl.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Określ limit czasu, po którym zostanie wygenerowany zrzut. Wartość limitu czasu jest określona w jednym z następujących formatów: 1,5 godziny, 1,5 godziny, 90 m, 90 min, 90 minut, 90 minut 5400 s, 5400 s, 5400 sekund, 5400 sekund, 5400 sekund. Wartość domyślna to 30 m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Określ limit czasu, po którym zostanie wygenerowany zrzut. Wartość limitu czasu jest określona w jednym z następujących formatów: 1,5 godziny, 1,5 godziny, 90 m, 90 min, 90 minut, 90 minut 5400 s, 5400 s, 5400 sekund, 5400 sekund, 5400 sekund. Wartość domyślna to 30 m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Określ typ zrzutu. Prawidłowe wartości to "Mini", "Heap", "Triage" (dostępne tylko na platformie .NET 6+) lub „Pełne”. Domyślny typ to „Pełne”</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Określ typ zrzutu. Prawidłowe wartości to "Mini", "Heap", "Triage" (dostępne tylko na platformie .NET 6+) lub „Pełne”. Domyślny typ to „Pełne”</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">Typ „{0}” nie jest prawidłowym typem zrzutu. Prawidłowe opcje to „Mini”, „Sterta", "Klasyfikacja" (dostępne tylko na platformie .NET 6+) i „Pełne”</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">Typ „{0}” nie jest prawidłowym typem zrzutu. Prawidłowe opcje to „Mini”, „Sterta", "Klasyfikacja" (dostępne tylko na platformie .NET 6+) i „Pełne”</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pl.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Określ limit czasu, po którym zostanie wygenerowany zrzut. Wartość limitu czasu jest określona w jednym z następujących formatów: 1,5 godziny, 1,5 godziny, 90 m, 90 min, 90 minut, 90 minut 5400 s, 5400 s, 5400 sekund, 5400 sekund, 5400 sekund. Wartość domyślna to 30 m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Especifique o tempo limite após o qual o despejo será gerado. O valor de tempo limite é especificado em um dos seguintes formatos: 1.5h, 1,5hora, 1,5horas, 90m, 90min, 90minuto, 90minutos 5400s, 5400seg, 5400segundo, 5400segundos. O padrão é 30m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Especifique o tempo limite após o qual o despejo será gerado. O valor de tempo limite é especificado em um dos seguintes formatos: 1.5h, 1,5hora, 1,5horas, 90m, 90min, 90minuto, 90minutos 5400s, 5400seg, 5400segundo, 5400segundos. O padrão é 30m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Especifique o tipo de despejo. Os valores válidos são ''Mini'', ''Heap'', ''Triage'' (disponível somente no .NET 6+) e ''Full'' O tipo padrão é ''Full''</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Especifique o tipo de despejo. Os valores válidos são ''Mini'', ''Heap'', ''Triage'' (disponível somente no .NET 6+) e ''Full'' O tipo padrão é ''Full''</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">''{0}'' não é um tipo de despejo válido. As opções válidas são ''Mini'', ''Heap'', ''Triage'' (disponível somente no .NET 6+) e ''Full''</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">''{0}'' não é um tipo de despejo válido. As opções válidas são ''Mini'', ''Heap'', ''Triage'' (disponível somente no .NET 6+) e ''Full''</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Especifique o tempo limite após o qual o despejo será gerado. O valor de tempo limite é especificado em um dos seguintes formatos: 1.5h, 1,5hora, 1,5horas, 90m, 90min, 90minuto, 90minutos 5400s, 5400seg, 5400segundo, 5400segundos. O padrão é 30m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ru.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Укажите время ожидания, по истечении которого будет создан дамп. Значение времени ожидания указано в одном из следующих форматов: 1,5 ч, 1,5 часа, 90 м, 90 мин, 90 минут, 5400 с, 5400 сек, 5400 секунд. Значение по умолчанию — 30 м.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ru.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Укажите время ожидания, по истечении которого будет создан дамп. Значение времени ожидания указано в одном из следующих форматов: 1,5 ч, 1,5 часа, 90 м, 90 мин, 90 минут, 5400 с, 5400 сек, 5400 секунд. Значение по умолчанию — 30 м.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Укажите время ожидания, по истечении которого будет создан дамп. Значение времени ожидания указано в одном из следующих форматов: 1,5 ч, 1,5 часа, 90 м, 90 мин, 90 минут, 5400 с, 5400 сек, 5400 секунд. Значение по умолчанию — 30 м.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Укажите тип дампа. Допустимые значения: "Mini", "Heap", "Triage" (доступно только в .NET 6+) или "Full". Тип по умолчанию — "Full"</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Укажите тип дампа. Допустимые значения: "Mini", "Heap", "Triage" (доступно только в .NET 6+) или "Full". Тип по умолчанию — "Full"</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">"{0}" не является допустимым типом дампа. Допустимые параметры: "Mini", "Heap", "Triage" (доступно только в .NET 6+) и "Full"</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">"{0}" не является допустимым типом дампа. Допустимые параметры: "Mini", "Heap", "Triage" (доступно только в .NET 6+) и "Full"</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.tr.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">Dökümün oluşturulacağı zaman aşımını belirtin. Zaman aşımı değeri şu formatlardan birinde belirtilir: 1,5 saat, 1,5 saat, 1,5 saat, 90 dakika, 90 dakika, 90 dakika, 90 dakika 5400s, 5400sn, 5400saniye, 5400saniye. Varsayılan değer 30m.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.tr.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">Dökümün oluşturulacağı zaman aşımını belirtin. Zaman aşımı değeri şu formatlardan birinde belirtilir: 1,5 saat, 1,5 saat, 1,5 saat, 90 dakika, 90 dakika, 90 dakika, 90 dakika 5400s, 5400sn, 5400saniye, 5400saniye. Varsayılan değer 30m.</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">Dökümün oluşturulacağı zaman aşımını belirtin. Zaman aşımı değeri şu formatlardan birinde belirtilir: 1,5 saat, 1,5 saat, 1,5 saat, 90 dakika, 90 dakika, 90 dakika, 90 dakika 5400s, 5400sn, 5400saniye, 5400saniye. Varsayılan değer 30m.</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">Dökümün türünü belirtin. Geçerli değerler 'Mini', 'Heap', 'Triage' (yalnızca .NET 6+'da mevcuttur) veya 'Full'dur. Varsayılan tür 'Tam'dır</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">Dökümün türünü belirtin. Geçerli değerler 'Mini', 'Heap', 'Triage' (yalnızca .NET 6+'da mevcuttur) veya 'Full'dur. Varsayılan tür 'Tam'dır</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}' geçerli bir döküm türü değil. Geçerli seçenekler 'Mini', 'Heap', 'Triage' (yalnızca .NET 6+'da mevcuttur) ve 'Full’dur</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}' geçerli bir döküm türü değil. Geçerli seçenekler 'Mini', 'Heap', 'Triage' (yalnızca .NET 6+'da mevcuttur) ve 'Full’dur</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">指定生成转储后的超时。超时值以以下格式之一指定: 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes 5400s、5400sec、5400second、5400seconds。默认值为 30m。</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">指定生成转储后的超时。超时值以以下格式之一指定: 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes 5400s、5400sec、5400second、5400seconds。默认值为 30m。</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">指定生成转储后的超时。超时值以以下格式之一指定: 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes 5400s、5400sec、5400second、5400seconds。默认值为 30m。</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">指定转储的类型。有效值为“Mini”、“Heap”、“Triage”(仅适用于 .NET 6+)或“Full”。默认类型为“Full”</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">指定转储的类型。有效值为“Mini”、“Heap”、“Triage”(仅适用于 .NET 6+)或“Full”。默认类型为“Full”</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">“{0}”不是有效的转储类型。有效选项为“Mini”、“Heap”、“Triage”(仅适用于 .NET 6+)和“Full”</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">“{0}”不是有效的转储类型。有效选项为“Mini”、“Heap”、“Triage”(仅适用于 .NET 6+)和“Full”</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -53,8 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
-        <source>Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.</source>
-        <target state="translated">指定產生傾印前的逾時時間。逾時值會以下列其中一種格式顯示: 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes 5400s、5400sec、5400second、5400seconds。預設為 30m。</target>
+        <source>Specify the timeout after which the dump will be generated.
+The timeout value is specified in one of the following formats: 
+    1.5h, 1.5hour, 1.5hours, 
+    90m, 90min, 90minute, 90minutes, 
+    5400s, 5400sec, 5400second, 5400seconds. 
+    Default is 30m.</source>
+        <target state="needs-review-translation">指定產生傾印前的逾時時間。逾時值會以下列其中一種格式顯示: 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes 5400s、5400sec、5400second、5400seconds。預設為 30m。</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionInvalidArgument">
@@ -63,13 +68,16 @@
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionDescription">
-        <source>Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'</source>
-        <target state="translated">指定傾印的類型。有效值為 'Mini'、'Heap'、'Triage' (只有在 .NET 6+ 可供使用) 或 'Full'。預設類型為 'Full'</target>
+        <source>Specify the type of the dump.
+Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+Default type is 'Full'</source>
+        <target state="needs-review-translation">指定傾印的類型。有效值為 'Mini'、'Heap'、'Triage' (只有在 .NET 6+ 可供使用) 或 'Full'。預設類型為 'Full'</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpTypeOptionInvalidType">
-        <source>'{0}' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
-        <target state="translated">'{0}' 不是有效的傾印類型。有效的選項為 'Mini'、'Heap'、'Triage' (只有在 .NET 6+ 可供使用) 和 'Full'</target>
+        <source>'{0}' is not a valid dump type.
+Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'</source>
+        <target state="needs-review-translation">'{0}' 不是有效的傾印類型。有效的選項為 'Mini'、'Heap'、'Triage' (只有在 .NET 6+ 可供使用) 和 'Full'</target>
         <note />
       </trans-unit>
       <trans-unit id="HangDumpUnsupportedRequestTypeErrorMessage">

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -54,10 +54,10 @@
       </trans-unit>
       <trans-unit id="HangDumpTimeoutOptionDescription">
         <source>Specify the timeout after which the dump will be generated.
-The timeout value is specified in one of the following formats: 
-    1.5h, 1.5hour, 1.5hours, 
-    90m, 90min, 90minute, 90minutes, 
-    5400s, 5400sec, 5400second, 5400seconds. 
+The timeout value is specified in one of the following formats:
+    1.5h, 1.5hour, 1.5hours,
+    90m, 90min, 90minute, 90minutes,
+    5400s, 5400sec, 5400second, 5400seconds.
     Default is 30m.</source>
         <target state="needs-review-translation">指定產生傾印前的逾時時間。逾時值會以下列其中一種格式顯示: 1.5h、1.5hour、1.5hours、90m、90min、90minute、90minutes 5400s、5400sec、5400second、5400seconds。預設為 30m。</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
@@ -131,7 +131,7 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
                 }
 
                 await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{optionInfoIndent}Hidden: {option.IsHidden}"));
-                await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{optionInfoIndent}Description: {option.Description}"));
+                await _platformOutputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"Description: {option.Description}") { Padding = optionInfoIndent.Length });
             }
         }
 
@@ -150,7 +150,7 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
                         await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{providerIdIndent}{provider.Uid}"));
                         await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{providerInfoIndent}Name: {provider.DisplayName}"));
                         await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{providerInfoIndent}Version: {provider.Version}"));
-                        await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{providerInfoIndent}Description: {provider.Description}"));
+                        await _platformOutputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"Description: {provider.Description}") { Padding = providerInfoIndent.Length });
                         await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{providerInfoIndent}Options:"));
                     }
 
@@ -201,7 +201,7 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"    Command: {tool.Name}"));
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"    Name: {tool.DisplayName}"));
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"    Version: {tool.Version}"));
-                    await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"    Description: {tool.Description}"));
+                    await _platformOutputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"Description: {tool.Description}") { Padding = 4 });
                     await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData("    Tool command line providers:"));
                     if (groupedToolExtensions.TryGetValue(tool.Name, out List<IToolCommandLineOptionsProvider>? providers))
                     {
@@ -267,11 +267,11 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
                 return false;
             }
 
-            int maxOptionNameLength = options.Max(option => option.Name.Length);
-
             foreach (CommandLineOption? option in options)
             {
-                await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData($"{new string(' ', leftPaddingDepth * 2)}--{option.Name}{new string(' ', maxOptionNameLength - option.Name.Length)} {option.Description}"));
+                await _platformOutputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"--{option.Name}") { Padding = 4 });
+                await _platformOutputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(option.Description) { Padding = 8 });
+                await _platformOutputDevice.DisplayAsync(this, new TextOutputDeviceData(string.Empty));
             }
 
             return options.Length != 0;

--- a/src/Platform/Microsoft.Testing.Platform/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/DotnetTestDataConsumer.cs
@@ -14,9 +14,7 @@ internal class DotnetTestDataConsumer : IDataConsumer, ITestSessionLifetimeHandl
     private readonly NamedPipeClient _dotnetTestPipeClient;
 
     public DotnetTestDataConsumer(NamedPipeClient dotnetTestPipeClient)
-    {
-        _dotnetTestPipeClient = dotnetTestPipeClient;
-    }
+        => _dotnetTestPipeClient = dotnetTestPipeClient;
 
     public Type[] DataTypesConsumed => new[]
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/FormattedTextOutputDeviceData.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/FormattedTextOutputDeviceData.cs
@@ -26,4 +26,9 @@ public sealed class FormattedTextOutputDeviceData : TextOutputDeviceData
     /// Gets or inits the background color of the text.
     /// </summary>
     public IColor? BackgroundColor { get; init; }
+
+    /// <summary>
+    /// Gets or inits the padding of the message.
+    /// </summary>
+    public int? Padding { get; init; }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -694,7 +694,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         });
     }
 
-    internal void WriteErrorMessage(string assembly, string? targetFramework, string? architecture, string text)
+    internal void WriteErrorMessage(string assembly, string? targetFramework, string? architecture, string text, int? padding)
     {
         TestProgressState asm = GetOrAddAssemblyRun(assembly, targetFramework, architecture);
         asm.AddError(text);
@@ -702,25 +702,41 @@ internal sealed partial class TerminalTestReporter : IDisposable
         _terminalWithProgress.WriteToTerminal(terminal =>
         {
             terminal.SetColor(TerminalColor.Red);
-            terminal.AppendLine(text);
+            if (padding == null)
+            {
+                terminal.AppendLine(text);
+            }
+            else
+            {
+                AppendIndentedLine(terminal, text, new string(' ', padding.Value));
+            }
+
             terminal.ResetColor();
         });
     }
 
-    internal void WriteWarningMessage(string assembly, string? targetFramework, string? architecture, string text)
+    internal void WriteWarningMessage(string assembly, string? targetFramework, string? architecture, string text, int? padding)
     {
         TestProgressState asm = GetOrAddAssemblyRun(assembly, targetFramework, architecture);
         asm.AddWarning(text);
         _terminalWithProgress.WriteToTerminal(terminal =>
         {
             terminal.SetColor(TerminalColor.Yellow);
-            terminal.AppendLine(text);
+            if (padding == null)
+            {
+                terminal.AppendLine(text);
+            }
+            else
+            {
+                AppendIndentedLine(terminal, text, new string(' ', padding.Value));
+            }
+
             terminal.ResetColor();
         });
     }
 
     internal void WriteErrorMessage(string assembly, string? targetFramework, string? architecture, Exception exception)
-        => WriteErrorMessage(assembly, targetFramework, architecture, exception.ToString());
+        => WriteErrorMessage(assembly, targetFramework, architecture, exception.ToString(), padding: null);
 
     internal void WriteMessage(string text, SystemConsoleColor? color = null, int? padding = null)
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -584,12 +584,10 @@ internal sealed partial class TerminalTestReporter : IDisposable
         terminal.Append(SingleIndentation);
         terminal.AppendLine(PlatformResources.Expected);
         AppendIndentedLine(terminal, expected, DoubleIndentation);
-        terminal.AppendLine();
         terminal.Append(SingleIndentation);
         terminal.AppendLine(PlatformResources.Actual);
         AppendIndentedLine(terminal, actual, DoubleIndentation);
         terminal.ResetColor();
-        terminal.AppendLine();
     }
 
     private static void FormatErrorMessage(ITerminal terminal, string? errorMessage)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -583,11 +583,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
         terminal.SetColor(TerminalColor.Red);
         terminal.Append(SingleIndentation);
         terminal.AppendLine(PlatformResources.Expected);
-        AppendIndentedMessage(terminal, expected, DoubleIndentation);
+        AppendIndentedLine(terminal, expected, DoubleIndentation);
         terminal.AppendLine();
         terminal.Append(SingleIndentation);
         terminal.AppendLine(PlatformResources.Actual);
-        AppendIndentedMessage(terminal, actual, DoubleIndentation);
+        AppendIndentedLine(terminal, actual, DoubleIndentation);
         terminal.ResetColor();
         terminal.AppendLine();
     }
@@ -600,12 +600,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
         }
 
         terminal.SetColor(TerminalColor.Red);
-        AppendIndentedMessage(terminal, errorMessage, SingleIndentation);
+        AppendIndentedLine(terminal, errorMessage, SingleIndentation);
         terminal.ResetColor();
-        terminal.AppendLine();
     }
 
-    private static void AppendIndentedMessage(ITerminal terminal, string? message, string indent)
+    private static void AppendIndentedLine(ITerminal terminal, string? message, string indent)
     {
         if (RoslynString.IsNullOrWhiteSpace(message))
         {
@@ -615,7 +614,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         if (!message.Contains('\n'))
         {
             terminal.Append(indent);
-            terminal.Append(message);
+            terminal.AppendLine(message);
             return;
         }
 
@@ -723,20 +722,38 @@ internal sealed partial class TerminalTestReporter : IDisposable
     internal void WriteErrorMessage(string assembly, string? targetFramework, string? architecture, Exception exception)
         => WriteErrorMessage(assembly, targetFramework, architecture, exception.ToString());
 
-    internal void WriteMessage(string text, SystemConsoleColor? color = null)
+    internal void WriteMessage(string text, SystemConsoleColor? color = null, int? padding = null)
     {
         if (color != null)
         {
             _terminalWithProgress.WriteToTerminal(terminal =>
             {
                 terminal.SetColor(ToTerminalColor(color.ConsoleColor));
-                terminal.AppendLine(text);
+                if (padding == null)
+                {
+                    terminal.AppendLine(text);
+                }
+                else
+                {
+                    AppendIndentedLine(terminal, text, new string(' ', padding.Value));
+                }
+
                 terminal.ResetColor();
             });
         }
         else
         {
-            _terminalWithProgress.WriteToTerminal(terminal => terminal.AppendLine(text));
+            _terminalWithProgress.WriteToTerminal(terminal =>
+            {
+                if (padding == null)
+                {
+                    terminal.AppendLine(text);
+                }
+                else
+                {
+                    AppendIndentedLine(terminal, text, new string(' ', padding.Value));
+                }
+            });
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -239,7 +239,7 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
                 }
                 else
                 {
-                    _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, string.Format(CultureInfo.CurrentCulture, PlatformResources.DiagnosticFileLevelWithAsyncFlush, _fileLoggerProvider.LogLevel, _fileLoggerProvider.FileLogger.FileName), padding: null );
+                    _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, string.Format(CultureInfo.CurrentCulture, PlatformResources.DiagnosticFileLevelWithAsyncFlush, _fileLoggerProvider.LogLevel, _fileLoggerProvider.FileLogger.FileName), padding: null);
                 }
             }
         }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -322,13 +322,13 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
                                 _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, formattedTextOutputDeviceData.Text);
                                 break;
                             default:
-                                _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text, color);
+                                _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text, color, formattedTextOutputDeviceData.Padding);
                                 break;
                         }
                     }
                     else
                     {
-                        _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text);
+                        _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text, padding: formattedTextOutputDeviceData.Padding);
                     }
 
                     break;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -235,11 +235,11 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
             {
                 if (_fileLoggerProvider.SyncFlush)
                 {
-                    _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, string.Format(CultureInfo.CurrentCulture, PlatformResources.DiagnosticFileLevelWithFlush, _fileLoggerProvider.LogLevel, _fileLoggerProvider.FileLogger.FileName));
+                    _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, string.Format(CultureInfo.CurrentCulture, PlatformResources.DiagnosticFileLevelWithFlush, _fileLoggerProvider.LogLevel, _fileLoggerProvider.FileLogger.FileName), padding: null);
                 }
                 else
                 {
-                    _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, string.Format(CultureInfo.CurrentCulture, PlatformResources.DiagnosticFileLevelWithAsyncFlush, _fileLoggerProvider.LogLevel, _fileLoggerProvider.FileLogger.FileName));
+                    _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, string.Format(CultureInfo.CurrentCulture, PlatformResources.DiagnosticFileLevelWithAsyncFlush, _fileLoggerProvider.LogLevel, _fileLoggerProvider.FileLogger.FileName), padding: null );
                 }
             }
         }
@@ -316,10 +316,10 @@ internal partial class TerminalOutputDevice : IPlatformOutputDevice,
                         switch (color.ConsoleColor)
                         {
                             case ConsoleColor.Red:
-                                _terminalTestReporter.WriteErrorMessage(_assemblyName, _targetFramework, _shortArchitecture, formattedTextOutputDeviceData.Text);
+                                _terminalTestReporter.WriteErrorMessage(_assemblyName, _targetFramework, _shortArchitecture, formattedTextOutputDeviceData.Text, formattedTextOutputDeviceData.Padding);
                                 break;
                             case ConsoleColor.Yellow:
-                                _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, formattedTextOutputDeviceData.Text);
+                                _terminalTestReporter.WriteWarningMessage(_assemblyName, _targetFramework, _shortArchitecture, formattedTextOutputDeviceData.Text, formattedTextOutputDeviceData.Padding);
                                 break;
                             default:
                                 _terminalTestReporter.WriteMessage(formattedTextOutputDeviceData.Text, color, formattedTextOutputDeviceData.Padding);

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Testing.Platform.OutputDevice.FormattedTextOutputDeviceData.Padding.get -> int?
+Microsoft.Testing.Platform.OutputDevice.FormattedTextOutputDeviceData.Padding.init -> void
 [TPEXP]Microsoft.Testing.Platform.Services.IClientInfo
 [TPEXP]Microsoft.Testing.Platform.Services.IClientInfo.Id.get -> string!
 [TPEXP]Microsoft.Testing.Platform.Services.IClientInfo.Version.get -> string!

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
@@ -719,7 +719,9 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force the built-in file logger to write the log synchronously. Useful for scenario where you don&apos;t want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution..
+        ///   Looks up a localized string similar to Force the built-in file logger to write the log synchronously. 
+        ///Useful for scenario where you don&apos;t want to lose any log (i.e. in case of crash). 
+        ///Note that this is slowing down the test execution..
         /// </summary>
         internal static string PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription {
             get {
@@ -728,7 +730,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable the diagnostic logging. The default log level is &apos;Trace&apos;. The file will be written in the output directory with the name log_[MMddHHssfff].diag.
+        ///   Looks up a localized string similar to Enable the diagnostic logging. The default log level is &apos;Trace&apos;.
+        ///The file will be written in the output directory with the name log_[MMddHHssfff].diag.
         /// </summary>
         internal static string PlatformCommandLineDiagnosticOptionDescription {
             get {
@@ -755,7 +758,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Output directory of the diagnostic logging, if not specified the file will be generated inside the default &apos;TestResults&apos; directory..
+        ///   Looks up a localized string similar to Output directory of the diagnostic logging.
+        ///If not specified the file will be generated inside the default &apos;TestResults&apos; directory..
         /// </summary>
         internal static string PlatformCommandLineDiagnosticOutputDirectoryOptionDescription {
             get {
@@ -773,7 +777,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Define the level of the verbosity for the --diagnostic. The available values are &apos;Trace&apos;, &apos;Debug&apos;, &apos;Information&apos;, &apos;Warning&apos;, &apos;Error&apos;, and &apos;Critical&apos;.
+        ///   Looks up a localized string similar to Define the level of the verbosity for the --diagnostic.
+        ///The available values are &apos;Trace&apos;, &apos;Debug&apos;, &apos;Information&apos;, &apos;Warning&apos;, &apos;Error&apos;, and &apos;Critical&apos;..
         /// </summary>
         internal static string PlatformCommandLineDiagnosticVerbosityOptionDescription {
             get {
@@ -837,7 +842,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do not report non successful exit value for specific exit codes (e.g. &apos;--ignore-exit-code 8;9&apos; ignore exit code 8 and 9 and will return 0 in these case).
+        ///   Looks up a localized string similar to Do not report non successful exit value for specific exit codes
+        ///(e.g. &apos;--ignore-exit-code 8;9&apos; ignore exit code 8 and 9 and will return 0 in these case).
         /// </summary>
         internal static string PlatformCommandLineIgnoreExitCodeOptionDescription {
             get {
@@ -864,7 +870,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;--minimum-expected-tests&apos; expects a single non-zero positive integer value (e.g. &apos;--minimum-expected-tests 10&apos;).
+        ///   Looks up a localized string similar to &apos;--minimum-expected-tests&apos; expects a single non-zero positive integer value
+        ///(e.g. &apos;--minimum-expected-tests 10&apos;).
         /// </summary>
         internal static string PlatformCommandLineMinimumExpectedTestsOptionSingleArgument {
             get {
@@ -918,7 +925,9 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The directory where the test results are going to be placed. If the specified directory doesn&apos;t exist, it&apos;s created. The default is TestResults in the directory that contains the test application..
+        ///   Looks up a localized string similar to The directory where the test results are going to be placed.
+        ///If the specified directory doesn&apos;t exist, it&apos;s created.
+        ///The default is TestResults in the directory that contains the test application..
         /// </summary>
         internal static string PlatformCommandLineResultDirectoryOptionDescription {
             get {
@@ -1148,7 +1157,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Output verbosity when reporting tests. Valid values are &apos;Normal&apos;, &apos;Detailed&apos;. Default is &apos;Normal&apos;..
+        ///   Looks up a localized string similar to Output verbosity when reporting tests.
+        ///Valid values are &apos;Normal&apos;, &apos;Detailed&apos;. Default is &apos;Normal&apos;..
         /// </summary>
         internal static string TerminalOutputOptionDescription {
             get {

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
@@ -719,8 +719,8 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force the built-in file logger to write the log synchronously. 
-        ///Useful for scenario where you don&apos;t want to lose any log (i.e. in case of crash). 
+        ///   Looks up a localized string similar to Force the built-in file logger to write the log synchronously.
+        ///Useful for scenario where you don&apos;t want to lose any log (i.e. in case of crash).
         ///Note that this is slowing down the test execution..
         /// </summary>
         internal static string PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription {

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -359,8 +359,8 @@
     <value>Specify the port of the client.</value>
   </data>
   <data name="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription" xml:space="preserve">
-    <value>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+    <value>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</value>
   </data>
   <data name="PlatformCommandLineDiagnosticOptionDescription" xml:space="preserve">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -359,10 +359,13 @@
     <value>Specify the port of the client.</value>
   </data>
   <data name="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription" xml:space="preserve">
-    <value>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</value>
+    <value>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</value>
   </data>
   <data name="PlatformCommandLineDiagnosticOptionDescription" xml:space="preserve">
-    <value>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</value>
+    <value>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</value>
   </data>
   <data name="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage" xml:space="preserve">
     <value>'--diagnostic-verbosity' expects a single level argument ('Trace', 'Debug', 'Information', 'Warning', 'Error', or 'Critical')</value>
@@ -371,13 +374,15 @@
     <value>'--{0}' requires '--diagnostic' to be provided</value>
   </data>
   <data name="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription" xml:space="preserve">
-    <value>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</value>
+    <value>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</value>
   </data>
   <data name="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription" xml:space="preserve">
     <value>Prefix for the log file name that will replace '[log]_.'</value>
   </data>
   <data name="PlatformCommandLineDiagnosticVerbosityOptionDescription" xml:space="preserve">
-    <value>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</value>
+    <value>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</value>
   </data>
   <data name="PlatformCommandLineDiscoverTestsOptionDescription" xml:space="preserve">
     <value>List available tests.</value>
@@ -392,7 +397,8 @@
     <value>'--list-tests' and '--minimum-expected-tests' are incompatible options</value>
   </data>
   <data name="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument" xml:space="preserve">
-    <value>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</value>
+    <value>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</value>
   </data>
   <data name="PlatformCommandLineNoBannerOptionDescription" xml:space="preserve">
     <value>Do not display the startup banner, the copyright message or the telemetry banner.</value>
@@ -410,7 +416,9 @@
     <value>Platform command line provider</value>
   </data>
   <data name="PlatformCommandLineResultDirectoryOptionDescription" xml:space="preserve">
-    <value>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</value>
+    <value>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</value>
   </data>
   <data name="PlatformCommandLineServerOptionDescription" xml:space="preserve">
     <value>Enable the server mode.</value>
@@ -475,7 +483,8 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
     <value>An unexpected exception occurred during byte conversion</value>
   </data>
   <data name="PlatformCommandLineIgnoreExitCodeOptionDescription" xml:space="preserve">
-    <value>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</value>
+    <value>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</value>
   </data>
   <data name="PlatformCommandLineExitOnProcessExitOptionDescription" xml:space="preserve">
     <value>Exit the test process if dependent process exits. PID must be provided.</value>
@@ -597,7 +606,8 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
     <value>Terminal test reporter</value>
   </data>
   <data name="TerminalOutputOptionDescription" xml:space="preserve">
-    <value>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</value>
+    <value>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</value>
   </data>
   <data name="TerminalOutputOptionInvalidArgument" xml:space="preserve">
     <value>--output expects a single parameter with value 'Normal' or 'Detailed'.</value>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Umožňuje vynutit synchronní zápis do protokolu integrovaným protokolovacím nástrojem souborů. Užitečné pro scénář, kdy nechcete přijít o žádný protokol (například v případě chybového ukončení). Poznámka: Toto zpomaluje provádění testu.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Umožňuje vynutit synchronní zápis do protokolu integrovaným protokolovacím nástrojem souborů. Užitečné pro scénář, kdy nechcete přijít o žádný protokol (například v případě chybového ukončení). Poznámka: Toto zpomaluje provádění testu.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Umožňuje povolit protokolování diagnostiky. Výchozí úroveň protokolování je Trasování. Soubor se zapíše do výstupního adresáře s názvem log_[MMddHHssfff].diag.</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Umožňuje povolit protokolování diagnostiky. Výchozí úroveň protokolování je Trasování. Soubor se zapíše do výstupního adresáře s názvem log_[MMddHHssfff].diag.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Výstupní adresář diagnostického protokolování. Pokud není zadaný, soubor se vygeneruje ve výchozím adresáři TestResults.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Výstupní adresář diagnostického protokolování. Pokud není zadaný, soubor se vygeneruje ve výchozím adresáři TestResults.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Umožňuje definovat úroveň podrobností pro možnost --diagnostic. Dostupné hodnoty jsou Trace, Debug, Information, Warning, Error a Critical.</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Umožňuje definovat úroveň podrobností pro možnost --diagnostic. Dostupné hodnoty jsou Trace, Debug, Information, Warning, Error a Critical.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Neohlašujte neúspěšnou ukončovací hodnotu pro konkrétní ukončovací kódy (např. „--ignore-exit-code 8; 9“ ignoruje ukončovací kód 8 a 9 a v takovém případě vrátí hodnotu 0.)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Neohlašujte neúspěšnou ukončovací hodnotu pro konkrétní ukončovací kódy (např. „--ignore-exit-code 8; 9“ ignoruje ukončovací kód 8 a 9 a v takovém případě vrátí hodnotu 0.)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">--minimum-expected-tests očekává jednu kladnou nenulovou celočíselnou hodnotu (např. --minimum-expected-tests 10).</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">--minimum-expected-tests očekává jednu kladnou nenulovou celočíselnou hodnotu (např. --minimum-expected-tests 10).</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Adresář, do kterého budou umístěny výsledky testu. Pokud zadaný adresář neexistuje, vytvoří se. Výchozí hodnota je TestResults v adresáři, který obsahuje testovací aplikaci.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Adresář, do kterého budou umístěny výsledky testu. Pokud zadaný adresář neexistuje, vytvoří se. Výchozí hodnota je TestResults v adresáři, který obsahuje testovací aplikaci.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Přečtěte si další informace o telemetrii Microsoft Testing Platform: https:
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Podrobnosti výstupu při vytváření sestav testů. Platné hodnoty jsou Normal a Detailed. Výchozí hodnota je Normal.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Podrobnosti výstupu při vytváření sestav testů. Platné hodnoty jsou Normal a Detailed. Výchozí hodnota je Normal.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Umožňuje vynutit synchronní zápis do protokolu integrovaným protokolovacím nástrojem souborů. Užitečné pro scénář, kdy nechcete přijít o žádný protokol (například v případě chybového ukončení). Poznámka: Toto zpomaluje provádění testu.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Erzwingen Sie, dass die integrierte Dateiprotokollierung das Protokoll synchron schreibt. Nützlich für Szenarien, in denen Sie keine Protokolle verlieren möchten (z. B. im Fall eines Absturzes). Beachten Sie, dass die Testausführung dadurch verlangsamt wird.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Erzwingen Sie, dass die integrierte Dateiprotokollierung das Protokoll synchron schreibt. Nützlich für Szenarien, in denen Sie keine Protokolle verlieren möchten (z. B. im Fall eines Absturzes). Beachten Sie, dass die Testausführung dadurch verlangsamt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Aktivieren Sie die Diagnoseprotokollierung. Die Standardprotokollebene ist "Ablaufverfolgung". Die Datei wird im Ausgabeverzeichnis mit dem Namen log_[MMddHHSSFFF].diag geschrieben</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Aktivieren Sie die Diagnoseprotokollierung. Die Standardprotokollebene ist "Ablaufverfolgung". Die Datei wird im Ausgabeverzeichnis mit dem Namen log_[MMddHHSSFFF].diag geschrieben</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Das Ausgabeverzeichnis der Diagnoseprotokollierung, sofern nicht angegeben, wird die Datei im Standardverzeichnis "TestResults" generiert.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Das Ausgabeverzeichnis der Diagnoseprotokollierung, sofern nicht angegeben, wird die Datei im Standardverzeichnis "TestResults" generiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Definieren Sie die Ausführlichkeitsstufe für --diagnostic. Die verfügbaren Werte sind "Trace", "Debug", "Information", "Warning", "Error" und "Critical".</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Definieren Sie die Ausführlichkeitsstufe für --diagnostic. Die verfügbaren Werte sind "Trace", "Debug", "Information", "Warning", "Error" und "Critical".</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Melden Sie keinen nicht erfolgreichen Beendigungswert für bestimmte Exitcodes (z. B. "--ignore-exit-code 8;9" Exitcode 8 und 9 ignorieren und in diesem Fall 0 zurückgeben)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Melden Sie keinen nicht erfolgreichen Beendigungswert für bestimmte Exitcodes (z. B. "--ignore-exit-code 8;9" Exitcode 8 und 9 ignorieren und in diesem Fall 0 zurückgeben)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">"--minimum-expected-tests" erwartet einen einzelnen positiven ganzzahligen Wert ungleich Null (z. B. "--minimum-expected-tests 10").</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">"--minimum-expected-tests" erwartet einen einzelnen positiven ganzzahligen Wert ungleich Null (z. B. "--minimum-expected-tests 10").</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Das Verzeichnis, in dem die Testergebnisse abgelegt werden. Wenn das angegebene Verzeichnis nicht vorhanden ist, wird es erstellt. Der Standardwert ist "TestResults" im Verzeichnis, das die Testanwendung enthält.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Das Verzeichnis, in dem die Testergebnisse abgelegt werden. Wenn das angegebene Verzeichnis nicht vorhanden ist, wird es erstellt. Der Standardwert ist "TestResults" im Verzeichnis, das die Testanwendung enthält.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Weitere Informationen zu Microsoft Testing Platform-Telemetriedaten: https://aka
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Ausgabeausführlichkeit beim Melden von Tests. Gültige Werte sind „Normal“, „Detailed“. Der Standardwert ist „Normal“.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Ausgabeausführlichkeit beim Melden von Tests. Gültige Werte sind „Normal“, „Detailed“. Der Standardwert ist „Normal“.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Erzwingen Sie, dass die integrierte Dateiprotokollierung das Protokoll synchron schreibt. Nützlich für Szenarien, in denen Sie keine Protokolle verlieren möchten (z. B. im Fall eines Absturzes). Beachten Sie, dass die Testausführung dadurch verlangsamt wird.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Fuerce al registrador de archivos integrado a escribir el registro de forma sincrónica. Resulta útil para escenarios en los que no quiere perder ningún registro (es decir, en caso de bloqueo). Tenga en cuenta que esto ralentiza la ejecución de pruebas.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Fuerce al registrador de archivos integrado a escribir el registro de forma sincrónica. Resulta útil para escenarios en los que no quiere perder ningún registro (es decir, en caso de bloqueo). Tenga en cuenta que esto ralentiza la ejecución de pruebas.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Fuerce al registrador de archivos integrado a escribir el registro de forma sincrónica. Resulta útil para escenarios en los que no quiere perder ningún registro (es decir, en caso de bloqueo). Tenga en cuenta que esto ralentiza la ejecución de pruebas.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Habilite el registro de diagnóstico. El nivel de registro predeterminado es "Seguimiento". El archivo se escribirá en el directorio de salida con el nombre log_[MMddHHssfff].diag</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Habilite el registro de diagnóstico. El nivel de registro predeterminado es "Seguimiento". El archivo se escribirá en el directorio de salida con el nombre log_[MMddHHssfff].diag</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Directorio de salida del registro de diagnóstico; si no se especifica, el archivo se generará dentro del directorio predeterminado “TestResults”.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Directorio de salida del registro de diagnóstico; si no se especifica, el archivo se generará dentro del directorio predeterminado “TestResults”.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Defina el nivel de detalle de --diagnostic. Los valores disponibles son “Seguimiento”, “Depurar”, “Información”, “Advertencia”, 'Error' y “Crítico”</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Defina el nivel de detalle de --diagnostic. Los valores disponibles son “Seguimiento”, “Depurar”, “Información”, “Advertencia”, 'Error' y “Crítico”</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">No notificar el valor de salida no correcto para códigos de salida específicos (por ejemplo, ''--ignore-exit-code 8; 9'' omitir código de salida 8 y 9 y devolverá 0 en este caso)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">No notificar el valor de salida no correcto para códigos de salida específicos (por ejemplo, ''--ignore-exit-code 8; 9'' omitir código de salida 8 y 9 y devolverá 0 en este caso)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">“--minimum-expected-tests” espera un único valor entero positivo distinto de cero (por ejemplo, “--minimum-expected-tests 10”)</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">“--minimum-expected-tests” espera un único valor entero positivo distinto de cero (por ejemplo, “--minimum-expected-tests 10”)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Directorio donde se van a colocar los resultados de las pruebas. Si el directorio especificado no existe, se crea. El valor predeterminado es TestResults en el directorio que contiene la aplicación de prueba.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Directorio donde se van a colocar los resultados de las pruebas. Si el directorio especificado no existe, se crea. El valor predeterminado es TestResults en el directorio que contiene la aplicación de prueba.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Más información sobre la telemetría de la Plataforma de pruebas de Microsoft:
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Nivel de detalle de la salida al crear informes de pruebas. Los valores válidos son "Normal", "Detallado". El valor predeterminado es "Normal".</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Nivel de detalle de la salida al crear informes de pruebas. Los valores válidos son "Normal", "Detallado". El valor predeterminado es "Normal".</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Forcer l’enregistreur d’événements de fichiers intégré à écrire le journal de manière synchrone. Utile pour les scénarios où vous ne voulez pas perdre de journal (c’est-à-dire en cas d’incident). Notez que cela ralentit l’exécution du test.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Forcer l’enregistreur d’événements de fichiers intégré à écrire le journal de manière synchrone. Utile pour les scénarios où vous ne voulez pas perdre de journal (c’est-à-dire en cas d’incident). Notez que cela ralentit l’exécution du test.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Activez la journalisation des diagnostics. Le niveau de consignation par défaut est « Trace ». Le fichier sera écrit dans le répertoire de sortie avec le nom log_[MMddHHssfff].diag</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Activez la journalisation des diagnostics. Le niveau de consignation par défaut est « Trace ». Le fichier sera écrit dans le répertoire de sortie avec le nom log_[MMddHHssfff].diag</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Répertoire de sortie de la journalisation des diagnostics. S’il n’est pas spécifié, le fichier est généré dans le répertoire ’TestResults’ par défaut.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Répertoire de sortie de la journalisation des diagnostics. S’il n’est pas spécifié, le fichier est généré dans le répertoire ’TestResults’ par défaut.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Définissez le niveau de verbosité pour le --diagnostic. Les valeurs disponibles sont « Trace », « Debug », « Information », « Warning », « Error » et « Critical »</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Définissez le niveau de verbosité pour le --diagnostic. Les valeurs disponibles sont « Trace », « Debug », « Information », « Warning », « Error » et « Critical »</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Ne signalez pas les valeurs de sortie non réussies pour des codes de sortie spécifiques (par exemple, « --ignore-exit-code 8;9 » ignore les codes de sortie 8 et 9 et renverra 0 dans ce cas)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Ne signalez pas les valeurs de sortie non réussies pour des codes de sortie spécifiques (par exemple, « --ignore-exit-code 8;9 » ignore les codes de sortie 8 et 9 et renverra 0 dans ce cas)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">« --minimum-expected-tests » attend une seule valeur entière positive différente de zéro (par ex., « --minimum-expected-tests 10 »)</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">« --minimum-expected-tests » attend une seule valeur entière positive différente de zéro (par ex., « --minimum-expected-tests 10 »)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Le répertoire dans lequel les résultats des tests vont être placés. Si le répertoire spécifié n’existe pas, il est créé. La valeur par défaut est TestResults dans le répertoire qui contient l’application de test.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Le répertoire dans lequel les résultats des tests vont être placés. Si le répertoire spécifié n’existe pas, il est créé. La valeur par défaut est TestResults dans le répertoire qui contient l’application de test.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ En savoir plus sur la télémétrie de la plateforme de tests Microsoft : https:
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Verbosité de la sortie lors de l’établissement des rapports de tests. Les valeurs valides sont « Normal » et « Détaillé ». La valeur par défaut est « Normal ».</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Verbosité de la sortie lors de l’établissement des rapports de tests. Les valeurs valides sont « Normal » et « Détaillé ». La valeur par défaut est « Normal ».</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Forcer l’enregistreur d’événements de fichiers intégré à écrire le journal de manière synchrone. Utile pour les scénarios où vous ne voulez pas perdre de journal (c’est-à-dire en cas d’incident). Notez que cela ralentit l’exécution du test.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Forza il logger di file predefinito per scrivere il log in modo sincrono. Utile per uno scenario in cui non si vuole perdere alcun log, ad esempio in caso di arresto anomalo del sistema. Si noti che l'esecuzione del test sta rallentando.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Forza il logger di file predefinito per scrivere il log in modo sincrono. Utile per uno scenario in cui non si vuole perdere alcun log, ad esempio in caso di arresto anomalo del sistema. Si noti che l'esecuzione del test sta rallentando.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Abilita la registrazione diagnostica. Il livello di log predefinito è 'Trace'. Il file verrà scritto nella directory di output con il nome log_[MMddHHssfff].diag</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Abilita la registrazione diagnostica. Il livello di log predefinito è 'Trace'. Il file verrà scritto nella directory di output con il nome log_[MMddHHssfff].diag</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Directory di output della registrazione diagnostica, se non specificato, il file verrà generato all'interno della directory 'TestResults' predefinita.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Directory di output della registrazione diagnostica, se non specificato, il file verrà generato all'interno della directory 'TestResults' predefinita.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Definire il livello di dettaglio per --diagnostic. I valori disponibili sono 'Trace', 'Debug', 'Information', 'Warning', 'Error' e 'Critical'</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Definire il livello di dettaglio per --diagnostic. I valori disponibili sono 'Trace', 'Debug', 'Information', 'Warning', 'Error' e 'Critical'</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Non segnalare il valore di uscita non riuscito per codici di uscita specifici (ad esempio, '--ignore-exit-code 8;9' ignora i codici di uscita 8 e 9 e restituisce 0 in questi casi)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Non segnalare il valore di uscita non riuscito per codici di uscita specifici (ad esempio, '--ignore-exit-code 8;9' ignora i codici di uscita 8 e 9 e restituisce 0 in questi casi)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">'--minimum-expected-tests' prevede un singolo valore intero positivo diverso da zero, ad esempio ('--minimum-expected-tests 10')</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">'--minimum-expected-tests' prevede un singolo valore intero positivo diverso da zero, ad esempio ('--minimum-expected-tests 10')</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Directory in cui verranno inseriti i risultati del test. Se la directory specificata non esiste, viene creata. Il valore predefinito è TestResults nella directory che contiene l'applicazione di test.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Directory in cui verranno inseriti i risultati del test. Se la directory specificata non esiste, viene creata. Il valore predefinito è TestResults nella directory che contiene l'applicazione di test.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Altre informazioni sulla telemetria della piattaforma di test Microsoft: https:/
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Livello di dettaglio di output durante la creazione di report di test. I valori validi sono 'Normal', 'Detailed'. L'impostazione predefinita è `Normal`.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Livello di dettaglio di output durante la creazione di report di test. I valori validi sono 'Normal', 'Detailed'. L'impostazione predefinita è `Normal`.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Forza il logger di file predefinito per scrivere il log in modo sincrono. Utile per uno scenario in cui non si vuole perdere alcun log, ad esempio in caso di arresto anomalo del sistema. Si noti che l'esecuzione del test sta rallentando.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">組み込みのファイル ロガーでログを同期的に書き込むことを強制します。ログを失わないシナリオ (クラッシュした場合など) に役立ちます。これにより、テストの実行速度が低下していることに注意してください。</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">組み込みのファイル ロガーでログを同期的に書き込むことを強制します。ログを失わないシナリオ (クラッシュした場合など) に役立ちます。これにより、テストの実行速度が低下していることに注意してください。</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">組み込みのファイル ロガーでログを同期的に書き込むことを強制します。ログを失わないシナリオ (クラッシュした場合など) に役立ちます。これにより、テストの実行速度が低下していることに注意してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">診断ログを有効にします。既定のログ レベルは 'Trace' です。ファイルは、出力ディレクトリに log_[MMddHHssfff].diag という名前で書き込まれます。</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">診断ログを有効にします。既定のログ レベルは 'Trace' です。ファイルは、出力ディレクトリに log_[MMddHHssfff].diag という名前で書き込まれます。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">診断ログの出力ディレクトリ。指定しない場合ファイルは既定の 'TestResults' ディレクトリ内に生成されます。</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">診断ログの出力ディレクトリ。指定しない場合ファイルは既定の 'TestResults' ディレクトリ内に生成されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">--diagnostic の詳細レベルを定義します。使用可能な値は、'Trace'、'Debug'、'Information'、'Warning'、'Error'、'Critical' です。</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">--diagnostic の詳細レベルを定義します。使用可能な値は、'Trace'、'Debug'、'Information'、'Warning'、'Error'、'Critical' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -440,8 +445,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">特定の終了コードの成功しなかった終了値を報告しない (例: '--ignore-exit-code 8;9' は終了コード 8 と 9 を無視し、この場合は 0 を返します)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">特定の終了コードの成功しなかった終了値を報告しない (例: '--ignore-exit-code 8;9' は終了コード 8 と 9 を無視し、この場合は 0 を返します)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -455,8 +461,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">'--minimum-expected-tests' には、0 以外の正の整数値が 1 つ必要です (例: '--minimum-expected-tests 10')</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">'--minimum-expected-tests' には、0 以外の正の整数値が 1 つ必要です (例: '--minimum-expected-tests 10')</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -485,8 +492,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">テスト結果を配置するディレクトリ。指定したディレクトリが存在しない場合は、作成されます。既定値は、テスト アプリケーションを含むディレクトリ内の TestResults です。</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">テスト結果を配置するディレクトリ。指定したディレクトリが存在しない場合は、作成されます。既定値は、テスト アプリケーションを含むディレクトリ内の TestResults です。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -625,8 +634,9 @@ Microsoft Testing Platform テレメトリの詳細: https://aka.ms/testingplatf
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">テストを報告する際の出力の詳細度。有効な値は 'Normal'、'Detailed' です。既定値は 'Normal' です。</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">テストを報告する際の出力の詳細度。有効な値は 'Normal'、'Detailed' です。既定値は 'Normal' です。</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">기본 제공 파일 로거가 로그를 동기적으로 기록하도록 강제합니다. 로그를 잃지 않으려는 시나리오(예: 충돌 시)에 유용합니다. 이로 인해 테스트 실행 속도가 느려집니다.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">기본 제공 파일 로거가 로그를 동기적으로 기록하도록 강제합니다. 로그를 잃지 않으려는 시나리오(예: 충돌 시)에 유용합니다. 이로 인해 테스트 실행 속도가 느려집니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">진단 로깅을 사용합니다. 기본값 로그 수준은 'Trace'입니다. 파일은 log_[MMddHHssfff].diag라는 이름으로 출력 디렉터리에 기록됩니다.</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">진단 로깅을 사용합니다. 기본값 로그 수준은 'Trace'입니다. 파일은 log_[MMddHHssfff].diag라는 이름으로 출력 디렉터리에 기록됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">진단 로깅의 출력 디렉터리를 지정하지 않으면 기본 'TestResults' 디렉터리 내에 파일이 생성됩니다.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">진단 로깅의 출력 디렉터리를 지정하지 않으면 기본 'TestResults' 디렉터리 내에 파일이 생성됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">--diagnostic에 대한 세부 정보 표시 수준을 정의합니다. 사용 가능한 값은 'Trace', 'Debug', 'Information', 'Warning', 'Error', 'Critical'입니다.</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">--diagnostic에 대한 세부 정보 표시 수준을 정의합니다. 사용 가능한 값은 'Trace', 'Debug', 'Information', 'Warning', 'Error', 'Critical'입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">특정 종료 코드에 대해 성공하지 못한 종료 값을 보고하지 마세요(예: '--ignore-exit-code 8; 9'는 종료 코드 8 및 9를 무시하고 이 경우 0을 반환함).</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">특정 종료 코드에 대해 성공하지 못한 종료 값을 보고하지 마세요(예: '--ignore-exit-code 8; 9'는 종료 코드 8 및 9를 무시하고 이 경우 0을 반환함).</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">'--minimum-expected-tests'에는 0이 아닌 단일 양의 정수 값(예: '--minimum-expected-tests 10')이 필요합니다.</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">'--minimum-expected-tests'에는 0이 아닌 단일 양의 정수 값(예: '--minimum-expected-tests 10')이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">테스트 결과를 배치할 디렉터리입니다. 지정한 디렉터리가 없으면 디렉터리가 만들어집니다. 기본값은 테스트 애플리케이션을 포함하는 디렉터리의 TestResults입니다.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">테스트 결과를 배치할 디렉터리입니다. 지정한 디렉터리가 없으면 디렉터리가 만들어집니다. 기본값은 테스트 애플리케이션을 포함하는 디렉터리의 TestResults입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Microsoft 테스트 플랫폼 원격 분석에 대해 자세히 알아보기: ht
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">테스트를 보고할 때 세부 정보 표시를 출력합니다. 유효한 값은 'Normal', 'Detailed'입니다. 기본값은 'Normal'입니다.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">테스트를 보고할 때 세부 정보 표시를 출력합니다. 유효한 값은 'Normal', 'Detailed'입니다. 기본값은 'Normal'입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">기본 제공 파일 로거가 로그를 동기적으로 기록하도록 강제합니다. 로그를 잃지 않으려는 시나리오(예: 충돌 시)에 유용합니다. 이로 인해 테스트 실행 속도가 느려집니다.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Wymuś synchroniczne zapisywanie dziennika przez wbudowany rejestrator plików. Przydatne w przypadku scenariusza, w którym nie chcesz utracić żadnego dziennika (tj. w przypadku awarii). Pamiętaj, że to spowalnia wykonywanie testu.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Wymuś synchroniczne zapisywanie dziennika przez wbudowany rejestrator plików. Przydatne w przypadku scenariusza, w którym nie chcesz utracić żadnego dziennika (tj. w przypadku awarii). Pamiętaj, że to spowalnia wykonywanie testu.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Wymuś synchroniczne zapisywanie dziennika przez wbudowany rejestrator plików. Przydatne w przypadku scenariusza, w którym nie chcesz utracić żadnego dziennika (tj. w przypadku awarii). Pamiętaj, że to spowalnia wykonywanie testu.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Włącz rejestrowanie diagnostyczne. Domyślny poziom dziennika to „Śledzenie”. Plik zostanie zapisany w katalogu wyjściowym o nazwie log_[MMddHHssfff].diag</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Włącz rejestrowanie diagnostyczne. Domyślny poziom dziennika to „Śledzenie”. Plik zostanie zapisany w katalogu wyjściowym o nazwie log_[MMddHHssfff].diag</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Katalog wyjściowy rejestrowania diagnostycznego, jeśli nie zostanie określony, plik zostanie wygenerowany w domyślnym katalogu „TestResults”.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Katalog wyjściowy rejestrowania diagnostycznego, jeśli nie zostanie określony, plik zostanie wygenerowany w domyślnym katalogu „TestResults”.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Zdefiniuj poziom szczegółowości dla parametru --diagnostic. Dostępne wartości to „Trace”, „Debug”, „Information”, „Warning”, „Error” i „Critical”</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Zdefiniuj poziom szczegółowości dla parametru --diagnostic. Dostępne wartości to „Trace”, „Debug”, „Information”, „Warning”, „Error” i „Critical”</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Nie zgłaszaj nieprawidłowej wartości zakończenia dla konkretnych kodów zakończenia (np. „--ignore-exit-code 8; 9” zignoruj kod zakończenia 8 i 9, a zwróci wartość 0 w tym przypadku)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Nie zgłaszaj nieprawidłowej wartości zakończenia dla konkretnych kodów zakończenia (np. „--ignore-exit-code 8; 9” zignoruj kod zakończenia 8 i 9, a zwróci wartość 0 w tym przypadku)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">Opcja „--minimum-expected-tests” oczekuje pojedynczej niezerowej dodatniej liczby całkowitej (np. „--minimum-expected-tests 10”)</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">Opcja „--minimum-expected-tests” oczekuje pojedynczej niezerowej dodatniej liczby całkowitej (np. „--minimum-expected-tests 10”)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Katalog, w którym zostaną umieszczone wyniki testów. Jeśli określony katalog nie istnieje, zostanie on utworzony. Wartość domyślna to TestResults w katalogu zawierającym aplikację testowa.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Katalog, w którym zostaną umieszczone wyniki testów. Jeśli określony katalog nie istnieje, zostanie on utworzony. Wartość domyślna to TestResults w katalogu zawierającym aplikację testowa.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Więcej informacji o telemetrii platformy testowej firmy Microsoft: https://aka.
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Szczegółowość danych wyjściowych podczas raportowania testów. Prawidłowe wartości to „Normalne”, „Szczegółowe”. Wartość domyślna to „Normalne”.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Szczegółowość danych wyjściowych podczas raportowania testów. Prawidłowe wartości to „Normalne”, „Szczegółowe”. Wartość domyślna to „Normalne”.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Force o agente de arquivo interno a gravar o log de forma síncrona. Útil para cenários em que você não deseja perder nenhum log (ou seja, em caso de falha). Observe que isso está diminuindo a execução do teste.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Force o agente de arquivo interno a gravar o log de forma síncrona. Útil para cenários em que você não deseja perder nenhum log (ou seja, em caso de falha). Observe que isso está diminuindo a execução do teste.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Habilite o log de diagnóstico. O nível de log padrão é “Trace”. O arquivo será gravado no diretório de saída com o nome log_[MMddHHssfff].diag</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Habilite o log de diagnóstico. O nível de log padrão é “Trace”. O arquivo será gravado no diretório de saída com o nome log_[MMddHHssfff].diag</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Diretório de saída do log de diagnóstico, se não especificado, o arquivo será gerado dentro do diretório padrão 'TestResults'.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Diretório de saída do log de diagnóstico, se não especificado, o arquivo será gerado dentro do diretório padrão 'TestResults'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Defina o nível de detalhamento do --diagnostic. Os valores disponíveis são 'Trace', 'Debug', 'Information', 'Warning', 'Error' e 'Critical'</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Defina o nível de detalhamento do --diagnostic. Os valores disponíveis são 'Trace', 'Debug', 'Information', 'Warning', 'Error' e 'Critical'</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Não relate o valor de saída sem sucesso para códigos de saída específicos (por exemplo, '--ignore-exit-code 8;9' ignore os códigos de saída 8 e 9 e retornará 0 nesse caso)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Não relate o valor de saída sem sucesso para códigos de saída específicos (por exemplo, '--ignore-exit-code 8;9' ignore os códigos de saída 8 e 9 e retornará 0 nesse caso)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">'--minimum-expected-tests' espera um único valor inteiro positivo diferente de zero (por exemplo, '--minimum-expected-tests 10')</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">'--minimum-expected-tests' espera um único valor inteiro positivo diferente de zero (por exemplo, '--minimum-expected-tests 10')</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">O diretório em que os resultados do teste serão colocados. Se o diretório especificado não existir, ele será criado. O padrão é TestResults no diretório que contém o aplicativo de teste.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">O diretório em que os resultados do teste serão colocados. Se o diretório especificado não existir, ele será criado. O padrão é TestResults no diretório que contém o aplicativo de teste.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Leia mais sobre a telemetria da Plataforma de Testes da Microsoft: https://aka.m
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Detalhamento da saída ao relatar testes. Os valores válidos são “Normal”, “Detalhado”. O padrão é “Normal”.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Detalhamento da saída ao relatar testes. Os valores válidos são “Normal”, “Detalhado”. O padrão é “Normal”.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Force o agente de arquivo interno a gravar o log de forma síncrona. Útil para cenários em que você não deseja perder nenhum log (ou seja, em caso de falha). Observe que isso está diminuindo a execução do teste.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Принудительная синхронная запись журнала с помощью встроенного средства ведения журнала файла. Удобно для сценария, в котором вы не хотите потерять журнал (например, в случае сбоя). Обратите внимание, что это замедляет выполнение теста.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Принудительная синхронная запись журнала с помощью встроенного средства ведения журнала файла. Удобно для сценария, в котором вы не хотите потерять журнал (например, в случае сбоя). Обратите внимание, что это замедляет выполнение теста.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Принудительная синхронная запись журнала с помощью встроенного средства ведения журнала файла. Удобно для сценария, в котором вы не хотите потерять журнал (например, в случае сбоя). Обратите внимание, что это замедляет выполнение теста.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Включить ведение журнала диагностики. Уровень журнала по умолчанию — "Трассировка". Файл с именем log_[MMddHHssfff].diag будет записан в выходной каталог</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Включить ведение журнала диагностики. Уровень журнала по умолчанию — "Трассировка". Файл с именем log_[MMddHHssfff].diag будет записан в выходной каталог</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Выходной каталог журнала диагностики, если не указан, файл будет создан в каталоге "TestResults" по умолчанию.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Выходной каталог журнала диагностики, если не указан, файл будет создан в каталоге "TestResults" по умолчанию.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">Определите уровень детализации для параметра --diagnostic. Доступные значения: "Trace", "Debug", "Information", "Warning", "Error" и "Critical"</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">Определите уровень детализации для параметра --diagnostic. Доступные значения: "Trace", "Debug", "Information", "Warning", "Error" и "Critical"</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Не сообщать о неудачном значении выхода для определенных кодов выхода (например, "--ignore-exit-code 8; 9' игнорировать код выхода 8 и 9 и в этом случае возвращать значение 0)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Не сообщать о неудачном значении выхода для определенных кодов выхода (например, "--ignore-exit-code 8; 9' игнорировать код выхода 8 и 9 и в этом случае возвращать значение 0)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">"--minimum-expected-tests" ожидает одно ненулевое положительное целое число (например, "--minimum-expected-tests 10")</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">"--minimum-expected-tests" ожидает одно ненулевое положительное целое число (например, "--minimum-expected-tests 10")</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Каталог, в котором будут размещены результаты теста. Если указанный каталог не существует, он будет создан. Значение по умолчанию — TestResults в каталоге, содержащем тестируемое приложение.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Каталог, в котором будут размещены результаты теста. Если указанный каталог не существует, он будет создан. Значение по умолчанию — TestResults в каталоге, содержащем тестируемое приложение.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Уровень детализации вывода при отправке отчетов о тестах. Допустимые значения: "Normal", "Detailed". Значение по умолчанию: "Normal".</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Уровень детализации вывода при отправке отчетов о тестах. Допустимые значения: "Normal", "Detailed". Значение по умолчанию: "Normal".</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">Yerleşik dosya kaydediciyi günlüğü eşzamanlı olarak yazmaya zorlar. Herhangi bir günlüğü (kilitlenme durumunda) kaybetmek istemediğiniz senaryolar için faydalıdır. Bunun test yürütmesini yavaşlatacağını unutmayın.</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">Yerleşik dosya kaydediciyi günlüğü eşzamanlı olarak yazmaya zorlar. Herhangi bir günlüğü (kilitlenme durumunda) kaybetmek istemediğiniz senaryolar için faydalıdır. Bunun test yürütmesini yavaşlatacağını unutmayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">Tanılama günlük kaydını etkinleştirir. Varsayılan günlük düzeyi: 'İzleme'. Dosya, çıkış dizinine log_[MMddHHssfff].diag adıyla yazılır</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">Tanılama günlük kaydını etkinleştirir. Varsayılan günlük düzeyi: 'İzleme'. Dosya, çıkış dizinine log_[MMddHHssfff].diag adıyla yazılır</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">Tanılama günlüğüne kaydetme için çıkış dizini belirtilmezse dosya varsayılan 'TestResults' dizini içinde oluşturulur.</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">Tanılama günlüğüne kaydetme için çıkış dizini belirtilmezse dosya varsayılan 'TestResults' dizini içinde oluşturulur.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">--diagnostic için ayrıntı düzeyini tanımlayın. Kullanılabilir değerler: 'Trace', 'Debug', 'Information', 'Warning', 'Error' ve 'Critical'</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">--diagnostic için ayrıntı düzeyini tanımlayın. Kullanılabilir değerler: 'Trace', 'Debug', 'Information', 'Warning', 'Error' ve 'Critical'</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Belirli çıkış kodları için başarılı olmayan çıkış değerini bildirme (örneğin, '--ignore-exit-code 8;9' çıkış kodu 8 ve 9'u yoksayar ve bu durumda 0 değerini döndürür)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">Belirli çıkış kodları için başarılı olmayan çıkış değerini bildirme (örneğin, '--ignore-exit-code 8;9' çıkış kodu 8 ve 9'u yoksayar ve bu durumda 0 değerini döndürür)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">'--minimum-expected-tests', sıfır olmayan tek bir pozitif tamsayı değeri (ör. '--minimum-expected-tests 10') bekler</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">'--minimum-expected-tests', sıfır olmayan tek bir pozitif tamsayı değeri (ör. '--minimum-expected-tests 10') bekler</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">Test sonuçlarının yerleştirileceği dizin. Belirtilen dizin yoksa oluşturulur. Varsayılan değer, test uygulamasını içeren dizindeki TestResults'dır.</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">Test sonuçlarının yerleştirileceği dizin. Belirtilen dizin yoksa oluşturulur. Varsayılan değer, test uygulamasını içeren dizindeki TestResults'dır.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Microsoft Test Platformu telemetrisi hakkında daha fazla bilgi edinin: https://
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">Testleri bildirirken çıkış ayrıntı düzeyi. Geçerli değerler: ‘Normal’, ‘Ayrıntılı’. Varsayılan değer: ‘Normal’.</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">Testleri bildirirken çıkış ayrıntı düzeyi. Geçerli değerler: ‘Normal’, ‘Ayrıntılı’. Varsayılan değer: ‘Normal’.</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">Yerleşik dosya kaydediciyi günlüğü eşzamanlı olarak yazmaya zorlar. Herhangi bir günlüğü (kilitlenme durumunda) kaybetmek istemediğiniz senaryolar için faydalıdır. Bunun test yürütmesini yavaşlatacağını unutmayın.</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">强制内置文件记录器同步写入日志。适用于不想丢失任何日志的情况 (即在故障的情况下)。请注意，这会减慢测试的执行速度。</target>
         <note />

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">强制内置文件记录器同步写入日志。适用于不想丢失任何日志的情况 (即在故障的情况下)。请注意，这会减慢测试的执行速度。</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">强制内置文件记录器同步写入日志。适用于不想丢失任何日志的情况 (即在故障的情况下)。请注意，这会减慢测试的执行速度。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">启用诊断日志记录。默认日志级别为 "Trace"。文件将写入输出目录，名称为 log_[MMddHHssfff].diag</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">启用诊断日志记录。默认日志级别为 "Trace"。文件将写入输出目录，名称为 log_[MMddHHssfff].diag</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">诊断日志记录的输出目录，如果未指定，则文件将在默认的“TestResults”目录中生成。</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">诊断日志记录的输出目录，如果未指定，则文件将在默认的“TestResults”目录中生成。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">定义 --diagnostic 的详细程度。可用值为 'Trace', 'Debug', 'Information', 'Warning', 'Error', 和 'Critical'</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">定义 --diagnostic 的详细程度。可用值为 'Trace', 'Debug', 'Information', 'Warning', 'Error', 和 'Critical'</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">不报告特定退出代码的不成功退出值（例如“--ignore-exit-code 8;9”会忽略退出代码 8 和 9，并在这些情况下返回 0）</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">不报告特定退出代码的不成功退出值（例如“--ignore-exit-code 8;9”会忽略退出代码 8 和 9，并在这些情况下返回 0）</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">“--minimum-expected-tests”应有单个非零正整数值 (例如，“--minimum-expected-tests 10”)</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">“--minimum-expected-tests”应有单个非零正整数值 (例如，“--minimum-expected-tests 10”)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">将要放置测试结果的目录。如果指定的目录不存在，则创建该目录。默认值是包含测试应用程序的目录中的 TestResults。</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">将要放置测试结果的目录。如果指定的目录不存在，则创建该目录。默认值是包含测试应用程序的目录中的 TestResults。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Microsoft 测试平台会收集使用数据，帮助我们改善体验。该数�
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">报告测试时的输出详细程度。有效值为“常规”、“详细”。默认值为“常规”。</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">报告测试时的输出详细程度。有效值为“常规”、“详细”。默认值为“常规”。</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -372,13 +372,16 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.</source>
-        <target state="translated">強制內建檔案記錄器以同步方式寫入記錄。適用於不想遺失任何記錄的案例 (例如損毀)。請注意，這會減慢測試執行的速度。</target>
+        <source>Force the built-in file logger to write the log synchronously. 
+Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+Note that this is slowing down the test execution.</source>
+        <target state="needs-review-translation">強制內建檔案記錄器以同步方式寫入記錄。適用於不想遺失任何記錄的案例 (例如損毀)。請注意，這會減慢測試執行的速度。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionDescription">
-        <source>Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
-        <target state="translated">啟用診斷記錄。預設記錄層級為 'Trace'。檔案將以 log_[MMddHHssfff].diag 名稱寫入輸出目錄中</target>
+        <source>Enable the diagnostic logging. The default log level is 'Trace'.
+The file will be written in the output directory with the name log_[MMddHHssfff].diag</source>
+        <target state="needs-review-translation">啟用診斷記錄。預設記錄層級為 'Trace'。檔案將以 log_[MMddHHssfff].diag 名稱寫入輸出目錄中</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage">
@@ -392,8 +395,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputDirectoryOptionDescription">
-        <source>Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.</source>
-        <target state="translated">診斷記錄的輸出目錄，若未指定，則會在預設的 'TestResults' 目錄內產生檔案。</target>
+        <source>Output directory of the diagnostic logging.
+If not specified the file will be generated inside the default 'TestResults' directory.</source>
+        <target state="needs-review-translation">診斷記錄的輸出目錄，若未指定，則會在預設的 'TestResults' 目錄內產生檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticOutputFilePrefixOptionDescription">
@@ -402,8 +406,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticVerbosityOptionDescription">
-        <source>Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'</source>
-        <target state="translated">定義 --diagnostic 的詳細程度層級。可用的值為 'Trace'、'Debug'、'Information'、'Warning'、'Error' 和 'Critical'</target>
+        <source>Define the level of the verbosity for the --diagnostic.
+The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.</source>
+        <target state="needs-review-translation">定義 --diagnostic 的詳細程度層級。可用的值為 'Trace'、'Debug'、'Information'、'Warning'、'Error' 和 'Critical'</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiscoverTestsOptionDescription">
@@ -439,8 +444,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">不要報告特定結束代碼的未成功結束值 (例如 '--ignore-exit-code 8;9' 會忽略結束代碼 8 和 9，而在這些情況下會傳回 0)</target>
+        <source>Do not report non successful exit value for specific exit codes
+(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
+        <target state="needs-review-translation">不要報告特定結束代碼的未成功結束值 (例如 '--ignore-exit-code 8;9' 會忽略結束代碼 8 和 9，而在這些情況下會傳回 0)</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
@@ -454,8 +460,9 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineMinimumExpectedTestsOptionSingleArgument">
-        <source>'--minimum-expected-tests' expects a single non-zero positive integer value (e.g. '--minimum-expected-tests 10')</source>
-        <target state="translated">'--minimum-expected-tests' 需要單一非零的正整數值 (例如 '--minimum-expected-tests 10')</target>
+        <source>'--minimum-expected-tests' expects a single non-zero positive integer value
+(e.g. '--minimum-expected-tests 10')</source>
+        <target state="needs-review-translation">'--minimum-expected-tests' 需要單一非零的正整數值 (例如 '--minimum-expected-tests 10')</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineNoBannerOptionDescription">
@@ -484,8 +491,10 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineResultDirectoryOptionDescription">
-        <source>The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.</source>
-        <target state="translated">將放置測試結果的目錄。如果指定的目錄不存在，系統會建立該目錄。預設值是包含測試應用程式之目錄中的 TestResults。</target>
+        <source>The directory where the test results are going to be placed.
+If the specified directory doesn't exist, it's created.
+The default is TestResults in the directory that contains the test application.</source>
+        <target state="needs-review-translation">將放置測試結果的目錄。如果指定的目錄不存在，系統會建立該目錄。預設值是包含測試應用程式之目錄中的 TestResults。</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">
@@ -624,8 +633,9 @@ Microsoft 測試平台會收集使用量資料，以協助我們改善您的體�
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionDescription">
-        <source>Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
-        <target state="translated">報告測試時的輸出詳細程度。有效值為 'Normal'、'Detailed'。預設為 'Normal'。</target>
+        <source>Output verbosity when reporting tests.
+Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
+        <target state="needs-review-translation">報告測試時的輸出詳細程度。有效值為 'Normal'、'Detailed'。預設為 'Normal'。</target>
         <note />
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -372,8 +372,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineDiagnosticFileLoggerSynchronousWriteOptionDescription">
-        <source>Force the built-in file logger to write the log synchronously. 
-Useful for scenario where you don't want to lose any log (i.e. in case of crash). 
+        <source>Force the built-in file logger to write the log synchronously.
+Useful for scenario where you don't want to lose any log (i.e. in case of crash).
 Note that this is slowing down the test execution.</source>
         <target state="needs-review-translation">強制內建檔案記錄器以同步方式寫入記錄。適用於不想遺失任何記錄的案例 (例如損毀)。請注意，這會減慢測試執行的速度。</target>
         <note />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -31,26 +31,55 @@ MSTest v{MSTestVersion} (UTC *) [* - *]
 Usage {AssetName}* [option providers] [extension option providers]
 Execute a .NET Test Application.
 Options:
-  --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
-  --diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
-  --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
-  --diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
-  --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
-  --exit-on-process-exit                   Exit the test process if dependent process exits. PID must be provided.
-  --help                                   Show the command line help.
-  --ignore-exit-code                       Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
-  --info                                   Display .NET test application information.
-  --list-tests                             List available tests.
-  --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run.
-  --results-directory                      The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
-  --timeout                                A global test execution timeout, it should have one argument as string in the format <value>[h|m|s] where 'value' is float.
+    --diagnostic
+        Enable the diagnostic logging. The default log level is 'Trace'.
+        The file will be written in the output directory with the name log_[MMddHHssfff].diag
+    --diagnostic-filelogger-synchronouswrite
+        Force the built-in file logger to write the log synchronously.
+        Useful for scenario where you don't want to lose any log (i.e. in case of crash).
+        Note that this is slowing down the test execution.
+    --diagnostic-output-directory
+        Output directory of the diagnostic logging.
+        If not specified the file will be generated inside the default 'TestResults' directory.
+    --diagnostic-output-fileprefix
+        Prefix for the log file name that will replace '[log]_.'
+    --diagnostic-verbosity
+        Define the level of the verbosity for the --diagnostic.
+        The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.
+    --exit-on-process-exit
+        Exit the test process if dependent process exits. PID must be provided.
+    --help
+        Show the command line help.
+    --ignore-exit-code
+        Do not report non successful exit value for specific exit codes
+        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+    --info
+        Display .NET test application information.
+    --list-tests
+        List available tests.
+    --minimum-expected-tests
+        Specifies the minimum number of tests that are expected to run.
+    --results-directory
+        The directory where the test results are going to be placed.
+        If the specified directory doesn't exist, it's created.
+        The default is TestResults in the directory that contains the test application.
+    --timeout
+        A global test execution timeout.
+        Takes one argument as string in the format <value>[h|m|s] where 'value' is float.
 Extension options:
-  --filter         Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.
-  --no-ansi        Disable outputting ANSI escape characters to screen.
-  --no-progress    Disable reporting progress to screen.
-  --output         Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
-  --settings       The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file
-  --test-parameter Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
+    --filter
+        Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.
+    --no-ansi
+        Disable outputting ANSI escape characters to screen.
+    --no-progress
+        Disable reporting progress to screen.
+    --output
+        Output verbosity when reporting tests.
+        Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+    --settings
+        The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file
+    --test-parameter
+        Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
 """;
 
         testHostResult.AssertOutputMatchesLines(wildcardMatchPattern);

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -52,7 +52,7 @@ Extension options:
   --test-parameter Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters
 """;
 
-        testHostResult.AssertOutputMatches(wildcardMatchPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardMatchPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
@@ -79,7 +79,10 @@ public sealed class HangDumpTests : AcceptanceTestBase
                 { "SLEEPTIMEMS2", "600000" },
             });
         testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
-        testHostResult.AssertOutputContains("Option '--hangdump-type' has invalid arguments: 'invalid' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'");
+        testHostResult.AssertOutputContains("""
+            Option '--hangdump-type' has invalid arguments: 'invalid' is not a valid dump type.
+            Valid options are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) and 'Full'
+            """);
     }
 
     [TestFixture(TestFixtureSharingStrategy.PerTestGroup)]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -27,26 +27,51 @@ public class HelpInfoTests : AcceptanceTestBase
 Usage {TestAssetFixture.NoExtensionAssetName}* [option providers] [extension option providers]
 Execute a .NET Test Application.
 Options:
-  --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
-  --diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
-  --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
-  --diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
-  --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
-  --exit-on-process-exit                   Exit the test process if dependent process exits. PID must be provided.
-  --help                                   Show the command line help.
-  --ignore-exit-code                       Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
-  --info                                   Display .NET test application information.
-  --list-tests                             List available tests.
-  --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run.
-  --results-directory                      The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
+    --diagnostic
+        Enable the diagnostic logging. The default log level is 'Trace'.
+        The file will be written in the output directory with the name log_[MMddHHssfff].diag
+    --diagnostic-filelogger-synchronouswrite
+        Force the built-in file logger to write the log synchronously.
+        Useful for scenario where you don't want to lose any log (i.e. in case of crash).
+        Note that this is slowing down the test execution.
+    --diagnostic-output-directory
+        Output directory of the diagnostic logging.
+        If not specified the file will be generated inside the default 'TestResults' directory.
+    --diagnostic-output-fileprefix
+        Prefix for the log file name that will replace '[log]_.'
+    --diagnostic-verbosity
+        Define the level of the verbosity for the --diagnostic.
+        The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.
+    --exit-on-process-exit
+        Exit the test process if dependent process exits. PID must be provided.
+    --help
+        Show the command line help.
+    --ignore-exit-code
+        Do not report non successful exit value for specific exit codes
+        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+    --info
+        Display .NET test application information.
+    --list-tests
+        List available tests.
+    --minimum-expected-tests
+        Specifies the minimum number of tests that are expected to run.
+    --results-directory
+        The directory where the test results are going to be placed.
+        If the specified directory doesn't exist, it's created.
+        The default is TestResults in the directory that contains the test application.
 Extension options:
-  --no-ansi         Disable outputting ANSI escape characters to screen.
-  --no-progress     Disable reporting progress to screen.
-  --output          Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
-  --treenode-filter Use a tree filter to filter down the tests to execute
+    --no-ansi
+        Disable outputting ANSI escape characters to screen.
+    --no-progress
+        Disable reporting progress to screen.
+    --output
+        Output verbosity when reporting tests.
+        Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+    --treenode-filter
+        Use a tree filter to filter down the tests to execute
 """;
 
-        testHostResult.AssertOutputMatches(wildcardMatchPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardMatchPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
@@ -62,26 +87,9 @@ Extension options:
 Usage {TestAssetFixture.NoExtensionAssetName}* [option providers] [extension option providers]
 Execute a .NET Test Application.
 Options:
-  --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
-  --diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
-  --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
-  --diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
-  --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
-  --exit-on-process-exit                   Exit the test process if dependent process exits. PID must be provided.
-  --help                                   Show the command line help.
-  --ignore-exit-code                       Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
-  --info                                   Display .NET test application information.
-  --list-tests                             List available tests.
-  --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run.
-  --results-directory                      The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
-Extension options:
-  --no-ansi         Disable outputting ANSI escape characters to screen.
-  --no-progress     Disable reporting progress to screen.
-  --output          Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
-  --treenode-filter Use a tree filter to filter down the tests to execute
 """;
 
-        testHostResult.AssertOutputMatches(wildcardMatchPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardMatchPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
@@ -100,26 +108,9 @@ Unknown option '--{UnknownOption}'
 Usage {TestAssetFixture.NoExtensionAssetName}* [option providers] [extension option providers]
 Execute a .NET Test Application.
 Options:
-  --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
-  --diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
-  --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
-  --diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
-  --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
-  --exit-on-process-exit                   Exit the test process if dependent process exits. PID must be provided.
-  --help                                   Show the command line help.
-  --ignore-exit-code                       Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
-  --info                                   Display .NET test application information.
-  --list-tests                             List available tests.
-  --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run.
-  --results-directory                      The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
-Extension options:
-  --no-ansi         Disable outputting ANSI escape characters to screen.
-  --no-progress     Disable reporting progress to screen.
-  --output          Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
-  --treenode-filter Use a tree filter to filter down the tests to execute
 """;
 
-        testHostResult.AssertOutputMatches(wildcardMatchPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardMatchPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
@@ -135,7 +126,8 @@ Extension options:
 Microsoft Testing Platform:
   Version: .+
   Dynamic Code Supported: True
-  Runtime information: .+({Environment.NewLine}  Runtime location: .+)?
+  Runtime information: .+
+  {(tfm != TargetFrameworks.NetFramework[0].Arguments ? "###SKIP###" : $"Runtime location: .+")}
   Test module: .+{TestAssetFixture.NoExtensionAssetName}.*
 Built-in command line providers:
   PlatformCommandLineProvider
@@ -158,15 +150,19 @@ Built-in command line providers:
       --diagnostic
         Arity: 0
         Hidden: False
-        Description: Enable the diagnostic logging\. The default log level is 'Trace'\. The file will be written in the output directory with the name log_\[MMddHHssfff\]\.diag
+        Description: Enable the diagnostic logging\. The default log level is 'Trace'\.
+        The file will be written in the output directory with the name log_\[MMddHHssfff\]\.diag
       --diagnostic-filelogger-synchronouswrite
         Arity: 0
         Hidden: False
-        Description: Force the built-in file logger to write the log synchronously\. Useful for scenario where you don't want to lose any log \(i\.e\. in case of crash\)\. Note that this is slowing down the test execution\.
+        Description: Force the built-in file logger to write the log synchronously\.
+        Useful for scenario where you don't want to lose any log \(i\.e\. in case of crash\)\.
+        Note that this is slowing down the test execution\.
       --diagnostic-output-directory
         Arity: 1
         Hidden: False
-        Description: Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory\.
+        Description: Output directory of the diagnostic logging.
+        If not specified the file will be generated inside the default 'TestResults' directory\.
       --diagnostic-output-fileprefix
         Arity: 1
         Hidden: False
@@ -174,7 +170,8 @@ Built-in command line providers:
       --diagnostic-verbosity
         Arity: 1
         Hidden: False
-        Description: Define the level of the verbosity for the --diagnostic\. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
+        Description: Define the level of the verbosity for the --diagnostic\.
+        The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
       --dotnet-test-pipe
         Arity: 1
         Hidden: True
@@ -190,7 +187,8 @@ Built-in command line providers:
       --ignore-exit-code
         Arity: 1
         Hidden: False
-        Description: Do not report non successful exit value for specific exit codes \(e\.g\. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case\)
+        Description: Do not report non successful exit value for specific exit codes
+        \(e\.g\. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case\)
       --info
         Arity: 0
         Hidden: False
@@ -226,7 +224,9 @@ Built-in command line providers:
       --results-directory
         Arity: 1
         Hidden: False
-        Description: The directory where the test results are going to be placed\. If the specified directory doesn't exist, it's created\. The default is TestResults in the directory that contains the test application\.
+        Description: The directory where the test results are going to be placed\.
+        If the specified directory doesn't exist, it's created\.
+        The default is TestResults in the directory that contains the test application\.
       --server
         Arity: 0\.\.1
         Hidden: True
@@ -248,7 +248,8 @@ Registered command line providers:
       --output
         Arity: 1
         Hidden: False
-        Description: Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+        Description: Output verbosity when reporting tests.
+        Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   TestingFrameworkExtension
     Name: Microsoft Testing Framework
     Version: .+
@@ -262,7 +263,7 @@ Registered tools:
   There are no registered tools\.
 """;
 
-        testHostResult.AssertOutputMatchesRegex(regexMatchPattern);
+        testHostResult.AssertOutputMatchesRegexLines(regexMatchPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
@@ -278,38 +279,84 @@ Registered tools:
 Usage {TestAssetFixture.AllExtensionsAssetName}* [option providers] [extension option providers]
 Execute a .NET Test Application.
 Options:
-  --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
-  --diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
-  --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
-  --diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
-  --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
-  --exit-on-process-exit                   Exit the test process if dependent process exits. PID must be provided.
-  --help                                   Show the command line help.
-  --ignore-exit-code                       Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
-  --info                                   Display .NET test application information.
-  --list-tests                             List available tests.
-  --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run.
-  --results-directory                      The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
-  --retry-failed-tests                     Enable retry failed tests
-  --retry-failed-tests-max-percentage      Disable retry mechanism if the percentage of failed tests is greater than the specified value
-  --retry-failed-tests-max-tests           Disable retry mechanism if the number of failed tests is greater than the specified value
+    --diagnostic
+        Enable the diagnostic logging. The default log level is 'Trace'.
+        The file will be written in the output directory with the name log_[MMddHHssfff].diag
+    --diagnostic-filelogger-synchronouswrite
+        Force the built-in file logger to write the log synchronously.
+        Useful for scenario where you don't want to lose any log (i.e. in case of crash).
+        Note that this is slowing down the test execution.
+    --diagnostic-output-directory
+        Output directory of the diagnostic logging.
+        If not specified the file will be generated inside the default 'TestResults' directory.
+    --diagnostic-output-fileprefix
+        Prefix for the log file name that will replace '[log]_.'
+    --diagnostic-verbosity
+        Define the level of the verbosity for the --diagnostic.
+        The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.
+    --exit-on-process-exit
+        Exit the test process if dependent process exits. PID must be provided.
+    --help
+        Show the command line help.
+    --ignore-exit-code
+        Do not report non successful exit value for specific exit codes
+        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+    --info
+        Display .NET test application information.
+    --list-tests
+        List available tests.
+    --minimum-expected-tests
+        Specifies the minimum number of tests that are expected to run.
+    --results-directory
+        The directory where the test results are going to be placed.
+        If the specified directory doesn't exist, it's created.
+        The default is TestResults in the directory that contains the test application.
+    --retry-failed-tests
+        Enable retry failed tests
+    --retry-failed-tests-max-percentage
+        Disable retry mechanism if the percentage of failed tests is greater than the specified value
+    --retry-failed-tests-max-tests
+        Disable retry mechanism if the number of failed tests is greater than the specified value
 Extension options:
-  --crashdump           [net6.0+ only] Generate a dump file if the test process crashes
-  --crashdump-filename  Specify the name of the dump file
-  --crashdump-type      Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps
-  --hangdump            Generate a dump file if the test process hangs
-  --hangdump-filename   Specify the name of the dump file
-  --hangdump-timeout    Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.
-  --hangdump-type       Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'
-  --no-ansi             Disable outputting ANSI escape characters to screen.
-  --no-progress         Disable reporting progress to screen.
-  --output              Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
-  --report-trx          Enable generating TRX report
-  --report-trx-filename The name of the generated TRX report
-  --treenode-filter     Use a tree filter to filter down the tests to execute
+    --crashdump
+        [net6.0+ only] Generate a dump file if the test process crashes
+    --crashdump-filename
+        Specify the name of the dump file
+    --crashdump-type
+        Specify the type of the dump.
+        Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
+        For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps
+    --hangdump
+        Generate a dump file if the test process hangs
+    --hangdump-filename
+        Specify the name of the dump file
+    --hangdump-timeout
+        Specify the timeout after which the dump will be generated.
+        The timeout value is specified in one of the following formats:
+            1.5h, 1.5hour, 1.5hours,
+            90m, 90min, 90minute, 90minutes,
+            5400s, 5400sec, 5400second, 5400seconds.
+            Default is 30m.
+    --hangdump-type
+        Specify the type of the dump.
+        Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+        Default type is 'Full'
+    --no-ansi
+        Disable outputting ANSI escape characters to screen.
+    --no-progress
+        Disable reporting progress to screen.
+    --output
+        Output verbosity when reporting tests.
+        Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+    --report-trx
+        Enable generating TRX report
+    --report-trx-filename
+        The name of the generated TRX report
+    --treenode-filter
+        Use a tree filter to filter down the tests to execute
 """;
 
-        testHostResult.AssertOutputMatches(wildcardPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
@@ -325,38 +372,9 @@ Extension options:
 Usage {TestAssetFixture.AllExtensionsAssetName}* [option providers] [extension option providers]
 Execute a .NET Test Application.
 Options:
-  --diagnostic                             Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
-  --diagnostic-filelogger-synchronouswrite Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
-  --diagnostic-output-directory            Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
-  --diagnostic-output-fileprefix           Prefix for the log file name that will replace '[log]_.'
-  --diagnostic-verbosity                   Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
-  --exit-on-process-exit                   Exit the test process if dependent process exits. PID must be provided.
-  --help                                   Show the command line help.
-  --ignore-exit-code                       Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
-  --info                                   Display .NET test application information.
-  --list-tests                             List available tests.
-  --minimum-expected-tests                 Specifies the minimum number of tests that are expected to run.
-  --results-directory                      The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
-  --retry-failed-tests                     Enable retry failed tests
-  --retry-failed-tests-max-percentage      Disable retry mechanism if the percentage of failed tests is greater than the specified value
-  --retry-failed-tests-max-tests           Disable retry mechanism if the number of failed tests is greater than the specified value
-Extension options:
-  --crashdump           [net6.0+ only] Generate a dump file if the test process crashes
-  --crashdump-filename  Specify the name of the dump file
-  --crashdump-type      Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps
-  --hangdump            Generate a dump file if the test process hangs
-  --hangdump-filename   Specify the name of the dump file
-  --hangdump-timeout    Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.
-  --hangdump-type       Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'
-  --no-ansi             Disable outputting ANSI escape characters to screen.
-  --no-progress         Disable reporting progress to screen.
-  --output              Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
-  --report-trx          Enable generating TRX report
-  --report-trx-filename The name of the generated TRX report
-  --treenode-filter     Use a tree filter to filter down the tests to execute
 """;
 
-        testHostResult.AssertOutputMatches(wildcardPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardPattern);
     }
 
     [ArgumentsProvider(nameof(TargetFrameworks.All), typeof(TargetFrameworks))]
@@ -372,7 +390,8 @@ Extension options:
 Microsoft Testing Platform:
   Version: *
   Dynamic Code Supported: True
-  Runtime information: *{(tfm == TargetFrameworks.NetFramework[0].Arguments ? $"{Environment.NewLine}  Runtime location: *" : string.Empty)}
+  Runtime information: *
+  {(tfm != TargetFrameworks.NetFramework[0].Arguments ? "###SKIP###" : $"Runtime location: *")}
   Test module: *{TestAssetFixture.AllExtensionsAssetName}*
 Built-in command line providers:
   PlatformCommandLineProvider
@@ -395,15 +414,19 @@ Built-in command line providers:
       --diagnostic
         Arity: 0
         Hidden: False
-        Description: Enable the diagnostic logging. The default log level is 'Trace'. The file will be written in the output directory with the name log_[MMddHHssfff].diag
+        Description: Enable the diagnostic logging. The default log level is 'Trace'.
+        The file will be written in the output directory with the name log_[MMddHHssfff].diag
       --diagnostic-filelogger-synchronouswrite
         Arity: 0
         Hidden: False
-        Description: Force the built-in file logger to write the log synchronously. Useful for scenario where you don't want to lose any log (i.e. in case of crash). Note that this is slowing down the test execution.
+        Description: Force the built-in file logger to write the log synchronously.
+        Useful for scenario where you don't want to lose any log (i.e. in case of crash).
+        Note that this is slowing down the test execution.
       --diagnostic-output-directory
         Arity: 1
         Hidden: False
-        Description: Output directory of the diagnostic logging, if not specified the file will be generated inside the default 'TestResults' directory.
+        Description: Output directory of the diagnostic logging.
+        If not specified the file will be generated inside the default 'TestResults' directory.
       --diagnostic-output-fileprefix
         Arity: 1
         Hidden: False
@@ -411,7 +434,8 @@ Built-in command line providers:
       --diagnostic-verbosity
         Arity: 1
         Hidden: False
-        Description: Define the level of the verbosity for the --diagnostic. The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'
+        Description: Define the level of the verbosity for the --diagnostic.
+        The available values are 'Trace', 'Debug', 'Information', 'Warning', 'Error', and 'Critical'.
       --dotnet-test-pipe
         Arity: 1
         Hidden: True
@@ -427,7 +451,8 @@ Built-in command line providers:
       --ignore-exit-code
         Arity: 1
         Hidden: False
-        Description: Do not report non successful exit value for specific exit codes (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+        Description: Do not report non successful exit value for specific exit codes
+        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
       --info
         Arity: 0
         Hidden: False
@@ -463,7 +488,9 @@ Built-in command line providers:
       --results-directory
         Arity: 1
         Hidden: False
-        Description: The directory where the test results are going to be placed. If the specified directory doesn't exist, it's created. The default is TestResults in the directory that contains the test application.
+        Description: The directory where the test results are going to be placed.
+        If the specified directory doesn't exist, it's created.
+        The default is TestResults in the directory that contains the test application.
       --server
         Arity: 0..1
         Hidden: True
@@ -485,7 +512,9 @@ Registered command line providers:
       --crashdump-type
         Arity: 1
         Hidden: False
-        Description: Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'. For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps
+        Description: Specify the type of the dump.
+        Valid values are 'Mini', 'Heap', 'Triage' or 'Full'. Default type is 'Full'.
+        For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/collect-dumps-crash#types-of-mini-dumps
   HangDumpCommandLineProvider
     Name: Hang dump
     Version: *
@@ -502,11 +531,18 @@ Registered command line providers:
       --hangdump-timeout
         Arity: 1
         Hidden: False
-        Description: Specify the timeout after which the dump will be generated. The timeout value is specified in one of the following formats: 1.5h, 1.5hour, 1.5hours, 90m, 90min, 90minute, 90minutes 5400s, 5400sec, 5400second, 5400seconds. Default is 30m.
+        Description: Specify the timeout after which the dump will be generated.
+        The timeout value is specified in one of the following formats:
+            1.5h, 1.5hour, 1.5hours,
+            90m, 90min, 90minute, 90minutes,
+            5400s, 5400sec, 5400second, 5400seconds.
+            Default is 30m.
       --hangdump-type
         Arity: 1
         Hidden: False
-        Description: Specify the type of the dump. Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'. Default type is 'Full'
+        Description: Specify the type of the dump.
+        Valid values are 'Mini', 'Heap', 'Triage' (only available in .NET 6+) or 'Full'.
+        Default type is 'Full'
   RetryCommandLineOptionsProvider
     Name: Retry failed tests
     Version: *
@@ -544,7 +580,8 @@ Registered command line providers:
       --output
         Arity: 1
         Hidden: False
-        Description: Output verbosity when reporting tests. Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
+        Description: Output verbosity when reporting tests.
+        Valid values are 'Normal', 'Detailed'. Default is 'Normal'.
   TestingFrameworkExtension
     Name: Microsoft Testing Framework
     Version: *
@@ -589,7 +626,7 @@ Registered tools:
             Description: The TRX file to compare with the baseline
 """;
 
-        testHostResult.AssertOutputMatches(wildcardPattern);
+        testHostResult.AssertOutputMatchesLines(wildcardPattern);
     }
 
     [TestFixture(TestFixtureSharingStrategy.PerTestGroup)]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -146,8 +146,7 @@ public class MSBuildTests_Test : AcceptanceTestBase
             .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
             .PatchCodeWithReplace("$MicrosoftTestingEnterpriseExtensionsVersion$", MicrosoftTestingEnterpriseExtensionsVersion));
         string binlogFile = Path.Combine(testAsset.TargetAssetPath, Guid.NewGuid().ToString("N"), "msbuild.binlog");
-        string testResultFolder = Path.Combine(testAsset.TargetAssetPath, Guid.NewGuid().ToString("N"));
-        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
+        await DotnetCli.RunAsync(
             $"test --arch x86 -p:TestingPlatformDotnetTestSupport=True -p:Configuration=Release -p:nodeReuse=false -bl:{binlogFile} \"{testAsset.TargetAssetPath}\"",
             _acceptanceFixture.NuGetGlobalPackagesFolder.Path,
             environmentVariables: dotnetRootX86,

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -92,12 +92,12 @@ public sealed class TerminalTestReporterTests : TestBase
             ␛[31;1mfailed (canceled)␛[m TimedoutTest1␛[90;1m ␛[90;1m(10s 000ms)␛[m
             ␛[31;1mfailed (canceled)␛[m CanceledTest1␛[90;1m ␛[90;1m(10s 000ms)␛[m
             ␛[31;1mfailed␛[m FailedTest1␛[90;1m ␛[90;1m(10s 000ms)␛[m
-            ␛[91;1m  Tests failed␛[m
-            ␛[91;1m  Expected
+            ␛[91;1m  Tests failed
+            ␛[m␛[91;1m  Expected
                 ABC
               Actual
-                DEF␛[m
-            ␛[31;1m  Stack Trace:
+                DEF
+            ␛[m␛[31;1m  Stack Trace:
                 ␛[90;1mat ␛[m␛[91;1mFailingTest()␛[90;1m in ␛[90;1m␛]8;;file:///{folderLink}codefile.cs␛\{folder}codefile.cs:10␛]8;;␛\␛[m
 
 


### PR DESCRIPTION
Change help formatting from 

![image](https://github.com/user-attachments/assets/61b0acab-441e-48fb-8c7a-0cac5fc08954)


to 

![image (4)](https://github.com/user-attachments/assets/6d5e0d67-b6d3-4085-b884-3f636071bd62)

This avoids the help being pushed to right side by the longest option.

We **DO NOT** split the lines automatically and reflow them, you need to put newlines in the description manually, and keep each line short. This is to avoid splitting links (so they remain clickable), and to let the terminal reflow long lines, so user can widen their terminal and get the correct view without re-running.