### PR TITLE
Revert "Show the text that timed out in regex match"

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -4,13 +4,9 @@
 #if !NET7_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-
 #endif
 
 using System.Globalization;
-#if !NETSTANDARD
-using System.Runtime.ExceptionServices;
-#endif
 using System.Text.RegularExpressions;
 
 using Microsoft.Testing.Platform.Helpers;
@@ -657,26 +653,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     internal /* for testing */ static void AppendStackFrame(ITerminal terminal, string stackTraceLine)
     {
         terminal.Append(DoubleIndentation);
-        Match match;
-        try
-        {
-            match = GetFrameRegex().Match(stackTraceLine);
-        }
-        catch (RegexMatchTimeoutException ex)
-        {
-            // Add the stack trace line that was being matched to test locally.
-            var newTimeoutException = new RegexMatchTimeoutException(string.Format(CultureInfo.CurrentCulture, PlatformResources.TimeoutInRegexStackTraceLineParsing, stackTraceLine), ex);
-#if !NETSTANDARD
-            throw ex.StackTrace is null
-                ? newTimeoutException
-                // Otherwise preserve the stack trace, so we can tell if this was using
-                // the generated regex or not.
-                : ExceptionDispatchInfo.SetRemoteStackTrace(newTimeoutException, ex.StackTrace);
-#else
-            throw newTimeoutException;
-#endif
-        }
-
+        Match match = GetFrameRegex().Match(stackTraceLine);
         if (match.Success)
         {
             bool weHaveFilePathAndCodeLine = !RoslynString.IsNullOrWhiteSpace(match.Groups["code"].Value);

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -671,8 +671,4 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
   <data name="ConfigurationFileNotFound" xml:space="preserve">
     <value>The configuration file '{0}' specified with '--config-file' could not be found.</value>
   </data>
-  <data name="TimeoutInRegexStackTraceLineParsing" xml:space="preserve">
-    <value>Parsing stack trace line with regex timed out. Input: '{0}'</value>
-    <comment>{0} is the line that was being matched</comment>
-  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -825,11 +825,6 @@ Platné hodnoty jsou Normal a Detailed. Výchozí hodnota je Normal.</target>
         <target state="translated">Nepovedlo se vyprázdnit protokoly před vypršením časového limitu {0} s.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Celkem</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -825,11 +825,6 @@ Gültige Werte sind „Normal“, „Detailed“. Der Standardwert ist „Normal
         <target state="translated">Fehler beim Leeren von Protokollen vor dem Timeout von "{0}" Sekunden</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Gesamt</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -825,11 +825,6 @@ Los valores válidos son 'Normal', 'Detallado'. El valor predeterminado es 'Norm
         <target state="translated">No se pudieron vaciar los registros antes del tiempo de espera de “{0}” segundos</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Total</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -825,11 +825,6 @@ Les valeurs valides sont « Normal » et « Détaillé ». La valeur par dé
         <target state="translated">Échec du vidage des journaux avant le délai d’expiration de « {0} » secondes</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Total</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -825,11 +825,6 @@ I valori validi sono 'Normal', 'Detailed'. L'impostazione predefinita è 'Normal
         <target state="translated">Non è stato possibile scaricare i log prima del timeout di '{0}' secondi</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Totale</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -826,11 +826,6 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">'{0}' 秒のタイムアウト前にログをフラッシュできませんでした</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">合計</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -825,11 +825,6 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">'{0}'초의 시간 제한 전에 로그를 플러시하지 못했습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">합계</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -825,11 +825,6 @@ Prawidłowe wartości to „Normalne”, „Szczegółowe”. Wartość domyśln
         <target state="translated">Nie można opróżnić dzienników przed upływem limitu czasu wynoszącego „{0}” s</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Łącznie</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -825,11 +825,6 @@ Os valores válidos são “Normal”, “Detalhado”. O padrão é “Normal�
         <target state="translated">Falha ao liberar logs antes do tempo limite de '{0}' segundos</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Total</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -825,11 +825,6 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">Не удалось записать журналы на диск до истечения времени ожидания ("{0}" с)</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Всего</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -825,11 +825,6 @@ Geçerli değerler: ‘Normal’, ‘Ayrıntılı’. Varsayılan değer: ‘Nor
         <target state="translated">'{0}' saniyelik zaman aşımından önce günlükler boşaltılamadı</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">Toplam</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -825,11 +825,6 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">未能在“{0}”秒超时之前刷新日志</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">总计</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -825,11 +825,6 @@ Valid values are 'Normal', 'Detailed'. Default is 'Normal'.</source>
         <target state="translated">無法在 '{0}' 秒逾時前排清記錄</target>
         <note />
       </trans-unit>
-      <trans-unit id="TimeoutInRegexStackTraceLineParsing">
-        <source>Parsing stack trace line with regex timed out. Input: '{0}'</source>
-        <target state="new">Parsing stack trace line with regex timed out. Input: '{0}'</target>
-        <note>{0} is the line that was being matched</note>
-      </trans-unit>
       <trans-unit id="Total">
         <source>Total</source>
         <target state="translated">總計</target>


### PR DESCRIPTION
Reverts microsoft/testfx#4175

There is no timeout on the regex anymore.