### PR TITLE
Move off validate arg from VSTest ObjectModel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
-    <PackageVersion Include="Polyfill" Version="6.9.0" />
+    <PackageVersion Include="Polyfill" Version="7.4.0" />
     <!-- CVE-2019-0820 -->
     <PackageVersion Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <!-- CVE-2019-0981, CVE-2019-0980, CVE-2019-0657 -->

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -53,7 +53,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -401,7 +401,7 @@ public class MSTestSettings
     /// <returns>An instance of the <see cref="MSTestSettings"/> class.</returns>
     private static MSTestSettings ToSettings(XmlReader reader, IMessageLogger? logger)
     {
-        ValidateArg.NotNull(reader, "reader");
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -9,7 +9,6 @@ using System.Xml.Linq;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -31,9 +31,9 @@ public class MSTestDiscoverer : ITestDiscoverer
 
     internal static void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, IConfiguration? configuration)
     {
-        ValidateArg.NotNull(sources, "sources");
-        ValidateArg.NotNull(logger, "logger");
-        ValidateArg.NotNull(discoverySink, "discoverySink");
+        Guard.NotNull(sources);
+        Guard.NotNull(logger);
+        Guard.NotNull(discoverySink);
 
         if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext, logger, configuration))
         {

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -51,8 +51,8 @@ public class MSTestExecutor : ITestExecutor
     internal void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration)
     {
         PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor.RunTests: Running tests from testcases.");
-        ValidateArg.NotNull(frameworkHandle, "frameworkHandle");
-        ValidateArg.NotNullOrEmpty(tests, "tests");
+        Guard.NotNull(frameworkHandle);
+        Guard.NotNullOrEmpty(tests);
 
         if (!MSTestDiscovererHelpers.InitializeDiscovery(from test in tests select test.Source, runContext, frameworkHandle, configuration))
         {
@@ -65,8 +65,8 @@ public class MSTestExecutor : ITestExecutor
     internal void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration)
     {
         PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor.RunTests: Running tests from sources.");
-        ValidateArg.NotNull(frameworkHandle, "frameworkHandle");
-        ValidateArg.NotNullOrEmpty(sources, "sources");
+        Guard.NotNull(frameworkHandle);
+        Guard.NotNullOrEmpty(sources);
         if (!MSTestDiscovererHelpers.InitializeDiscovery(sources, runContext, frameworkHandle, configuration))
         {
             return;

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -35,7 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Condition=" '$(TargetFramework)' == '$(WinUiMinimum)' " />
   </ItemGroup>
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
@@ -55,7 +55,7 @@ public class MSTestAdapterSettings
     /// <returns>An instance of the <see cref="MSTestAdapterSettings"/> class.</returns>
     public static MSTestAdapterSettings ToSettings(XmlReader reader)
     {
-        ValidateArg.NotNull(reader, "reader");
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //
@@ -317,7 +317,7 @@ public class MSTestAdapterSettings
 
     private void ReadAssemblyResolutionPath(XmlReader reader)
     {
-        ValidateArg.NotNull(reader, "reader");
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
@@ -5,9 +5,6 @@ using System.Xml;
 
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-#if !WINDOWS_UWP
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-#endif
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
@@ -57,7 +57,7 @@ public class MSTestSettingsProvider : ISettingsProvider
     public void Load(XmlReader reader)
     {
 #if !WINDOWS_UWP
-        ValidateArg.NotNull(reader, "reader");
+        Guard.NotNull(reader);
         s_settings = MSTestAdapterSettings.ToSettings(reader);
 #endif
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
@@ -145,7 +145,7 @@ internal abstract class DeploymentUtilityBase
         // Copy the deployment items. (As deployment item can correspond to directories as well, so each deployment item may map to n files)
         foreach (DeploymentItem deploymentItem in deploymentItems)
         {
-            ValidateArg.NotNull(deploymentItem, "deploymentItem should not be null.");
+            Guard.NotNull(deploymentItem);
 
             // Validate the output directory.
             if (!IsOutputDirectoryValid(deploymentItem, deploymentDirectory, warnings))
@@ -399,7 +399,7 @@ internal abstract class DeploymentUtilityBase
 
     private bool Deploy(string source, IRunContext? runContext, ITestExecutionRecorder testExecutionRecorder, IList<DeploymentItem> deploymentItems, TestRunDirectories runDirectories)
     {
-        ValidateArg.NotNull(runDirectories, "runDirectories");
+        Guard.NotNull(runDirectories);
         if (EqtTrace.IsInfoEnabled)
         {
             EqtTrace.Info("MSTestExecutor: Found that deployment items for source {0} are: ", source);

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/Condition.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/Condition.cs
@@ -78,7 +78,7 @@ internal sealed class Condition
     /// </summary>
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
+        Guard.NotNull(propertyValueProvider);
         bool result = false;
         string[]? multiValue = GetPropertyValue(propertyValueProvider);
         switch (Operation)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FastFilter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FastFilter.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 
 using Microsoft.Testing.Platform;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.Testing.Extensions.VSTestBridge.ObjectModel;
 

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FastFilter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FastFilter.cs
@@ -17,7 +17,7 @@ internal sealed class FastFilter
 {
     internal FastFilter(ImmutableDictionary<string, ISet<string>> filterProperties, Operation filterOperation, Operator filterOperator)
     {
-        ValidateArg.NotNullOrEmpty(filterProperties, nameof(filterProperties));
+        Guard.NotNullOrEmpty(filterProperties);
 
         FilterProperties = filterProperties;
 
@@ -45,7 +45,7 @@ internal sealed class FastFilter
 
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
+        Guard.NotNull(propertyValueProvider);
 
         bool matched = false;
         foreach (string name in FilterProperties.Keys)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpression.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpression.cs
@@ -154,7 +154,7 @@ internal sealed partial class FilterExpression
     /// </summary>
     internal static FilterExpression Parse(string filterString, out FastFilter? fastFilter)
     {
-        ValidateArg.NotNull(filterString, nameof(filterString));
+        Guard.NotNull(filterString);
 
         // Below parsing doesn't error out on pattern (), so explicitly search for that (empty parenthesis).
         Match invalidInput = GetEmptyParenthesisPattern().Match(filterString);
@@ -318,7 +318,7 @@ internal sealed partial class FilterExpression
     /// <returns> True if evaluation is successful. </returns>
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
+        Guard.NotNull(propertyValueProvider);
 
         return IterateFilterExpression<bool>((current, result) =>
         {
@@ -341,7 +341,7 @@ internal sealed partial class FilterExpression
 
     internal static IEnumerable<string> TokenizeFilterExpressionString(string str)
     {
-        ValidateArg.NotNull(str, nameof(str));
+        Guard.NotNull(str);
         return TokenizeFilterExpressionStringHelper(str);
 
         static IEnumerable<string> TokenizeFilterExpressionStringHelper(string s)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpressionWrapper.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpressionWrapper.cs
@@ -34,7 +34,7 @@ internal class FilterExpressionWrapper
     /// </summary>
     public FilterExpressionWrapper(string filterString, FilterOptions? options)
     {
-        ValidateArg.NotNullOrEmpty(filterString, nameof(filterString));
+        Guard.NotNullOrEmpty(filterString);
 
         FilterString = filterString;
         FilterOptions = options;
@@ -112,7 +112,7 @@ internal class FilterExpressionWrapper
     /// </summary>
     public bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
+        Guard.NotNull(propertyValueProvider);
 
         return UseFastFilter
             ? _fastFilter.Evaluate(propertyValueProvider)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseFilterExpression.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseFilterExpression.cs
@@ -56,8 +56,8 @@ internal sealed class TestCaseFilterExpression : ITestCaseFilterExpression
     /// </summary>
     public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider)
     {
-        ValidateArg.NotNull(testCase, nameof(testCase));
-        ValidateArg.NotNull(propertyValueProvider, nameof(propertyValueProvider));
+        Guard.NotNull(testCase);
+        Guard.NotNull(propertyValueProvider);
 
         return _validForMatch && _filterWrapper.Evaluate(propertyValueProvider);
     }

--- a/test/IntegrationTests/MSTest.IntegrationTests/MSTest.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.IntegrationTests/MSTest.IntegrationTests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/TestCaseFilterFactory.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/TestCaseFilterFactory.cs
@@ -20,7 +20,7 @@ internal static class TestCaseFilterFactory
 
     public static ITestCaseFilterExpression ParseTestFilter(string filterString)
     {
-        ValidateArg.NotNullOrEmpty(filterString, nameof(filterString));
+        Guard.NotNullOrEmpty(filterString);
         if (Regex.IsMatch(filterString, @"\(\s*\)"))
         {
             throw new FormatException($"Invalid filter, empty parenthesis: {filterString}");
@@ -119,7 +119,7 @@ internal static class TestCaseFilterFactory
 
     private static void MergeExpression(Stack<Expression<Func<Func<string, object>, bool>>> exp, Operator op)
     {
-        ValidateArg.NotNull(exp, nameof(exp));
+        Guard.NotNull(exp);
         if (op is not Operator.And and not Operator.Or)
         {
             throw new ArgumentException($"Unexpected operator: {op}", nameof(op));
@@ -190,7 +190,7 @@ internal static class TestCaseFilterFactory
 
     private static IEnumerable<string> TokenizeCondition(string conditionString)
     {
-        ValidateArg.NotNullOrEmpty(conditionString, nameof(conditionString));
+        Guard.NotNullOrEmpty(conditionString);
         var token = new StringBuilder(conditionString.Length);
 
         bool escaped = false;
@@ -294,7 +294,7 @@ internal static class TestCaseFilterFactory
 
     private static Expression<Func<Func<string, object>, bool>> ConditionExpresion(string conditionString)
     {
-        ValidateArg.NotNull(conditionString, nameof(conditionString));
+        Guard.NotNull(conditionString);
 
         string[] condition = TokenizeCondition(conditionString).ToArray();
 


### PR DESCRIPTION
Since PolyFill Guard is already enabled and leverages CallerArgumentExpression