### PR TITLE
Avoid using ToUnitTestResults in unit tests

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
@@ -281,11 +281,6 @@ public class TestExecutionManager
 
             var testResult = unitTestResult.ToTestResult(test, startTime, endTime, _environment.MachineName, MSTestSettings.CurrentSettings);
 
-            if (unitTestResult.DatarowIndex >= 0)
-            {
-                testResult.DisplayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, test.DisplayName, unitTestResult.DatarowIndex);
-            }
-
             testExecutionRecorder.RecordEnd(test, testResult.Outcome);
 
             if (testResult.Outcome == TestOutcome.Failed)

--- a/src/Adapter/MSTest.TestAdapter/Extensions/TestResultExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/TestResultExtensions.cs
@@ -90,6 +90,11 @@ public static class TestResultExtensions
             testResult.Attachments.Add(attachmentSet);
         }
 
+        if (frameworkTestResult.DatarowIndex >= 0)
+        {
+            testResult.DisplayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, testCase.DisplayName, frameworkTestResult.DatarowIndex);
+        }
+
         return testResult;
     }
 
@@ -99,11 +104,8 @@ public static class TestResultExtensions
     /// <param name="testResults">The test framework's TestResult object array.</param>
     /// <returns>The serializable UnitTestResult object array.</returns>
     public static UnitTestResult[] ToUnitTestResults(this UTF.TestResult[] testResults)
-        => ToUnitTestResults((IReadOnlyCollection<UTF.TestResult>)testResults);
-
-    internal static UnitTestResult[] ToUnitTestResults(this IReadOnlyCollection<UTF.TestResult> testResults)
     {
-        var unitTestResults = new UnitTestResult[testResults.Count];
+        var unitTestResults = new UnitTestResult[testResults.Length];
 
         int i = 0;
         foreach (UTF.TestResult testResult in testResults)

--- a/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Execution/TestMethodRunnerTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
-using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
@@ -14,7 +13,6 @@ using Moq;
 
 using TestFramework.ForTestingMSTest;
 
-using AdapterTestOutcome = Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestOutcome;
 using UTF = Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution;
@@ -78,14 +76,14 @@ public class TestMethodRunnerTests : TestContainer
         }
     }
 
-    public void ExecuteForTestThrowingExceptionShouldReturnUnitTestResultWithFailedOutcome()
+    public void ExecuteForTestThrowingExceptionShouldReturnTestResultWithFailedOutcome()
     {
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => throw new Exception("DummyException"));
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
-        Verify(results[0].Outcome == AdapterTestOutcome.Failed);
-        Verify(results[0].ErrorMessage.StartsWith(
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Failed);
+        Verify(results[0].ExceptionMessage.StartsWith(
             """            
             An unhandled exception was thrown by the 'Execute' method. Please report this error to the author of the attribute 'Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute'.
             System.Exception: DummyException
@@ -93,13 +91,13 @@ public class TestMethodRunnerTests : TestContainer
             StringComparison.Ordinal));
     }
 
-    public void ExecuteForPassingTestShouldReturnUnitTestResultWithPassedOutcome()
+    public void ExecuteForPassingTestShouldReturnTestResultWithPassedOutcome()
     {
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => new TestResult() { Outcome = UTF.UnitTestOutcome.Passed });
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
-        Verify(results[0].Outcome == AdapterTestOutcome.Passed);
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Passed);
     }
 
     public void ExecuteShouldNotFillInDebugAndTraceLogsIfDebugTraceDisabled()
@@ -110,7 +108,7 @@ public class TestMethodRunnerTests : TestContainer
         StringWriter writer = new(new StringBuilder("DummyTrace"));
         _testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
         Verify(results[0].DebugTrace == string.Empty);
     }
 
@@ -132,19 +130,19 @@ public class TestMethodRunnerTests : TestContainer
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
         _testablePlatformServiceProvider.MockTraceListener.Setup(tl => tl.GetWriter()).Returns(writer);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
 
         Verify(results[0].DebugTrace == string.Empty);
     }
 
-    public void RunTestMethodForTestThrowingExceptionShouldReturnUnitTestResultWithFailedOutcome()
+    public void RunTestMethodForTestThrowingExceptionShouldReturnTestResultWithFailedOutcome()
     {
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => throw new Exception("Dummy Exception"));
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
-        Verify(results[0].Outcome == AdapterTestOutcome.Failed);
-        Verify(results[0].ErrorMessage.StartsWith(
+        TestResult[] results = testMethodRunner.RunTestMethod();
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Failed);
+        Verify(results[0].ExceptionMessage.StartsWith(
             """            
             An unhandled exception was thrown by the 'Execute' method. Please report this error to the author of the attribute 'Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute'.
             System.Exception: Dummy Exception
@@ -166,29 +164,29 @@ public class TestMethodRunnerTests : TestContainer
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, localTestMethodOptions, null);
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
         Verify(results.Length == 2);
 
-        Verify(results[0].Outcome == AdapterTestOutcome.Passed);
-        Verify(results[1].Outcome == AdapterTestOutcome.Failed);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Passed);
+        Verify(results[1].Outcome == UTF.UnitTestOutcome.Failed);
     }
 
