### PR TITLE
Implement codefix for 'Are[Not]Same' usage with value types

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidAssertAreSameWithValueTypesFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidAssertAreSameWithValueTypesFixer.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+
+using Analyzer.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AvoidAssertAreSameWithValueTypesFixer))]
+[Shared]
+public sealed class AvoidAssertAreSameWithValueTypesFixer : CodeFixProvider
+{
+    public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(DiagnosticIds.AvoidAssertAreSameWithValueTypesRuleId);
+
+    public override FixAllProvider GetFixAllProvider()
+        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        Diagnostic diagnostic = context.Diagnostics[0];
+
+        string? replacement = diagnostic.Properties[AvoidAssertAreSameWithValueTypesAnalyzer.ReplacemenyKey]
+            ?? throw ApplicationStateGuard.Unreachable();
+
+        SyntaxNode diagnosticNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        if (diagnosticNode is not InvocationExpressionSyntax invocation)
+        {
+            Debug.Fail($"Is this an interesting scenario where IInvocationOperation for Assert call isn't associated with InvocationExpressionSyntax? SyntaxNode type: '{diagnosticNode.GetType()}', Text: '{diagnosticNode.GetText()}'");
+            return;
+        }
+
+        SyntaxNode methodNameIdentifier = invocation.Expression;
+        if (methodNameIdentifier is MemberAccessExpressionSyntax memberAccess)
+        {
+            methodNameIdentifier = memberAccess.Name;
+        }
+
+        if (methodNameIdentifier is not SimpleNameSyntax simpleNameSyntax)
+        {
+            Debug.Fail($"Is this an interesting scenario where we are unable to retrieve SimpleNameSyntax corresponding to the assert method? SyntaxNode type: '{methodNameIdentifier}', Text: '{methodNameIdentifier.GetText()}'.");
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: string.Format(CultureInfo.InvariantCulture, CodeFixResources.AvoidAssertAreSameWithValueTypesFix, replacement),
+                ct => FixMethodNameAsync(context.Document, simpleNameSyntax, replacement, ct),
+                equivalenceKey: nameof(AvoidAssertAreSameWithValueTypesFixer)),
+            diagnostic);
+    }
+
+    private static async Task<Document> FixMethodNameAsync(Document document, SimpleNameSyntax simpleNameSyntax, string properAssertMethodName, CancellationToken cancellationToken)
+    {
+        DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        editor.ReplaceNode(simpleNameSyntax, simpleNameSyntax.WithIdentifier(SyntaxFactory.Identifier(properAssertMethodName)));
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -88,6 +88,15 @@ namespace MSTest.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;{0}&apos;.
+        /// </summary>
+        internal static string AvoidAssertAreSameWithValueTypesFix {
+            get {
+                return ResourceManager.GetString("AvoidAssertAreSameWithValueTypesFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change method accessibility to &apos;private&apos;.
         /// </summary>
         internal static string ChangeMethodAccessibilityToPrivateFix {

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -174,4 +174,7 @@
   <data name="AssertionArgsShouldAvoidConditionalAccessFix" xml:space="preserve">
     <value>Move conditional access in assertion to separate 'Assert.IsNotNull' check</value>
   </data>
+  <data name="AvoidAssertAreSameWithValueTypesFix" xml:space="preserve">
+    <value>Use '{0}'</value>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Přesunout podmíněný přístup v kontrolním výrazu, aby se oddělila kontrola Assert.IsNotNull</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Změnit přístupnost metody na private</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Bedingten Zugriff in Assertion auf separate "Assert.IsNotNull"-Überprüfung verschieben</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Methodenzugriff auf „privat“ ändern</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Mover el acceso condicional en la aserción para separar la comprobación 'Assert.IsNotNull'</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Cambiar la accesibilidad del método a "private"</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Déplacer l’accès conditionnel dans l’assertion pour séparer les case activée 'Assert.IsNotNull'</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Remplacer l’accessibilité de la méthode par « privé »</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Sposta l'accesso condizionale nell'asserzione per separare il controllo 'Assert.IsNotNull'</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Modifica l'accessibilità del metodo in 'privato'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">アサーション内の条件付きアクセスを個別の 'Assert.IsNotNull' チェックに移動します</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">メソッドのアクセシビリティを 'private' に変更する</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">어설션의 조건부 액세스를 'Assert.IsNotNull' 검사 구분하도록 이동합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">메서드 접근성 '비공개'로 변경하기</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Przenieś dostęp warunkowy w asercji do oddzielnego sprawdzenia "Assert.IsNotNull"</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Zmień dostępność metody na „private” (prywatna)</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Mover o acesso condicional na asserção para separar o 'Assert.IsNotNull' marcar</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Alterar a acessibilidade do método para 'privado'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Переместить условный доступ в утверждении, чтобы разделить "Assert.IsNotNull" проверка</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Изменить доступность метода на "private"</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Onaylamadaki koşullu erişimi 'Assert.IsNotNull' denetimine ayırmaya taşı</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">Yöntem erişilebilirliğini ‘özel’ olarak değiştir</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">将断言中的条件访问移动到分隔 “Assert.IsNotNull” 检查</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">将方法可访问性更改为“private”</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">將判斷提示中的條件式存取移動到個別的 『Assert.IsNotNull』 檢查</target>
         <note />
       </trans-unit>
+      <trans-unit id="AvoidAssertAreSameWithValueTypesFix">
+        <source>Use '{0}'</source>
+        <target state="new">Use '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChangeMethodAccessibilityToPrivateFix">
         <source>Change method accessibility to 'private'</source>
         <target state="translated">將方法協助工具變更為 'private'</target>

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreSameWithValueTypesAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreSameWithValueTypesAnalyzer.cs
@@ -24,6 +24,8 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzer : DiagnosticAnalyze
     private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.AvoidAssertAreSameWithValueTypesMessageFormat), Resources.ResourceManager, typeof(Resources));
     private static readonly LocalizableResourceString Description = new(nameof(Resources.AvoidAssertAreSameWithValueTypesDescription), Resources.ResourceManager, typeof(Resources));
 
+    internal const string ReplacemenyKey = nameof(ReplacemenyKey);
+
     internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
         DiagnosticIds.AvoidAssertAreSameWithValueTypesRuleId,
         Title,
@@ -69,11 +71,16 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzer : DiagnosticAnalyze
             return;
         }
 
-        if (argExpected.Value.WalkDownConversion().Type?.IsValueType == true ||
-            argActual.Value.WalkDownConversion().Type?.IsValueType == true)
+        ITypeSymbol? expectedType = argExpected.Value.WalkDownConversion().Type;
+        ITypeSymbol? actualType = argActual.Value.WalkDownConversion().Type;
+
+        if (expectedType?.IsValueType == true ||
+            actualType?.IsValueType == true)
         {
             string suggestedReplacement = targetMethod.Name == "AreSame" ? "AreEqual" : "AreNotEqual";
-            context.ReportDiagnostic(operation.CreateDiagnostic(Rule, targetMethod.Name, suggestedReplacement));
+            ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+                .Add(ReplacemenyKey, suggestedReplacement);
+            context.ReportDiagnostic(operation.CreateDiagnostic(Rule, properties, targetMethod.Name, suggestedReplacement));
         }
     }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
@@ -3,7 +3,7 @@
 
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
     MSTest.Analyzers.AvoidAssertAreSameWithValueTypesAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    MSTest.Analyzers.AvoidAssertAreSameWithValueTypesFixer>;
 
 namespace MSTest.Analyzers.UnitTests;
 
@@ -55,7 +55,49 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
             }
             """;
 
-        await VerifyCS.VerifyCodeFixAsync(code, code);
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    // Both are value types
+                    Assert.AreEqual(0, 0);
+                    Assert.AreEqual(0, 0, "Message");
+                    Assert.AreEqual(0, 0, "Message {0}", "Arg");
+                    Assert.AreEqual(message: "Message", expected: 0, actual: 0);
+
+                    Assert.AreEqual<object>(0, 0);
+                    Assert.AreEqual<object>(0, 0, "Message");
+                    Assert.AreEqual<object>(0, 0, "Message {0}", "Arg");
+                    Assert.AreEqual<object>(message: "Message", expected: 0, actual: 0);
+
+                    // Expected is value type. This is always-failing assert.
+                    Assert.AreEqual<object>("0", 0);
+                    Assert.AreEqual<object>("0", 0, "Message");
+                    Assert.AreEqual<object>("0", 0, "Message {0}", "Arg");
+                    Assert.AreEqual<object>(message: "Message", expected: "0", actual: 0);
+
+                    // Actual is value type. This is always-failing assert.
+                    Assert.AreEqual<object>(0, "0");
+                    Assert.AreEqual<object>(0, "0", "Message");
+                    Assert.AreEqual<object>(0, "0", "Message {0}", "Arg");
+                    Assert.AreEqual<object>(message: "Message", expected: 0, actual: "0");
+
+                    // Both are reference types. No diagnostic.
+                    Assert.AreSame("0", "0");
+                    Assert.AreSame("0", "0", "Message");
+                    Assert.AreSame("0", "0", "Message {0}", "Arg");
+                    Assert.AreSame(message: "Message", expected: "0", actual: "0");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
 
     [TestMethod]
@@ -103,6 +145,48 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
             }
             """;
 
