### PR TITLE
Disable out of process extensions in case of `--list-tests`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -380,7 +380,7 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
 
         // ======= TEST HOST ORCHESTRATOR ======== //
         TestHostOrchestratorConfiguration testHostOrchestratorConfiguration = await TestHostOrchestratorManager.BuildAsync(serviceProvider);
-        if (testHostOrchestratorConfiguration.TestHostOrchestrators.Length > 0)
+        if (testHostOrchestratorConfiguration.TestHostOrchestrators.Length > 0 && !commandLineHandler.IsOptionSet(PlatformCommandLineProvider.DiscoverTestsOptionKey))
         {
             return new TestHostOrchestratorHost(testHostOrchestratorConfiguration, serviceProvider);
         }
@@ -388,8 +388,9 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
         // ======= TEST HOST CONTROLLER MODE ======== //
         // Check if we're in the test host or we should check test controllers extensions
         // Environment variable check should not be needed but in case we will rollback to use only env var we will need it.
-        if (!testHostControllerInfo.HasTestHostController ||
+        if ((!testHostControllerInfo.HasTestHostController ||
             systemEnvironment.GetEnvironmentVariable($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_SKIPEXTENSION}_{testHostControllerInfo.GetTestHostControllerPID(true)}") != "1")
+            && !commandLineHandler.IsOptionSet(PlatformCommandLineProvider.DiscoverTestsOptionKey))
         {
             // Clone the service provider to avoid to add the message bus proxy to the main service provider.
             var testHostControllersServiceProvider = (ServiceProvider)serviceProvider.Clone();


### PR DESCRIPTION
Extensions don't know nothing about the concept of discovery and we want to keep them far from it.

contributes to https://github.com/microsoft/testfx/issues/3721