### PR TITLE
Fix bug in TestResultMessagesSerializer

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -324,4 +324,6 @@ internal abstract class BaseSerializer
         Type type when type == typeof(bool) => sizeof(bool),
         _ => 0,
     };
+
+    public static bool IsNullOrEmpty<T>(T[]? list) => list is null || list.Length == 0;
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -155,8 +155,6 @@ internal class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                 await _dotnetTestConnection.SendMessageAsync(fileArtifactMessages);
                 break;
         }
-
-        await Task.CompletedTask;
     }
 
     private static void GetTestNodeDetails(TestNodeUpdateMessage testNodeUpdateMessage, out byte? state, out string? reason, out string? errorMessage, out string? errorStackTrace)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -163,7 +163,7 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
 
     private static ushort GetFieldCount(CommandLineOptionMessages commandLineOptionMessages) =>
         (ushort)((commandLineOptionMessages.ModulePath is null ? 0 : 1) +
-        (commandLineOptionMessages.CommandLineOptionMessageList is null ? 0 : 1));
+        (IsNullOrEmpty(commandLineOptionMessages.CommandLineOptionMessageList) ? 0 : 1));
 
     private static ushort GetFieldCount(CommandLineOptionMessage commandLineOptionMessage) =>
         (ushort)((commandLineOptionMessage.Name is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -144,7 +144,7 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
 
     private static ushort GetFieldCount(DiscoveredTestMessages discoveredTestMessages) =>
         (ushort)((discoveredTestMessages.ExecutionId is null ? 0 : 1) +
-        (discoveredTestMessages.DiscoveredMessages is null ? 0 : 1));
+        (IsNullOrEmpty(discoveredTestMessages.DiscoveredMessages) ? 0 : 1));
 
     private static ushort GetFieldCount(DiscoveredTestMessage discoveredTestMessage) =>
         (ushort)((discoveredTestMessage.Uid is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -180,7 +180,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
 
     private static ushort GetFieldCount(FileArtifactMessages fileArtifactMessages) =>
         (ushort)((fileArtifactMessages.ExecutionId is null ? 0 : 1) +
-        (fileArtifactMessages.FileArtifacts is null ? 0 : 1));
+        (IsNullOrEmpty(fileArtifactMessages.FileArtifacts) ? 0 : 1));
 
     private static ushort GetFieldCount(FileArtifactMessage fileArtifactMessage) =>
         (ushort)((fileArtifactMessage.FullPath is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -280,7 +280,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
             return;
         }
 
-        WriteShort(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList);
+        WriteShort(stream, TestResultMessagesFieldsId.FailedTestMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -288,17 +288,17 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
 
         long before = stream.Position;
         WriteInt(stream, failedTestResultMessages.Length);
-        foreach (FailedTestResultMessage successfulTestResultMessage in failedTestResultMessages)
+        foreach (FailedTestResultMessage failedTestResultMessage in failedTestResultMessages)
         {
-            WriteShort(stream, GetFieldCount(successfulTestResultMessage));
+            WriteShort(stream, GetFieldCount(failedTestResultMessage));
 
-            WriteField(stream, FailedTestResultMessageFieldsId.Uid, successfulTestResultMessage.Uid);
-            WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, successfulTestResultMessage.DisplayName);
-            WriteField(stream, FailedTestResultMessageFieldsId.State, successfulTestResultMessage.State);
-            WriteField(stream, FailedTestResultMessageFieldsId.Reason, successfulTestResultMessage.Reason);
-            WriteField(stream, FailedTestResultMessageFieldsId.ErrorMessage, successfulTestResultMessage.ErrorMessage);
-            WriteField(stream, FailedTestResultMessageFieldsId.ErrorStackTrace, successfulTestResultMessage.ErrorStackTrace);
-            WriteField(stream, FailedTestResultMessageFieldsId.SessionUid, successfulTestResultMessage.SessionUid);
+            WriteField(stream, FailedTestResultMessageFieldsId.Uid, failedTestResultMessage.Uid);
+            WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, failedTestResultMessage.DisplayName);
+            WriteField(stream, FailedTestResultMessageFieldsId.State, failedTestResultMessage.State);
+            WriteField(stream, FailedTestResultMessageFieldsId.Reason, failedTestResultMessage.Reason);
+            WriteField(stream, FailedTestResultMessageFieldsId.ErrorMessage, failedTestResultMessage.ErrorMessage);
+            WriteField(stream, FailedTestResultMessageFieldsId.ErrorStackTrace, failedTestResultMessage.ErrorStackTrace);
+            WriteField(stream, FailedTestResultMessageFieldsId.SessionUid, failedTestResultMessage.SessionUid);
         }
 
         // NOTE: We are able to seek only if we are using a MemoryStream
@@ -308,8 +308,8 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
 
     private static ushort GetFieldCount(TestResultMessages testResultMessages) =>
         (ushort)((testResultMessages.ExecutionId is null ? 0 : 1) +
-        (testResultMessages.SuccessfulTestMessages is null ? 0 : 1) +
-        (testResultMessages.FailedTestMessages is null ? 0 : 1));
+        (IsNullOrEmpty(testResultMessages.SuccessfulTestMessages) ? 0 : 1) +
+        (IsNullOrEmpty(testResultMessages.FailedTestMessages) ? 0 : 1));
 
     private static ushort GetFieldCount(SuccessfulTestResultMessage successfulTestResultMessage) =>
         (ushort)((successfulTestResultMessage.Uid is null ? 0 : 1) +


### PR DESCRIPTION
Failing tests in the test project were preventing dotnet test to run normally.