### PR TITLE
Remove redundant explicit override of NuGet.Packaging and MessagePack

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,16 +67,16 @@
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.1" />
     <PackageVersion Include="Microsoft.TestPlatform" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
+
     <!-- Pinned to 4.18.4 for security -->
     <PackageVersion Include="Moq" Version="4.18.4" />
+
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.386" />
     <PackageVersion Include="MSTest.Analyzers" Version="$(MSTestVersion)" />
     <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
     <PackageVersion Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <!-- CVE-2024-0057 / Transitive deps of code analysis testing packages -->
-    <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
+
     <PackageVersion Include="Polly" Version="8.5.0" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.20" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,10 +65,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.2" />
     <PackageVersion Include="Microsoft.TestPlatform" Version="$(MicrosoftNETTestSdkVersion)" />
-
     <!-- Pinned to 4.18.4 for security -->
     <PackageVersion Include="Moq" Version="4.18.4" />
-
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.386" />
     <PackageVersion Include="MSTest.Analyzers" Version="$(MSTestVersion)" />
     <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,8 +59,6 @@
     <PackageVersion Include="Codecov" Version="1.12.3" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FSharp.Core" Version="8.0.200" />
-    <!-- CVE-2024-48924 / Transitive deps of StreamJsonRpc -->
-    <PackageVersion Include="MessagePack" Version="2.5.187" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj
@@ -25,9 +25,6 @@
 
     <!-- Deps of MSTest.TestAdapter -->
     <PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" />
-
-    <!-- CVE-2024-0057 / Transitive deps of code analysis testing packages -->
-    <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The security concerns mentioned in comments were addressed by https://github.com/dotnet/roslyn-sdk/pull/1148 and https://github.com/microsoft/vs-streamjsonrpc/pull/1095