### PR TITLE
Fix CollectionAssert.AreEqual fails for list of strings using IEqualityComparer following

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs
+++ b/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs
@@ -1641,8 +1641,11 @@ public sealed class CollectionAssert
 
                 object? curExpected = expectedEnum.Current;
                 object? curActual = actualEnum.Current;
-
-                if (curExpected is IEnumerable curExpectedEnum && curActual is IEnumerable curActualEnum)
+                if (comparer.Compare(curExpected, curActual) == 0)
+                {
+                    position++;
+                }
+                else if (curExpected is IEnumerable curExpectedEnum && curActual is IEnumerable curActualEnum)
                 {
                     stack.Push(new(expectedEnum, actualEnum, position + 1));
                     stack.Push(new(curExpectedEnum.GetEnumerator(), curActualEnum.GetEnumerator(), 0));
@@ -1656,8 +1659,6 @@ public sealed class CollectionAssert
                         position);
                     return false;
                 }
-
-                position++;
             }
 
             if (actualEnum.MoveNext() && !expectedEnum.MoveNext())

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
@@ -198,6 +198,13 @@ public class CollectionAssertTests : TestContainer
         comparer.ToString(); // no warning
     }
 
+    public void CollectionAssertAreEqual_WithIgnoreCaseComparer_DoesNotThrow()
+    {
+        List<string> expected = ["one", "two"];
+        List<string> actual = ["ONE", "tWo"];
+        CollectionAssert.AreEqual(expected, actual, StringComparer.OrdinalIgnoreCase);
+    }
+
     public void CollectionAssertAreEqualComparerMessageNullabilityPostConditions()
     {
         ICollection? collection1 = GetCollection();
@@ -262,6 +269,13 @@ public class CollectionAssertTests : TestContainer
         ICollection? collection2 = GetNotMatchingNestedLists();
 
         CollectionAssert.AreNotEqual(collection1, collection2);
+    }
+
+    public void CollectionAssertAreNotEqual_WithIgnoreCaseComparer_Fails()
+    {
+        List<string> expected = ["one", "two"];
+        List<string> actual = ["ONE", "tWo"];
+        VerifyThrows(() => CollectionAssert.AreNotEqual(expected, actual, StringComparer.OrdinalIgnoreCase));
     }
 
     public void CollectionAssertAreNotEqual_EqualNestedLists_Fails()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
@@ -205,6 +205,13 @@ public class CollectionAssertTests : TestContainer
         CollectionAssert.AreEqual(expected, actual, StringComparer.OrdinalIgnoreCase);
     }
 
+    public void CollectionAssertAreEqual_WithCaseSensetiveComparer_Fails()
+    {
+        List<string> expected = ["one", "two"];
+        List<string> actual = ["ONE", "tWo"];
+        VerifyThrows(() => CollectionAssert.AreEqual(expected, actual, StringComparer.Ordinal));
+    }
+
     public void CollectionAssertAreEqualComparerMessageNullabilityPostConditions()
     {
         ICollection? collection1 = GetCollection();
@@ -276,6 +283,13 @@ public class CollectionAssertTests : TestContainer
         List<string> expected = ["one", "two"];
         List<string> actual = ["ONE", "tWo"];
         VerifyThrows(() => CollectionAssert.AreNotEqual(expected, actual, StringComparer.OrdinalIgnoreCase));
+    }
+
+    public void CollectionAssertAreNotEqual_WithCaseSensitiveComparer_Passes()
+    {
+        List<string> expected = ["one", "two"];
+        List<string> actual = ["ONE", "tWo"];
+        CollectionAssert.AreNotEqual(expected, actual, StringComparer.Ordinal);
     }
 
     public void CollectionAssertAreNotEqual_EqualNestedLists_Fails()


### PR DESCRIPTION
fix: https://github.com/microsoft/testfx/issues/3822