### PR TITLE
Fix "Could not load file or assembly 'Microsoft.Testing.Platform'" exception

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -22,7 +22,7 @@ function Confirm-NugetPackages {
         "MSTest.Sdk"                            = 15;
         "MSTest.Internal.TestFx.Documentation"  = 10;
         "MSTest.TestFramework"                  = 148;
-        "MSTest.TestAdapter"                    = 74;
+        "MSTest.TestAdapter"                    = 75;
         "MSTest"                                = 6;
         "MSTest.Analyzers"                      = 50;
     }

--- a/src/Adapter/MSTest.TestAdapter/BannedSymbols.txt
+++ b/src/Adapter/MSTest.TestAdapter/BannedSymbols.txt
@@ -1,1 +1,2 @@
 ﻿M:Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.ReflectHelper.#ctor; This is allowed only for tests.
+N:Microsoft.Testing.Platform

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
@@ -401,12 +401,10 @@ public class TestExecutionManager
             ExecuteTestsWithTestRunner(testsToRun, frameworkHandle, source, sourceLevelParameters, testRunner);
         }
 
-#if !WINDOWS_UWP
-        if (MSTestGracefulStopTestExecutionCapability.Instance.IsStopRequested)
+        if (PlatformServiceProvider.Instance.IsGracefulStopRequested)
         {
             testRunner.ForceCleanup();
         }
-#endif
 
         PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Executed tests belonging to source {0}", source);
     }
@@ -428,12 +426,10 @@ public class TestExecutionManager
         foreach (TestCase currentTest in orderedTests)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
-#if !WINDOWS_UWP
-            if (MSTestGracefulStopTestExecutionCapability.Instance.IsStopRequested)
+            if (PlatformServiceProvider.Instance.IsGracefulStopRequested)
             {
                 break;
             }
-#endif
 
             // If it is a fixture test, add it to the list of fixture tests and do not execute it.
             // It is executed by test itself.

--- a/src/Adapter/MSTest.TestAdapter/Helpers/MSTestDiscovererHelpers.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/MSTestDiscovererHelpers.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 

--- a/src/Adapter/MSTest.TestAdapter/IPlatformServiceProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/IPlatformServiceProvider.cs
@@ -56,6 +56,8 @@ internal interface IPlatformServiceProvider
     /// </summary>
     TestRunCancellationToken? TestRunCancellationToken { get; set; }
 
+    bool IsGracefulStopRequested { get; set; }
+
     /// <summary>
     /// Creates an instance to the platform service for a test source host.
     /// </summary>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -99,6 +99,16 @@
     <file src="net462\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="build\net462\" />
     <file src="net462\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="build\net462\" />
     <file src="net462\Microsoft.TestPlatform.AdapterUtilities.dll" target="build\net462\" />
+    <!--
+      For .NET Framework, when using AppDomains (default) with VSTest, VSTest uses a custom assembly resolver that only
+      considers VS folders and MSTest.TestAdapter NuGet folder to look for deps, resulting in TestFramework.dll not
+      being found.
+      There is no way to fix this issue, but we can work around it by copying the TestFramework.dll to the NuGet
+      folder, as it was done before 3.7 cleanup. The original issue mentions MTP which is fixed by not taking explicit
+      deps to it in the "engine" project and keep them only under the TestingPlatformAdapter folder.
+      See https://github.com/microsoft/testfx/issues/4426
+    -->
+    <file src="net462\Microsoft.VisualStudio.TestPlatform.TestFramework.dll" target="build\net462\" />
 
     <!-- Localization -->
     <!-- All TFMs share the same resx, copy only TestAdapter TestAdapter.PlatformServices, do NOT copy TestFramework and other dependency resource dlls. -->

--- a/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestSettings.cs
@@ -6,8 +6,8 @@ using System.Globalization;
 using System.Xml;
 using System.Xml.Linq;
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 #if !WINDOWS_UWP
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 #endif

