### PR TITLE
Remove the '&' from the sln file

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -150,7 +150,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestingPlatformRunner", "Te
 		eng\TestingPlatformRunner\TestingPlatformRunner.targets = eng\TestingPlatformRunner\TestingPlatformRunner.targets
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1 - Platform & Extensions", "1 - Platform & Extensions", "{6AEE1440-FDF0-4729-8196-B24D0E333550}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "1 - Platform and Extensions", "1 - Platform and Extensions", "{6AEE1440-FDF0-4729-8196-B24D0E333550}"
 	ProjectSection(SolutionItems) = preProject
 		src\Platform\Directory.Build.props = src\Platform\Directory.Build.props
 	EndProjectSection


### PR DESCRIPTION
The latest .sln solution parser assumes that the folder names in the solution must comply with the file path restrictions of Windows. This makes msbuild fail the build of TestFx.sln as one of the folders contains the '&' sign.

Here's what the faulty exception looks like:

```
C:\code\testfx\TestFx.sln : error MSB4025: The project file could not be loaded. System.AggregateException: One or more
 errors occurred. ---> Microsoft.VisualStudio.SolutionPersistence.Model.SolutionException: Names cannot:
C:\code\testfx\TestFx.sln : error MSB4025: - contain any of the following characters: / ? : \ * " < > | # & %
C:\code\testfx\TestFx.sln : error MSB4025: - contain control characters
C:\code\testfx\TestFx.sln : error MSB4025: - be system reserved names, including 'CON', 'AUX', 'PRN', 'COM1' or 'LPT2'
C:\code\testfx\TestFx.sln : error MSB4025: - be '.' or '..'
C:\code\testfx\TestFx.sln : error MSB4025: Parameter name: name ---> System.ArgumentException: Names cannot:
C:\code\testfx\TestFx.sln : error MSB4025: - contain any of the following characters: / ? : \ * " < > | # & %
C:\code\testfx\TestFx.sln : error MSB4025: - contain control characters
C:\code\testfx\TestFx.sln : error MSB4025: - be system reserved names, including 'CON', 'AUX', 'PRN', 'COM1' or 'LPT2'
C:\code\testfx\TestFx.sln : error MSB4025: - be '.' or '..'
C:\code\testfx\TestFx.sln : error MSB4025: Parameter name: name
C:\code\testfx\TestFx.sln : error MSB4025:    at Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.Validat
eName(ReadOnlySpan`1 name)
C:\code\testfx\TestFx.sln : error MSB4025:    at Microsoft.VisualStudio.SolutionPersistence.Model.SolutionModel.CreateF
older(String name)
C:\code\testfx\TestFx.sln : error MSB4025:    at Microsoft.VisualStudio.SolutionPersistence.Serializer.SlnV12.SlnFileV1
2Serializer.Reader.ReadProjectInfo(SolutionModel solution, StringTokenizer& tokenizer)
C:\code\testfx\TestFx.sln : error MSB4025:    at Microsoft.VisualStudio.SolutionPersistence.Serializer.SlnV12.SlnFileV1
2Serializer.Reader.ParseAsync(ISolutionSerializer serializer, String fullPath, CancellationToken cancellationToken)
C:\code\testfx\TestFx.sln : error MSB4025:    --- End of inner exception stack trace ---
```