### PR TITLE
remove redundant IPushOnlyProtocol.Name

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -38,8 +38,6 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol,
 
     public bool IsServerMode => _dotnetTestPipeClient?.IsConnected == true;
 
-    public string Name => PlatformCommandLineProvider.DotnetTestCliProtocolName;
-
     public Task<IPushOnlyProtocolConsumer> GetDataConsumerAsync()
         => Task.FromResult((IPushOnlyProtocolConsumer)new DotnetTestDataConsumer(this, _environment));
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
@@ -9,8 +9,6 @@ internal interface IPushOnlyProtocol :
 #endif
     IDisposable
 {
-    string Name { get; }
-
     bool IsServerMode { get; }
 
     Task AfterCommonServiceSetupAsync();


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->