### PR TITLE
Don't make TestDataSourceDiscoveryOption obsolete

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/ReflectHelper.cs
@@ -272,7 +272,6 @@ internal class ReflectHelper : MarshalByRefObject
     /// Gets TestDataSourceDiscovery assembly level attribute.
     /// </summary>
     /// <param name="assembly"> The test assembly. </param>
-    [Obsolete]
     internal static TestDataSourceDiscoveryOption? GetTestDataSourceDiscoveryOption(Assembly assembly)
         => PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributes(assembly, typeof(TestDataSourceDiscoveryAttribute))
             .OfType<TestDataSourceDiscoveryAttribute>()

--- a/src/TestFramework/TestFramework/Attributes/DataSource/TestDataSourceDiscoveryAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/TestDataSourceDiscoveryAttribute.cs
@@ -1,17 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// Specifies how to discover <see cref="ITestDataSource"/> tests.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly)]
-#if NET6_0_OR_GREATER
-[Obsolete("Attribute is obsolete and will be removed in v4, instead use 'TestDataSourceOptionsAttribute'.", DiagnosticId = "MSTESTOBS")]
-#else
-[Obsolete("Attribute is obsolete and will be removed in v4, instead use 'TestDataSourceOptionsAttribute'.")]
-#endif
+[EditorBrowsable(EditorBrowsableState.Never)]
 public class TestDataSourceDiscoveryAttribute : Attribute
 {
     /// <summary>

--- a/src/TestFramework/TestFramework/Attributes/DataSource/TestDataSourceDiscoveryOption.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/TestDataSourceDiscoveryOption.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
 /// The supported discovery modes for <see cref="ITestDataSource"/> tests.
 /// </summary>
-#if NET6_0_OR_GREATER
-[Obsolete("Type is obsolete and will be removed in v4, instead use 'TestDataSourceUnfoldingStrategy'.", DiagnosticId = "MSTESTOBS")]
-#else
-[Obsolete("Type is obsolete and will be removed in v4, instead use 'TestDataSourceUnfoldingStrategy'.")]
-#endif
+[EditorBrowsable(EditorBrowsableState.Never)]
 public enum TestDataSourceDiscoveryOption
 {
     /// <summary>


### PR DESCRIPTION
Avoid warning/errors on users by removing added obsolete on `TestDataSourceDiscoveryOption`. Instead make it editor browsable hidden and update docs to recommend different usage.

In v4, based on remaining usages we would either deprecate and drop in v5 or drop directly in v4.