### PR TITLE
Fix NaN behavior for Assert.AreEqual/AreNotEqual

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -648,11 +648,10 @@ public sealed partial class Assert
 
     private static bool AreEqualFailing(float expected, float actual, float delta)
     {
-        if (float.IsNaN(delta))
+        if (float.IsNaN(delta) || delta < 0)
         {
-            // NaN doesn't make sense as a delta value. Consider the assert failing.
-            // TODO: Maybe throwing ArgumentException is a better fit here?
-            return true;
+            // NaN and negative values don't make sense as a delta value.
+            throw new ArgumentOutOfRangeException(nameof(delta));
         }
 
         if (expected.Equals(actual))
@@ -669,12 +668,10 @@ public sealed partial class Assert
 
     private static bool AreEqualFailing(double expected, double actual, double delta)
     {
-        if (double.IsNaN(delta))
+        if (double.IsNaN(delta) || delta < 0)
         {
-            // Even if expected and actual are same, NaN doesn't make much sense as a value of delta.
-            // We fail the assert.
-            // TODO: Maybe throwing ArgumentException is a better fit here?
-            return true;
+            // NaN and negative values don't make sense as a delta value.
+            throw new ArgumentOutOfRangeException(nameof(delta));
         }
 
         if (expected.Equals(actual))
@@ -685,7 +682,7 @@ public sealed partial class Assert
         // If both doubles are NaN, then they were considered equal in the previous check.
         // If only one of them is NaN, then they are not equal regardless of the value of delta.
         // Then, the subtraction comparison to delta isn't involving NaNs.
-        return double.IsNaN(expected) || double.IsNaN(actual) || double.IsNaN(delta) ||
+        return double.IsNaN(expected) || double.IsNaN(actual) ||
                 Math.Abs(expected - actual) > delta;
     }
 
@@ -1122,11 +1119,10 @@ public sealed partial class Assert
 
     private static bool AreNotEqualFailing(float notExpected, float actual, float delta)
     {
-        if (float.IsNaN(delta))
+        if (float.IsNaN(delta) || delta < 0)
         {
-            // NaN doesn't make sense as a delta value. Consider the assert failing.
-            // TODO: Maybe throwing ArgumentException is a better fit here?
-            return true;
+            // NaN and negative values don't make sense as a delta value.
+            throw new ArgumentOutOfRangeException(nameof(delta));
         }
 
         if (float.IsNaN(notExpected) && float.IsNaN(actual))
@@ -1700,11 +1696,10 @@ public sealed partial class Assert
 
     private static bool AreNotEqualFailing(double notExpected, double actual, double delta)
     {
-        if (double.IsNaN(delta))
+        if (double.IsNaN(delta) || delta < 0)
         {
-            // NaN doesn't make sense as a delta value. Consider the assert failing.
-            // TODO: Maybe throwing ArgumentException is a better fit here?
-            return true;
+            // NaN and negative values don't make sense as a delta value.
+            throw new ArgumentOutOfRangeException(nameof(delta));
         }
 
         if (double.IsNaN(notExpected) && double.IsNaN(actual))

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -647,12 +647,47 @@ public sealed partial class Assert
         => CompareInternal(expected, actual, ignoreCase, culture) != 0;
 
     private static bool AreEqualFailing(float expected, float actual, float delta)
-        => float.IsNaN(expected) || float.IsNaN(actual) || float.IsNaN(delta) ||
-            Math.Abs(expected - actual) > delta;
+    {
+        if (float.IsNaN(delta))
+        {
+            // NaN doesn't make sense as a delta value. Consider the assert failing.
+            // TODO: Maybe throwing ArgumentException is a better fit here?
+            return true;
+        }
+
+        if (expected.Equals(actual))
+        {
+            return false;
+        }
+
+        // If both floats are NaN, then they were considered equal in the previous check.
+        // If only one of them is NaN, then they are not equal regardless of the value of delta.
+        // Then, the subtraction comparison to delta isn't involving NaNs.
+        return float.IsNaN(expected) || float.IsNaN(actual) ||
+                Math.Abs(expected - actual) > delta;
+    }
 
     private static bool AreEqualFailing(double expected, double actual, double delta)
-        => double.IsNaN(expected) || double.IsNaN(actual) || double.IsNaN(delta) ||
-            Math.Abs(expected - actual) > delta;
+    {
+        if (double.IsNaN(delta))
+        {
+            // Even if expected and actual are same, NaN doesn't make much sense as a value of delta.
+            // We fail the assert.
+            // TODO: Maybe throwing ArgumentException is a better fit here?
+            return true;
+        }
+
+        if (expected.Equals(actual))
+        {
+            return false;
+        }
+
+        // If both doubles are NaN, then they were considered equal in the previous check.
+        // If only one of them is NaN, then they are not equal regardless of the value of delta.
+        // Then, the subtraction comparison to delta isn't involving NaNs.
+        return double.IsNaN(expected) || double.IsNaN(actual) || double.IsNaN(delta) ||
+                Math.Abs(expected - actual) > delta;
+    }
 
     private static bool AreEqualFailing(decimal expected, decimal actual, decimal delta)
         => Math.Abs(expected - actual) > delta;
@@ -1086,7 +1121,26 @@ public sealed partial class Assert
     }
 
     private static bool AreNotEqualFailing(float notExpected, float actual, float delta)
-        => Math.Abs(notExpected - actual) <= delta;
+    {
+        if (float.IsNaN(delta))
+        {
+            // NaN doesn't make sense as a delta value. Consider the assert failing.
+            // TODO: Maybe throwing ArgumentException is a better fit here?
+            return true;
+        }
+
+        if (float.IsNaN(notExpected) && float.IsNaN(actual))
+        {
+            // If both notExpected and actual are NaN, then AreNotEqual should fail.
+            return true;
+        }
+
+        // Note: if both notExpected and actual are NaN, that was handled separately above.
+        // Now, if both are numerics, then the logic is good.
+        // And, if only one of them is NaN, we know they are not equal, meaning AreNotEqual shouldn't fail.
+        // And in this case we will correctly be returning false, because NaN <= anything is always false.
+        return Math.Abs(notExpected - actual) <= delta;
+    }
 
     /// <summary>
     /// Tests whether the specified decimals are equal and throws an exception
@@ -1645,7 +1699,26 @@ public sealed partial class Assert
     }
 
     private static bool AreNotEqualFailing(double notExpected, double actual, double delta)
-        => Math.Abs(notExpected - actual) <= delta;
+    {
+        if (double.IsNaN(delta))
+        {
+            // NaN doesn't make sense as a delta value. Consider the assert failing.
+            // TODO: Maybe throwing ArgumentException is a better fit here?
+            return true;
+        }
+
+        if (double.IsNaN(notExpected) && double.IsNaN(actual))
+        {
+            // If both notExpected and actual are NaN, then AreNotEqual should fail.
+            return true;
+        }
+
+        // Note: if both notExpected and actual are NaN, that was handled separately above.
+        // Now, if both are numerics, then the logic is good.
+        // And, if only one of them is NaN, we know they are not equal, meaning AreNotEqual shouldn't fail.
+        // And in this case we will correctly be returning false, because NaN <= anything is always false.
+        return Math.Abs(notExpected - actual) <= delta;
+    }
 
     [DoesNotReturn]
     private static void ThrowAssertAreNotEqualFailed<T>(T notExpected, T actual, T delta, string userMessage)

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -451,6 +451,250 @@ public partial class AssertTests : TestContainer
         Verify(o.WasToStringCalled);
     }
 
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, float.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <2>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, float.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <1>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, float.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <1>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, float.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, float.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <NaN>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(5.0f, 2.0f, 2.0f)); // difference is 3. Delta is 2
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <5> and actual value <2>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaNegative_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(2.0f, 5.0f, 2.0f)); // difference is -3. Delta is 2
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <2> and actual value <5>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaPositive_DeltaIsNumeric_ShouldPass()
+        => Assert.AreEqual(5.0f, 4.0f, 2.0f); // difference is 1. Delta is 2
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaNegative_DeltaIsNumeric_ShouldFail()
+        => Assert.AreEqual(4.0f, 5.0f, 2.0f); // difference is -1. Delta is 2
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(5.0f, float.NaN, 2.0f));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <5> and actual value <NaN>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 5.0f, 2.0f));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <NaN> and actual value <5>. ");
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNumeric_ShouldPass()
+        => Assert.AreEqual(float.NaN, float.NaN, 2.0f);
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, float.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <2>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, float.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <1>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, float.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <1>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, float.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, float.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <NaN>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldPass()
+        => Assert.AreNotEqual(5.0f, 2.0f, 2.0f); // difference is 3. Delta is 2
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaNegative_DeltaIsNumeric_ShouldPass()
+        => Assert.AreNotEqual(2.0f, 5.0f, 2.0f); // difference is -3. Delta is 2
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaPositive_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(5.0f, 4.0f, 2.0f)); // difference is 1. Delta is 2
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <2> between expected value <5> and actual value <4>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaNegative_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(4.0f, 5.0f, 2.0f)); // difference is -1. Delta is 2
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <2> between expected value <4> and actual value <5>. ");
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNumeric_ShouldPass() => Assert.AreNotEqual(5.0f, float.NaN, 2.0f);
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNumeric_ShouldPass()
+        => Assert.AreNotEqual(float.NaN, 5.0f, 2.0f);
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, 2.0f));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <2> between expected value <NaN> and actual value <NaN>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, double.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <2>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, double.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <1>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, double.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <1>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, double.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, double.NaN));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <NaN>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(5.0d, 2.0d, 2.0d)); // difference is 3. Delta is 2
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <5> and actual value <2>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaNegative_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(2.0d, 5.0d, 2.0d)); // difference is -3. Delta is 2
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <2> and actual value <5>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaPositive_DeltaIsNumeric_ShouldPass()
+        => Assert.AreEqual(5.0d, 4.0d, 2.0d); // difference is 1. Delta is 2
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaNegative_DeltaIsNumeric_ShouldFail()
+        => Assert.AreEqual(4.0d, 5.0d, 2.0d); // difference is -1. Delta is 2
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(5.0d, double.NaN, 2.0d));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <5> and actual value <NaN>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 5.0d, 2.0d));
+        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <2> between expected value <NaN> and actual value <5>. ");
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNumeric_ShouldPass()
+        => Assert.AreEqual(double.NaN, double.NaN, 2.0d);
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, double.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <2>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, double.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <1>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, double.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <1>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, double.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, double.NaN));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <NaN>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldPass()
+        => Assert.AreNotEqual(5.0d, 2.0d, 2.0d); // difference is 3. Delta is 2
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaNegative_DeltaIsNumeric_ShouldPass()
+        => Assert.AreNotEqual(2.0d, 5.0d, 2.0d); // difference is -3. Delta is 2
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaPositive_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(5.0d, 4.0d, 2.0d)); // difference is 1. Delta is 2
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <2> between expected value <5> and actual value <4>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceLessThanDeltaNegative_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(4.0d, 5.0d, 2.0d)); // difference is -1. Delta is 2
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <2> between expected value <4> and actual value <5>. ");
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNumeric_ShouldPass() => Assert.AreNotEqual(5.0d, double.NaN, 2.0d);
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNumeric_ShouldPass()
+        => Assert.AreNotEqual(double.NaN, 5.0d, 2.0d);
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNumeric_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, 2.0d));
+        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <2> between expected value <NaN> and actual value <NaN>. ");
+    }
+
     private CultureInfo? GetCultureInfo() => CultureInfo.CurrentCulture;
 
     private class TypeOverridesEquals

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -454,31 +454,136 @@ public partial class AssertTests : TestContainer
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, float.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <2>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, float.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, float.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, float.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, float.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldFail()
@@ -517,31 +622,136 @@ public partial class AssertTests : TestContainer
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, float.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <2>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, float.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, float.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, float.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, float.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, -1.0f));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, float.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldPass()
@@ -576,31 +786,136 @@ public partial class AssertTests : TestContainer
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, double.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <2>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, double.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, double.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, double.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, double.NaN));
-        Verify(ex.Message == "Assert.AreEqual failed. Expected a difference no greater than <NaN> between expected value <1> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldFail()
@@ -639,31 +954,136 @@ public partial class AssertTests : TestContainer
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, double.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <2>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, double.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, double.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <1>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, double.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <NaN> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, double.NaN));
-        Verify(ex.Message == "Assert.AreNotEqual failed. Expected a difference greater than <NaN> between expected value <1> and actual value <NaN>. ");
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, -1.0d));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
+    }
+
+    public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
+    {
+        Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, double.NegativeInfinity));
+        Verify(ex.Message == """
+            Specified argument was out of the range of valid values.
+            Parameter name: delta
+            """);
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldPass()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -454,136 +454,136 @@ public partial class AssertTests : TestContainer
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 2.0f, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, 1.0f, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, 1.0f, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(float.NaN, float.NaN, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0f, float.NaN, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldFail()
@@ -622,136 +622,136 @@ public partial class AssertTests : TestContainer
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, float.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 2.0f, -1.0f));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, 1.0f, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, 1.0f, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(float.NaN, float.NaN, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0f, float.NaN, float.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void FloatAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldPass()
@@ -786,136 +786,136 @@ public partial class AssertTests : TestContainer
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 2.0d, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, 1.0d, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, 1.0d, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(double.NaN, double.NaN, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreEqual(1.0d, double.NaN, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldFail()
@@ -954,136 +954,136 @@ public partial class AssertTests : TestContainer
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, double.NaN));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegative_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, -1.0d));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 2.0d, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, 1.0d, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, 1.0d, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(double.NaN, double.NaN, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNegativeInf_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.AreNotEqual(1.0d, double.NaN, double.NegativeInfinity));
-        Verify(ex.Message == """
+        Verify(ex.Message is """
             Specified argument was out of the range of valid values.
             Parameter name: delta
-            """);
+            """ or "Specified argument was out of the range of valid values. (Parameter 'delta')");
     }
 
     public void DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualDifferenceGreaterThanDeltaPositive_DeltaIsNumeric_ShouldPass()


### PR DESCRIPTION
Running the new tests on main, there are 14 failures. 7 are for `float` and 7 are for `double`. I'll list the test names for `float` failures only as the double ones are exact mirror.

```
DoubleAreEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNumeric_ShouldPass
DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNaN_ShouldFail
DoubleAreNotEqual_ExpectedIsNaN_ActualIsNaN_DeltaIsNumeric_ShouldFail
DoubleAreNotEqual_ExpectedIsNaN_ActualIsNumeric_DeltaIsNaN_ShouldFail
DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNaN_DeltaIsNaN_ShouldFail
DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualEquals_DeltaIsNaN_ShouldFail
DoubleAreNotEqual_ExpectedIsNumeric_ActualIsNumeric_ExpectedAndActualNotEquals_DeltaIsNaN_ShouldFail
```

Fixes #4530