### PR TITLE
Update azure-pipelines-official.yml

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,7 +91,7 @@ extends:
           enableTelemetry: true
           jobs:
           - job: Windows
-            timeoutInMinutes: 180
+            timeoutInMinutes: 240
             pool:
               name: $(DncEngInternalBuildPool)
               image: windows.vs2022.amd64
@@ -164,7 +164,7 @@ extends:
                 publishVstsFeed: 'public/test-tools'
 
           - job: Linux
-            timeoutInMinutes: 180
+            timeoutInMinutes: 240
             pool:
               name: $(DncEngInternalBuildPool)
               image: 1es-ubuntu-2204

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -91,7 +91,7 @@ extends:
           enableTelemetry: true
           jobs:
           - job: Windows
-            timeoutInMinutes: 150
+            timeoutInMinutes: 180
             pool:
               name: $(DncEngInternalBuildPool)
               image: windows.vs2022.amd64
@@ -164,7 +164,7 @@ extends:
                 publishVstsFeed: 'public/test-tools'
 
           - job: Linux
-            timeoutInMinutes: 150
+            timeoutInMinutes: 180
             pool:
               name: $(DncEngInternalBuildPool)
               image: 1es-ubuntu-2204

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ stages:
       enableTelemetry: true
       jobs:
       - job: Windows
-        timeoutInMinutes: 90
+        timeoutInMinutes: 240
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2022preview.amd64.open
@@ -115,7 +115,7 @@ stages:
             condition: failed()
 
       - job: Linux
-        timeoutInMinutes: 90
+        timeoutInMinutes: 240
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals build.ubuntu.2004.amd64.open


### PR DESCRIPTION
This pull request includes changes to the Azure Pipelines configuration to extend the timeout duration for both Windows and Linux jobs. The main changes involve increasing the `timeoutInMinutes` parameter to ensure that the jobs have sufficient time to complete.

### Azure Pipelines Configuration Changes:

* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L55-R55): Increased the `timeoutInMinutes` for the Windows job from 90 to 240 minutes.
* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L118-R118): Increased the `timeoutInMinutes` for the Linux job from 90 to 240 minutes.This pull request includes changes to the `azure-pipelines-official.yml` file, extending the timeout for both Windows and Linux jobs.

Build configuration updates:

* [`azure-pipelines-official.yml`](diffhunk://#diff-0ac0caa64198aeb415118552243454e121b7b66b4ee964d01687aa61b22fe476L94-R94): Increased the `timeoutInMinutes` for the Windows job from 150 to 180.
* [`azure-pipelines-official.yml`](diffhunk://#diff-0ac0caa64198aeb415118552243454e121b7b66b4ee964d01687aa61b22fe476L167-R167): Increased the `timeoutInMinutes` for the Linux job from 150 to 180.
