### PR TITLE
Don't reference MTP in UWP

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
@@ -401,10 +401,12 @@ public class TestExecutionManager
             ExecuteTestsWithTestRunner(testsToRun, frameworkHandle, source, sourceLevelParameters, testRunner);
         }
 
+#if !WINDOWS_UWP
         if (MSTestGracefulStopTestExecutionCapability.Instance.IsStopRequested)
         {
             testRunner.ForceCleanup();
         }
+#endif
 
         PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Executed tests belonging to source {0}", source);
     }
@@ -426,10 +428,12 @@ public class TestExecutionManager
         foreach (TestCase currentTest in orderedTests)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
+#if !WINDOWS_UWP
             if (MSTestGracefulStopTestExecutionCapability.Instance.IsStopRequested)
             {
                 break;
             }
+#endif
 
             // If it is a fixture test, add it to the list of fixture tests and do not execute it.
             // It is executed by test itself.

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -48,7 +48,8 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTestAdapter.PlatformServices\MSTestAdapter.PlatformServices.csproj" />
-    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.VSTestBridge\Microsoft.Testing.Extensions.VSTestBridge.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.VSTestBridge\Microsoft.Testing.Extensions.VSTestBridge.csproj"
+                      Condition=" '$(TargetFramework)' != '$(UwpMinimum)' " />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Internal.Analyzers\MSTest.Internal.Analyzers.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/Adapter/MSTest.TestAdapter/RunConfigurationSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/RunConfigurationSettings.cs
@@ -2,10 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Xml;
 
+#if !WINDOWS_UWP
+using System.Globalization;
+
 using Microsoft.Testing.Platform.Configurations;
+#endif
+
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions;
@@ -166,6 +170,7 @@ public class RunConfigurationSettings
         return settings;
     }
 
+#if !WINDOWS_UWP
     internal static RunConfigurationSettings SetRunConfigurationSettingsFromConfig(IConfiguration configuration, RunConfigurationSettings settings)
     {
         // Expected format of the json is: -
@@ -195,4 +200,5 @@ public class RunConfigurationSettings
 
         return settings;
     }
+#endif
 }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestGracefulStopTestExecutionCapability.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestGracefulStopTestExecutionCapability.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !WINDOWS_UWP
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -23,3 +24,4 @@ internal sealed class MSTestGracefulStopTestExecutionCapability : IGracefulStopT
         return Task.CompletedTask;
     }
 }
+#endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IConfiguration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IConfiguration.cs
@@ -4,7 +4,7 @@
 #if WINDOWS_UWP
 namespace Microsoft.Testing.Platform.Configurations;
 
-public interface IConfiguration
+internal interface IConfiguration
 {
 }
 #endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IConfiguration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IConfiguration.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS_UWP
+namespace Microsoft.Testing.Platform.Configurations;
+
+public interface IConfiguration
+{
+}
+#endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <!-- SDK top import -->
   <Import Project="Sdk.props" Sdk="MSBuild.Sdk.Extras" Condition=" '$(OS)' == 'Windows_NT' " />
@@ -31,7 +31,8 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework.Extensions\TestFramework.Extensions.csproj" />
-    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.VSTestBridge\Microsoft.Testing.Extensions.VSTestBridge.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.VSTestBridge\Microsoft.Testing.Extensions.VSTestBridge.csproj"
+                      Condition=" '$(TargetFramework)' != '$(UwpMinimum)' " />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Internal.Analyzers\MSTest.Internal.Analyzers.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -39,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition=" '$(TargetFramework)' == '$(UwpMinimum)' " />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Condition=" '$(TargetFramework)' == '$(WinUiMinimum)' " />
   </ItemGroup>
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/uap10.0.16299/PublicAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/uap10.0.16299/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-Microsoft.Testing.Platform.Configurations.IConfiguration

--- a/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/uap10.0.16299/PublicAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PublicAPI/uap10.0.16299/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Testing.Platform.Configurations.IConfiguration


### PR DESCRIPTION
Contributes to #4371

Thanks to the report, I have realized we were about to ship a version of MSTest broken for UWP. We are sadly having issues with having acceptance test for UWP because of arcade infra.