### PR TITLE
avoid 2x string allocs in TerminalOutputDevice

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -89,7 +89,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
         {
 #if !NETCOREAPP
             _longArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-            _shortArchitecture = GetShortArchitecture(RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant());
+            _shortArchitecture = GetShortArchitecture(_longArchitecture);
 #else
             // RID has the operating system, we want to see that in the banner, but not next to every dll.
             _longArchitecture = RuntimeInformation.RuntimeIdentifier;


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->