### PR TITLE
Simplify generated file name by using `DefaultLanguageSourceExtension`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -109,10 +109,7 @@
 
   <!-- Generate the entry point source using the user extensions informations -->
   <PropertyGroup>
-    <_TestingPlatformEntryPointSourceNameWithoutExtension>TestPlatformEntryPoint</_TestingPlatformEntryPointSourceNameWithoutExtension>
-    <_TestingPlatformEntryPointSourceName Condition=" $(Language) == 'C#' " >$(_TestingPlatformEntryPointSourceNameWithoutExtension).cs</_TestingPlatformEntryPointSourceName>
-    <_TestingPlatformEntryPointSourceName Condition=" $(Language) == 'VB' " >$(_TestingPlatformEntryPointSourceNameWithoutExtension).vb</_TestingPlatformEntryPointSourceName>
-    <_TestingPlatformEntryPointSourceName Condition=" $(Language) == 'F#' " >$(_TestingPlatformEntryPointSourceNameWithoutExtension).fs</_TestingPlatformEntryPointSourceName>
+    <_TestingPlatformEntryPointSourceName>TestPlatformEntryPoint$(DefaultLanguageSourceExtension)</_TestingPlatformEntryPointSourceName>
     <_TestingPlatformEntryPointSourcePath>$([System.IO.Path]::Combine($(IntermediateOutputPath),$(_TestingPlatformEntryPointSourceName)))</_TestingPlatformEntryPointSourcePath>
     <_TestingPlatformEntryPointSourcePath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_TestingPlatformEntryPointSourcePath)))</_TestingPlatformEntryPointSourcePath>
   </PropertyGroup>
@@ -188,10 +185,7 @@
 
   <!-- Generate the extensions source file using the user extensions informations -->
   <PropertyGroup>
-    <_SelfRegisteredExtensionsSourceNameWithoutExtension>SelfRegisteredExtensions</_SelfRegisteredExtensionsSourceNameWithoutExtension>
-    <_SelfRegisteredExtensionsSourceName Condition=" $(Language) == 'C#' " >$(_SelfRegisteredExtensionsSourceNameWithoutExtension).cs</_SelfRegisteredExtensionsSourceName>
-    <_SelfRegisteredExtensionsSourceName Condition=" $(Language) == 'VB' " >$(_SelfRegisteredExtensionsSourceNameWithoutExtension).vb</_SelfRegisteredExtensionsSourceName>
-    <_SelfRegisteredExtensionsSourceName Condition=" $(Language) == 'F#' " >$(_SelfRegisteredExtensionsSourceNameWithoutExtension).fs</_SelfRegisteredExtensionsSourceName>
+    <_SelfRegisteredExtensionsSourceName>SelfRegisteredExtensions$(DefaultLanguageSourceExtension)</_SelfRegisteredExtensionsSourceName>
     <_SelfRegisteredExtensionsSourcePath>$([System.IO.Path]::Combine($(IntermediateOutputPath),$(_SelfRegisteredExtensionsSourceName)))</_SelfRegisteredExtensionsSourcePath>
     <_SelfRegisteredExtensionsSourcePath>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(_SelfRegisteredExtensionsSourcePath)))</_SelfRegisteredExtensionsSourcePath>
   </PropertyGroup>


### PR DESCRIPTION
For C#:

https://github.com/dotnet/msbuild/blob/aff54559404d31214c71aa2ea6d2caa6003b0334/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L37

For VB:

https://github.com/dotnet/msbuild/blob/aff54559404d31214c71aa2ea6d2caa6003b0334/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets#L37

For F#:

https://github.com/dotnet/fsharp/blob/898c6c7a5b39f6bc0cfb42c21e3fcc167b192ab4/src/FSharp.Build/Microsoft.FSharp.Targets#L42