### PR TITLE
Reduce output when resizing to avoid breaking the progress

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -92,7 +92,7 @@ internal sealed class AnsiTerminalTestProgressFrame
 
         if (charsTaken < nonReservedWidth && (p.TargetFramework != null || p.Architecture != null))
         {
-            var lengthNeeded = 0;
+            int lengthNeeded = 0;
 
             lengthNeeded++; // for '('
             if (p.TargetFramework != null)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -3,8 +3,6 @@
 
 using System.Globalization;
 
-using Microsoft.Testing.Platform.Helpers;
-
 namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 
 /// <summary>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -156,7 +156,7 @@ internal sealed class AnsiTerminalTestProgressFrame
             if (charsTaken < width)
             {
                 int charsToTake = width - charsTaken;
-                string cutText = text.Substring(text.Length - charsToTake);
+                string cutText = text[^charsToTake..];
                 terminal.Append(cutText);
                 charsTaken += charsToTake;
             }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
@@ -19,6 +19,7 @@ public class CrashDumpTests(ITestExecutionContext testExecutionContext) : TestBa
     [Arguments("Full")]
     public async Task IsValid_If_CrashDumpType_Has_CorrectValue(string crashDumpType)
     {
+        Thread.Sleep(20_000);
         var provider = new CrashDumpCommandLineProvider();
         CommandLineOption option = provider.GetCommandLineOptions().First(x => x.Name == CrashDumpCommandLineOptions.CrashDumpTypeOptionName);
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
@@ -19,7 +19,6 @@ public class CrashDumpTests(ITestExecutionContext testExecutionContext) : TestBa
     [Arguments("Full")]
     public async Task IsValid_If_CrashDumpType_Has_CorrectValue(string crashDumpType)
     {
-        Thread.Sleep(20_000);
         var provider = new CrashDumpCommandLineProvider();
         CommandLineOption option = provider.GetCommandLineOptions().First(x => x.Name == CrashDumpCommandLineOptions.CrashDumpTypeOptionName);
 


### PR DESCRIPTION
Before: when the window gets smaller the progress is broken, and end up scrolling down on the screen. Same thing happens when assembly name is too long.

![sizing-broken](https://github.com/user-attachments/assets/233fe05d-bc6a-423e-9fa7-36de0a2005ce)

After: we hide the tfm and architecture first, then we start trimming the name from right prepending with ... to keep the output to correct width and keep the time on screen.

![sizing](https://github.com/user-attachments/assets/1e9deacd-dcab-493b-ab05-0bec46994cf2)