### PR TITLE
Follow-up to ignore fix

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodRunner.cs
@@ -170,7 +170,7 @@ internal sealed class TestMethodRunner
         var parentStopwatch = Stopwatch.StartNew();
         if (_test.DataType == DynamicDataType.ITestDataSource)
         {
-            if (!string.IsNullOrEmpty(_test.TestDataSourceIgnoreMessage))
+            if (_test.TestDataSourceIgnoreMessage is not null)
             {
                 _testContext.SetOutcome(UTF.UnitTestOutcome.Ignored);
                 return [TestResult.CreateIgnoredResult(_test.TestDataSourceIgnoreMessage)];
@@ -269,7 +269,7 @@ internal sealed class TestMethodRunner
 
         foreach (UTF.ITestDataSource testDataSource in testDataSources)
         {
-            if (testDataSource is ITestDataSourceIgnoreCapability { IgnoreMessage: { Length: > 0 } ignoreMessage })
+            if (testDataSource is ITestDataSourceIgnoreCapability { IgnoreMessage: { } ignoreMessage })
             {
                 results.Add(TestResult.CreateIgnoredResult(ignoreMessage));
                 continue;

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/TestMethod.cs
@@ -153,12 +153,7 @@ public sealed class TestMethod : ITestMethod
     /// Gets or sets the test data source ignore message.
     /// </summary>
     /// <remarks>
-    /// The test is ignored if this is set to non-null and non-empty string.
-    /// If set to empty string, the test is considered as not ignored.
-    /// In VSTest, when tests are expanded during discovery, we end up reading
-    /// this property as empty string, even though it was set to null.
-    /// (probably some serialization issue on VSTest side)
-    /// So, we treat null and empty string the same.
+    /// The test is ignored if this is set to non-null.
     /// </remarks>
     internal string? TestDataSourceIgnoreMessage { get; set; }
 

--- a/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTest.TestAdapter/ObjectModel/UnitTestElement.cs
@@ -195,7 +195,10 @@ internal sealed class UnitTestElement
 
             testCase.SetPropertyValue(Constants.TestDynamicDataTypeProperty, (int)TestMethod.DataType);
             testCase.SetPropertyValue(Constants.TestDynamicDataProperty, data);
-            testCase.SetPropertyValue(Constants.TestDataSourceIgnoreMessageProperty, TestMethod.TestDataSourceIgnoreMessage);
+            if (TestMethod.TestDataSourceIgnoreMessage is not null)
+            {
+                testCase.SetPropertyValue(Constants.TestDataSourceIgnoreMessageProperty, TestMethod.TestDataSourceIgnoreMessage);
+            }
         }
 
         SetTestCaseId(testCase, testFullName);

--- a/src/TestFramework/TestFramework/Interfaces/ITestDataSourceIgnoreCapability.cs
+++ b/src/TestFramework/TestFramework/Interfaces/ITestDataSourceIgnoreCapability.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 public interface ITestDataSourceIgnoreCapability
 {
     /// <summary>
-    /// Gets or sets a reason to ignore the test data source. Setting the property to non-null and non-empty string value will ignore the test data source.
+    /// Gets or sets a reason to ignore the test data source. Setting the property to non-null value will ignore the test data source.
     /// </summary>
     string? IgnoreMessage { get; set; }
 }


### PR DESCRIPTION
Follow-up to #5020

Per discussion with @nohwnd, the serialization/deserialization logic in vstest doesn't seem to round trip null string correctly, and we get it back as empty string. Changing the vstest behavior is risky as there may be users/components out there relying on that behavior. Not setting the property at all when it's null should be fine, and potentially having better performance.

This PR gets back the behavior of empty string being allowed to ignore the test, but still not regress the null case as we now don't set the property at all.

The change here is manually validated.