### PR TITLE
Ensure correct exit code in case of cancellation and add `OnExit` phase for for `IPushOnlyProtocol`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -142,6 +142,8 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol,
         }
     }
 
+    public Task OnExitAsync() => Task.CompletedTask;
+
     public void Dispose() => _dotnetTestPipeClient?.Dispose();
 
 #if NETCOREAPP

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
@@ -20,4 +20,6 @@ internal interface IPushOnlyProtocol :
     Task<bool> IsCompatibleProtocolAsync(string testHostType);
 
     Task<IPushOnlyProtocolConsumer> GetDataConsumerAsync();
+
+    Task OnExitAsync();
 }


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of test session cancellation and ensure proper disposal of resources in the `Microsoft.Testing.Platform` project. The most important changes include initializing the `exitCode` with a default failure value, handling the cancellation token in various parts of the `RunAsync` method, and adding a new method to the `IPushOnlyProtocol` interface.

### Improvements to test session cancellation handling:

* [`src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs`](diffhunk://#diff-d3fda3cb4312704ea9abea7557b28ebe5bad6aa45ddf54cbb231447dd552fca0L29-R45): Initialized `exitCode` with `ExitCodes.GenericFailure` and added checks for `testApplicationCancellationToken.IsCancellationRequested` to set `exitCode` to `ExitCodes.TestSessionAborted` when necessary. [[1]](diffhunk://#diff-d3fda3cb4312704ea9abea7557b28ebe5bad6aa45ddf54cbb231447dd552fca0L29-R45) [[2]](diffhunk://#diff-d3fda3cb4312704ea9abea7557b28ebe5bad6aa45ddf54cbb231447dd552fca0R75-R79)

### Resource disposal enhancements:

* [`src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs`](diffhunk://#diff-d3fda3cb4312704ea9abea7557b28ebe5bad6aa45ddf54cbb231447dd552fca0R55-L50): Added a `finally` block to call `PushOnlyProtocol.OnExitAsync()` if `PushOnlyProtocol` is not null, ensuring proper cleanup.
* [`src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs`](diffhunk://#diff-d3fda3cb4312704ea9abea7557b28ebe5bad6aa45ddf54cbb231447dd552fca0L220-R241): Updated `DisposeServiceProviderAsync` to continue if the service is an `IPushOnlyProtocol`, ensuring it is not disposed prematurely.

### Interface and method additions:

* [`src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs`](diffhunk://#diff-cd7ac1cdf3f59d94fd5828ac75e2ee5eebe28713b8b216c313ab3f2c483dfc5fR23-R24): Added the `OnExitAsync` method to the `IPushOnlyProtocol` interface.
* [`src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs`](diffhunk://#diff-b7da561a91f34714028e7b5d18d05c78a0cc246f7d23a002b49c61754d273463R145-R146): Implemented the `OnExitAsync` method to return a completed task.