### PR TITLE
Set SkipArcadeNoWarnCS1591 to true

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestContext.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestContext.cs
@@ -86,5 +86,10 @@ public interface ITestContext
     /// <param name="displayName">The display name.</param>
     void SetDisplayName(string? displayName);
 
+    /// <summary>
+    /// Displays a message in the output.
+    /// </summary>
+    /// <param name="messageLevel">The level of the message.</param>
+    /// <param name="message">The message to display.</param>
     void DisplayMessage(MessageLevel messageLevel, string message);
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,9 +1,12 @@
 <Project>
 
-  <Import Project="../Directory.Build.props" />
-
   <PropertyGroup>
     <Nullable>enable</Nullable>
+    <!-- This needs to happen before importing Arcade props (which is imported via the parent Directory.Build.props) -->
+    <!-- Otherwise, Arcade would have already included 1591 in NoWarn -->
+    <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>
   </PropertyGroup>
+
+  <Import Project="../Directory.Build.props" />
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/IGracefulStopTestExecutionCapability.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/IGracefulStopTestExecutionCapability.cs
@@ -13,5 +13,9 @@ namespace Microsoft.Testing.Platform.Capabilities.TestFramework;
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IGracefulStopTestExecutionCapability : ITestFrameworkCapability
 {
+    /// <summary>
+    /// Stops the test execution gracefully.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
     Task StopTestExecutionAsync(CancellationToken cancellationToken);
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUid.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUid.cs
@@ -14,15 +14,35 @@ public sealed class TestNodeUid(string value) : IEquatable<TestNodeUid>
     /// </summary>
     public string Value { get; init; } = Guard.NotNullOrWhiteSpace(value);
 
+    /// <summary>
+    /// Implicitly converts a <see cref="TestNodeUid"/> to a <see cref="string"/>.
+    /// </summary>
+    /// <param name="testNode">The <see cref="TestNodeUid"/> value to convert.</param>
     public static implicit operator string(TestNodeUid testNode)
         => testNode.Value;
 
+    /// <summary>
+    /// Implicitly converts a string to a <see cref="TestNodeUid"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="TestNodeUid"/> value as <see cref="string"/>.</param>
     public static implicit operator TestNodeUid(string value)
         => new(value);
 
+    /// <summary>
+    /// Checks whether two <see cref="TestNodeUid"/> instances are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="TestNodeUid"/>.</param>
+    /// <param name="right">The second <see cref="TestNodeUid"/>.</param>
+    /// <returns><c>true</c> if the two instances are equal; <c>false</c> otherwise.</returns>
     public static bool operator ==(TestNodeUid left, TestNodeUid right)
         => left.Equals(right);
 
+    /// <summary>
+    /// Checks whether two <see cref="TestNodeUid"/> instances are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="TestNodeUid"/>.</param>
+    /// <param name="right">The second <see cref="TestNodeUid"/>.</param>
+    /// <returns><c>true</c> if the two instances are not equal; <c>false</c> otherwise.</returns>
     public static bool operator !=(TestNodeUid left, TestNodeUid right)
         => !left.Equals(right);
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertAreEqualInterpolatedStringHandler<TArgument>
     {
         private readonly StringBuilder? _builder;
@@ -365,6 +366,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests whether the specified values are equal and throws an exception

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreSame.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreSame.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertAreSameInterpolatedStringHandler<TArgument>
     {
         private readonly StringBuilder? _builder;
@@ -131,6 +132,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests whether the specified objects both refer to the same object and

--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertSingleInterpolatedStringHandler<TItem>
     {
         private readonly StringBuilder? _builder;
@@ -88,6 +89,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests whether the specified collection contains exactly one element.

--- a/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertCountInterpolatedStringHandler<TItem>
     {
         private readonly StringBuilder? _builder;
@@ -162,6 +163,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests that the collection is not empty.

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsInstanceOfTypeInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
@@ -255,6 +256,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests whether the specified object is an instance of the expected

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsNullInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
@@ -69,10 +70,12 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsNotNullInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
@@ -127,6 +130,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests whether the specified object is null and throws an exception

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsTrueInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
@@ -127,6 +128,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Tests whether the specified condition is true and throws an exception

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
@@ -15,6 +15,7 @@ public sealed partial class Assert
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "This is not meant to be consumed by users.")]
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertNonStrictThrowsInterpolatedStringHandler<TException>
         where TException : Exception
     {
@@ -147,6 +148,7 @@ public sealed partial class Assert
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Asserts that the delegate <paramref name="action"/> throws an exception of type <typeparamref name="TException"/>

--- a/src/TestFramework/TestFramework/Interfaces/ITestDataSourceUnfoldingCapability.cs
+++ b/src/TestFramework/TestFramework/Interfaces/ITestDataSourceUnfoldingCapability.cs
@@ -10,6 +10,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public interface ITestDataSourceUnfoldingCapability
 {
+    /// <summary>
+    /// Gets the strategy for unfolding parameterized tests.
+    /// </summary>
     TestDataSourceUnfoldingStrategy UnfoldingStrategy { get; }
 }
 


### PR DESCRIPTION
I noticed there is no doc comment for

https://github.com/microsoft/testfx/blob/4210f00ff9cca0eb2a7004663cbffa5ec00e55f7/src/TestFramework/TestFramework/Interfaces/ITestDataSourceUnfoldingCapability.cs#L13

So maybe StyleCop doesn't catch all cases. Let's see if the compiler is able to capture this, then we should fix the build errors.


cc @Evangelink