### PR TITLE
More efficient reflection

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs
@@ -83,7 +83,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
 
         Assembly assembly = PlatformServiceProvider.Instance.FileOperations.LoadAssembly(assemblyFileName, isReflectionOnly: false);
 
-        IReadOnlyList<Type> types = GetTypes(assembly, assemblyFileName, warningMessages);
+        Type[] types = GetTypes(assembly, assemblyFileName, warningMessages);
         bool discoverInternals = ReflectHelper.GetDiscoverInternalsAttribute(assembly) != null;
         TestIdGenerationStrategy testIdGenerationStrategy = ReflectHelper.GetTestIdGenerationStrategy(assembly);
 

--- a/src/Adapter/MSTest.TestAdapter/Discovery/TypeValidator.cs
+++ b/src/Adapter/MSTest.TestAdapter/Discovery/TypeValidator.cs
@@ -106,7 +106,7 @@ internal class TypeValidator
     {
         DebugEx.Assert(type != null, "HasCorrectTestContextSignature type is null");
 
-        IEnumerable<PropertyInfo> propertyInfoEnumerable = PlatformServiceProvider.Instance.ReflectionOperations.GetDeclaredProperties(type);
+        PropertyInfo[] propertyInfoEnumerable = PlatformServiceProvider.Instance.ReflectionOperations.GetDeclaredProperties(type);
         var propertyInfo = new List<PropertyInfo>();
 
         foreach (PropertyInfo pinfo in propertyInfoEnumerable)

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -399,7 +399,7 @@ internal sealed class TypeCache : MarshalByRefObject
 
         assemblyInfo = new TestAssemblyInfo(assembly);
 
-        IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(assembly, assembly.FullName!, null);
+        Type[] types = AssemblyEnumerator.GetTypes(assembly, assembly.FullName!, null);
 
         foreach (Type t in types)
         {

--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -259,7 +259,7 @@ internal sealed class TypeCache : MarshalByRefObject
     /// <returns> The <see cref="TestClassInfo"/>. </returns>
     private TestClassInfo CreateClassInfo(Type classType, TestMethod testMethod)
     {
-        IEnumerable<ConstructorInfo> constructors = PlatformServiceProvider.Instance.ReflectionOperations.GetDeclaredConstructors(classType);
+        ConstructorInfo[] constructors = PlatformServiceProvider.Instance.ReflectionOperations.GetDeclaredConstructors(classType);
         (ConstructorInfo CtorInfo, bool IsParameterless)? selectedConstructor = null;
 
         foreach (ConstructorInfo ctor in constructors)

--- a/src/Adapter/MSTest.TestAdapter/SourceGeneration/SourceGeneratedReflectionOperations.cs
+++ b/src/Adapter/MSTest.TestAdapter/SourceGeneration/SourceGeneratedReflectionOperations.cs
@@ -68,7 +68,7 @@ internal sealed class SourceGeneratedReflectionOperations : IReflectionOperation
     public Type[] GetDefinedTypes(Assembly assembly)
         => ReflectionDataProvider.Types;
 
-    public IEnumerable<MethodInfo> GetRuntimeMethods(Type type)
+    public MethodInfo[] GetRuntimeMethods(Type type)
         => ReflectionDataProvider.TypeMethods[type];
 
     public MethodInfo? GetRuntimeMethod(Type declaringType, string methodName, Type[] parameters) => throw new NotImplementedException();

--- a/src/Adapter/MSTest.TestAdapter/SourceGeneration/SourceGeneratedReflectionOperations.cs
+++ b/src/Adapter/MSTest.TestAdapter/SourceGeneration/SourceGeneratedReflectionOperations.cs
@@ -50,16 +50,16 @@ internal sealed class SourceGeneratedReflectionOperations : IReflectionOperation
         return attributes.ToArray();
     }
 
-    public IEnumerable<ConstructorInfo> GetDeclaredConstructors(Type classType)
+    public ConstructorInfo[] GetDeclaredConstructors(Type classType)
         => ReflectionDataProvider.TypeConstructors[classType];
 
     public MethodInfo? GetDeclaredMethod(Type dynamicDataDeclaringType, string dynamicDataSourceName)
         => GetDeclaredMethods(dynamicDataDeclaringType).FirstOrDefault(m => m.Name == dynamicDataSourceName);
 
-    public IEnumerable<MethodInfo> GetDeclaredMethods(Type classType)
+    public MethodInfo[] GetDeclaredMethods(Type classType)
         => ReflectionDataProvider.TypeMethods[classType];
 
-    public IEnumerable<PropertyInfo> GetDeclaredProperties(Type type)
+    public PropertyInfo[] GetDeclaredProperties(Type type)
         => ReflectionDataProvider.TypeProperties[type];
 
     public PropertyInfo? GetDeclaredProperty(Type type, string propertyName)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IReflectionOperations2.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IReflectionOperations2.cs
@@ -7,19 +7,19 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
 
 internal interface IReflectionOperations2 : IReflectionOperations
 {
-    IEnumerable<ConstructorInfo> GetDeclaredConstructors(Type classType);
+    ConstructorInfo[] GetDeclaredConstructors(Type classType);
 
     MethodInfo? GetDeclaredMethod(Type dynamicDataDeclaringType, string dynamicDataSourceName);
 
-    IEnumerable<MethodInfo> GetDeclaredMethods(Type classType);
+    MethodInfo[] GetDeclaredMethods(Type classType);
 
-    IEnumerable<PropertyInfo> GetDeclaredProperties(Type type);
+    PropertyInfo[] GetDeclaredProperties(Type type);
 
     PropertyInfo? GetDeclaredProperty(Type type, string propertyName);
 
     Type[] GetDefinedTypes(Assembly assembly);
 
-    IEnumerable<MethodInfo> GetRuntimeMethods(Type type);
+    MethodInfo[] GetRuntimeMethods(Type type);
 
     MethodInfo? GetRuntimeMethod(Type declaringType, string methodName, Type[] parameters);
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations2.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations2.cs
@@ -9,6 +9,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
 internal sealed class ReflectionOperations2 : ReflectionOperations, IReflectionOperations2
 {
+    private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+    private const BindingFlags Everything = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+
     public ReflectionOperations2()
     {
 #if NET8_0_OR_GREATER
@@ -23,26 +26,26 @@ internal sealed class ReflectionOperations2 : ReflectionOperations, IReflectionO
 #pragma warning disable IL2026 // Members attributed with RequiresUnreferencedCode may break when trimming
 #pragma warning disable IL2067 // 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.
 #pragma warning disable IL2057 // Unrecognized value passed to the typeName parameter of 'System.Type.GetType(String)'
-    public IEnumerable<ConstructorInfo> GetDeclaredConstructors(Type classType)
-        => classType.GetTypeInfo().DeclaredConstructors;
+    public ConstructorInfo[] GetDeclaredConstructors(Type classType)
+        => classType.GetConstructors(DeclaredOnlyLookup);
 
     public MethodInfo? GetDeclaredMethod(Type type, string methodName)
-        => type.GetTypeInfo().GetDeclaredMethod(methodName);
+        => type.GetMethod(methodName, DeclaredOnlyLookup);
 
-    public IEnumerable<MethodInfo> GetDeclaredMethods(Type classType)
-        => classType.GetTypeInfo().DeclaredMethods;
+    public MethodInfo[] GetDeclaredMethods(Type classType)
+        => classType.GetMethods(DeclaredOnlyLookup);
 
-    public IEnumerable<PropertyInfo> GetDeclaredProperties(Type type)
-        => type.GetTypeInfo().DeclaredProperties;
+    public PropertyInfo[] GetDeclaredProperties(Type type)
+        => type.GetProperties(DeclaredOnlyLookup);
 
     public PropertyInfo? GetDeclaredProperty(Type type, string propertyName)
-        => type.GetTypeInfo().GetDeclaredProperty(propertyName);
+        => type.GetProperty(propertyName, DeclaredOnlyLookup);
 
     public Type[] GetDefinedTypes(Assembly assembly)
-        => assembly.DefinedTypes.ToArray();
+        => assembly.GetTypes();
 
-    public IEnumerable<MethodInfo> GetRuntimeMethods(Type type)
-        => type.GetRuntimeMethods();
+    public MethodInfo[] GetRuntimeMethods(Type type)
+        => type.GetMethods(Everything);
 
     public MethodInfo? GetRuntimeMethod(Type declaringType, string methodName, Type[] parameters)
         => declaringType.GetRuntimeMethod(methodName, parameters);

--- a/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorTests.cs
@@ -123,7 +123,7 @@ public class AssemblyEnumeratorTests : TestContainer
         var reflectedTypes = new Type[] { typeof(DummyTestClass) };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Throws(new ReflectionTypeLoadException(reflectedTypes, null));
+        mockAssembly.Setup(a => a.GetTypes()).Throws(new ReflectionTypeLoadException(reflectedTypes, null));
 
         IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings);
 
@@ -137,8 +137,8 @@ public class AssemblyEnumeratorTests : TestContainer
         var exceptions = new Exception[] { new("DummyLoaderException") };
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Throws(new ReflectionTypeLoadException(null, exceptions));
-        mockAssembly.Setup(a => a.DefinedTypes).Throws(new ReflectionTypeLoadException(null, exceptions));
+        mockAssembly.Setup(a => a.GetTypes()).Throws(new ReflectionTypeLoadException(null, exceptions));
+        mockAssembly.Setup(a => a.GetTypes()).Throws(new ReflectionTypeLoadException(null, exceptions));
 
         IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(mockAssembly.Object, "DummyAssembly", _warnings);
 

--- a/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Discovery/AssemblyEnumeratorTests.cs
@@ -101,7 +101,7 @@ public class AssemblyEnumeratorTests : TestContainer
         TypeInfo[] expectedTypes = [typeof(DummyTestClass).GetTypeInfo(), typeof(DummyTestClass).GetTypeInfo()];
 
         // Setup mocks
-        mockAssembly.Setup(a => a.DefinedTypes).Returns(expectedTypes);
+        mockAssembly.Setup(a => a.GetTypes()).Returns(expectedTypes);
 
         IReadOnlyList<Type> types = AssemblyEnumerator.GetTypes(mockAssembly.Object, string.Empty, _warnings);
         Verify(expectedTypes.SequenceEqual(types));
@@ -237,7 +237,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
@@ -256,7 +256,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
@@ -278,7 +278,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
@@ -300,7 +300,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass), typeof(DummyTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(DummyTestClass).GetTypeInfo(), typeof(DummyTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
@@ -323,7 +323,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(InternalTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(InternalTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
@@ -345,7 +345,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(InternalTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(InternalTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);
@@ -365,7 +365,7 @@ public class AssemblyEnumeratorTests : TestContainer
         // Setup mocks
         mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(InternalTestClass)]);
-        mockAssembly.Setup(a => a.DefinedTypes)
+        mockAssembly.Setup(a => a.GetTypes())
             .Returns([typeof(InternalTestClass).GetTypeInfo()]);
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("DummyAssembly", false))
             .Returns(mockAssembly.Object);


### PR DESCRIPTION
These changes seems to be more efficient, even if not super significant, but also will help when https://github.com/dotnet/runtime/issues/53217 is implemented (this analyzer is already approved). See also https://github.com/dotnet/runtime/pull/89317 which now hides GetTypeInfo for .NET 10