### PR TITLE
Avoid repetitive string.Format call for every character of command-line options

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
@@ -29,9 +29,10 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
         Guard.NotNullOrWhiteSpace(description);
         ArgumentGuard.Ensure(arity.Max >= arity.Min, nameof(arity), PlatformResources.CommandLineInvalidArityErrorMessage);
 
+        string errorMessage = string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineInvalidOptionName, name);
         for (int i = 0; i < name.Length; i++)
         {
-            ArgumentGuard.Ensure(char.IsLetterOrDigit(name[i]) || name[i] == '-' || name[i] == '?', nameof(name), string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineInvalidOptionName, name));
+            ArgumentGuard.Ensure(char.IsLetterOrDigit(name[i]) || name[i] == '-' || name[i] == '?', nameof(name), errorMessage);
         }
 
         Name = name;


### PR DESCRIPTION
Noticed when profiling Playground.

![image](https://github.com/user-attachments/assets/0877bdcf-6bfe-482b-b1de-ca8d4259866a)

For big test projects, this won't have that much of an effect though, but it's still a good improvement to take I think.