### PR TITLE
[test] bump dotnet publish timeout to 90s

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -120,6 +120,7 @@ public class UnitTest1
                 DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
                     $"publish -m:1 -nodeReuse:false {generator.TargetAssetPath} -r {RID}",
                     _acceptanceFixture.NuGetGlobalPackagesFolder.Path,
+                    timeoutInSeconds: 90,
                     retryCount: 0);
                 compilationResult.AssertOutputContains("Generating native code");
 


### PR DESCRIPTION
We are seeing increasing frequency of test flakiness for the acceptance test `NativeAotTests_WillRunWithExitCodeZero`. The error message is:

```text
System.TimeoutException: Timeout after 50s on command line: 'D:\a\_work\1\s/.dotnet/dotnet.exe publish -m:1 -nodeReuse:false D:\a\_work\1\s\artifacts\tmp\Release\testsuite\AKtK1\NativeAotTests -r win-x64 /warnaserror -p:SuppressNETCoreSdkPreviewMessage=true'
```

In a result, I am trying to bump to 90s (arbitrary value).