### PR TITLE
[Performance] Avoid TraitCollection.AddRange call with empty array

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
@@ -170,7 +170,7 @@ internal sealed class UnitTestElement
             testCase.SetPropertyValue(Constants.PriorityProperty, Priority.Value);
         }
 
-        if (Traits != null)
+        if (Traits is { Length: > 0 })
         {
             testCase.Traits.AddRange(Traits);
         }


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->