### PR TITLE
Fix localization info to avoid translating workers and scope

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.TestAdapter/Resources/Resource.resx
@@ -290,6 +290,7 @@ Error: {1}</value>
   </data>
   <data name="TestParallelizationBanner" xml:space="preserve">
     <value>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</value>
+    <comment>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</comment>
   </data>
   <data name="InvalidParallelScopeValue" xml:space="preserve">
     <value>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</value>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.cs.xlf
@@ -384,8 +384,8 @@ Chyba: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Je povolená paralelizace testu pro {0} (pracovní procesy: {1}, obor: {2}).</target>
-        <note />
+        <target state="needs-review-translation">Je povolená paralelizace testu pro {0} (pracovní procesy: {1}, obor: {2}).</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.de.xlf
@@ -384,8 +384,8 @@ Fehler: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Testparallelisierung aktiviert für {0} (Worker: {1}, Bereich: {2})</target>
-        <note />
+        <target state="needs-review-translation">Testparallelisierung aktiviert für {0} (Worker: {1}, Bereich: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.es.xlf
@@ -384,8 +384,8 @@ Error: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Probar paralelización habilitada para {0} (Trabajos: {1}, Ámbito: {2})</target>
-        <note />
+        <target state="needs-review-translation">Probar paralelización habilitada para {0} (Trabajos: {1}, Ámbito: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.fr.xlf
@@ -384,8 +384,8 @@ Erreur : {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Parallélisation des tests activée pour {0} (Workers : {1}, Étendue : {2}).</target>
-        <note />
+        <target state="needs-review-translation">Parallélisation des tests activée pour {0} (Workers : {1}, Étendue : {2}).</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.it.xlf
@@ -384,8 +384,8 @@ Errore: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Parallelizzazione test abilitata per {0} (Processi di lavoro: {1}. Ambito: {2}).</target>
-        <note />
+        <target state="needs-review-translation">Parallelizzazione test abilitata per {0} (Processi di lavoro: {1}. Ambito: {2}).</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ja.xlf
@@ -385,8 +385,8 @@ Error: {1}</source>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">{0} でテスト並列処理が有効にされています (Workers: {1}、Scope: {2})。</target>
-        <note />
+        <target state="needs-review-translation">{0} でテスト並列処理が有効にされています (Workers: {1}、Scope: {2})。</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ko.xlf
@@ -384,8 +384,8 @@ Error: {1}</source>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">{0}에 대해 테스트 병렬 처리를 사용합니다(Workers: {1}, Scope: {2}).</target>
-        <note />
+        <target state="needs-review-translation">{0}에 대해 테스트 병렬 처리를 사용합니다(Workers: {1}, Scope: {2}).</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pl.xlf
@@ -384,8 +384,8 @@ Błąd: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Przetwarzanie równoległe testów włączono dla {0} (procesy robocze: {1}, zakres: {2})</target>
-        <note />
+        <target state="needs-review-translation">Przetwarzanie równoległe testów włączono dla {0} (procesy robocze: {1}, zakres: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.pt-BR.xlf
@@ -384,8 +384,8 @@ Erro: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Paralelização de Teste habilitada para {0} (Trabalhos: {1}, Escopo: {2})</target>
-        <note />
+        <target state="needs-review-translation">Paralelização de Teste habilitada para {0} (Trabalhos: {1}, Escopo: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.ru.xlf
@@ -384,8 +384,8 @@ Error: {1}</source>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">Включена параллелизация тестов для {0} (рабочие роли: {1}, область: {2})</target>
-        <note />
+        <target state="needs-review-translation">Включена параллелизация тестов для {0} (рабочие роли: {1}, область: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.tr.xlf
@@ -384,8 +384,8 @@ Hata: {1}</target>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">{0} için Test Paralelleştirme etkin (Çalışanlar: {1}, Kapsam: {2}).</target>
-        <note />
+        <target state="needs-review-translation">{0} için Test Paralelleştirme etkin (Çalışanlar: {1}, Kapsam: {2}).</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hans.xlf
@@ -384,8 +384,8 @@ Error: {1}</source>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">已为 {0} 启用测试并行化(工作线程: {1}，范围: {2})</target>
-        <note />
+        <target state="needs-review-translation">已为 {0} 启用测试并行化(工作线程: {1}，范围: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/Resource.zh-Hant.xlf
@@ -384,8 +384,8 @@ Error: {1}</source>
       </trans-unit>
       <trans-unit id="TestParallelizationBanner">
         <source>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</source>
-        <target state="translated">已為 {0} 啟用平行測試 (背景工作角色: {1}，範圍: {2})</target>
-        <note />
+        <target state="needs-review-translation">已為 {0} 啟用平行測試 (背景工作角色: {1}，範圍: {2})</target>
+        <note>`Workers` is a setting name that shouldn't be localized. 'Scope' is a setting name that shouldn't be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>


### PR DESCRIPTION
Other options say to not localize workers and scope, but not the banner.