### PR TITLE
[rel/3.6] Fix localization of test adapter messages

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/build/net/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/net/MSTest.TestAdapter.targets
@@ -73,18 +73,18 @@
 
   <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
   <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild" Condition=" '$(EnableMSTestV2CopyResources)' == 'true' " DependsOnTargets="GetMSTestV2CultureHierarchy">
-    <PropertyGroup>
-      <CurrentUICultureHierarchy>%(CurrentUICultureHierarchy.Identity)</CurrentUICultureHierarchy>
-    </PropertyGroup>
 
+    <!-- Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item. -->
     <ItemGroup>
-      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\*.dll" />
+      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
+        <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
+      </MSTestV2Files>
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="@(MSTestV2Files->'%(RootDir)%(Directory)$(CurrentUICultureHierarchy)\%(FileName).resources.dll')"
-               Condition="Exists('%(RootDir)%(Directory)$(CurrentUICultureHierarchy)\%(FileName).resources.dll')">
-        <Link>$(CurrentUICultureHierarchy)\%(FileName).resources.dll</Link>
+      <!-- Add the localization file as content so it gets copied from nuget to bin folder. -->
+      <Content Include="@(MSTestV2Files->'%(FullPath)')">
+        <Link>%(MSTestV2Files.UICulture)\%(FileName).dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <BaseAssemblyFullPath>%(FullPath)</BaseAssemblyFullPath>
         <Visible>False</Visible>

--- a/src/Adapter/MSTest.TestAdapter/build/netfx-netcore-netstandard/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/netfx-netcore-netstandard/MSTest.TestAdapter.targets
@@ -66,14 +66,20 @@
 
   <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
   <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild" Condition=" '$(EnableMSTestV2CopyResources)' == 'true' " DependsOnTargets="GetMSTestV2CultureHierarchy">
-    <ItemGroup>
-      <MSTestV2ResourceFiles Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*resources.dll">
-        <CultureString>%(CurrentUICultureHierarchy.Identity)</CultureString>
-      </MSTestV2ResourceFiles>
 
-      <Content Include="@(MSTestV2ResourceFiles)" Condition=" @(MSTestV2ResourceFiles) != '' ">
-        <Link>%(MSTestV2ResourceFiles.CultureString)\%(Filename)%(Extension)</Link>
+    <!-- Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item. -->
+    <ItemGroup>
+      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
+        <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
+      </MSTestV2Files>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Add the localization file as content so it gets copied from nuget to bin folder. -->
+      <Content Include="@(MSTestV2Files->'%(FullPath)')">
+        <Link>%(MSTestV2Files.UICulture)\%(FileName).dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <BaseAssemblyFullPath>%(FullPath)</BaseAssemblyFullPath>
         <Visible>False</Visible>
       </Content>
     </ItemGroup>

--- a/src/Adapter/MSTest.TestAdapter/build/uwp/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/uwp/MSTest.TestAdapter.targets
@@ -29,19 +29,20 @@
   <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
   <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild" Condition=" '$(EnableMSTestV2CopyResources)' == 'true' " DependsOnTargets="GetMSTestV2CultureHierarchy">
 
-    <PropertyGroup>
-      <CurrentUICultureHierarchy>%(CurrentUICultureHierarchy.Identity)</CurrentUICultureHierarchy>
-    </PropertyGroup>
-
+    <!-- Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item. -->
     <ItemGroup>
-      <MSTestV2Files Include="$(MSBuildThisFileDirectory)../_localization/Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" />
-      <MSTestV2Files Include="$(MSBuildThisFileDirectory)*.dll" />
+      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
+        <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
+      </MSTestV2Files>
+      <MSTestV2Files Include="$(MSBuildThisFileDirectory)*.dll">
+        <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
+      </MSTestV2Files>
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="@(MSTestV2Files->'%(RootDir)%(Directory)$(CurrentUICultureHierarchy)\%(FileName).resources.dll')"
-               Condition="Exists('%(RootDir)%(Directory)$(CurrentUICultureHierarchy)\%(FileName).resources.dll')">
-        <Link>$(CurrentUICultureHierarchy)\%(FileName).resources.dll</Link>
+      <!-- Add the localization file as content so it gets copied from nuget to bin folder. -->
+      <Content Include="@(MSTestV2Files->'%(FullPath)')">
+        <Link>%(MSTestV2Files.UICulture)\%(FileName).dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <BaseAssemblyFullPath>%(FullPath)</BaseAssemblyFullPath>
         <Visible>False</Visible>


### PR DESCRIPTION
Copy the resource dlls into the correct localization folders for localized runs.

![image](https://github.com/user-attachments/assets/6f041481-664e-464e-9a47-8c29c094cf2c)

Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2221503?src=WorkItemMention&src-action=artifact_link 

Backport of https://github.com/microsoft/testfx/pull/3867