### PR TITLE
Fix RunSettings/RunConfiguration/ResultsDirectory

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Helpers/TestApplicationBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Helpers/TestApplicationBuilderExtensions.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.VSTestBridge.CommandLine;
+using Microsoft.Testing.Extensions.VSTestBridge.Configurations;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.VSTestBridge.Helpers;
 
@@ -26,7 +28,14 @@ public static class TestApplicationBuilderExtensions
     /// <param name="builder">The test application builder.</param>
     /// <param name="extension">The extension that will be used as the source of registration for this helper service.</param>
     public static void AddRunSettingsService(this ITestApplicationBuilder builder, IExtension extension)
-        => builder.CommandLine.AddProvider(() => new RunSettingsCommandLineOptionsProvider(extension));
+    {
+        if (builder is TestApplicationBuilder testApplicationBuilder)
+        {
+            testApplicationBuilder.Configuration.AddConfigurationSource(() => new RunSettingsConfigurationProvider(new SystemFileSystem()));
+        }
+
+        builder.CommandLine.AddProvider(() => new RunSettingsCommandLineOptionsProvider(extension));
+    }
 
     /// <summary>
     /// Allows to register the VSTest TestRunParameters service.

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationSource.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.Configurations;
@@ -19,8 +20,10 @@ internal class EnvironmentVariablesConfigurationSource(IEnvironment environmentV
     // Can be empty string because it's not used in the UI
     public string Description => string.Empty;
 
+    public int Order => 1;
+
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
-    public IConfigurationProvider Build()
-        => new EnvironmentVariablesConfigurationProvider(_environmentVariables);
+    public Task<IConfigurationProvider> BuildAsync(CommandLineParseResult commandLineParseResult)
+        => Task.FromResult<IConfigurationProvider>(new EnvironmentVariablesConfigurationProvider(_environmentVariables));
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSource.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSource.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
 
 namespace Microsoft.Testing.Platform.Configurations;
 
 internal interface IConfigurationSource : IExtension
 {
-    IConfigurationProvider Build();
+    int Order { get; }
+
+    Task<IConfigurationProvider> BuildAsync(CommandLineParseResult commandLineParseResult);
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationSource.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
@@ -27,9 +28,11 @@ internal sealed partial class JsonConfigurationSource(ITestApplicationModuleInfo
     // Can be empty string because it's not used in the UI
     public string Description { get; } = string.Empty;
 
+    public int Order => 3;
+
     /// <inheritdoc />
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
-    public IConfigurationProvider Build()
-        => new JsonConfigurationProvider(_testApplicationModuleInfo, _fileSystem, _fileLoggerProvider?.CreateLogger(typeof(JsonConfigurationProvider).ToString()));
+    public Task<IConfigurationProvider> BuildAsync(CommandLineParseResult commandLineParseResult)
+        => Task.FromResult((IConfigurationProvider)new JsonConfigurationProvider(_testApplicationModuleInfo, _fileSystem, _fileLoggerProvider?.CreateLogger(typeof(JsonConfigurationProvider).ToString())));
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs
@@ -16,4 +16,6 @@ internal interface IFileSystem
     IFileStream NewFileStream(string path, FileMode mode, FileAccess access);
 
     string ReadAllText(string path);
+
+    Task<string> ReadAllTextAsync(string path);
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
@@ -16,4 +16,15 @@ internal sealed class SystemFileSystem : IFileSystem
     public IFileStream NewFileStream(string path, FileMode mode, FileAccess access) => new SystemFileStream(path, mode, access);
 
     public string ReadAllText(string path) => File.ReadAllText(path);
+
+#if NETCOREAPP
+    public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
+#else
+    public Task<string> ReadAllTextAsync(string path)
+    {
+        using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using StreamReader reader = new(stream);
+        return reader.ReadToEndAsync();
+    }
+#endif
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
@@ -20,11 +20,11 @@ internal sealed class SystemFileSystem : IFileSystem
 #if NETCOREAPP
     public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
 #else
-    public Task<string> ReadAllTextAsync(string path)
+    public async Task<string> ReadAllTextAsync(string path)
     {
         using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan);
         using StreamReader reader = new(stream);
-        return reader.ReadToEndAsync();
+        return await reader.ReadToEndAsync();
     }
 #endif
 }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -136,7 +136,7 @@ internal class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature runtimeFe
         Configuration.AddConfigurationSource(() => new JsonConfigurationSource(_testApplicationModuleInfo, _fileSystem, loggingState.FileLoggerProvider));
 
         // Build the IConfiguration - we need special treatment because the configuration is needed by extensions.
-        var configuration = (AggregatedConfiguration)await ((ConfigurationManager)Configuration).BuildAsync(loggingState.FileLoggerProvider);
+        var configuration = (AggregatedConfiguration)await ((ConfigurationManager)Configuration).BuildAsync(loggingState.FileLoggerProvider, loggingState.CommandLineParseResult);
         serviceProvider.TryAddService(configuration);
 
         // Current test platform is picky on unhandled exception, we will tear down the process in that case.


### PR DESCRIPTION
This pull request introduces several changes to the configuration management in the Microsoft Testing Platform. The key changes include the addition of asynchronous methods for building configuration providers, the introduction of an order property for configuration sources, and updates to unit tests to accommodate these changes.

### Configuration Management Enhancements:

* [`src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Configurations/RunSettingsConfigurationProvider.cs`](diffhunk://#diff-dcc99abc6e9742ffc0afc0e8b4ac601c665f6e46a9efe4ae674c2db55eb6c89dR6-R17): Added an asynchronous `BuildAsync` method and an `Order` property to the `RunSettingsConfigurationProvider` class. [[1]](diffhunk://#diff-dcc99abc6e9742ffc0afc0e8b4ac601c665f6e46a9efe4ae674c2db55eb6c89dR6-R17) [[2]](diffhunk://#diff-dcc99abc6e9742ffc0afc0e8b4ac601c665f6e46a9efe4ae674c2db55eb6c89dR31-R32) [[3]](diffhunk://#diff-dcc99abc6e9742ffc0afc0e8b4ac601c665f6e46a9efe4ae674c2db55eb6c89dR42-R50) [[4]](diffhunk://#diff-dcc99abc6e9742ffc0afc0e8b4ac601c665f6e46a9efe4ae674c2db55eb6c89dL53-R74)
* [`src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationManager.cs`](diffhunk://#diff-4c1aa3bad02c12bbe2de035b8cc69151014e4dfbe5f954b195974c4bc74cccc4L22-R25): Updated the `BuildAsync` method to accept a `CommandLineParseResult` parameter and order configuration providers based on their `Order` property. [[1]](diffhunk://#diff-4c1aa3bad02c12bbe2de035b8cc69151014e4dfbe5f954b195974c4bc74cccc4L22-R25) [[2]](diffhunk://#diff-4c1aa3bad02c12bbe2de035b8cc69151014e4dfbe5f954b195974c4bc74cccc4L36-R44) [[3]](diffhunk://#diff-4c1aa3bad02c12bbe2de035b8cc69151014e4dfbe5f954b195974c4bc74cccc4L60-R61)

### Asynchronous Configuration Source Methods:

* [`src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSource.cs`](diffhunk://#diff-9995df9245d60fc106258cf7171ad393bc14675819ff45e0b2e1eb7fd86847ebR4-R13): Added the `Order` property and changed the `Build` method to `BuildAsync`.
* [`src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationSource.cs`](diffhunk://#diff-1ab81f8b05fd5cf56d06ad56d7c5b80d3392ac6e49884b924fff9bbc2fafa5a1R23-R28): Updated to include the `Order` property and the `BuildAsync` method.
* [`src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationSource.cs`](diffhunk://#diff-4f790f787e6e95eeafa98771fcc8d01cd64882422a6c86d18133c3187a809ea0R31-R37): Added the `Order` property and the `BuildAsync` method.

### File System Enhancements:

* [`src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs`](diffhunk://#diff-5c04b4c7011b36e7fdde4bef55957ff553187d0667e075a8dcc3a44950a2d2e7R19-R20): Added an asynchronous `ReadAllTextAsync` method.
* [`src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs`](diffhunk://#diff-f5f4d31aa3e2e4a43d9ae52bc50bf879bbf05e17b2689de4739895508280cbf0R19-R29): Implemented the `ReadAllTextAsync` method, with conditional compilation for different .NET versions.

### Unit Tests Updates:

* [`test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationManagerTests.cs`](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL37-R38): Updated unit tests to use the new `BuildAsync` method with the `CommandLineParseResult` parameter. [[1]](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL37-R38) [[2]](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL67-R68) [[3]](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL93-R94) [[4]](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL103-R104) [[5]](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL115-R116) [[6]](diffhunk://#diff-ccd3849a256dbb63134b73e38377bc9e2762180f71542551acbf64b85314d37fL134-R135)