### PR TITLE
[rel/3.6] Only ship TestAdapter related resources

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -22,7 +22,7 @@ function Confirm-NugetPackages {
         "MSTest.Sdk"                            = 15;
         "MSTest.Internal.TestFx.Documentation"  = 10;
         "MSTest.TestFramework"                  = 130;
-        "MSTest.TestAdapter"                    = 167;
+        "MSTest.TestAdapter"                    = 76;
         "MSTest"                                = 6;
         "MSTest.Analyzers"                      = 10;
     }

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -93,8 +93,8 @@
     <file src="net462\Microsoft.TestPlatform.AdapterUtilities.dll" target="build\net462\" />
 
     <!-- Localization -->
-    <!-- All TFMs share the same resx + TestAdapter depends on PlatformServices + TestFramework so all resources are available -->
-    <file src="net462\**\*.resources.dll" target="\build\_localization\" />
+    <!-- All TFMs share the same resx, copy only TestAdapter TestAdapter.PlatformServices, do NOT copy TestFramework and other dependency resource dlls. -->
+    <file src="net462\**\Microsoft.VisualStudio.TestPlatform.*Adapter*.resources.dll" target="\build\_localization\" />
 
     <!-- Source code -->
     <file src="$srcroot$\**\*.cs" target="src" />


### PR DESCRIPTION
Backport #4012 
Fix #4006 