### PR TITLE
Simplify inclusion of MSTestVersion.cs and PlatformVersion.cs

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -106,19 +106,6 @@
     </None>
   </ItemGroup>
 
-  <!-- Insert the MSTestVersion.cs -->
-  <PropertyGroup>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**/*.cs" Exclude="**/*.user; **/*.*proj; **/*.sln; **/*.vssscc" />
-  </ItemGroup>
-  <Target Name="InsertMSTestVersion" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <Compile Include="$(Compile);$(IntermediateOutputPath)/MSTestVersion.cs" />
-    </ItemGroup>
-  </Target>
-
   <!-- Version templating -->
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)" AllowExplicitReference="true" PrivateAssets="All" IsImplicitlyDefined="true" />
@@ -140,6 +127,9 @@
     <GenerateFileFromTemplate TemplateFile="%(_TemplateCsproj.Identity)" OutputPath="%(_TemplateCsproj.Destination)" Properties="$(_TemplateProperties)">
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
     </GenerateFileFromTemplate>
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)/MSTestVersion.cs" />
+    </ItemGroup>
   </Target>
 
   <ItemGroup>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -127,6 +127,7 @@
     <GenerateFileFromTemplate TemplateFile="%(_TemplateCsproj.Identity)" OutputPath="%(_TemplateCsproj.Destination)" Properties="$(_TemplateProperties)">
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
     </GenerateFileFromTemplate>
+
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)/MSTestVersion.cs" />
     </ItemGroup>

--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -89,6 +89,7 @@ This package provides the core platform and the .NET implementation of the proto
     <GenerateFileFromTemplate TemplateFile="%(_TemplateCsproj.Identity)" OutputPath="%(_TemplateCsproj.Destination)" Properties="$(_TemplateProperties)">
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
     </GenerateFileFromTemplate>
+
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)/PlatformVersion.cs" />
     </ItemGroup>

--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -1,21 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(MicrosoftTestingTargetFrameworks);netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-
-  <!-- Insert the PlatformVersion.cs -->
-  <PropertyGroup>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**/*.cs" Exclude="**/*.user; **/*.*proj; **/*.sln; **/*.vssscc" />
-  </ItemGroup>
-  <Target Name="InsertPlatformVersion" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <Compile Include="$(Compile);$(IntermediateOutputPath)/PlatformVersion.cs" />
-    </ItemGroup>
-  </Target>
 
   <ItemGroup>
     <AssemblyMetadata Include="Microsoft.Testing.Platform.Application.BuildTimeUTC" Value="$([System.DateTime]::UtcNow.ToString('yyyy/MM/dd'))" />
@@ -102,6 +89,9 @@ This package provides the core platform and the .NET implementation of the proto
     <GenerateFileFromTemplate TemplateFile="%(_TemplateCsproj.Identity)" OutputPath="%(_TemplateCsproj.Destination)" Properties="$(_TemplateProperties)">
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
     </GenerateFileFromTemplate>
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)/PlatformVersion.cs" />
+    </ItemGroup>
   </Target>
 
   <!-- NuGet package layout -->


### PR DESCRIPTION
It seems unnecessarily complex currently.