### PR TITLE
[do not merge] Collect test assets on failed tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,13 @@ stages:
             displayName: Upload coverage to codecov.io
             condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
 
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish test assets temp folders'
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite'
+              ArtifactName: TmpArtifacts_Windows_$(_BuildConfig)
+            condition: failed()
+
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
           - task: PublishBuildArtifacts@1
@@ -153,3 +160,10 @@ stages:
               ./test.sh --configuration $(_BuildConfig) --ci --test --integrationTest --nobl
             name: Test
             displayName: Tests
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish test assets temp folders'
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite'
+              ArtifactName: TmpArtifacts_Linux_$(_BuildConfig)
+            condition: failed()

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.InteropServices;
-
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 
@@ -100,7 +98,6 @@ public class UnitTest1
            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
            .PatchCodeWithReplace("$MSTestEngineVersion$", MSTestEngineVersion),
            addPublicFeeds: true);
-
 
         await DotnetCli.RunAsync(
             $"restore -m:1 -nodeReuse:false {generator.TargetAssetPath} -r {RID}",


### PR DESCRIPTION
For runtime team to properly investigate the flakiness of the native aot publication, publish failing artifacts so we can share them for investigation. We are mainly looking at the `obj` folder but capturing all is easier.