### PR TITLE
Fix hangdump space in dump path

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+#if NETCOREAPP
+using System.Runtime.InteropServices;
+#endif
 
 using Microsoft.Testing.Extensions.Diagnostics.Resources;
 using Microsoft.Testing.Extensions.HangDump.Serializers;
@@ -19,8 +22,6 @@ using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.OutputDevice;
 using Microsoft.Testing.Platform.Services;
-using System.Runtime.InteropServices;
-
 
 #if NETCOREAPP
 using Microsoft.Diagnostics.NETCore.Client;

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -19,6 +19,8 @@ using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.OutputDevice;
 using Microsoft.Testing.Platform.Services;
+using System.Runtime.InteropServices;
+
 
 #if NETCOREAPP
 using Microsoft.Diagnostics.NETCore.Client;
@@ -361,6 +363,13 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
             "full" => DumpType.Full,
             _ => throw ApplicationStateGuard.Unreachable(),
         };
+
+        // Wrap the dump path into "" when it has space in it, this is a workaround for this runtime issue: https://github.com/dotnet/diagnostics/issues/5020
+        // It only affects windows. Otherwise the dump creation fails with: [createdump] The pid argument is no longer supported
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && finalDumpFileName.Contains(' '))
+        {
+            finalDumpFileName = $"\"{finalDumpFileName}\"";
+        }
 
         diagnosticsClient.WriteDump(dumpType, finalDumpFileName, true);
 #else


### PR DESCRIPTION
Workaround for https://github.com/dotnet/diagnostics/issues/5020
Workaround for https://github.com/microsoft/testfx/issues/3961