### PR TITLE
Fix trx in case of exit code != 0

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxDataConsumer.cs
@@ -187,11 +187,13 @@ internal sealed class TrxReportGenerator :
         {
             await _logger.LogDebugAsync($"""
 PlatformCommandLineProvider.ServerOption: {_commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey)}
+CrashDumpCommandLineOptions.CrashDumpOptionName: {_commandLineOptionsService.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName)}
 TrxReportGeneratorCommandLine.IsTrxReportEnabled: {_commandLineOptionsService.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName)}
 """);
         }
 
-        if (!_commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey))
+        if (!_commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey) &&
+            _commandLineOptionsService.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName))
         {
             ApplicationStateGuard.Ensure(_trxTestApplicationLifecycleCallbacks is not null);
             ApplicationStateGuard.Ensure(_trxTestApplicationLifecycleCallbacks.NamedPipeClient is not null);

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxEnvironmentVariableProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxEnvironmentVariableProvider.cs
@@ -38,9 +38,7 @@ internal sealed class TrxEnvironmentVariableProvider : ITestHostEnvironmentVaria
             // TrxReportGenerator is enabled only when trx report is enabled
             _commandLineOptions.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName)
             // TestController is not used when we run in server mode
-            && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey)
-            // If crash dump is not enabled we run trx in-process only
-            && _commandLineOptions.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName));
+            && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey));
 #pragma warning restore SA1114 // Parameter list should follow declaration
 
     public Task UpdateAsync(IEnvironmentVariables environmentVariables)

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxEnvironmentVariableProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxEnvironmentVariableProvider.cs
@@ -38,7 +38,9 @@ internal sealed class TrxEnvironmentVariableProvider : ITestHostEnvironmentVaria
             // TrxReportGenerator is enabled only when trx report is enabled
             _commandLineOptions.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName)
             // TestController is not used when we run in server mode
-            && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey));
+            && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey)
+            // If crash dump is not enabled we run trx in-process only
+            && _commandLineOptions.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName));
 #pragma warning restore SA1114 // Parameter list should follow declaration
 
     public Task UpdateAsync(IEnvironmentVariables environmentVariables)

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
@@ -91,9 +91,7 @@ internal sealed class TrxProcessLifetimeHandler :
            // TrxReportGenerator is enabled only when trx report is enabled
            _commandLineOptions.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName)
            // TestController is not used when we run in server mode
-           && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey)
-           // If crash dump is not enabled we run trx in-process only
-           && _commandLineOptions.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName));
+           && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey));
 #pragma warning restore SA1114 // Parameter list should follow declaration
 
     public Task BeforeTestHostProcessStartAsync(CancellationToken cancellation)
@@ -164,6 +162,7 @@ internal sealed class TrxProcessLifetimeHandler :
                 adapterSupportTrxCapability: null,
                 new TestAdapterInfo(_testAdapterInformationRequest!.TestAdapterId, _testAdapterInformationRequest.TestAdapterVersion),
                 _startTime,
+                testHostProcessInformation.ExitCode,
                 cancellation);
 
             await _messageBus.PublishAsync(
@@ -194,6 +193,7 @@ internal sealed class TrxProcessLifetimeHandler :
                false,
                new TestAdapterInfo(_testAdapterInformationRequest!.TestAdapterId, _testAdapterInformationRequest.TestAdapterVersion),
                _startTime,
+               testHostProcessInformation.ExitCode,
                cancellation);
 
             await trxReportGeneratorEngine.AddArtifactsAsync(trxFile, artifacts);

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
@@ -91,7 +91,9 @@ internal sealed class TrxProcessLifetimeHandler :
            // TrxReportGenerator is enabled only when trx report is enabled
            _commandLineOptions.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName)
            // TestController is not used when we run in server mode
