### PR TITLE
Ignore dispose error

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
@@ -105,7 +105,15 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
     {
         if (GetShowProgress())
         {
-            _cts.Cancel();
+            try
+            {
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // When we dispose _cts too early this will throw.
+            }
+
             _refresher?.Join();
 
             _terminal.EraseProgress();


### PR DESCRIPTION
We don't control our lifetime, and need to dispose because we use WaitHandle of the token source. When we get callback once we are disposed this throws. Both calls to Dispose and to StopShowingProgress are out of our hands.

Fix #3695