-    public void RunTestMethodForPassingTestThrowingExceptionShouldReturnUnitTestResultWithPassedOutcome()
+    public void RunTestMethodForPassingTestThrowingExceptionShouldReturnTestResultWithPassedOutcome()
     {
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => new TestResult() { Outcome = UTF.UnitTestOutcome.Passed });
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
-        Verify(results[0].Outcome == AdapterTestOutcome.Passed);
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Passed);
     }
 
-    public void RunTestMethodForFailingTestThrowingExceptionShouldReturnUnitTestResultWithFailedOutcome()
+    public void RunTestMethodForFailingTestThrowingExceptionShouldReturnTestResultWithFailedOutcome()
     {
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => new TestResult() { Outcome = UTF.UnitTestOutcome.Failed });
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty).ToUnitTestResults();
-        Verify(results[0].Outcome == AdapterTestOutcome.Failed);
+        TestResult[] results = testMethodRunner.Execute(string.Empty, string.Empty, string.Empty, string.Empty);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Failed);
     }
 
     public void RunTestMethodShouldGiveTestResultAsPassedWhenTestMethodPasses()
@@ -196,10 +194,10 @@ public class TestMethodRunnerTests : TestContainer
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => new TestResult() { Outcome = UTF.UnitTestOutcome.Passed });
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         // Since data is not provided, tests run normally giving passed as outcome.
-        Verify(results[0].Outcome == AdapterTestOutcome.Passed);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Passed);
     }
 
     public void RunTestMethodShouldGiveTestResultAsFailedWhenTestMethodFails()
@@ -207,10 +205,10 @@ public class TestMethodRunnerTests : TestContainer
         var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () => new TestResult() { Outcome = UTF.UnitTestOutcome.Failed });
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         // Since data is not provided, tests run normally giving passed as outcome.
-        Verify(results[0].Outcome == AdapterTestOutcome.Failed);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Failed);
     }
 
     public void RunTestMethodShouldRunDataDrivenTestsWhenDataIsProvidedUsingDataSourceAttribute()
@@ -228,12 +226,12 @@ public class TestMethodRunnerTests : TestContainer
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(_methodInfo, It.IsAny<bool>())).Returns(attributes);
         _testablePlatformServiceProvider.MockTestDataSource.Setup(tds => tds.GetData(testMethodInfo, _testContextImplementation)).Returns([1, 2, 3]);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         // check for outcome
-        Verify(results[0].Outcome == AdapterTestOutcome.Passed);
-        Verify(results[1].Outcome == AdapterTestOutcome.Passed);
-        Verify(results[2].Outcome == AdapterTestOutcome.Passed);
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Passed);
+        Verify(results[1].Outcome == UTF.UnitTestOutcome.Passed);
+        Verify(results[2].Outcome == UTF.UnitTestOutcome.Passed);
     }
 
     public void RunTestMethodShouldRunDataDrivenTestsWhenDataIsProvidedUsingDataRowAttribute()
@@ -257,8 +255,8 @@ public class TestMethodRunnerTests : TestContainer
         // Setup mocks
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(ro => ro.GetCustomAttributes(_methodInfo, It.IsAny<Type>(), It.IsAny<bool>())).Returns(attributes);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
-        Verify(results[0].Outcome == AdapterTestOutcome.Inconclusive);
+        TestResult[] results = testMethodRunner.RunTestMethod();
+        Verify(results[0].Outcome == UTF.UnitTestOutcome.Inconclusive);
     }
 
     public void RunTestMethodShouldSetDataRowIndexForDataDrivenTestsWhenDataIsProvidedUsingDataSourceAttribute()