-           && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey));
+           && !_commandLineOptions.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey)
+           // If crash dump is not enabled we run trx in-process only
+           && _commandLineOptions.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName));
 #pragma warning restore SA1114 // Parameter list should follow declaration
 
     public Task BeforeTestHostProcessStartAsync(CancellationToken cancellation)

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportExtensions.cs
@@ -36,6 +36,7 @@ public static class TrxReportExtensions
                 serviceProvider.GetOutputDevice(),
                 serviceProvider.GetTestFramework(),
                 serviceProvider.GetTestFrameworkCapabilities(),
+                serviceProvider.GetTestApplicationProcessExitCode(),
                 serviceProvider.GetService<TrxTestApplicationLifecycleCallbacks>(),
                 serviceProvider.GetLoggerFactory().CreateLogger<TrxReportGenerator>()));
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxTestApplicationLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxTestApplicationLifecycleCallbacks.cs
@@ -29,10 +29,7 @@ internal class TrxTestApplicationLifecycleCallbacks : ITestApplicationLifecycleC
            commandLineOptionsService.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName) &&
 
            // TestController is not used when we run in server mode
-           !commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey) &&
-
-           // If crash dump is not enabled we run trx in-process only
-           commandLineOptionsService.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName);
+           !commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey);
 
         _environment = environment;
     }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxTestApplicationLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxTestApplicationLifecycleCallbacks.cs
@@ -24,12 +24,12 @@ internal class TrxTestApplicationLifecycleCallbacks : ITestApplicationLifecycleC
         IEnvironment environment)
     {
         _isEnabled =
-
            // TrxReportGenerator is enabled only when trx report is enabled
            commandLineOptionsService.IsOptionSet(TrxReportGeneratorCommandLine.TrxReportOptionName) &&
-
            // TestController is not used when we run in server mode
-           !commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey);
+           !commandLineOptionsService.IsOptionSet(PlatformCommandLineProvider.ServerOptionKey) &&
+           // If crash dump is not enabled we run trx in-process only
+           commandLineOptionsService.IsOptionSet(CrashDumpCommandLineOptions.CrashDumpOptionName);
 
         _environment = environment;
     }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
@@ -94,7 +94,7 @@ internal sealed class ConsoleTestHost(
             // Get the exit code service to be able to set the exit code
             ITestApplicationProcessExitCode testApplicationResult = ServiceProvider.GetTestApplicationProcessExitCode();
             statistics = testApplicationResult.GetStatistics();
-            exitCode = await testApplicationResult.GetProcessExitCodeAsync();
+            exitCode = testApplicationResult.GetProcessExitCode();
 
             await _logger.LogInformationAsync($"Test session '{ServiceProvider.GetTestSessionContext().SessionId}' ended with exit code '{exitCode}' in {consoleRunStarted.Elapsed}");
 

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -324,6 +324,10 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
             serviceProvider.AddService(nonCooperativeParentProcessListener);
         }
 
+        // Add TestApplicationResultProxy
+        TestApplicationResultProxy testApplicationResultProxy = new();
+        serviceProvider.AddService(testApplicationResultProxy);
+
         // ============= SETUP COMMON SERVICE USED IN ALL MODES END ===============//
 
         // ============= SELECT AND RUN THE ACTUAL MODE ===============//
@@ -730,7 +734,11 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
             serviceProvider.GetTestApplicationCancellationTokenSource(),
             serviceProvider.GetCommandLineOptions(),
             serviceProvider.GetEnvironment());
