### PR TITLE
Fix WriteSize() in BaseSerializer.cs

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -71,10 +71,9 @@ internal abstract class BaseSerializer
         stream.Write(len);
     }
 
-    protected static void WriteSize<T>(Stream stream)
-        where T : struct
+    protected static void WriteSize(Stream stream)
     {
-        int sizeInBytes = GetSize<T>();
+        int sizeInBytes = GetSize<int>();
         Span<byte> len = stackalloc byte[sizeof(int)];
 
         ApplicationStateGuard.Ensure(BitConverter.TryWriteBytes(len, sizeInBytes), PlatformResources.UnexpectedExceptionDuringByteConversionErrorMessage);
@@ -185,10 +184,9 @@ internal abstract class BaseSerializer
         stream.Write(len, 0, len.Length);
     }
 
-    protected static void WriteSize<T>(Stream stream)
-        where T : struct
+    protected static void WriteSize(Stream stream)
     {
-        int sizeInBytes = GetSize<T>();
+        int sizeInBytes = GetSize<int>();
         byte[] len = BitConverter.GetBytes(sizeInBytes);
         stream.Write(len, 0, sizeInBytes);
     }
@@ -290,7 +288,7 @@ internal abstract class BaseSerializer
         }
 
         WriteShort(stream, id);
-        WriteSize<bool>(stream);
+        WriteSize(stream);
         WriteBool(stream, value.Value);
     }
 
@@ -302,7 +300,7 @@ internal abstract class BaseSerializer
         }
 
         WriteShort(stream, id);
-        WriteSize<bool>(stream);
+        WriteSize(stream);
         WriteByte(stream, value.Value);
     }
 


### PR DESCRIPTION
This pull request includes changes to the `BaseSerializer` class in the `Microsoft.Testing.Platform` project to simplify the `WriteSize` method and its usage across multiple methods.