### PR TITLE
Fix infinite loop in exception formatting when exceptions have cyclic references

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -145,10 +145,19 @@ internal static class ExceptionHelper
 
         StringBuilder result = new();
         bool first = true;
+        HashSet<Exception> seenExceptions = new();
+
         for (Exception? curException = ex;
              curException != null;
              curException = curException.InnerException)
         {
+            if (seenExceptions.Contains(curException))
+            {
+                result.Append(" ---> [Cyclic Exception Reference]");
+                break;
+            }
+            seenExceptions.Add(curException);
+
             // Get the exception message. Need to check for errors because the Message property
             // may have been overridden by the exception type in user code.
             string msg;

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/ExceptionHelperTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/ExceptionHelperTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution
+{
+    [TestClass]
+    public class ExceptionHelperTests
+    {
+        [TestMethod]
+        public void GetFormattedExceptionMessage_WithCyclicExceptions_ShouldNotLoopInfinitely()
+        {
+            // Arrange
+            var exceptionA = new Exception("Exception A");
+            var exceptionB = new Exception("Exception B", exceptionA);
+            
+            // Use reflection to set exceptionA's InnerException to exceptionB, creating a cycle
+            var innerExceptionField = typeof(Exception).GetField("_innerException", BindingFlags.Instance | BindingFlags.NonPublic);
+            innerExceptionField.SetValue(exceptionA, exceptionB);
+
+            // Act
+            string formattedMessage = ExceptionHelper.GetFormattedExceptionMessage(exceptionA);
+
+            // Assert
+            StringAssert.Contains(formattedMessage, "[Cyclic Exception Reference]");
+        }
+
+        [TestMethod]
+        public void GetFormattedExceptionMessage_WithNoCyclicExceptions_ShouldFormatNormally()
+        {
+            // Arrange
+            var exceptionA = new Exception("Exception A");
+            var exceptionB = new Exception("Exception B", exceptionA);
+
+            // Act  
+            string formattedMessage = ExceptionHelper.GetFormattedExceptionMessage(exceptionB);
+
+            // Assert
+            StringAssert.Contains(formattedMessage, "Exception A");
+            StringAssert.Contains(formattedMessage, "Exception B");
+            StringAssert.DoesNotMatch(formattedMessage, new Regex(@"\[Cyclic Exception Reference\]"));
+        }
+    }
+}


### PR DESCRIPTION
The GetFormattedExceptionMessage method in ExceptionHelper.cs recursively traverses the inner exceptions of an exception to build a formatted error message string. However, it didn't handle the case where the inner exceptions have a cyclic reference, causing an infinite loop.

This change fixes that issue by keeping track of the exceptions seen during traversal in a HashSet. If an exception is encountered again, it breaks out of the loop and appends a "[Cyclic Exception Reference]" message to the output, avoiding the infinite recursion.

**The key changes are:**
- Introduce a HashSet seenExceptions to keep track of exceptions encountered so far.
- Check if the current exception has already been seen. If so, append a "[Cyclic Exception Reference]" message and break out of the loop.
- If the current exception hasn't been seen, add it to the seenExceptions set and continue processing as before.
- A new test class ExceptionHelperTests has also been added with two test methods:
- GetFormattedExceptionMessage_WithCyclicExceptions_ShouldNotLoopInfinitely - Verifies that cyclic exceptions are handled correctly and don't cause infinite loops.
- GetFormattedExceptionMessage_WithNoCyclicExceptions_ShouldFormatNormally - Ensures that the normal formatting still works as expected for non-cyclic exceptions.

**This fixes #3971**