-        await RegisterAsServiceOrConsumerOrBothAsync(testApplicationResult, serviceProvider, dataConsumersBuilder);
+
+        // Set the concrete TestApplicationResult
+        TestApplicationResultProxy testApplicationResultProxy = serviceProvider.GetRequiredService<TestApplicationResultProxy>();
+        testApplicationResultProxy.SetTestApplicationProcessExitCode(testApplicationResult);
+        await RegisterAsServiceOrConsumerOrBothAsync(testApplicationResultProxy, serviceProvider, dataConsumersBuilder);
 
         // We register the data consumer handler if we're connected to the dotnet test pipe
         if (pushOnlyProtocolDataConsumer is not null)

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.Designer.cs
@@ -1312,6 +1312,15 @@ namespace Microsoft.Testing.Platform.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The ITestApplicationResult has not been built yet..
+        /// </summary>
+        internal static string TestApplicationResultNotReady {
+            get {
+                return ResourceManager.GetString("TestApplicationResultNotReady", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to VSTest mode only supports a single TestApplicationBuilder per process.
         /// </summary>
         internal static string TestApplicationVSTestModeTooManyBuilders {

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -631,4 +631,7 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
   <data name="MissingClientPortFoJsonRpc" xml:space="preserve">
     <value>Expected --client-port when jsonRpc protocol is used.</value>
   </data>
+  <data name="TestApplicationResultNotReady" xml:space="preserve">
+    <value>The ITestApplicationResult has not been built yet.</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -730,6 +730,11 @@ Platné hodnoty jsou Normal a Detailed. Výchozí hodnota je Normal.</target>
         <target state="translated">Výsledek testovací aplikace</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">Režim VSTest podporuje jen jeden TestApplicationBuilder na proces.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -730,6 +730,11 @@ Gültige Werte sind „Normal“, „Detailed“. Der Standardwert ist „Normal
         <target state="translated">Testanwendungsergebnis</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">Der VSTest-Modus unterstützt nur einen einzelnen TestApplicationBuilder pro Prozess.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -730,6 +730,11 @@ Los valores válidos son 'Normal', 'Detallado'. El valor predeterminado es 'Norm
         <target state="translated">Resultado de la aplicación de prueba</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">El modo VSTest solo admite un único TestApplicationBuilder por proceso</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -730,6 +730,11 @@ Les valeurs valides sont « Normal » et « Détaillé ». La valeur par dé
         <target state="translated">Résultat de l’application de test</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">Le mode VSTest ne prend en charge qu’un seul TestApplicationBuilder par processus</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -730,6 +730,11 @@ I valori validi sono 'Normal', 'Detailed'. L'impostazione predefinita è 'Normal
         <target state="translated">Risultato del test dell'applicazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">La modalità VSTest supporta solo un singolo TestApplicationBuilder per processo</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -731,6 +731,11 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">テスト アプリケーションの結果</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">VSTest モードは、プロセスごとに 1 つの TestApplicationBuilder のみをサポートします</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -730,6 +730,11 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">테스트 애플리케이션 결과</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">VSTest 모드는 프로세스당 단일 TestApplicationBuilder만 지원합니다.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -730,6 +730,11 @@ Prawidłowe wartości to „Normalne”, „Szczegółowe”. Wartość domyśln
         <target state="translated">Wynik aplikacji testowej</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">Tryb VSTest obsługuje tylko jeden element TestApplicationBuilder na proces</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -730,6 +730,11 @@ Os valores válidos são “Normal”, “Detalhado”. O padrão é “Normal�
         <target state="translated">Resultado do aplicativo de teste</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">O modo VSTest dá suporte apenas a um único TestApplicationBuilder por processo</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -730,6 +730,11 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">Результат приложения для тестирования</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">Режим VSTest поддерживает только один TestApplicationBuilder для каждого процесса</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -730,6 +730,11 @@ Geçerli değerler: ‘Normal’, ‘Ayrıntılı’. Varsayılan değer: ‘Nor
         <target state="translated">Test uygulaması sonucu</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">VSTest modu, işlem başına yalnızca tek bir TestApplicationBuilder destekler</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -730,6 +730,11 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">测试应用程序结果</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">VSTest 模式仅支持每个进程一个 TestApplicationBuilder</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -730,6 +730,11 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">測試應用程式結果</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestApplicationResultNotReady">
+        <source>The ITestApplicationResult has not been built yet.</source>
+        <target state="new">The ITestApplicationResult has not been built yet.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TestApplicationVSTestModeTooManyBuilders">
         <source>VSTest mode only supports a single TestApplicationBuilder per process</source>
         <target state="translated">VSTest 模式僅支援每一程序的單一 TestApplicationBuilder</target>

--- a/src/Platform/Microsoft.Testing.Platform/Services/ITestApplicationProcessExitCode.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ITestApplicationProcessExitCode.cs
@@ -13,7 +13,8 @@ internal interface ITestApplicationProcessExitCode : IDataConsumer
 
     Task SetTestAdapterTestSessionFailureAsync(string errorMessage);
 
-    Task<int> GetProcessExitCodeAsync();
+    // If we decide to open this extension we should make it Task<int> GetProcessExitCodeAsync();
+    int GetProcessExitCode();
 
     Statistics GetStatistics();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResultProxy.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResultProxy.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+
+namespace Microsoft.Testing.Platform.Services;
+
+internal class TestApplicationResultProxy : ITestApplicationProcessExitCode
+{
+    private ITestApplicationProcessExitCode? _testApplicationProcessExitCode;
+
+    public bool HasTestAdapterTestSessionFailure
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.HasTestAdapterTestSessionFailure;
+
+    public string? TestAdapterTestSessionFailureErrorMessage
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.TestAdapterTestSessionFailureErrorMessage;
+
+    public Type[] DataTypesConsumed
+         => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.DataTypesConsumed;
+
+    public string Uid
+         => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.Uid;
+
+    public string Version
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.Version;
+
+    public string DisplayName
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.DisplayName;
+
+    public string Description
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.Description;
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.ConsumeAsync(dataProducer, value, cancellationToken);
+
+    public int GetProcessExitCode()
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.GetProcessExitCode();
+
+    public Statistics GetStatistics()
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.GetStatistics();
+
+    public Task<bool> IsEnabledAsync()
+        => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.IsEnabledAsync();
+
+    public Task SetTestAdapterTestSessionFailureAsync(string errorMessage)
+         => _testApplicationProcessExitCode is null ?
+            throw new InvalidOperationException(Resources.PlatformResources.TestApplicationResultNotReady) :
+            _testApplicationProcessExitCode.SetTestAdapterTestSessionFailureAsync(errorMessage);
+
+    public void SetTestApplicationProcessExitCode(ITestApplicationProcessExitCode testApplicationProcessExitCode)
+    {
+        Guard.NotNull(testApplicationProcessExitCode);
+        _testApplicationProcessExitCode = testApplicationProcessExitCode;
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
@@ -80,7 +80,7 @@ Out of process file artifacts produced:
 
         Assert.That(trxContent.Contains(@"<UnitTest name=""TestMethod1"), trxContent);
         Assert.That(trxContent.Contains(@"<TestEntry "), trxContent);
-        Assert.That(trxContent.Contains("""<ResultSummary outcome="Completed">"""), trxContent);
+        Assert.That(trxContent.Contains("""<ResultSummary outcome="Failed">"""), trxContent);
         Assert.That(trxContent.Contains("""<Counters total="2" executed="0" passed="0" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="2" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />"""), trxContent);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -396,7 +396,7 @@ public class TrxTests(ITestExecutionContext testExecutionContext) : TestBase(tes
         _ = _testApplicationModuleInfoMock.Setup(_ => _.GetCurrentTestApplicationFullPath()).Returns("TestAppPath");
         TrxReportEngine trxReportEngine = new(_fileSystem.Object, _testApplicationModuleInfoMock.Object, _environmentMock.Object, _commandLineOptionsMock.Object,
             _configurationMock.Object, _clockMock.Object, [], 0, 0, 0, 0,
-            _artifactsByExtension, _artifactsByTestNode, true, _testFrameworkMock.Object, DateTime.UtcNow, CancellationToken.None,
+            _artifactsByExtension, _artifactsByTestNode, true, _testFrameworkMock.Object, DateTime.UtcNow, 0, CancellationToken.None,
             isCopyingFileAllowed: false);
 
         // Act
@@ -451,7 +451,7 @@ public class TrxTests(ITestExecutionContext testExecutionContext) : TestBase(tes
 
         return new TrxReportEngine(_fileSystem.Object, _testApplicationModuleInfoMock.Object, _environmentMock.Object, _commandLineOptionsMock.Object,
                    _configurationMock.Object, _clockMock.Object, testNodeUpdatedMessages, failedTestsCount, passedTestsCount, notExecutedTestsCount, timeoutTestsCount,
-                   _artifactsByExtension, _artifactsByTestNode, adapterSupportTrxCapability, _testFrameworkMock.Object, testStartTime, cancellationToken,
+                   _artifactsByExtension, _artifactsByTestNode, adapterSupportTrxCapability, _testFrameworkMock.Object, testStartTime, 0, cancellationToken,
                    isCopyingFileAllowed: false);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
@@ -33,7 +33,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(SkippedTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.ZeroTests, await _testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
     }
 
     public async Task GetProcessExitCodeAsync_If_No_Tests_Ran_Returns_ZeroTestsRan()
@@ -47,7 +47,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.ZeroTests, await _testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
     }
 
     [ArgumentsProvider(nameof(FailedState))]
@@ -62,7 +62,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(testNodeStateProperty),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.AtLeastOneTestFailed, await _testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.AtLeastOneTestFailed, _testApplicationResult.GetProcessExitCode());
     }
 
     public async Task GetProcessExitCodeAsync_If_Canceled_Returns_TestSessionAborted()
@@ -87,7 +87,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.TestSessionAborted, await testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.TestSessionAborted, testApplicationResult.GetProcessExitCode());
     }
 
     public async Task GetProcessExitCodeAsync_If_TestAdapter_Returns_TestAdapterTestSessionFailure()
@@ -102,7 +102,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(PassedTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.TestAdapterTestSessionFailure, await _testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.TestAdapterTestSessionFailure, _testApplicationResult.GetProcessExitCode());
     }
 
     public async Task GetProcessExitCodeAsync_If_MinimumExpectedTests_Violated_Returns_MinimumExpectedTestsPolicyViolation()
@@ -130,7 +130,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(InProgressTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.MinimumExpectedTestsPolicyViolation, await testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.MinimumExpectedTestsPolicyViolation, testApplicationResult.GetProcessExitCode());
     }
 
     public async Task GetProcessExitCodeAsync_OnDiscovery_No_Tests_Discovered_Returns_ZeroTests()
@@ -148,7 +148,7 @@ public sealed class TestApplicationResultTests : TestBase
                 DisplayName = "DisplayName",
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.ZeroTests, await testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.ZeroTests, testApplicationResult.GetProcessExitCode());
     }
 
     public async Task GetProcessExitCodeAsync_OnDiscovery_Some_Tests_Discovered_Returns_Success()
