### PR TITLE
Avoid handling tuples for test methods with only `object[]` parameter

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
@@ -374,6 +374,22 @@ internal sealed class TestMethodRunner
         {
             // Handled already.
         }
+        else if (TestDataSourceHelpers.IsDataConsideredSingleArgumentValue(data, _testMethodInfo.ParameterTypes))
+        {
+            // SPECIAL CASE:
+            // This condition is a duplicate of the condition in InvokeAsSynchronousTask.
+            //
+            // The known scenario we know of that shows importance of that check is if we have DynamicData using this member
+            //
+            // public static IEnumerable<object[]> GetData()
+            // {
+            //     yield return new object[] { ("Hello", "World") };
+            // }
+            //
+            // If the test method has a single parameter which is 'object[]', then we should pass the tuple array as is.
+            // Note that normally, the array in this code path represents the arguments of the test method.
+            // However, InvokeAsSynchronousTask uses the above check to mean "the whole array is the single argument to the test method"
+        }
         else if (data?.Length == 1 && TestDataSourceHelpers.TryHandleTupleDataSource(data[0], _testMethodInfo.ParameterTypes, out object?[] tupleExpandedToArray))
         {
             data = tupleExpandedToArray;

--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -137,10 +137,7 @@ internal static class MethodInfoExtensions
 
         object? invokeResult;
 
-        if (arguments is not null
-            && (arguments.Length != 1 || arguments[0] is not null)
-            && methodParameters.Length == 1
-            && methodParameters[0].ParameterType == typeof(object[]))
+        if (TestDataSourceHelpers.IsDataConsideredSingleArgumentValue(arguments, methodParameters))
         {
             invokeResult = methodInfo.Invoke(classInstance, [arguments]);
         }

--- a/src/Adapter/MSTest.TestAdapter/Helpers/TestDataSourceHelpers.cs
+++ b/src/Adapter/MSTest.TestAdapter/Helpers/TestDataSourceHelpers.cs
@@ -7,6 +7,12 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 
 internal static class TestDataSourceHelpers
 {
+    public static bool IsDataConsideredSingleArgumentValue(object?[]? data, ParameterInfo[] parameters)
+        => data is not null
+            && (data.Length != 1 || data[0] is not null)
+            && parameters.Length == 1
+            && parameters[0].ParameterType == typeof(object[]);
+
     public static bool TryHandleITestDataRow(
         object?[] d,
         ParameterInfo[] testMethodParameters,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TupleDynamicDataTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TupleDynamicDataTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -15,7 +15,7 @@ public sealed class TupleDynamicDataTests : AcceptanceTestBase<TupleDynamicDataT
     public async Task CanUseLongTuplesAndValueTuplesForAllFrameworks(string tfm)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
-        TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings");
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ClassName=CanUseLongTuplesAndValueTuplesForAllFrameworks --settings my.runsettings");
 
         // Assert
         testHostResult.AssertExitCodeIs(ExitCodes.Success);
@@ -34,6 +34,22 @@ public sealed class TupleDynamicDataTests : AcceptanceTestBase<TupleDynamicDataT
             Hello2, , World2
             """);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 12, skipped: 0);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task TupleSupportDoesNotBreakObjectArraySupport(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ClassName=TupleSupportDoesNotBreakObjectArraySupport --settings my.runsettings");
+
+        // Assert
+        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertOutputContains("""
+            Length: 1
+            (Hello, World)
+            """);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase(AcceptanceFixture.NuGetGlobalPackagesFolder)
@@ -73,14 +89,14 @@ public sealed class TupleDynamicDataTests : AcceptanceTestBase<TupleDynamicDataT
   </ItemGroup>
 </Project>
 
-#file UnitTest1.cs
+#file CanUseLongTuplesAndValueTuplesForAllFrameworks.cs
 using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [TestClass]
-public class UnitTest1
+public class CanUseLongTuplesAndValueTuplesForAllFrameworks
 {
     private static readonly StringBuilder s_builder = new();
 
@@ -151,6 +167,31 @@ public class UnitTest1
     ];
 }
 
+#file TupleSupportDoesNotBreakObjectArraySupport.cs
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class TupleSupportDoesNotBreakObjectArraySupport
+{
+    [TestMethod]
+    [DynamicData(nameof(GetData))]
+    public void TestMethod1(object[] data)
+    {
+        Console.WriteLine($"Length: {data.Length}");
+        Assert.AreEqual(1, data.Length);
+
+        Console.WriteLine(data[0]);
+        Assert.AreEqual(("Hello", "World"), data[0]);
+    }
+
+    private static IEnumerable<object[]> GetData()
+    {
+        yield return new object[] { ("Hello", "World") };
+    }
+}
 
 #file my.runsettings
 <RunSettings>


### PR DESCRIPTION
Fixes #5012
