### PR TITLE
Drop `-m:1 -nodeReuse:false` from acceptance tests infra

### DIFF
--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -36,7 +36,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         => await Parallel.ForEachAsync(GetAssetsToGenerate(), async (asset, _) =>
         {
             TestAsset testAsset = await TestAsset.GenerateAssetAsync(asset.Name, asset.Code);
-            DotnetMuxerResult result = await DotnetCli.RunAsync($"build -m:1 -nodeReuse:false {testAsset.TargetAssetPath} -c Release", _nugetGlobalPackagesDirectory.Path);
+            DotnetMuxerResult result = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -c Release", _nugetGlobalPackagesDirectory.Path);
             testAsset.DotnetResult = result;
             _testAssets.TryAdd(asset.ID, testAsset);
         });
@@ -44,7 +44,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         => await Task.WhenAll(GetAssetsToGenerate().Select(async asset =>
         {
             TestAsset testAsset = await TestAsset.GenerateAssetAsync(asset.Name, asset.Code);
-            DotnetMuxerResult result = await DotnetCli.RunAsync($"build -m:1 -nodeReuse:false {testAsset.TargetAssetPath} -c Release", _nugetGlobalPackagesDirectory.Path);
+            DotnetMuxerResult result = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -c Release", _nugetGlobalPackagesDirectory.Path);
             testAsset.DotnetResult = result;
             _testAssets.TryAdd(asset.ID, testAsset);
         }));


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->