-        await VerifyCS.VerifyCodeFixAsync(code, code);
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    // Both are value types
+                    Assert.AreNotEqual(0, 1);
+                    Assert.AreNotEqual(0, 1, "Message");
+                    Assert.AreNotEqual(0, 1, "Message {0}", "Arg");
+                    Assert.AreNotEqual(message: "Message", notExpected: 0, actual: 1);
+
+                    Assert.AreNotEqual<object>(0, 1);
+                    Assert.AreNotEqual<object>(0, 1, "Message");
+                    Assert.AreNotEqual<object>(0, 1, "Message {0}", "Arg");
+                    Assert.AreNotEqual<object>(message: "Message", notExpected: 0, actual: 1);
+
+                    // Expected is value type. This is always-failing assert.
+                    Assert.AreNotEqual<object>("0", 1);
+                    Assert.AreNotEqual<object>("0", 1, "Message");
+                    Assert.AreNotEqual<object>("0", 1, "Message {0}", "Arg");
+                    Assert.AreNotEqual<object>(message: "Message", notExpected: "0", actual: 1);
+
+                    // Actual is value type. This is always-failing assert.
+                    Assert.AreNotEqual<object>(0, "1");
+                    Assert.AreNotEqual<object>(0, "1", "Message");
+                    Assert.AreNotEqual<object>(0, "1", "Message {0}", "Arg");
+                    Assert.AreNotEqual<object>(message: "Message", notExpected: 0, actual: "1");
+
+                    // Both are reference types. No diagnostic.
+                    Assert.AreNotSame("0", "1");
+                    Assert.AreNotSame("0", "1", "Message");
+                    Assert.AreNotSame("0", "1", "Message {0}", "Arg");
+                    Assert.AreNotSame(message: "Message", notExpected: "0", actual: "1");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
 }


### PR DESCRIPTION
Fixes #4516