### PR TITLE
Bridge message logger also forward info to output

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.TestAdapter/Resources/Resource.Designer.cs
@@ -486,7 +486,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})..
+        ///   Looks up a localized string similar to Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).
         /// </summary>
         internal static string TestParallelizationBanner {
             get {

--- a/src/Adapter/MSTest.TestAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.TestAdapter/Resources/Resource.resx
@@ -289,7 +289,7 @@ Error: {1}</value>
     <value>[MSTest][Discovery][{0}] {1}</value>
   </data>
   <data name="TestParallelizationBanner" xml:space="preserve">
-    <value>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</value>
+    <value>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</value>
   </data>
   <data name="InvalidParallelScopeValue" xml:space="preserve">
     <value>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</value>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.cs.xlf
@@ -383,9 +383,9 @@ Chyba: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">Prováděcí modul MSTest: Je povolená paralelizace testu pro {0} (pracovní procesy: {1}, obor: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">Prováděcí modul MSTest: Je povolená paralelizace testu pro {0} (pracovní procesy: {1}, obor: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.de.xlf
@@ -383,9 +383,9 @@ Fehler: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest-Executor: Testparallelisierung für "{0}" aktiviert (Worker: {1}, Bereich: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest-Executor: Testparallelisierung für "{0}" aktiviert (Worker: {1}, Bereich: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.es.xlf
@@ -383,9 +383,9 @@ Error: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">Ejecutor de MSTest Executor: paralelización de prueba habilitada para {0} (Trabajadores: {1}, Ámbito: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">Ejecutor de MSTest Executor: paralelización de prueba habilitada para {0} (Trabajadores: {1}, Ámbito: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.fr.xlf
@@ -383,9 +383,9 @@ Erreur : {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">Exécuteur MSTest : parallélisation des tests activée pour {0} (threads de travail : {1}, portée : {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">Exécuteur MSTest : parallélisation des tests activée pour {0} (threads de travail : {1}, portée : {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.it.xlf
@@ -383,9 +383,9 @@ Errore: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">Executor MSTest: Parallelizzazione test abilitata per {0} (Workers: {1}. Scope: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">Executor MSTest: Parallelizzazione test abilitata per {0} (Workers: {1}. Scope: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ja.xlf
@@ -384,9 +384,9 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest 実行プログラム: {0} でテスト並列処理が有効にされています (Workers: {1}、Scope: {2})。</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest 実行プログラム: {0} でテスト並列処理が有効にされています (Workers: {1}、Scope: {2})。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ko.xlf
@@ -383,9 +383,9 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest 실행기: {0}에 대해 테스트 병렬 처리를 사용합니다(Workers: {1}, Scope: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest 실행기: {0}에 대해 테스트 병렬 처리를 사용합니다(Workers: {1}, Scope: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pl.xlf
@@ -383,9 +383,9 @@ Błąd: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">Moduł wykonywania MSTest: włączono obsługę równoległego wykonywania testów dla elementu {0} (procesy robocze: {1}, zakres: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">Moduł wykonywania MSTest: włączono obsługę równoległego wykonywania testów dla elementu {0} (procesy robocze: {1}, zakres: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pt-BR.xlf
@@ -383,9 +383,9 @@ Erro: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest Executor: paralelização de teste habilitada para {0} (Workers: {1}, Scope: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest Executor: paralelização de teste habilitada para {0} (Workers: {1}, Scope: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ru.xlf
@@ -383,9 +383,9 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">Исполнитель MSTest: включена параллелизация тестов для {0} (рабочие роли: {1}, область: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">Исполнитель MSTest: включена параллелизация тестов для {0} (рабочие роли: {1}, область: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.tr.xlf
@@ -383,9 +383,9 @@ Hata: {1}</target>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest Yürütücü: {0} için Test Paralelleştirme etkin (Workers: {1}, Scope: {2}).</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest Yürütücü: {0} için Test Paralelleştirme etkin (Workers: {1}, Scope: {2}).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hans.xlf
@@ -383,9 +383,9 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest 执行程序: 为 {0} 启用测试并行化(辅助角色: {1}，范围: {2})。</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest 执行程序: 为 {0} 启用测试并行化(辅助角色: {1}，范围: {2})。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hant.xlf
@@ -383,9 +383,9 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
-        <source>MSTest Executor: Test Parallelization enabled for {0} (Workers: {1}, Scope: {2}).</source>
-        <target state="translated">MSTest 執行程式: 已為 {0} 啟用平行測試。(Workers: {1}，Scope: {2})。</target>
-        <note></note>
+        <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
+        <target state="needs-review-translation">MSTest 執行程式: 已為 {0} 啟用平行測試。(Workers: {1}，Scope: {2})。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/MessageLoggerAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/MessageLoggerAdapter.cs
@@ -49,6 +49,7 @@ internal sealed class MessageLoggerAdapter : IMessageLogger, IOutputDeviceDataPr
         {
             case TestMessageLevel.Informational:
                 _logger.LogInformation(message);
+                _outputDevice.DisplayAsync(this, new TextOutputDeviceData(message)).Await();
                 break;
             case TestMessageLevel.Warning:
                 _logger.LogWarning(message);


### PR DESCRIPTION
Before this fix, info messages were only added to the log whereas warnings and errors were written both to log and output.

Fixing this allows to have MSTest parallelization message showing up:

![image](https://github.com/user-attachments/assets/20488961-2c7b-4c30-aa21-0cefd1ebd387)