@@ -167,7 +167,7 @@ public sealed class TestApplicationResultTests : TestBase
                 Properties = new PropertyBag(DiscoveredTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.Success, await testApplicationResult.GetProcessExitCodeAsync());
+        Assert.AreEqual(ExitCodes.Success, testApplicationResult.GetProcessExitCode());
     }
 
     [Arguments("8", ExitCodes.Success)]
@@ -181,7 +181,7 @@ public sealed class TestApplicationResultTests : TestBase
     [Arguments(";", ExitCodes.ZeroTests)]
     [Arguments(null, ExitCodes.ZeroTests)]
     [Arguments("", ExitCodes.ZeroTests)]
-    public async Task GetProcessExitCodeAsync_IgnoreExitCodes(string argument, int expectedExitCode)
+    public void GetProcessExitCodeAsync_IgnoreExitCodes(string argument, int expectedExitCode)
     {
         Mock<IEnvironment> environment = new();
         environment.Setup(x => x.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_EXITCODE_IGNORE)).Returns(argument);
@@ -196,7 +196,7 @@ public sealed class TestApplicationResultTests : TestBase
                 environment.Object),
         })
         {
-            Assert.AreEqual(expectedExitCode, await testApplicationResult.GetProcessExitCodeAsync());
+            Assert.AreEqual(expectedExitCode, testApplicationResult.GetProcessExitCode());
         }
     }
 


