### PR TITLE
Mark IgnoreAttribute as not inherited

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/TestMethod/IgnoreAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/IgnoreAttribute.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// <summary>
 /// The ignore attribute.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
 public sealed class IgnoreAttribute : Attribute
 {
     /// <summary>


### PR DESCRIPTION
It makes better sense to reflect the real semantics of the attribute.

@Evangelink Any backcompat concerns with this change?