### PR TITLE
Add '$schema' to 'cgmanifest.json'

### DIFF
--- a/eng/cgmanifest.json
+++ b/eng/cgmanifest.json
@@ -1,13 +1,14 @@
 {
-    "Registrations":[
-        {
-            "Component": {
-                "Type": "git",
-                "Git": {
-                  "RepositoryUrl": "https://github.com/xoofx/jsonite",
-                  "CommitHash": "35ecf451b18bfe1ec4bb278654f61a8b3dfec2a2"
-                }
-            }
+  "Registrations":[
+    {
+      "Component": {
+        "Type": "git",
+        "Git": {
+          "RepositoryUrl": "https://github.com/xoofx/jsonite",
+          "CommitHash": "35ecf451b18bfe1ec4bb278654f61a8b3dfec2a2"
         }
-    ]
+      }
+    }
+  ],
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json"
 }


### PR DESCRIPTION
From Merlin BOT:

This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a built-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

If you have any other questions contact us at OpenSourceEngSupport@microsoft.com.

---



For feedback or questions about this PR, please find the contact information in the above description. If none exists, please contact the [Gardener team](mailto:gardener@microsoft.com) to help route.

---

This change was automatically generated by [1ES Gardener](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/gardener/1es-gardener) (a [MerlinBot](https://aka.ms/MerlinBot) extension) which is an initiative by the 1ES team to help repos stay up-to-date with latest tools, features, and best practices.