### PR TITLE
use EnumPolyfill.GetNames correctly

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -503,11 +503,7 @@ public class MSTestSettings
                                         CultureInfo.CurrentCulture,
                                         Resource.InvalidClassCleanupLifecycleValue,
                                         value,
-#if NET
-                                        string.Join(", ", Enum.GetNames<ClassCleanupBehavior>())));
-#else
                                         string.Join(", ", EnumPolyfill.GetNames<ClassCleanupBehavior>())));
-#endif
 
                             break;
                         }
@@ -834,11 +830,7 @@ public class MSTestSettings
                                         CultureInfo.CurrentCulture,
                                         Resource.InvalidParallelScopeValue,
                                         value,
-#if NET
-                                        string.Join(", ", Enum.GetNames<ExecutionScope>())));
-#else
                                         string.Join(", ", EnumPolyfill.GetNames<ExecutionScope>())));
-#endif
 
                             break;
                         }
@@ -1001,11 +993,7 @@ public class MSTestSettings
                     CultureInfo.CurrentCulture,
                     Resource.InvalidClassCleanupLifecycleValue,
                     classCleanupLifecycle,
-#if NET
-                    string.Join(", ", Enum.GetNames<ClassCleanupBehavior>())));
-#else
                     string.Join(", ", EnumPolyfill.GetNames<ClassCleanupBehavior>())));
-#endif
             }
         }
 
@@ -1040,11 +1028,7 @@ public class MSTestSettings
                     CultureInfo.CurrentCulture,
                     Resource.InvalidParallelScopeValue,
                     value,
-#if NET
-                    string.Join(", ", Enum.GetNames<ExecutionScope>())));
-#else
                     string.Join(", ", EnumPolyfill.GetNames<ExecutionScope>())));
-#endif
             }
         }
 

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -983,11 +983,7 @@ public class MSTestSettings
 
         if (configuration["mstest:classCleanupLifecycle"] is string classCleanupLifecycle)
         {
-            if (TryParseEnum(classCleanupLifecycle, out ClassCleanupBehavior lifecycle))
-            {
-                settings.ClassCleanupLifecycle = lifecycle;
-            }
-            else
+            if (!TryParseEnum(classCleanupLifecycle, out ClassCleanupBehavior lifecycle))
             {
                 throw new AdapterSettingsException(string.Format(
                     CultureInfo.CurrentCulture,
@@ -995,6 +991,8 @@ public class MSTestSettings
                     classCleanupLifecycle,
                     string.Join(", ", EnumPolyfill.GetNames<ClassCleanupBehavior>())));
             }
+
+            settings.ClassCleanupLifecycle = lifecycle;
         }
 
         if (configuration["mstest:parallelism:workers"] is string workers)
@@ -1018,11 +1016,7 @@ public class MSTestSettings
         {
             value = value.Equals("class", StringComparison.OrdinalIgnoreCase) ? "ClassLevel"
                     : value.Equals("methood", StringComparison.OrdinalIgnoreCase) ? "MethodLevel" : value;
-            if (TryParseEnum(value, out ExecutionScope scope))
-            {
-                settings.ParallelizationScope = scope;
-            }
-            else
+            if (!TryParseEnum(value, out ExecutionScope scope))
             {
                 throw new AdapterSettingsException(string.Format(
                     CultureInfo.CurrentCulture,
@@ -1030,6 +1024,8 @@ public class MSTestSettings
                     value,
                     string.Join(", ", EnumPolyfill.GetNames<ExecutionScope>())));
             }
+
+            settings.ParallelizationScope = scope;
         }
 
         MSTestSettingsProvider.Load(configuration);


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

the *Polyfill types are meant to be used as a replacement to remove the need for the ifdef

on newer frameworks they redirect to correct implementation