### PR TITLE
Preserve TestIdGenerationStrategy in the execution AppDomain - round 2

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestAssemblySettingsProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestAssemblySettingsProvider.cs
@@ -30,6 +30,13 @@ internal sealed class TestAssemblySettingsProvider : MarshalByRefObject
         // Load the source.
         Assembly testAssembly = PlatformServiceProvider.Instance.FileOperations.LoadAssembly(source, isReflectionOnly: false);
 
+        TestIdGenerationStrategy testIdGenerationStrategy = ReflectHelper.GetTestIdGenerationStrategy(testAssembly);
+
+        // Set the test ID generation strategy for DataRowAttribute and DynamicDataAttribute so we can improve display name without
+        // causing a breaking change.
+        DataRowAttribute.TestIdGenerationStrategy = testIdGenerationStrategy;
+        DynamicDataAttribute.TestIdGenerationStrategy = testIdGenerationStrategy;
+
         ParallelizeAttribute? parallelizeAttribute = ReflectHelper.GetParallelizeAttribute(testAssembly);
 
         if (parallelizeAttribute != null)


### PR DESCRIPTION
Follow-up to #4942

Initially, we set the correct value here:

https://github.com/microsoft/testfx/blob/0f6963807ad19fdcc11a860158a1c34261879ddb/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumerator.cs#L82-L85

This is the discovery app domain (we create it [here](https://github.com/microsoft/testfx/blob/b9cef47d99842580a111001dc84ba4ebb14ead31/src/Adapter/MSTest.TestAdapter/Discovery/AssemblyEnumeratorWrapper.cs#L98))

Then, the code in this PR will set the `TestIdGenerationStrategy` in the main AppDomain.

After that, when we create the UnitTestRunner, the value from the main AppDomain will flow to the newly created AppDomain via the code added in #4942

It may be hard to follow, but... AppDomains.

The test added in https://github.com/microsoft/testfx/pull/4930 will make sure this doesn't regress, and I'll explicitly document the test in the other PR.