### PR TITLE
Avoid keeping trx stream open in unit tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -39,7 +39,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -58,7 +58,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream, notExecutedTestsCount: 1);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -77,7 +77,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream, timeoutTestsCount: 1);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -98,7 +98,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         Assert.IsTrue(fileName.Equals("argumentTrxReportFileName", StringComparison.OrdinalIgnoreCase));
@@ -117,7 +117,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         Assert.IsTrue(fileName.Equals("_NUL", StringComparison.OrdinalIgnoreCase));
@@ -134,7 +134,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(isTestHostCrashed: true, keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync(isTestHostCrashed: true);
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -151,7 +151,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(0, 0, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -170,7 +170,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(0, 1, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -203,7 +203,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(0, 1, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -231,7 +231,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(0, 1, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -262,7 +262,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -289,7 +289,7 @@ public class TrxTests
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(0, 1, propertyBag, memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -317,7 +317,7 @@ public class TrxTests
             propertyBag, memoryStream, true);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -337,7 +337,7 @@ public class TrxTests
             new(new PassedTestNodeStateProperty()), memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -366,7 +366,7 @@ public class TrxTests
             new(new PassedTestNodeStateProperty()), memoryStream);
 
         // Act
-        string fileName = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        string fileName = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         AssertExpectedTrxFileName(fileName);
@@ -413,7 +413,7 @@ public class TrxTests
             isCopyingFileAllowed: false);
 
         // Act
-        _ = await trxReportEngine.GenerateReportAsync(keepReportFileStreamOpen: true);
+        _ = await trxReportEngine.GenerateReportAsync();
 
         // Assert
         Assert.AreEqual(4, retryCount);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -489,8 +489,11 @@ public class TrxTests
 
         private void SetTrxContent()
         {
-            _ = Stream.Seek(0, SeekOrigin.Begin);
-            TrxContent = XDocument.Load(Stream);
+            if (TrxContent is null)
+            {
+                _ = Stream.Seek(0, SeekOrigin.Begin);
+                TrxContent = XDocument.Load(Stream);
+            }
         }
 
         void IDisposable.Dispose()

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -43,7 +43,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         Assert.IsFalse(trxContent.Contains(@"className="));
@@ -62,7 +63,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         Assert.IsTrue(trxContent.Contains(@"notExecuted=""1"""));
@@ -81,7 +83,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         Assert.IsTrue(trxContent.Contains(@"timeout=""1"""));
@@ -102,7 +105,8 @@ public class TrxTests
 
         // Assert
         Assert.IsTrue(fileName.Equals("argumentTrxReportFileName", StringComparison.OrdinalIgnoreCase));
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
     }
 
@@ -121,7 +125,8 @@ public class TrxTests
 
         // Assert
         Assert.IsTrue(fileName.Equals("_NUL", StringComparison.OrdinalIgnoreCase));
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
     }
 
@@ -138,7 +143,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Failed");
     }
 
@@ -155,7 +161,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
     }
 
@@ -174,7 +181,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Failed");
 
         XElement? testRun = xml.Root;
@@ -207,7 +215,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Failed");
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
@@ -235,7 +244,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Failed");
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
@@ -266,7 +276,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
@@ -293,7 +304,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Failed");
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
@@ -321,7 +333,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         Assert.IsTrue(trxContent.Contains(@"className=""TrxFullyQualifiedTypeName"), trxContent);
@@ -341,7 +354,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
@@ -370,7 +384,8 @@ public class TrxTests
 
         // Assert
         AssertExpectedTrxFileName(fileName);
-        XDocument xml = GetTrxContent(memoryStream);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XDocument xml = memoryStream.TrxContent;
         AssertTrxOutcome(xml, "Completed");
         string trxContent = xml.ToString();
         string trxContentsPattern = @"
@@ -417,13 +432,6 @@ public class TrxTests
 
         // Assert
         Assert.AreEqual(4, retryCount);
-    }
-
-    private static XDocument GetTrxContent(MemoryFileStream memoryStream)
-    {
-        Assert.IsNotNull(memoryStream);
-        _ = memoryStream.Stream.Seek(0, SeekOrigin.Begin);
-        return XDocument.Load(memoryStream.Stream);
     }
 
     private static void AssertTrxOutcome(XDocument xml, string expectedOutcome)
@@ -473,16 +481,30 @@ public class TrxTests
 
         public MemoryStream Stream { get; }
 
+        public XDocument? TrxContent { get; private set; }
+
         Stream IFileStream.Stream => Stream;
 
         string IFileStream.Name => string.Empty;
 
+        private void SetTrxContent()
+        {
+            _ = Stream.Seek(0, SeekOrigin.Begin);
+            TrxContent = XDocument.Load(Stream);
+        }
+
         void IDisposable.Dispose()
-            => Stream.Dispose();
+        {
+            SetTrxContent();
+            Stream.Dispose();
+        }
 
 #if NETCOREAPP
         ValueTask IAsyncDisposable.DisposeAsync()
-            => Stream.DisposeAsync();
+        {
+            SetTrxContent();
+            return Stream.DisposeAsync();
+        }
 #endif
     }
 }


### PR DESCRIPTION
TrxTests works by creating a MemoryStream, and mocking NewFileStream to return that instance. Then later, the tests tries to use that stream. For that reason, tests are passing a flag to prevent production code form disposing the stream.

This PR cleans up product code, but makes tests more verbose. Now, product code will **always** dispose, without any flag that's used by tests. However, the "fake" stream created by tests will create the `XDocument` that the test needs when Dispose is called. That way, we don't need the stream anymore and we use the XDocument.

@Evangelink How do you feel about this change? I generally don't like when there is a code path in product code that's test only and prefer more ugly tests but cleaner product code. That's a personal taste though.