### PR TITLE
[rel/3.6] Fix timedout test does not fail test run (in ui)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -382,9 +382,8 @@ internal sealed partial class TerminalTestReporter : IDisposable
         switch (outcome)
         {
             case TestOutcome.Error:
-                asm.FailedTests++;
-                asm.TotalTests++;
-                break;
+            case TestOutcome.Timeout:
+            case TestOutcome.Canceled:
             case TestOutcome.Fail:
                 asm.FailedTests++;
                 asm.TotalTests++;
@@ -395,14 +394,6 @@ internal sealed partial class TerminalTestReporter : IDisposable
                 break;
             case TestOutcome.Skipped:
                 asm.SkippedTests++;
-                asm.TotalTests++;
-                break;
-            case TestOutcome.Timeout:
-                asm.TimedOutTests++;
-                asm.TotalTests++;
-                break;
-            case TestOutcome.Canceled:
-                asm.CanceledTests++;
                 asm.TotalTests++;
                 break;
         }
@@ -645,7 +636,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private static void AppendAssemblySummary(TestProgressState assemblyRun, ITerminal terminal)
     {
-        int failedTests = assemblyRun.FailedTests + assemblyRun.CanceledTests + assemblyRun.TimedOutTests;
+        int failedTests = assemblyRun.FailedTests;
         int warnings = 0;
 
         AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyRun.Assembly, assemblyRun.TargetFramework, assemblyRun.Architecture);

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
@@ -38,10 +38,6 @@ internal sealed class TestProgressState
 
     public int TotalTests { get; internal set; }
 
-    public int TimedOutTests { get; internal set; }
-
-    public int CanceledTests { get; internal set; }
-
     public string? Detail { get; internal set; }
 
     public int SlotIndex { get; internal set; }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -73,6 +73,7 @@ public sealed class TerminalTestReporterTests : TestBase
             errorMessage: null, errorStackTrace: null, expected: null, actual: null);
         terminalReporter.TestCompleted(assembly, targetFramework, architecture, "SkippedTest1", TestOutcome.Skipped, TimeSpan.FromSeconds(10),
             errorMessage: null, errorStackTrace: null, expected: null, actual: null);
+        // timed out + cancelled + failed should all report as failed in summary
         terminalReporter.TestCompleted(assembly, targetFramework, architecture, "TimedoutTest1", TestOutcome.Timeout, TimeSpan.FromSeconds(10),
             errorMessage: null, errorStackTrace: null, expected: null, actual: null);
         terminalReporter.TestCompleted(assembly, targetFramework, architecture, "CanceledTest1", TestOutcome.Canceled, TimeSpan.FromSeconds(10),
@@ -107,7 +108,7 @@ public sealed class TerminalTestReporterTests : TestBase
                 - ␛[90;1m␛]8;;file:///{folderLink}artifact2.txt␛\{folder}artifact2.txt␛]8;;␛\␛[m
             ␛[91;1mTest run summary: Failed!␛[90;1m - ␛[m␛[90;1m␛]8;;file:///{folderLinkNoSlash}␛\{folder}assembly.dll␛]8;;␛\␛[m (net8.0|x64)
             ␛[m  total: 5
-            ␛[91;1m  failed: 1
+            ␛[91;1m  failed: 3
             ␛[m  succeeded: 1
               skipped: 1
               duration: 3652058d 23h 59m 59s 999ms


### PR DESCRIPTION
Fix https://github.com/microsoft/testfx/issues/3762