### PR TITLE
Simplify HasCorrectTimeout

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -418,7 +418,7 @@ internal class TypeCache : MarshalByRefObject
                     TimeoutAttribute? timeoutAttribute = _reflectionHelper.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(methodInfo, inherit: false);
                     if (timeoutAttribute != null)
                     {
-                        if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+                        if (!timeoutAttribute.HasCorrectTimeout)
                         {
                             string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, methodInfo.DeclaringType!.FullName, methodInfo.Name);
                             throw new TypeInspectionException(message);
@@ -437,7 +437,7 @@ internal class TypeCache : MarshalByRefObject
                     TimeoutAttribute? timeoutAttribute = _reflectionHelper.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(methodInfo, inherit: false);
                     if (timeoutAttribute != null)
                     {
-                        if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+                        if (!timeoutAttribute.HasCorrectTimeout)
                         {
                             string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, methodInfo.DeclaringType!.FullName, methodInfo.Name);
                             throw new TypeInspectionException(message);
@@ -578,7 +578,7 @@ internal class TypeCache : MarshalByRefObject
             TimeoutAttribute? timeoutAttribute = _reflectionHelper.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(methodInfo, inherit: false);
             if (timeoutAttribute != null)
             {
-                if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+                if (!timeoutAttribute.HasCorrectTimeout)
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, methodInfo.DeclaringType!.FullName, methodInfo.Name);
                     throw new TypeInspectionException(message);
@@ -611,7 +611,7 @@ internal class TypeCache : MarshalByRefObject
             TimeoutAttribute? timeoutAttribute = _reflectionHelper.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(methodInfo, inherit: false);
             if (timeoutAttribute != null)
             {
-                if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+                if (!timeoutAttribute.HasCorrectTimeout)
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, methodInfo.DeclaringType!.FullName, methodInfo.Name);
                     throw new TypeInspectionException(message);
@@ -677,7 +677,7 @@ internal class TypeCache : MarshalByRefObject
             TimeoutAttribute? timeoutAttribute = _reflectionHelper.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(methodInfo, inherit: false);
             if (timeoutAttribute != null)
             {
-                if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+                if (!timeoutAttribute.HasCorrectTimeout)
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, methodInfo.DeclaringType!.FullName, methodInfo.Name);
                     throw new TypeInspectionException(message);
@@ -708,7 +708,7 @@ internal class TypeCache : MarshalByRefObject
             TimeoutAttribute? timeoutAttribute = _reflectionHelper.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(methodInfo, inherit: false);
             if (timeoutAttribute != null)
             {
-                if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+                if (!timeoutAttribute.HasCorrectTimeout)
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, methodInfo.DeclaringType!.FullName, methodInfo.Name);
                     throw new TypeInspectionException(message);
@@ -875,7 +875,7 @@ internal class TypeCache : MarshalByRefObject
 
         if (timeoutAttribute != null)
         {
-            if (!methodInfo.HasCorrectTimeout(timeoutAttribute))
+            if (!timeoutAttribute.HasCorrectTimeout)
             {
                 string message = string.Format(CultureInfo.CurrentCulture, Resource.UTA_ErrorInvalidTimeout, testMethod.FullClassName, testMethod.Name);
                 throw new TypeInspectionException(message);

--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -81,22 +81,6 @@ internal static class MethodInfoExtensions
     }
 
     /// <summary>
-    /// Checks whether test method has correct Timeout attribute.
-    /// </summary>
-    /// <param name="method">The method to verify.</param>
-    /// <param name="timeoutAttribute">The timeout attribute when we already have it.</param>
-    /// <returns>True if the method has the right test timeout signature.</returns>
-    internal static bool HasCorrectTimeout(this MethodInfo method, TimeoutAttribute? timeoutAttribute = null)
-    {
-        DebugEx.Assert(method != null, "method should not be null.");
-
-        // TODO: redesign this, probably change this to GetTimeout? so we don't have to do this weird dance?
-        timeoutAttribute ??= ReflectHelper.Instance.GetFirstNonDerivedAttributeOrDefault<TimeoutAttribute>(method, inherit: false);
-
-        return timeoutAttribute?.Timeout > 0;
-    }
-
-    /// <summary>
     /// Check is return type is void for non async and Task for async methods.
     /// </summary>
     /// <param name="method">The method to verify.</param>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -25,7 +25,11 @@ public sealed class TimeoutAttribute : Attribute
     /// <param name="timeout">
     /// The timeout.
     /// </param>
-    public TimeoutAttribute(TestTimeout timeout) => Timeout = (int)timeout;
+    public TimeoutAttribute(TestTimeout timeout)
+    {
+        Timeout = (int)timeout;
+        HasCorrectTimeout = Timeout > 0;
+    }
 
     /// <summary>
     /// Gets the timeout in milliseconds.
@@ -51,6 +55,11 @@ public sealed class TimeoutAttribute : Attribute
             _isCooperativeCancellation = value;
         }
     }
+
+    /// <summary>
+    /// Gets a value indicating whether the instance has the correct test timeout signature.
+    /// </summary>
+    internal bool HasCorrectTimeout { get; private set; }
 
     internal bool IsCooperativeCancellationSet { get; private set; }
 }

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TimeoutAttribute.cs
@@ -17,7 +17,11 @@ public sealed class TimeoutAttribute : Attribute
     /// <param name="timeout">
     /// The timeout in milliseconds.
     /// </param>
-    public TimeoutAttribute(int timeout) => Timeout = timeout;
+    public TimeoutAttribute(int timeout)
+    {
+        Timeout = timeout;
+        HasCorrectTimeout = Timeout > 0;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TimeoutAttribute"/> class with a preset timeout.
@@ -26,9 +30,8 @@ public sealed class TimeoutAttribute : Attribute
     /// The timeout.
     /// </param>
     public TimeoutAttribute(TestTimeout timeout)
+        : this((int)timeout)
     {
-        Timeout = (int)timeout;
-        HasCorrectTimeout = Timeout > 0;
     }
 
     /// <summary>

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/MethodInfoExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/MethodInfoExtensionsTests.cs
@@ -244,28 +244,6 @@ public class MethodInfoExtensionsTests : TestContainer
 
     #endregion
 
-    #region HasCorrectTimeout tests
-
-    public void HasCorrectTimeoutShouldReturnFalseForMethodsWithoutTimeoutAttribute()
-    {
-        MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("PublicMethod");
-        Verify(!methodInfo.HasCorrectTimeout());
-    }
-
-    public void HasCorrectTimeoutShouldReturnFalseForMethodsWithInvalidTimeoutAttribute()
-    {
-        MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("PublicMethodWithInvalidTimeout");
-        Verify(!methodInfo.HasCorrectTimeout());
-    }
-
-    public void HasCorrectTimeoutShouldReturnTrueForMethodsWithTimeoutAttribute()
-    {
-        MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("PublicMethodWithTimeout");
-        Verify(methodInfo.HasCorrectTimeout());
-    }
-
-    #endregion
-
     #region IsVoidOrTaskReturnType tests
 
     public void IsVoidOrTaskReturnTypeShouldReturnTrueForVoidMethods()


### PR DESCRIPTION
it was never called with a null value. so move it to a calculated property on the attribute