### PR TITLE
Avoid generating entrypoint when IsTestingPlatformApplication is false but EnableMSTestRunner is true

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -2,8 +2,8 @@
 
   <!-- Handle the coexistence between testing platform and Microsoft.NET.Test.Sdk  -->
   <PropertyGroup>
-    <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' ">$(EnableMSTestRunner)</GenerateTestingPlatformEntryPoint>
-    <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' ">$(EnableMSTestRunner)</GenerateSelfRegisteredExtensions>
+    <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' AND !('$(IsTestingPlatformApplication)' == 'false' AND '$(EnableMSTestRunner)' == 'true') ">$(EnableMSTestRunner)</GenerateTestingPlatformEntryPoint>
+    <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' AND !('$(IsTestingPlatformApplication)' == 'false' AND '$(EnableMSTestRunner)' == 'true') ">$(EnableMSTestRunner)</GenerateSelfRegisteredExtensions>
     <GenerateProgramFile Condition=" '$(EnableMSTestRunner)' == 'true' ">false</GenerateProgramFile>
     <DisableTestingPlatformServerCapability Condition=" '$(EnableMSTestRunner)' == 'false' or '$(EnableMSTestRunner)' == '' " >true</DisableTestingPlatformServerCapability>
   </PropertyGroup>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -21,6 +21,7 @@ public abstract class AcceptanceTestBase<TFixture>
     $EnableMSTestRunner$
     $Extra$
     <NoWarn>$(NoWarn);NETSDK1201</NoWarn>
+    <DefineConstants Condition="'$(ManualEntryPoint)'=='true'">$(DefineConstants);MANUAL_ENTRYPOINT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,15 @@ public abstract class AcceptanceTestBase<TFixture>
 
 #file UnitTest1.cs
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#if MANUAL_ENTRYPOINT
+internal static class Program
+{
+    public static void Main()
+    {
+    }
+}
+#endif
 
 [TestClass]
 public class UnitTest1


### PR DESCRIPTION
In case `EnableMSTestRunner` is **true**, but `IsTestingPlatformApplication` is **false**, we don't want to generate an entry point. This fix is not ideal. I think our props/targets needs an extensive refactoring. But this is to unblock 3.8.1.

Fixes #5016