### PR TITLE
Fix CollectionAssert.AreEqual for collection of collections ignores even-items

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs
+++ b/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs
@@ -1649,7 +1649,7 @@ public sealed class CollectionAssert
                 {
                     stack.Push(new(expectedEnum, actualEnum, position + 1));
                     stack.Push(new(curExpectedEnum.GetEnumerator(), curActualEnum.GetEnumerator(), 0));
-                    break;
+                    continue;
                 }
                 else if (comparer.Compare(curExpected, curActual) != 0)
                 {

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
@@ -205,6 +205,13 @@ public class CollectionAssertTests : TestContainer
         CollectionAssert.AreEqual(expected, actual, StringComparer.OrdinalIgnoreCase);
     }
 
+    public void CollectionAssertAreEqual_WithNestedDiffSizedArrays_Fails()
+    {
+        int[][] expected = [[1, 2], [3, 4], [5, 6], [7, 8], [9]];
+        int[][] actual = [[1, 2], [999, 999, 999, 999, 999], [5, 6], [], [9]];
+        VerifyThrows(() => CollectionAssert.AreEqual(expected, actual));
+    }
+
     public void CollectionAssertAreEqual_WithCaseSensetiveComparer_Fails()
     {
         List<string> expected = ["one", "two"];


### PR DESCRIPTION
fix: https://github.com/microsoft/testfx/issues/3879