--- a/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/PlatformServiceProvider.cs
@@ -140,6 +140,8 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     /// </summary>
     public TestRunCancellationToken? TestRunCancellationToken { get; set; }
 
+    public bool IsGracefulStopRequested { get; set; }
+
     /// <summary>
     /// Gets or sets the instance for the platform service.
     /// </summary>

--- a/src/Adapter/MSTest.TestAdapter/RunConfigurationSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/RunConfigurationSettings.cs
@@ -7,7 +7,7 @@ using System.Xml;
 #if !WINDOWS_UWP
 using System.Globalization;
 
-using Microsoft.Testing.Platform.Configurations;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 #endif
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/BridgedConfiguration.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/BridgedConfiguration.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Testing.Platform.Configurations;
+
+using PlatformServicesConfiguration = Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.IConfiguration;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class BridgedConfiguration : PlatformServicesConfiguration
+{
+    private readonly IConfiguration _configuration;
+
+    public BridgedConfiguration(IConfiguration configuration)
+        => _configuration = configuration;
+
+    public string? this[string key] => _configuration[key];
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBannerCapability.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBannerCapability.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -11,6 +12,8 @@ using Microsoft.Testing.Platform.Services;
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 internal sealed class MSTestBannerCapability : IBannerMessageOwnerCapability
 {
     private readonly IPlatformInformation _platformInformation;

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
@@ -3,26 +3,27 @@
 
 #if !WINDOWS_UWP
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Microsoft.Testing.Extensions.VSTestBridge;
 using Microsoft.Testing.Extensions.VSTestBridge.Requests;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.Services;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTestBridgedTestFramework
 {
-    private readonly IConfiguration? _configuration;
+    private readonly BridgedConfiguration? _configuration;
 
     public MSTestBridgedTestFramework(MSTestExtension mstestExtension, Func<IEnumerable<Assembly>> getTestAssemblies,
         IServiceProvider serviceProvider, ITestFrameworkCapabilities capabilities)
         : base(mstestExtension, getTestAssemblies, serviceProvider, capabilities)
-        => _configuration = serviceProvider.GetConfiguration();
+        => _configuration = new(serviceProvider.GetConfiguration());
 
     /// <inheritdoc />
     protected override Task SynchronizedDiscoverTestsAsync(VSTestDiscoverTestExecutionRequest request, IMessageBus messageBus,

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestExtension.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestExtension.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Microsoft.Testing.Platform.Extensions;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 internal sealed class MSTestExtension : IExtension
 {
     public string Uid { get; } = GetExtensionUid();

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestGracefulStopTestExecutionCapability.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestGracefulStopTestExecutionCapability.cs
@@ -2,11 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 internal sealed class MSTestGracefulStopTestExecutionCapability : IGracefulStopTestExecutionCapability
 #pragma warning restore TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 {
@@ -16,11 +21,9 @@ internal sealed class MSTestGracefulStopTestExecutionCapability : IGracefulStopT
 
     public static MSTestGracefulStopTestExecutionCapability Instance { get; } = new();
 
-    public bool IsStopRequested { get; private set; }
-
     public Task StopTestExecutionAsync(CancellationToken cancellationToken)
     {
-        IsStopRequested = true;
+        PlatformServiceProvider.Instance.IsGracefulStopRequested = true;
         return Task.CompletedTask;
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
@@ -13,6 +14,7 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 public static class TestApplicationBuilderExtensions
 {
     public static void AddMSTest(this ITestApplicationBuilder testApplicationBuilder, Func<IEnumerable<Assembly>> getTestAssemblies)

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestingPlatformBuilderHook.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestingPlatformBuilderHook.cs
@@ -2,15 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Microsoft.Testing.Platform.Builder;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 public static class TestingPlatformBuilderHook
 {
 #pragma warning disable IDE0060 // Remove unused parameter
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] arguments) => testApplicationBuilder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] arguments)
+        => testApplicationBuilder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 }
 #endif

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.Configurations;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -34,7 +34,8 @@ public class MSTestDiscoverer : ITestDiscoverer
     /// <param name="discoverySink">Used to send testcases and discovery related events back to Discoverer manager.</param>
     [System.Security.SecurityCritical]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0", Justification = "Discovery context can be null.")]
-    public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink) => MSTestDiscoverer.DiscoverTests(sources, discoveryContext, logger, discoverySink, null);
+    public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+        => DiscoverTests(sources, discoveryContext, logger, discoverySink, null);
 
     internal static void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, IConfiguration? configuration)
     {

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -3,8 +3,8 @@
 
 using System.Runtime.InteropServices;
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -51,9 +51,11 @@ public class MSTestExecutor : ITestExecutor
     /// </summary>
     public TestExecutionManager TestExecutionManager { get; protected set; }
 
-    public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle) => RunTests(tests, runContext, frameworkHandle, null);
+    public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+        => RunTests(tests, runContext, frameworkHandle, null);
 
-    public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle) => RunTests(sources, runContext, frameworkHandle, null);
+    public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
+        => RunTests(sources, runContext, frameworkHandle, null);
 
     internal void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration)
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IConfiguration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IConfiguration.cs
@@ -1,10 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if WINDOWS_UWP
-namespace Microsoft.Testing.Platform.Configurations;
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 
+/// <summary>
+/// Represents a configuration interface.
+/// </summary>
 internal interface IConfiguration
 {
+    /// <summary>
+    /// Gets or sets the value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the value to get or set.</param>
+    /// <returns>The value associated with the specified key.</returns>
+    string? this[string key] { get; }
 }
