### PR TITLE
Add UsingMSTestSdk property

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Sdk.props.template
+++ b/src/Package/MSTest.Sdk/Sdk/Sdk.props.template
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project>
 
+  <PropertyGroup>
+    <!--
+      Indicate to other targets that MSTest.Sdk is being used.
+    -->
+    <UsingMSTestSdk>true</UsingMSTestSdk>
+  </PropertyGroup>
+
   <!-- Implicit top import -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 


### PR DESCRIPTION
The `Microsoft.NET.Sdk` sets a `UsingMicrosoftNETSdk` property which allows other imported files to rely on it, for example in Directory.Build.{props, targets}. This PR adds a similar `UsingMSTestSdk` for the MSTest SDK.