### PR TITLE
Fix MSTest hook to be always generated

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/build/common/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/common/MSTest.TestAdapter.props
@@ -12,7 +12,7 @@
       DO NOT CHANGE THE GUID, IT'S A WELL KNOWN EXTENSION POINT AND THIS EXTENSION NEEDS TO BE REGISTERED AT THE END
       WE HAVE CODE INSIDE THE TASK 'TestingPlatformEntryPoint' TO ENSURE THE ORDER OF THE REGISTRATION BASED ON THIS GUID
     -->
-    <TestingPlatformBuilderHook Include="031F8871-2660-4208-8F6B-FC142B40ABFF" Condition=" $(GenerateTestingPlatformEntryPoint) == 'true' " >
+    <TestingPlatformBuilderHook Include="031F8871-2660-4208-8F6B-FC142B40ABFF">
       <DisplayName>MSTest</DisplayName>
       <TypeFullName>Microsoft.VisualStudio.TestTools.UnitTesting.TestingPlatformBuilderHook</TypeFullName>
     </TestingPlatformBuilderHook>


### PR DESCRIPTION
Relates to #3883, it was missed on #3524.

Code Coverage was fixed, we are waiting for a release on their side.