### PR TITLE
Fix hangdump not showing tests in progress

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
@@ -35,7 +35,7 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
     private readonly ManualResetEventSlim _signalActivity = new(false);
     private readonly ManualResetEventSlim _mutexCreated = new(false);
     private readonly bool _traceLevelEnabled;
-    private readonly ConcurrentDictionary<string, (string Name, Type Type, DateTimeOffset StartTime)> _testsCurrentExecutionState = new();
+    private readonly ConcurrentDictionary<TestNodeUid, (string Name, Type Type, DateTimeOffset StartTime)> _testsCurrentExecutionState = new();
 
     private Task? _signalActivityIndicatorTask;
     private Mutex? _activityIndicatorMutex;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpOutputTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpOutputTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestGroup]
+public sealed class HangDumpOutputTests : AcceptanceTestBase
+{
+    private readonly TestAssetFixture _testAssetFixture;
+
+    public HangDumpOutputTests(ITestExecutionContext testExecutionContext, TestAssetFixture testAssetFixture)
+        : base(testExecutionContext) => _testAssetFixture = testAssetFixture;
+
+    [Arguments("Mini")]
+    public async Task HangDump_Outputs_HangingTests_EvenWhenHangingTestsHaveTheSameDisplayName(string format)
+    {
+        // This test makes sure that when tests have the same display name (e.g. like Test1 from both Class1 and Class2)
+        // they will still show up in the hanging tests. This was not the case before when we were just putting them into
+        // a dictionary based on DisplayName. In that case both tests were started at the same time, and only 1 entry was added
+        // to currently executing tests. When first test with name Test1 completed we removed that entry, but Class2.Test1 was still
+        // running. Solution is to use a more unique identifier.
+        string resultDirectory = Path.Combine(_testAssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"), format);
+        var testHost = TestInfrastructure.TestHost.LocateFrom(_testAssetFixture.TargetAssetPath, "HangDump", TargetFrameworks.NetCurrent.Arguments);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--hangdump --hangdump-timeout 8s --hangdump-type {format} --results-directory {resultDirectory} --no-progress",
+            new Dictionary<string, string>
+            {
+                { "SLEEPTIMEMS1", "100" },
+                { "SLEEPTIMEMS2", "600000" },
+            });
+        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertOutputContains("Test1");
+    }
+
+    [TestFixture(TestFixtureSharingStrategy.PerTestGroup)]
+    public sealed class TestAssetFixture(AcceptanceFixture acceptanceFixture) : TestAssetFixtureBase(acceptanceFixture.NuGetGlobalPackagesFolder)
+    {
+        private const string AssetName = "TestAssetFixture";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override IEnumerable<(string ID, string Name, string Code)> GetAssetsToGenerate()
+        {
+            yield return (AssetName, AssetName,
+                Sources
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+        }
+
+        private const string Sources = """
+#file HangDump.csproj
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>true</UseAppHost>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$MicrosoftTestingPlatformVersion$" />
+  </ItemGroup>
+</Project>
+
+#file Program.cs
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Globalization;
+
+using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Requests;
+using Microsoft.Testing.Platform.Services;
+
+public class Startup
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_,__) => new DummyTestAdapter());
+        builder.AddHangDumpProvider();
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public class DummyTestAdapter : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DummyTestAdapter);
+
+    public string Version => "2.0.0";
+
+    public string DisplayName => nameof(DummyTestAdapter);
+
+    public string Description => nameof(DummyTestAdapter);
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Class1.Test1",
+            DisplayName = "Test1",
+            Properties = new PropertyBag(new InProgressTestNodeStateProperty()),
+        }));
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Class2.Test1",
+            DisplayName = "Test1",
+            Properties = new PropertyBag(new InProgressTestNodeStateProperty()),
+        }));
+
+        Thread.Sleep(int.Parse(Environment.GetEnvironmentVariable("SLEEPTIMEMS1")!, CultureInfo.InvariantCulture));
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Class1.Test1",
+            DisplayName = "Test1",
+            Properties = new PropertyBag(new PassedTestNodeStateProperty()),
+        }));
+
+        Thread.Sleep(int.Parse(Environment.GetEnvironmentVariable("SLEEPTIMEMS2")!, CultureInfo.InvariantCulture));
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Class2.Test1",
+            DisplayName = "Test1",
+            Properties = new PropertyBag(new PassedTestNodeStateProperty()),
+        }));
+
+        context.Complete();
+    }
+}
+""";
+    }
+}


### PR DESCRIPTION
Fixes cases where method names are same in multiple classes (e.g. TestMethod1) and are not visible among the hanging tests.

The bug happens when Class1.TestMethod1 and Class2.TestMethod1 run in parallel, and one of them is not hanging. The first one to complete will remove the entry from tests in progress. 

Using UID reduces the chance of this happening significantly, and will also correctly show  that two tests with name TestMethod1 were running.