### PR TITLE
Include RootNamespace in hash calculation for MTP MSBuild generated files

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -88,6 +88,8 @@
     <ItemGroup>
       <!-- Items to hash-->
       <_GenerateTestingPlatformEntryPointInputsCacheToHash Include="@(TestingPlatformBuilderHook)"/>
+      <_GenerateTestingPlatformEntryPointInputsCacheToHash Include="$(RootNamespace)"/>
+
       <!-- Export the items name for the _GenerateTestingPlatformInjectEntryPoint task-->
       <GenerateTestingPlatformEntryPointInputsCacheFilePath Include="$(_GenerateTestingPlatformEntryPointInputsCachFilePath)" />
     </ItemGroup>
@@ -165,6 +167,8 @@
     <ItemGroup>
       <!-- Items to hash-->
       <_GenerateSelfRegisteredExtensionsInputsCacheToHash Include="@(TestingPlatformBuilderHook)"/>
+      <_GenerateSelfRegisteredExtensionsInputsCacheToHash Include="$(RootNamespace)"/>
+
       <!-- Export the items name for the _GenerateSelfRegisteredExtensions task-->
       <GenerateSelfRegisteredExtensionsInputsCacheFilePath Include="$(_GenerateSelfRegisteredExtensionsInputsCachFilePath)" />
     </ItemGroup>


### PR DESCRIPTION
If a user updates from 3.7 to 3.8 (not yet released at time of writing), the compilation may fail without this change. This is because the user may have TestingPlatformEntryPoint.cs already generated, and it will be seen as up-to-date because RootNamespace isn't included in the hash (the generation in 3.7 didn't use RootNamespace at all, while we do use it in 3.8). This change makes sure that the entry point file will be re-generated.

This is also relevant even if the user starts a clean build on 3.8, then changes `RootNamespace` in csproj after that.