### PR TITLE
Workaround flakiness for AnalysisMode test

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AnalyzersTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AnalyzersTests.cs
@@ -54,6 +54,7 @@ public class UnitTest1
     }
 
     [TestMethod]
+    [DoNotParallelize] // flaky when parallelized.
     public async Task VerifyMSTestAnalysisModeForDifferentAnalyzers()
     {
         string code = """


### PR DESCRIPTION
Hopefully, works around this failure.

```
/mnt/vss/_work/1/s/artifacts/tmp/Debug/testsuite/dTeXr/VerifyMSTestAnalysisModeForDifferentAnalyzers/VerifyMSTestAnalysisModeForDifferentAnalyzers.csproj Could not resolve SDK "MSTest.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
  SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" returned null.
  Failed to resolve SDK 'MSTest.Sdk/3.8.0-ci'. Package restore was successful but a package with the ID of "MSTest.Sdk" was not installed.
```