-#endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -31,8 +31,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework.Extensions\TestFramework.Extensions.csproj" />
-    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.VSTestBridge\Microsoft.Testing.Extensions.VSTestBridge.csproj"
-                      Condition=" '$(TargetFramework)' != '$(UwpMinimum)' " />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Internal.Analyzers\MSTest.Internal.Analyzers.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -40,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition=" '$(TargetFramework)' == '$(UwpMinimum)' " />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Condition=" '$(TargetFramework)' == '$(WinUiMinimum)' " />
   </ItemGroup>
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
@@ -5,7 +5,7 @@
 using System.Globalization;
 using System.Xml;
 
-using Microsoft.Testing.Platform.Configurations;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Xml;
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
@@ -3,8 +3,8 @@
 
 using System.Xml;
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestSettingsTests.cs
@@ -3,9 +3,9 @@
 
 using System.Xml;
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/test/UnitTests/MSTestAdapter.UnitTests/RunConfigurationSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/RunConfigurationSettingsTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.Configurations;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;

--- a/test/UnitTests/MSTestAdapter.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
@@ -125,6 +125,8 @@ internal class TestablePlatformServiceProvider : IPlatformServiceProvider
 
     public TestRunCancellationToken TestRunCancellationToken { get; set; }
 
+    public bool IsGracefulStopRequested { get; set; }
+
     public ITestContext GetTestContext(ITestMethod testMethod, StringWriter writer, IDictionary<string, object> properties) => new TestContextImplementation(testMethod, writer, properties);
 
     public ITestSourceHost CreateTestSourceHost(string source, TestPlatform.ObjectModel.Adapter.IRunSettings runSettings, TestPlatform.ObjectModel.Adapter.IFrameworkHandle frameworkHandle) => MockTestSourceHost.Object;


### PR DESCRIPTION
During the investigation, I realized that VSTest custom assembly resolver, enabled only when AppDomains are enabled and only for netfx, includes only VS folders and MSTest.TestAdapter. On 3.7, we started to depend upon some types from MTP leading to the dll being required but not loaded in this mode (the deps is part of a different NuGet). 

As part of the analysis, I have also noticed that we are required to keep the framework under the adapter folder for the exact same reason.

I have restored the framework, only for netfx, that will be resolved only when under the customer resolver for netfx in VSTest. For MTP, I have decided not to copy the dll but instead to have wrapper types so we don't "pollute" the engine with types specific to a given platform.

Fixes #4426