### PR TITLE
Fix parameterized test treated as ignored when using VSTest in Test E…

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
@@ -170,7 +170,7 @@ internal sealed class TestMethodRunner
         var parentStopwatch = Stopwatch.StartNew();
         if (_test.DataType == DynamicDataType.ITestDataSource)
         {
-            if (_test.TestDataSourceIgnoreMessage is not null)
+            if (!string.IsNullOrEmpty(_test.TestDataSourceIgnoreMessage))
             {
                 _testContext.SetOutcome(UTF.UnitTestOutcome.Ignored);
                 return [TestResult.CreateIgnoredResult(_test.TestDataSourceIgnoreMessage)];
@@ -269,7 +269,7 @@ internal sealed class TestMethodRunner
 
         foreach (UTF.ITestDataSource testDataSource in testDataSources)
         {
-            if (testDataSource is ITestDataSourceIgnoreCapability { IgnoreMessage: { } ignoreMessage })
+            if (testDataSource is ITestDataSourceIgnoreCapability { IgnoreMessage: { Length: > 0 } ignoreMessage })
             {
                 results.Add(TestResult.CreateIgnoredResult(ignoreMessage));
                 continue;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethod.cs
@@ -149,6 +149,17 @@ public sealed class TestMethod : ITestMethod
     /// </summary>
     internal string?[]? SerializedData { get; set; }
 
+    /// <summary>
+    /// Gets or sets the test data source ignore message.
+    /// </summary>
+    /// <remarks>
+    /// The test is ignored if this is set to non-null and non-empty string.
+    /// If set to empty string, the test is considered as not ignored.
+    /// In VSTest, when tests are expanded during discovery, we end up reading
+    /// this property as empty string, even though it was set to null.
+    /// (probably some serialization issue on VSTest side)
+    /// So, we treat null and empty string the same.
+    /// </remarks>
     internal string? TestDataSourceIgnoreMessage { get; set; }
 
     /// <summary>

--- a/src/TestFramework/TestFramework/Interfaces/ITestDataSourceIgnoreCapability.cs
+++ b/src/TestFramework/TestFramework/Interfaces/ITestDataSourceIgnoreCapability.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 public interface ITestDataSourceIgnoreCapability
 {
     /// <summary>
-    /// Gets or sets a reason to ignore the test data source. Setting the property to non-null value will ignore the test data source.
+    /// Gets or sets a reason to ignore the test data source. Setting the property to non-null and non-empty string value will ignore the test data source.
     /// </summary>
     string? IgnoreMessage { get; set; }
 }


### PR DESCRIPTION
Issue is only on TE. No good way to write a test. The fix is manually verified using locally-built packages.

Fixes #5018