### PR TITLE
Fix ClassCleanup not called when the first test in class is ignored

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestClassInfo.cs
@@ -616,6 +616,7 @@ public class TestClassInfo
                 // If ClassInitialize method has not been executed, then we should not execute ClassCleanup
                 // Note that if there is no ClassInitialze method at all, we will still set
                 // IsClassInitializeExecuted to true in RunClassInitialize
+                // IsClassInitializeExecuted can be false if all tests in the class are ignored.
                 || !IsClassInitializeExecuted)
             {
                 return null;

--- a/src/Adapter/MSTest.TestAdapter/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/UnitTestRunner.cs
@@ -211,10 +211,11 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 }
             }
 
+            ITestContext testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
+            testMethodInfo?.Parent.RunClassCleanup(testContextForClassCleanup, _classCleanupManager, testMethodInfo, testMethod, result);
+
             if (testMethodInfo?.Parent.Parent.IsAssemblyInitializeExecuted == true)
             {
-                ITestContext testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
-                testMethodInfo.Parent.RunClassCleanup(testContextForClassCleanup, _classCleanupManager, testMethodInfo, testMethod, result);
                 ITestContext testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
                 RunAssemblyCleanupIfNeeded(testContextForAssemblyCleanup, _classCleanupManager, _typeCache, result);
             }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/IgnoreTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/IgnoreTests.cs
@@ -193,6 +193,7 @@ public class SubClass : IntermediateClass
     public static void SubClassCleanup()
         => Console.WriteLine("SubClass.ClassCleanup");
 
+    // Ignore the first test on purpose, see https://github.com/microsoft/testfx/issues/5062
     [TestMethod]
     [Ignore]
     public void IgnoredMethod()

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/IgnoreTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/IgnoreTests.cs
@@ -18,9 +18,11 @@ public sealed class IgnoreTests : AcceptanceTestBase<IgnoreTests.TestAssetFixtur
 
         // Assert
         testHostResult.AssertExitCodeIs(ExitCodes.Success);
-        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 11, skipped: 7);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 11, skipped: 8);
 
         testHostResult.AssertOutputContains("SubClass.Method");
+        testHostResult.AssertOutputContains("SubClass.ClassCleanup");
+        testHostResult.AssertOutputDoesNotContain("SubClass.IgnoredMethod");
     }
 
     [TestMethod]
@@ -190,6 +192,11 @@ public class SubClass : IntermediateClass
     [ClassCleanup]
     public static void SubClassCleanup()
         => Console.WriteLine("SubClass.ClassCleanup");
+
+    [TestMethod]
+    [Ignore]
+    public void IgnoredMethod()
+        => Console.WriteLine("SubClass.IgnoredMethod");
 
     [TestMethod]
     public void Method()


### PR DESCRIPTION
When the first test of a class is ignored (and the first test ever in the assembly), we will not call AssemblyInitialize, so `IsAssemblyInitializeExecuted` will be false.

However, in that case, we still want to call `RunClassCleanup` so that the test is marked as completed (see `MarkTestComplete`). Not marking the ignored test as completed is problematic, because later on when all tests in the class are executed, we will still be viewing remaining tests in the class, hence we will not call class cleanup.

Note that even with this change, we respect the case where all tests in class are ignored, and we will not call ClassCleanup. The logic in `ExecuteClassCleanup` handles the case when class init wasn't called.

Fixes #5062