### PR TITLE
[Performance] Avoid System.Action allocations for test context cancellation

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
@@ -305,7 +305,7 @@ public class TestExecutionManager
             [MSTestSettings.CurrentSettings, unitTestElements, (int)sourceSettings.ClassCleanupLifecycle])!;
 
         // Ensures that the cancellation token gets through AppDomain boundary.
-        _testRunCancellationToken?.Register(testRunner.Cancel);
+        _testRunCancellationToken?.Register(static state => ((UnitTestRunner)state!).Cancel(), testRunner);
 
         if (MSTestSettings.CurrentSettings.ParallelizationWorkers.HasValue)
         {

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestRunCancellationToken.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestRunCancellationToken.cs
@@ -19,7 +19,7 @@ public class TestRunCancellationToken
     /// Callbacks to be invoked when canceled.
     /// Needs to be a concurrent collection, see https://github.com/microsoft/testfx/issues/3953.
     /// </summary>
-    private readonly ConcurrentBag<Action> _registeredCallbacks = new();
+    private readonly ConcurrentBag<(Action<object?>, object?)> _registeredCallbacks = new();
 
     public TestRunCancellationToken()
         : this(CancellationToken.None)
@@ -43,9 +43,9 @@ public class TestRunCancellationToken
 
             if (!previousValue && value)
             {
-                foreach (Action callBack in _registeredCallbacks)
+                foreach ((Action<object?> callBack, object? state) in _registeredCallbacks)
                 {
-                    callBack.Invoke();
+                    callBack.Invoke(state);
                 }
             }
         }
@@ -60,7 +60,9 @@ public class TestRunCancellationToken
     /// Registers a callback method to be invoked when canceled.
     /// </summary>
     /// <param name="callback">Callback delegate for handling cancellation.</param>
-    public void Register(Action callback) => _registeredCallbacks.Add(callback);
+    public void Register(Action callback) => _registeredCallbacks.Add((_ => callback(), null));
+
+    internal void Register(Action<object?> callback, object? state) => _registeredCallbacks.Add((callback, state));
 
     /// <summary>
     /// Unregister the callback method.

--- a/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 #if !WINDOWS_UWP
@@ -17,6 +18,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 /// </summary>
 internal sealed class PlatformServiceProvider : IPlatformServiceProvider
 {
+    private static readonly Action<object?> CancelDelegate = static s => ((CancellationTokenSource)s!).Cancel();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PlatformServiceProvider"/> class - a singleton.
     /// </summary>
@@ -223,7 +226,7 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     public ITestContext GetTestContext(ITestMethod testMethod, StringWriter writer, IDictionary<string, object?> properties)
     {
         var testContextImplementation = new TestContextImplementation(testMethod, writer, properties);
-        TestRunCancellationToken?.Register(testContextImplementation.Context.CancellationTokenSource.Cancel);
+        TestRunCancellationToken?.Register(static state => ((TestContextImplementation)state!).Context.CancellationTokenSource.Cancel(), testContextImplementation);
         return testContextImplementation;
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 #if !WINDOWS_UWP
@@ -18,7 +17,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 /// </summary>
 internal sealed class PlatformServiceProvider : IPlatformServiceProvider
 {
-    private static readonly Action<object?> CancelDelegate = static s => ((CancellationTokenSource)s!).Cancel();
+    private static readonly Action<object?> CancelDelegate = static state => ((TestContextImplementation)state!).Context.CancellationTokenSource.Cancel();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlatformServiceProvider"/> class - a singleton.
@@ -226,7 +225,7 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     public ITestContext GetTestContext(ITestMethod testMethod, StringWriter writer, IDictionary<string, object?> properties)
     {
         var testContextImplementation = new TestContextImplementation(testMethod, writer, properties);
-        TestRunCancellationToken?.Register(static state => ((TestContextImplementation)state!).Context.CancellationTokenSource.Cancel(), testContextImplementation);
+        TestRunCancellationToken?.Register(CancelDelegate, testContextImplementation);
         return testContextImplementation;
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/26d8cb6e-3446-4a7e-b948-f625f1937b13)
