### PR TITLE
Use reflection provider for class constructors

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -260,23 +260,41 @@ internal class TypeCache : MarshalByRefObject
     private TestClassInfo CreateClassInfo(Type classType, TestMethod testMethod)
     {
         IEnumerable<ConstructorInfo> constructors = PlatformServiceProvider.Instance.ReflectionOperations.GetDeclaredConstructors(classType);
-        ConstructorInfo? constructor = constructors.FirstOrDefault(ctor => ctor.GetParameters().Length == 0 && ctor.IsPublic);
-        bool isParameterLessConstructor;
+        (ConstructorInfo? CtorInfo, bool IsParameterless)? selectedConstructor = null;
 
-        if (classType.GetConstructor([typeof(TestContext)]) is { } testContextCtor)
+        foreach (ConstructorInfo ctor in constructors)
         {
-            constructor = testContextCtor;
-            isParameterLessConstructor = false;
+            if (!ctor.IsPublic)
+            {
+                continue;
+            }
+
+            ParameterInfo[] parameters = ctor.GetParameters();
+
+            // There are just 2 ctor shapes that we know, so the code is quite simple,
+            // but if we add more, add a priority to the search, and shortcircuit this search so we only iterate
+            // through the collection once, to avoid re-allocating GetParameters multiple times.
+            if (parameters.Length == 1 && parameters[0].ParameterType == typeof(TestContext))
+            {
+                selectedConstructor ??= (ctor, IsParameterless: false);
+
+                // This is the preferred constructor, no point in searching for more.
+                break;
+            }
+
+            if (parameters.Length == 0)
+            {
+                selectedConstructor = (ctor, IsParameterless: true);
+            }
         }
-        else if (classType.GetConstructor([]) is { } parameterLessCtor)
-        {
-            constructor = parameterLessCtor;
-            isParameterLessConstructor = true;
-        }
-        else
+
+        if (selectedConstructor is null)
         {
             throw new TypeInspectionException(string.Format(CultureInfo.CurrentCulture, Resource.UTA_NoValidConstructor, testMethod.FullClassName));
         }
+
+        ConstructorInfo constructor = selectedConstructor.Value.CtorInfo;
+        bool isParameterLessConstructor = selectedConstructor.Value.IsParameterless;
 
         PropertyInfo? testContextProperty = ResolveTestContext(classType);
 

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -260,7 +260,7 @@ internal class TypeCache : MarshalByRefObject
     private TestClassInfo CreateClassInfo(Type classType, TestMethod testMethod)
     {
         IEnumerable<ConstructorInfo> constructors = PlatformServiceProvider.Instance.ReflectionOperations.GetDeclaredConstructors(classType);
-        (ConstructorInfo? CtorInfo, bool IsParameterless)? selectedConstructor = null;
+        (ConstructorInfo CtorInfo, bool IsParameterless)? selectedConstructor = null;
 
         foreach (ConstructorInfo ctor in constructors)
         {
@@ -272,11 +272,11 @@ internal class TypeCache : MarshalByRefObject
             ParameterInfo[] parameters = ctor.GetParameters();
 
             // There are just 2 ctor shapes that we know, so the code is quite simple,
-            // but if we add more, add a priority to the search, and shortcircuit this search so we only iterate
+            // but if we add more, add a priority to the search, and short-circuit this search so we only iterate
             // through the collection once, to avoid re-allocating GetParameters multiple times.
             if (parameters.Length == 1 && parameters[0].ParameterType == typeof(TestContext))
             {
-                selectedConstructor ??= (ctor, IsParameterless: false);
+                selectedConstructor = (ctor, IsParameterless: false);
 
                 // This is the preferred constructor, no point in searching for more.
                 break;
@@ -284,7 +284,8 @@ internal class TypeCache : MarshalByRefObject
 
             if (parameters.Length == 0)
             {
-                selectedConstructor = (ctor, IsParameterless: true);
+                // Otherwise take the first parameterless constructor we can find.
+                selectedConstructor ??= (ctor, IsParameterless: true);
             }
         }
 

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -576,6 +576,9 @@ public class TestExecutionManagerTests : TestContainer
             var originalReflectionOperation = new ReflectionOperations2();
             var originalFileOperation = new FileOperations();
 
+            testablePlatformService.MockReflectionOperations.Setup(ro => ro.GetDeclaredConstructors(It.IsAny<Type>()))
+                .Returns((Type classType) => originalReflectionOperation.GetDeclaredConstructors(classType));
+
             testablePlatformService.MockReflectionOperations.Setup(
                 ro => ro.GetCustomAttributes(It.IsAny<Assembly>(), It.IsAny<Type>())).
                 Returns((Assembly asm, Type type) => type.FullName.Equals(typeof(ParallelizeAttribute).FullName, StringComparison.Ordinal)
@@ -631,6 +634,9 @@ public class TestExecutionManagerTests : TestContainer
 
             var originalReflectionOperation = new ReflectionOperations2();
             var originalFileOperation = new FileOperations();
+
+            testablePlatformService.MockReflectionOperations.Setup(ro => ro.GetDeclaredConstructors(It.IsAny<Type>()))
+                .Returns((Type classType) => originalReflectionOperation.GetDeclaredConstructors(classType));
 
             testablePlatformService.MockReflectionOperations.Setup(
                 ro => ro.GetCustomAttributes(It.IsAny<Assembly>(), It.IsAny<Type>())).
@@ -729,6 +735,9 @@ public class TestExecutionManagerTests : TestContainer
 
             var originalReflectionOperation = new ReflectionOperations2();
             var originalFileOperation = new FileOperations();
+
+            testablePlatformService.MockReflectionOperations.Setup(ro => ro.GetDeclaredConstructors(It.IsAny<Type>()))
+                .Returns((Type classType) => originalReflectionOperation.GetDeclaredConstructors(classType));
 
             testablePlatformService.MockReflectionOperations.Setup(
                 ro => ro.GetCustomAttributes(It.IsAny<Assembly>(), It.IsAny<Type>())).


### PR DESCRIPTION
Fixes oversight in code where we grab the constructors from Reflection rather than getting them from the metadata provider.

Replace https://github.com/microsoft/testfx/pull/4033