### PR TITLE
Fix casing for event key value

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcMethods.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcMethods.cs
@@ -63,7 +63,7 @@ internal static class JsonRpcStrings
     public const string Message = "message";
 
     // Telemetry
-    public const string EventName = "EventName";
+    public const string EventName = "eventName";
     public const string Metrics = "metrics";
 
     // Process

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -152,7 +152,7 @@ public class FormatterUtilitiesTests : TestBase
 
         if (type == typeof(TelemetryEventArgs))
         {
-            Assert.AreEqual("""{"EventName":"eventName","metrics":{"key":1}}""".Replace(" ", string.Empty), instanceSerialized, because);
+            Assert.AreEqual("""{"eventName":"eventName","metrics":{"key":1}}""".Replace(" ", string.Empty), instanceSerialized, because);
             return;
         }
 


### PR DESCRIPTION
This pull request includes a change to the `JsonRpcStrings` class in the `JsonRpcMethods.cs` file to standardize the casing of the `EventName` constant. 

Standardization of constant naming:

* [`src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcMethods.cs`](diffhunk://#diff-539514614a82756525e83e46acd035d448ce4be466bb603029d5be7009812f28L66-R66): Changed the constant `EventName` to `eventName` to maintain consistent casing.

cc: @drognanar 