### PR TITLE
Remove `TestRequestExecutionTimeInfo` from `TerminalOutputDevice.DataTypesConsumed`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -173,7 +173,6 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
         typeof(SessionFileArtifact),
         typeof(TestNodeFileArtifact),
         typeof(FileArtifact),
-        typeof(TestRequestExecutionTimeInfo),
     ];
 
     /// <inheritdoc />


### PR DESCRIPTION
Follow-up to #4845