### PR TITLE
Banner uses runtime framework and live test output uses target framework

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TargetFrameworkParser.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TargetFrameworkParser.cs
@@ -7,8 +7,13 @@ namespace Microsoft.Testing.Platform.OutputDevice;
 
 internal static class TargetFrameworkParser
 {
-    public static string? GetShortTargetFramework(string frameworkDescription)
+    public static string? GetShortTargetFramework(string? frameworkDescription)
     {
+        if (frameworkDescription == null)
+        {
+            return null;
+        }
+
         // https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription
         string netFramework = ".NET Framework";
         if (frameworkDescription.StartsWith(netFramework, ignoreCase: false, CultureInfo.InvariantCulture))


### PR DESCRIPTION
Fix #3669

![image](https://github.com/user-attachments/assets/a4e2b173-0c9f-42e8-885e-bd4a88476209)

Show the runtime version in header, and targeted framework in other places.