### PR TITLE
Add TestData property to the TestContext

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
@@ -354,8 +354,8 @@ internal class TestMethodRunner
     private TestResult[] ExecuteTestWithDataSource(UTF.ITestDataSource? testDataSource, object?[]? data)
     {
         var stopwatch = Stopwatch.StartNew();
-
         _testMethodInfo.SetArguments(data);
+        _testContext.SetTestData(data);
         TestResult[] testResults = ExecuteTest(_testMethodInfo);
         stopwatch.Stop();
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestContext.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestContext.cs
@@ -43,6 +43,13 @@ public interface ITestContext
     void SetDataRow(object? dataRow);
 
     /// <summary>
+    /// Sets the data that will be provided to the test.
+    /// For non-parameterized tests, the value will be <see langword="null"/>.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    void SetTestData(object?[]? data);
+
+    /// <summary>
     /// Set connection for TestContext.
     /// </summary>
     /// <param name="dbConnection">db Connection.</param>

--- a/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ITestContext.SetTestData(object?[]? data) -> void
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SetTestData(object?[]? data) -> void

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -269,6 +269,9 @@ public class TestContextImplementation : TestContext, ITestContext
 #endif
     }
 
+    /// <inheritdoc/>
+    public void SetTestData(object?[]? data) => TestData = data;
+
     /// <summary>
     /// Set connection for TestContext.
     /// </summary>

--- a/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestData.get -> object?[]?
+Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestData.set -> void

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -53,6 +53,8 @@ public abstract class TestContext
     /// </summary>
     public virtual CancellationTokenSource CancellationTokenSource { get; protected set; } = new();
 
+    public object?[]? TestData { get; protected set; }
+
 #if NETFRAMEWORK
     /// <summary>
     /// Gets the current data row when test is used for data driven testing.


### PR DESCRIPTION
Makes TestContext aware of the parameters that will be passed to the test method so user could have different behavior in the test init or cleanup,

Fixes #385