### PR TITLE
Retry: mark as experimental extension points

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -262,6 +262,7 @@ dotnet_diagnostic.VSTHRD002.severity = none             # VSTHRD002 Avoid proble
 dotnet_diagnostic.VSTHRD003.severity = none             # VSTHRD003: Avoid awaiting foreign Tasks
 dotnet_diagnostic.VSTHRD105.severity = none             # VSTHRD105: Avoid method overloads that assume TaskScheduler.Current
 
+dotnet_diagnostic.MSTESTEXP.severity = none             # MSTESTEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 dotnet_diagnostic.TPEXP.severity = none                 # TPEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 #### Naming styles ####

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
@@ -21,6 +21,7 @@ public abstract class RetryBaseAttribute : Attribute
     /// The other results are currently not used, but may be used in the future for tooling to show the
     /// state of the failed attempts.
     /// </returns>
+    [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
     protected internal abstract Task<RetryResult> ExecuteAsync(RetryContext retryContext);
 
     internal static bool IsAcceptableResultForRetry(TestResult[] results)

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryContext.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryContext.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public readonly struct RetryContext
 {
     internal RetryContext(Func<Task<TestResult[]>> executeTaskGetter)

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public sealed class RetryResult
 {
     private readonly List<TestResult[]> _testResults = new();

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -2,7 +2,6 @@
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute.IgnoreMessage.get -> string?
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute.GroupName.get -> string!
 abstract Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute.ShouldRun.get -> bool
-abstract Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute.ExecuteAsync(Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext retryContext) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult!>!
 Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AssertIsNotEmptyInterpolatedStringHandler<TItem>
 Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AssertIsNotEmptyInterpolatedStringHandler<TItem>.AppendFormatted(object? value, int alignment = 0, string? format = null) -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AssertIsNotEmptyInterpolatedStringHandler<TItem>.AppendFormatted(string? value) -> void
@@ -265,12 +264,6 @@ Microsoft.VisualStudio.TestTools.UnitTesting.RetryAttribute.MillisecondsDelayBet
 Microsoft.VisualStudio.TestTools.UnitTesting.RetryAttribute.RetryAttribute(int maxRetryAttempts) -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute
 Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute.RetryBaseAttribute() -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext
-Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext.ExecuteTaskGetter.get -> System.Func<System.Threading.Tasks.Task<Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]!>!>!
-Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext.RetryContext() -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult
-Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult.AddResult(Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]! testResults) -> void
-Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult.RetryResult() -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome.Ignored = 10 -> Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome
 override Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute.IgnoreMessage.get -> string?
 override Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute.GroupName.get -> string!
@@ -353,3 +346,10 @@ static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowsExactly<TExcept
 static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowsExactlyAsync<TException>(System.Func<System.Threading.Tasks.Task!>! action, string! message = "", params object![]! messageArgs) -> System.Threading.Tasks.Task<TException!>!
 static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowsExactlyAsync<TException>(System.Func<System.Threading.Tasks.Task!>! action, System.Func<System.Exception?, string!>! messageBuilder) -> System.Threading.Tasks.Task<TException!>!
 *REMOVED*Microsoft.VisualStudio.TestTools.UnitTesting.IgnoreAttribute.IgnoreMessage.get -> string?
+[MSTESTEXP]abstract Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute.ExecuteAsync(Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext retryContext) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult!>!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext.ExecuteTaskGetter.get -> System.Func<System.Threading.Tasks.Task<Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]!>!>!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext.RetryContext() -> void
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult.AddResult(Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]! testResults) -> void
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult.RetryResult() -> void


### PR DESCRIPTION
Following internal discussions, there are some unclear parts as to how we want to really allow extension of the retry capabilities so marking it as experimental so we can allow some extensibility while reserving right to modify the public API.