### PR TITLE
Revert "[main] Bump MSTest from 3.8.0-preview.25063.12 to 3.8.0-preview.25065.17"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Test dependencies">
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.3-beta1.24423.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
-    <MSTestVersion>3.8.0-preview.25065.17</MSTestVersion>
+    <MSTestVersion>3.8.0-preview.25063.12</MSTestVersion>
   </PropertyGroup>
   <ItemGroup Label="Analyzers">
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />


### PR DESCRIPTION
Reverts microsoft/testfx#4673

This is breaking main and we need to wait for a package that contains https://github.com/microsoft/testfx/pull/4678