### PR TITLE
Use FailFast instead of throwing in DebugEx.Assert under .NET Framework

### DIFF
--- a/src/TestFramework/TestFramework/Internal/DebugEx.cs
+++ b/src/TestFramework/TestFramework/Internal/DebugEx.cs
@@ -14,8 +14,11 @@ internal static class DebugEx
         if (!b)
         {
             // In CI scenarios, we don't want Debug.Assert to show a dialog that
-            // ends up causing the job to timeout. Instead, we want to throw an Exception
-            throw new Exception($"Debug.Assert failed: {message}");
+            // ends up causing the job to timeout. We use FailFast instead.
+            // FailFast is better than throwing an exception to avoid anyone
+            // catching an exception and masking an assert failure.
+            var ex = new Exception($"Debug.Assert failed: {message}");
+            Environment.FailFast(ex.Message, ex);
         }
     }
 #else


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->