### PR TITLE
Reduce alloc in GetStackTraceInformation

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -79,7 +79,7 @@ internal static class ExceptionHelper
         {
             if (!first)
             {
-                result.Append(s_utaEndOfInnerExceptionTrace);
+                result.Append(utaEndOfInnerExceptionTrace);
             }
 
             result.Append(' ');
@@ -91,7 +91,7 @@ internal static class ExceptionHelper
         return CreateStackTraceInformation(ex, true, result.ToString());
     }
 
-    static readonly string s_utaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
+    private static readonly string utaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
 
     /// <summary>
     /// Removes all stack frames that refer to Microsoft.VisualStudio.TestTools.UnitTesting.Assertion.

--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -91,7 +91,7 @@ internal static class ExceptionHelper
         return CreateStackTraceInformation(ex, true, result.ToString());
     }
 
-    static string s_utaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
+    static readonly string s_utaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
 
     /// <summary>
     /// Removes all stack frames that refer to Microsoft.VisualStudio.TestTools.UnitTesting.Assertion.

--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -79,7 +79,7 @@ internal static class ExceptionHelper
         {
             if (!first)
             {
-                result.Append(utaEndOfInnerExceptionTrace);
+                result.Append(UtaEndOfInnerExceptionTrace);
             }
 
             result.Append(' ');
@@ -91,7 +91,7 @@ internal static class ExceptionHelper
         return CreateStackTraceInformation(ex, true, result.ToString());
     }
 
-    private static readonly string utaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
+    private static readonly string UtaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
 
     /// <summary>
     /// Removes all stack frames that refer to Microsoft.VisualStudio.TestTools.UnitTesting.Assertion.

--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -79,7 +79,7 @@ internal static class ExceptionHelper
         {
             if (!first)
             {
-                result.Append(UtaEndOfInnerExceptionTrace);
+                result.AppendLine(Resource.UTA_EndOfInnerExceptionTrace);
             }
 
             result.Append(' ');
@@ -90,8 +90,6 @@ internal static class ExceptionHelper
 
         return CreateStackTraceInformation(ex, true, result.ToString());
     }
-
-    private static readonly string UtaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
 
     /// <summary>
     /// Removes all stack frames that refer to Microsoft.VisualStudio.TestTools.UnitTesting.Assertion.

--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -77,17 +77,21 @@ internal static class ExceptionHelper
         bool first = true;
         while (stackTraces.Count != 0)
         {
-            result.AppendFormat(
-                    CultureInfo.CurrentCulture,
-                    "{0} {1}{2}",
-                    first ? string.Empty : (Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine),
-                    stackTraces.Pop(),
-                    Environment.NewLine);
+            if (!first)
+            {
+                result.Append(s_utaEndOfInnerExceptionTrace);
+            }
+
+            result.Append(' ');
+            result.AppendLine(stackTraces.Pop());
+
             first = false;
         }
 
         return CreateStackTraceInformation(ex, true, result.ToString());
     }
+
+    static string s_utaEndOfInnerExceptionTrace = Resource.UTA_EndOfInnerExceptionTrace + Environment.NewLine;
 
     /// <summary>
     /// Removes all stack frames that refer to Microsoft.VisualStudio.TestTools.UnitTesting.Assertion.


### PR DESCRIPTION
 * cache s_utaEndOfInnerExceptionTrace  statically to avoid the string concat on every iteration of the loop
 * remove CurrentCulture usage. they are all strings
 * avoid the concat with the popped value. yes this is redundant on newer runtimes, but not for older