### PR TITLE
[Performance] Avoid repetitive string allocations from TestRunDirectories

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Deployment/TestRunDirectories.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Deployment/TestRunDirectories.cs
@@ -3,6 +3,8 @@
 
 #if !WINDOWS_UWP
 
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
@@ -40,28 +42,43 @@ public class TestRunDirectories
         RootDeploymentDirectory = rootDirectory;
     }
 
+    [MemberNotNull(nameof(InDirectory), nameof(OutDirectory), nameof(InMachineNameDirectory))]
+    private void OnRootDeploymentDirectoryUpdated()
+    {
+        InDirectory = Path.Combine(RootDeploymentDirectory, DeploymentInDirectorySuffix);
+        OutDirectory = Path.Combine(RootDeploymentDirectory, DeploymentOutDirectorySuffix);
+        InMachineNameDirectory = Path.Combine(InDirectory, Environment.MachineName);
+    }
+
     /// <summary>
     /// Gets or sets the root deployment directory.
     /// </summary>
-    public string RootDeploymentDirectory { get; set; }
+    public string RootDeploymentDirectory
+    {
+        get => field;
+        // TODO: Remove the setter as a breaking change and simplify the code.
+        [MemberNotNull(nameof(InDirectory), nameof(OutDirectory), nameof(InMachineNameDirectory))]
+        set
+        {
+            field = value;
+            OnRootDeploymentDirectoryUpdated();
+        }
+    }
 
     /// <summary>
     /// Gets the In directory.
     /// </summary>
-    public string InDirectory
-        => Path.Combine(RootDeploymentDirectory, DeploymentInDirectorySuffix);
+    public string InDirectory { get; private set; }
 
     /// <summary>
     /// Gets the Out directory.
     /// </summary>
-    public string OutDirectory
-        => Path.Combine(RootDeploymentDirectory, DeploymentOutDirectorySuffix);
+    public string OutDirectory { get; private set; }
 
     /// <summary>
     /// Gets In\MachineName directory.
     /// </summary>
-    public string InMachineNameDirectory
-        => Path.Combine(Path.Combine(RootDeploymentDirectory, DeploymentInDirectorySuffix), Environment.MachineName);
+    public string InMachineNameDirectory { get; private set; }
 }
 
 #endif


### PR DESCRIPTION
Scenario being profiled:

Adjusted version of Playground with about 150 test method split across 10 test classes.

**Before**

![image](https://github.com/user-attachments/assets/dc358956-d93f-4034-a275-12763189f876)

**After**

No longer showing up:

![image](https://github.com/user-attachments/assets/0ac8df94-d61e-4fb2-958f-1a84d222a356)
