### PR TITLE
StopUpdate in Finally Block

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Text;
 
 using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Resources;
 
 namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 
@@ -122,7 +123,7 @@ internal sealed class NonAnsiTerminal : ITerminal
     {
         if (_isBatching)
         {
-            throw new InvalidOperationException("Console is already in batching mode.");
+            throw new InvalidOperationException(PlatformResources.ConsoleIsAlreadyInBatchingMode);
         }
 
         _stringBuilder.Clear();


### PR DESCRIPTION
#4146 

I'm getting this on my pipelines on GitHub actions sometimes:

```
  Error: Unhandled exception. System.InvalidOperationException: Console is already
  in batching mode.
     at 
  Microsoft.Testing.Platform.OutputDevice.Terminal.NonAnsiTerminal.StartUpdate() 
  in 
  /_/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal
  .cs:line 125
     at 
  Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressStateAwareTerminal.
  ThreadProc() in 
  /_/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressSta
  teAwareTerminal.cs:line 45
     at System.Threading.Thread.StartCallback()
```

Looking at the code, every call to `StartUpdate` is within a `lock` statement so that all looks correct, so the only thing I can think of is we're hitting some exception (although I can't see anything in the output - Maybe I need to tweak my verbosity?) and therefore not calling `StopUpdate`?

It should probably be in a `finally` block to ensure it's always called.