@@ -274,7 +272,7 @@ public class TestMethodRunnerTests : TestContainer
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(_methodInfo, It.IsAny<bool>())).Returns(attributes);
         _testablePlatformServiceProvider.MockTestDataSource.Setup(tds => tds.GetData(testMethodInfo, _testContextImplementation)).Returns([1, 2, 3]);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         // check for datarowIndex
         Verify(results[0].DatarowIndex == 0);
@@ -300,7 +298,7 @@ public class TestMethodRunnerTests : TestContainer
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(_methodInfo, It.IsAny<bool>())).Returns(attributes);
         _testablePlatformServiceProvider.MockTestDataSource.Setup(tds => tds.GetData(testMethodInfo, _testContextImplementation)).Returns([1, 2, 3]);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         // check for datarowIndex as only DataSource Tests are Run
         Verify(results[0].DatarowIndex == 0);
@@ -326,7 +324,7 @@ public class TestMethodRunnerTests : TestContainer
         // Setup mocks
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(ro => ro.GetCustomAttributes(_methodInfo, It.IsAny<bool>())).Returns(attributes);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         Verify(results.Length == 1);
         Verify(results[0].DisplayName == "DataRowTestDisplayName");
@@ -349,7 +347,7 @@ public class TestMethodRunnerTests : TestContainer
         // Setup mocks
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(_methodInfo, It.IsAny<bool>())).Returns(attributes);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
 
         Verify(results.Length == 1);
         Verify(results[0].DisplayName is "dummyTestName (2,\"DummyString\")" or "DummyTestMethod (2,DummyString)", $"Display name: {results[0].DisplayName}");
@@ -375,7 +373,7 @@ public class TestMethodRunnerTests : TestContainer
         // Setup mocks
         _testablePlatformServiceProvider.MockReflectionOperations.Setup(rf => rf.GetCustomAttributes(_methodInfo, It.IsAny<bool>())).Returns(attributes);
 
-        UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
+        TestResult[] results = testMethodRunner.RunTestMethod();
         Verify(results[0].ResultFiles.ToList().Contains("C:\\temp.txt"));
         Verify(results[1].ResultFiles.ToList().Contains("C:\\temp.txt"));
     }
@@ -415,8 +413,8 @@ public class TestMethodRunnerTests : TestContainer
 
             if (considerEmptyAsInconclusive)
             {
-                UnitTestResult[] results = testMethodRunner.RunTestMethod().ToUnitTestResults();
-                Verify(results[0].Outcome == AdapterTestOutcome.Inconclusive);
+                TestResult[] results = testMethodRunner.RunTestMethod();
+                Verify(results[0].Outcome == UTF.UnitTestOutcome.Inconclusive);
             }
             else
             {

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/TestResultExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/TestResultExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
 using TestFramework.ForTestingMSTest;
 
@@ -173,8 +174,12 @@ public class TestResultExtensionsTests : TestContainer
 
     public void ToUnitTestResultsShouldHaveResultsFileProvidedToTestResult()
     {
-        var result = new UTF.TestResult() { ResultFiles = new List<string>() { "DummyFile.txt" } };
+        // NOTE: TextContextImplementation.AddResultFile calls Path.GetFullPath.
+        // Otherwise, ToTestResult will crash because it calls new Uri on the result file.
+        string resultFile = Path.GetFullPath("DummyFile.txt");
+
+        var result = new UTF.TestResult() { ResultFiles = new List<string>() { resultFile } };
         var convertedResult = result.ToTestResult(new(), default, default, string.Empty, new());
-        Verify(convertedResult.Attachments[0].Attachments[0].Description == "DummyFile.txt");
+        Verify(convertedResult.Attachments[0].Attachments[0].Description == resultFile);
     }
 }

--- a/test/UnitTests/MSTestAdapter.UnitTests/Extensions/TestResultExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Extensions/TestResultExtensionsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
-using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
 using TestFramework.ForTestingMSTest;
 


### PR DESCRIPTION
`UnitTestResult` is no longer used in production code and is kept ONLY for backcompat because it's public. The tests are now using `ToTestResult` which converts from TestFramework model to VSTest model, which better reflects what happens in production.