### PR TITLE
Set MTP editorconfig as non-root explicitly

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/.editorconfig
+++ b/src/Platform/Microsoft.Testing.Platform/.editorconfig
@@ -1,3 +1,5 @@
+root = false
+
 [*.{cs,vb}]
 # TPEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 dotnet_diagnostic.TPEXP.severity = none


### PR DESCRIPTION
Maybe this is already the default, I don't know. But it's better to be explicit IMO.