### PR TITLE
Honor `--no-build` when we use `dotnet run`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -76,6 +76,9 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     [Required]
     public ITaskItem ProjectFullPath { get; set; }
 
+    [Required]
+    public ITaskItem VSTestNoBuild { get; set; }
+
     public ITaskItem? DotnetHostPath { get; set; }
 
     public ITaskItem? TestingPlatformCommandLineArguments { get; set; }
@@ -173,6 +176,11 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
                     builder.AppendSwitchIfNotNull("--project ", ProjectFullPath.ItemSpec);
                     builder.AppendSwitchIfNotNull("--framework ", TargetFramework.ItemSpec);
                     builder.AppendSwitchIfNotNull("--arch ", TestArchitecture.ItemSpec.ToLowerInvariant());
+                    if (bool.TryParse(VSTestNoBuild.ItemSpec, out bool noBuild) && noBuild)
+                    {
+                        builder.AppendSwitch("--no-build");
+                    }
+
                     builder.AppendTextUnquoted($" -- ");
                 }
                 else

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -178,7 +178,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
                     builder.AppendSwitchIfNotNull("--arch ", TestArchitecture.ItemSpec.ToLowerInvariant());
                     if (bool.TryParse(VSTestNoBuild.ItemSpec, out bool noBuild) && noBuild)
                     {
-                        builder.AppendSwitch("--no-build");
+                        builder.AppendSwitch("--no-build ");
                     }
 
                     builder.AppendTextUnquoted($" -- ");

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -324,6 +324,7 @@
                                TestingPlatformShowTestsFailure="$(TestingPlatformShowTestsFailure)"
                                TestingPlatformCommandLineArguments="$(TestingPlatformCommandLineArguments)"
                                VSTestCLIRunSettings="$(VSTestCLIRunSettings)"
+                               VSTestNoBuild="$(VSTestNoBuild)"
                                TestingPlatformCaptureOutput="$(TestingPlatformCaptureOutput)"
                                DotnetHostPath="$(DOTNET_HOST_PATH)" />
   </Target>


### PR DESCRIPTION
closes https://github.com/microsoft/testfx/issues/3689

<img width="773" alt="image" src="https://github.com/user-attachments/assets/f52a8635-c507-406e-b210-858ddd08b6e8">

<img width="670" alt="image" src="https://github.com/user-attachments/assets/9bacc9fe-25da-4f75-897f-94ff7e610b50">

<img width="674" alt="image" src="https://github.com/user-attachments/assets/ef1db33b-0ffc-4dd8-82a6-c1ed9b090ba8">


The `--no-restore` is not available as MSBuild parameter, but looks like the perf are anyway good.
