### PR TITLE
Add dotnet test client to be used in dotnet/sdk

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -214,6 +214,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Testing.Extension
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Testing.Extensions.Retry", "src\Platform\Microsoft.Testing.Extensions.Retry\Microsoft.Testing.Extensions.Retry.csproj", "{FB4ED3AA-A12E-4192-861F-4B025876AA0F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Testing.Platform.DotNetTestClient", "src\Package\Microsoft.Testing.Platform.DotNetTestClient\Microsoft.Testing.Platform.DotNetTestClient.csproj", "{4E4F965E-2EEF-471B-A5DA-A53BFA967A95}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -500,6 +502,10 @@ Global
 		{FB4ED3AA-A12E-4192-861F-4B025876AA0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB4ED3AA-A12E-4192-861F-4B025876AA0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB4ED3AA-A12E-4192-861F-4B025876AA0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E4F965E-2EEF-471B-A5DA-A53BFA967A95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E4F965E-2EEF-471B-A5DA-A53BFA967A95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E4F965E-2EEF-471B-A5DA-A53BFA967A95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E4F965E-2EEF-471B-A5DA-A53BFA967A95}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -587,6 +593,7 @@ Global
 		{4A93E1A2-B61E-31B2-33F2-478156A9B5E7} = {E7F15C9C-3928-47AD-8462-64FD29FFCA54}
 		{53EBA540-F6CF-0715-1F62-241A53F537EC} = {6AEE1440-FDF0-4729-8196-B24D0E333550}
 		{FB4ED3AA-A12E-4192-861F-4B025876AA0F} = {6AEE1440-FDF0-4729-8196-B24D0E333550}
+		{4E4F965E-2EEF-471B-A5DA-A53BFA967A95} = {E374A3A6-C364-4890-B315-D60F5C682B6E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31E0F4D5-975A-41CC-933E-545B2201FAF9}

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,9 +6,9 @@
 
   <Choose>
     <When Condition=" '$(DotNetBuildSourceOnly)' == 'true' ">
-      <!-- When building for source build we only want to build the platform, this is the only component shared to dotnet/sdk. -->
-      <ItemGroup>
-        <ProjectToBuild Include="$(RepoRoot)src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj" />
+      <!-- When building for source build we only want to build the DotnetTestClient, this is the only component shared to dotnet/sdk. -->
+      <ItemGroup>  
+        <ProjectToBuild Include="$(RepoRoot)src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -7,7 +7,7 @@
   <Choose>
     <When Condition=" '$(DotNetBuildSourceOnly)' == 'true' ">
       <!-- When building for source build we only want to build the DotnetTestClient, this is the only component shared to dotnet/sdk. -->
-      <ItemGroup>  
+      <ItemGroup>
         <ProjectToBuild Include="$(RepoRoot)src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj" />
       </ItemGroup>
     </When>

--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 Param(
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [System.String] $configuration
 )
 
@@ -19,12 +19,13 @@ function Unzip {
 function Confirm-NugetPackages {
     Write-Verbose "Starting Confirm-NugetPackages."
     $expectedNumOfFiles = @{
-        "MSTest.Sdk"                            = 15;
-        "MSTest.Internal.TestFx.Documentation"  = 10;
-        "MSTest.TestFramework"                  = 148;
-        "MSTest.TestAdapter"                    = 74;
-        "MSTest"                                = 6;
-        "MSTest.Analyzers"                      = 50;
+        "MSTest.Sdk"                                  = 15
+        "MSTest.Internal.TestFx.Documentation"        = 10
+        "MSTest.TestFramework"                        = 148
+        "MSTest.TestAdapter"                          = 74
+        "MSTest"                                      = 6
+        "MSTest.Analyzers"                            = 50
+        "Microsoft.Testing.Platform.DotNetTestClient" = 7
     }
 
     $packageDirectory = Resolve-Path "$PSScriptRoot/../artifacts/packages/$configuration"
@@ -79,7 +80,8 @@ function Confirm-NugetPackages {
 
     if ($errors) {
         Write-Error "Validation of NuGet packages failed with $($errors.Count) errors:`n$($errors -join "`n")"
-    } else {
+    }
+    else {
         Write-Host "Successfully validated content of NuGet packages"
     }
 }

--- a/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj
+++ b/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <!--
+      This package ships shipped dlls that are consumed by dotnet/sdk and shipped after repacking.
+      Based on this definition such nuget is not shipping, because it does not directly ship the dlls to customers.
+      https://github.com/dotnet/arcade/blob/main/Documentation/ArcadeSdk.md#project-properties-defined-by-the-sdk
+    -->
+    <IsShipping>false</IsShipping>
+    <NuspecFile>Microsoft.Testing.Platform.DotNetTestClient.nuspec</NuspecFile>
+    <NuspecBasePath>$(OutputPath)</NuspecBasePath>
+    <PackageId>Microsoft.Testing.Platform.DotNetTestClient</PackageId>
+    <PackageTags></PackageTags>
+    <PackageDescription>
+      This package contains types that are required by `dotnet test` in dotnet/SDK to communicate with an Microsoft.Testing.Platform test executable.
+
+      Supported platforms:
+      - .NET 10
+    </PackageDescription>
+    <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\**\*.cs" LinkBase="IPC" />
+    <Compile Remove="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\DotnetTestDataConsumer.cs" />
+
+    <Compile Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\IPC\I*.cs" LinkBase="IPC" />
+    <Compile Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\IPC\NamedPipeBase.cs" LinkBase="IPC" />
+    <Compile Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\IPC\PipeNameDescription.cs" LinkBase="IPC" />
+    <Compile Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\IPC\*\*.cs" LinkBase="IPC" />
+
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ApplicationStateGuard.cs" LinkBase="Helpers" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynDebug.cs" LinkBase="Helpers" />
+
+    <EmbeddedResource Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.resx" GenerateSource="true" LinkBase="Resources" Namespace="Microsoft.Testing.Platform.Resources" />
+  </ItemGroup>
+
+  <ItemGroup Label="NuGet">
+    <NuspecProperty Include="TestPlatformVersion=$(MicrosoftNETTestSdkVersion)" />
+    <NuspecProperty Include="RepoRoot=$(RepoRoot)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj
+++ b/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net9.0</TargetFrameworks>
+    <VersionPrefix>$(TestingPlatformVersionPrefix)</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,6 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="dotnet" Key="$(MicrosoftAspNetCorePublicKey)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\**\*.cs" LinkBase="IPC" />
     <Compile Remove="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\DotnetTestDataConsumer.cs" />
 
@@ -36,7 +41,18 @@
 
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ApplicationStateGuard.cs" LinkBase="Helpers" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynDebug.cs" LinkBase="Helpers" />
-
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" LinkBase="Helpers" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\IConsole.cs" LinkBase="Helpers" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\IStopwatch.cs" LinkBase="Helpers" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\SystemStopwatch.cs" LinkBase="Helpers" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\SystemConsole.cs" LinkBase="Helpers" />
+    
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\SystemConsoleColor.cs" LinkBase="Terminal" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\IColor.cs" LinkBase="Terminal" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\Terminal\*" LinkBase="Terminal" />
+    <Compile Remove="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\Terminal\TerminalTestReporterCommandLineOptionsProvider.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" LinkBase="Terminal" />
+    
     <EmbeddedResource Include="$(RepoRoot)\src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.resx" GenerateSource="true" LinkBase="Resources" Namespace="Microsoft.Testing.Platform.Resources" />
   </ItemGroup>
 

--- a/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj
+++ b/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.csproj
@@ -57,7 +57,6 @@
   </ItemGroup>
 
   <ItemGroup Label="NuGet">
-    <NuspecProperty Include="TestPlatformVersion=$(MicrosoftNETTestSdkVersion)" />
     <NuspecProperty Include="RepoRoot=$(RepoRoot)" />
   </ItemGroup>
 

--- a/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.nuspec
+++ b/src/Package/Microsoft.Testing.Platform.DotNetTestClient/Microsoft.Testing.Platform.DotNetTestClient.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    $CommonMetadataElements$
+    <readme>PACKAGE.md</readme>
+    <dependencies>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    $CommonFileElements$
+
+    <file src="net9.0\Microsoft.Testing.Platform.DotNetTestClient.dll" target="lib\net9.0\" />
+    <file src="$RepoRoot$src\Package\MSTest\PACKAGE.md" target="" />
+  </files>
+</package>

--- a/src/Package/Microsoft.Testing.Platform.DotNetTestClient/PACKAGE.md
+++ b/src/Package/Microsoft.Testing.Platform.DotNetTestClient/PACKAGE.md
@@ -1,0 +1,7 @@
+# Microsoft.Testing.Platform.DotNetTestClient
+
+This package contains types that are required by `dotnet test` in dotnet/SDK to communicate with an Microsoft.Testing.Platform test executable.
+
+Supported platforms:
+
+- .NET 10

--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -48,7 +48,6 @@ This package provides the core platform and the .NET implementation of the proto
   <!-- end netstandard2.0 polyfill -->
 
   <ItemGroup>
-    <InternalsVisibleTo Include="dotnet" Key="$(MicrosoftAspNetCorePublicKey)" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.CrashDump" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.Experimental" Key="$(VsPublicKey)" />


### PR DESCRIPTION
Add selected classes to make a package with no dependencies that can be shipped into dotnet/sdk to minimize the dependencies we need in source build.