### PR TITLE
Give to json default protocol a name `--server jsonrpc`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
@@ -35,7 +35,9 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
     public const string PortOptionKey = "port";
     public const string ClientPortOptionKey = "client-port";
     public const string ClientHostOptionKey = "client-host";
+    public const string JsonRpcProtocolName = "jsonrpc";
     public const string DotNetTestPipeOptionKey = "dotnet-test-pipe";
+    public const string DotnetTestCliProtocolName = "dotnettestcli";
 
     private static readonly string[] VerbosityOptions = ["Trace", "Debug", "Information", "Warning", "Error", "Critical"];
 


### PR DESCRIPTION
Now that we have more than one supported protocol we give a name to the default one `jsonrpc` in case of `--server` with empty protocol name the `jsonrpc` will be the default

cc: @mariam-abdulla @drognanar 