### PR TITLE
Fix main build

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 
 using Analyzer.Utilities.Extensions;


### PR DESCRIPTION
History:

- https://github.com/microsoft/testfx/pull/4439 added the using due to the use of ConcurrentBag. This alone was green.
- https://github.com/microsoft/testfx/pull/4424 added System.Collections.Concurrent as global using. This alone was green.

When both PRs got to main, it's now failing because the using in the analyzer is now redundant due to it being already a global using.