### PR DESCRIPTION
This pull request introduces changes to the `TrxReportGenerator` and related classes to include the process exit code in the TRX report generation. The most important changes include adding a new dependency for `ITestApplicationProcessExitCode`, updating the `TrxReportEngine` to handle the exit code, and modifying the result summary to reflect the exit code.

### Changes to `TrxReportGenerator` and Dependencies:

* [`src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxDataConsumer.cs`](diffhunk://#diff-60ba0552e9a8b5737b7826674f199f9d3058ccd3e5a3e420c657f52b6c4a6b34R41): Added `ITestApplicationProcessExitCode` as a dependency and updated the constructor and `OnTestSessionFinishingAsync` method to use it. [[1]](diffhunk://#diff-60ba0552e9a8b5737b7826674f199f9d3058ccd3e5a3e420c657f52b6c4a6b34R41) [[2]](diffhunk://#diff-60ba0552e9a8b5737b7826674f199f9d3058ccd3e5a3e420c657f52b6c4a6b34R66) [[3]](diffhunk://#diff-60ba0552e9a8b5737b7826674f199f9d3058ccd3e5a3e420c657f52b6c4a6b34R80) [[4]](diffhunk://#diff-60ba0552e9a8b5737b7826674f199f9d3058ccd3e5a3e420c657f52b6c4a6b34R238-L244)

### Changes to `TrxReportEngine`:

* [`src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs`](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7R105-R110): Added `_exitCode` field and updated the constructor and methods to handle the exit code, including modifying the `GenerateReportAsync` and `AddResultSummaryAsync` methods to use the exit code. [[1]](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7R105-R110) [[2]](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7R128-R133) [[3]](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7R151) [[4]](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7L178-R183) [[5]](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7L292-R295) [[6]](diffhunk://#diff-75cc3ee59522950bbccfd7756765e20489d4e5c2fc38e2f33a7514e034ea84b7R335-R347)

### Changes to `TrxProcessLifetimeHandler`:

* [`src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs`](diffhunk://#diff-89c02c4bb6de19bc11e8f8e2e11f7ad84329f171b4c91163af61b2e600931388R167): Updated methods to include the exit code when publishing messages. [[1]](diffhunk://#diff-89c02c4bb6de19bc11e8f8e2e11f7ad84329f171b4c91163af61b2e600931388R167) [[2]](diffhunk://#diff-89c02c4bb6de19bc11e8f8e2e11f7ad84329f171b4c91163af61b2e600931388R198)

### Additional Changes:

* [`src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportExtensions.cs`](diffhunk://#diff-fc4a87634de9aa3738a4ae230ac7e56b4d3ca13102d16c4c2cd5ffd091203493R39): Updated to include `ITestApplicationProcessExitCode` in the service provider.
* [`src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs`](diffhunk://#diff-67a3b598b5285091efda43f720c3cddbb0575640ed8100a14ea53a181d6ffb07L97-R97): Changed to use synchronous `GetProcessExitCode` method.
* [`src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs`](diffhunk://#diff-fd03859abf3ce63600df95db662df8182c0e921fb08f936be0bf9fd0bff00807R327-R330): Added and set up `TestApplicationResultProxy` to manage the exit code service. [[1]](diffhunk://#diff-fd03859abf3ce63600df95db662df8182c0e921fb08f936be0bf9fd0bff00807R327-R330) [[2]](diffhunk://#diff-fd03859abf3ce63600df95db662df8182c0e921fb08f936be0bf9fd0bff00807L733-R741)

### Localization Updates:

* Added new localized string for "The ITestApplicationResult has not been built yet." in multiple resource files. [[1]](diffhunk://#diff-c9e61ffa525dc95ff69151188c7a00713cb87e158ac8a3d09ca8fe94ddffa245R1314-R1322) [[2]](diffhunk://#diff-bee6ee99574df151cd67fe4e9ed254398918ff5cb9fd4e87a27c0b2ffd39ad2bR634-R636) [[3]](diffhunk://#diff-5c28c00fce1e898fd36ec2063496ac8829ce2ce77460468f07692cd86dbf763aR733-R737) [[4]](diffhunk://#diff-f3bd223dc29f328910a51fea1eaaf6ff4c02530850d4636b96387872bb1b783bR733-R737) [[5]](diffhunk://#diff-0b27ddf6a97a1cc80030b3cef91fa0efdb15e6cfcdaf1bb03d78e0674c54e6edR733-R737) [[6]](diffhunk://#diff-753c00e316bf4086e77e1f7b4e01fd7cc9cd81361053fd7ceafbe38d82ff2e1aR733-R737)


fixes https://github.com/microsoft/testfx/issues/3768