### PR TITLE
Respect EditorConfig spec about comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -83,37 +83,78 @@ file_header_template = Copyright (c) Microsoft Corporation. All rights reserved.
 ## Styling conventions
 
 # Code style defaults
-dotnet_code_quality_unused_parameters = all:suggestion                                  # IDE0060: Remove unused parameter
+# IDE0060: Remove unused parameter
+dotnet_code_quality_unused_parameters = all:suggestion
+
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-dotnet_style_readonly_field = true:warning                                              # IDE0044: Add readonly modifier
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent         # IDE0040: Add accessibility modifiers
+
+# IDE0044: Add readonly modifier
+dotnet_style_readonly_field = true:warning
+
+# IDE0040: Add accessibility modifiers
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
 
 # Expression-level preferences
 dotnet_style_coalesce_expression = true:warning
-dotnet_style_collection_initializer = true:warning                                      # IDE0028: Use collection initializers
-dotnet_style_explicit_tuple_names = true:warning                                        # IDE0033: Use explicitly provided tuple name
-dotnet_style_namespace_match_folder = false                                             # IDE0130: Namespace does not match folder structure
-dotnet_style_object_initializer = true:warning                                          # IDE0017: Use object initializers
+
+# IDE0028: Use collection initializers
+dotnet_style_collection_initializer = true:warning
+
+# IDE0033: Use explicitly provided tuple name
+dotnet_style_explicit_tuple_names = true:warning
+
+# IDE0130: Namespace does not match folder structure
+dotnet_style_namespace_match_folder = false
+
+# IDE0017: Use object initializers
+dotnet_style_object_initializer = true:warning
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_prefer_auto_properties = true:warning                                      # IDE0032: Use auto-implemented property
-dotnet_style_prefer_compound_assignment = true:suggestion                               # IDE0054: Use compound assignment / IDE0074:Use coalesce compound assignment
-dotnet_style_prefer_conditional_expression_over_assignment = true:warning               # IDE0045: Use conditional expression for assignment
-dotnet_style_prefer_conditional_expression_over_return = true:warning                   # IDE0046: Use conditional expression for return
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning                 # IDE0037: Use inferred member name
-dotnet_style_prefer_inferred_tuple_names = true:warning                                 # IDE0037: Use inferred member name
-dotnet_style_prefer_simplified_boolean_expressions = true:warning                       # IDE0075: Simplify conditional expression
-dotnet_style_prefer_simplified_interpolation = true:suggestion                          # IDE0071: Simplify interpolation
+
+# IDE0032: Use auto-implemented property
+dotnet_style_prefer_auto_properties = true:warning
+
+# IDE0054: Use compound assignment / IDE0074:Use coalesce compound assignment
+dotnet_style_prefer_compound_assignment = true:suggestion
+
+# IDE0045: Use conditional expression for assignment
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+
+# IDE0046: Use conditional expression for return
+dotnet_style_prefer_conditional_expression_over_return = true:warning
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+
+# IDE0037: Use inferred member name
+dotnet_style_prefer_inferred_tuple_names = true:warning
+
+# IDE0075: Simplify conditional expression
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+
+# IDE0071: Simplify interpolation
+dotnet_style_prefer_simplified_interpolation = true:suggestion
 
 # Null-checking preferences
-csharp_style_conditional_delegate_call = true:warning                                   # IDE1005: Use conditional delegate call
-csharp_style_prefer_null_check_over_type_check = true:warning                           # IDE0150: Prefer null check over type check
-csharp_style_throw_expression = true:warning                                            # IDE0016: Use throw expression
-dotnet_style_coalesce_expression = true:warning                                         # IDE0029: Use coalesce expression (non-nullable types) / IDE0030: Use coalesce expression (nullable types)
-dotnet_style_null_propagation = true:warning                                            # IDE0031: Use null propagation
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning         # IDE0041: Use 'is null' check
+# IDE1005: Use conditional delegate call
+csharp_style_conditional_delegate_call = true:warning
+
+# IDE0150: Prefer null check over type check
+csharp_style_prefer_null_check_over_type_check = true:warning
+
+# IDE0016: Use throw expression
+csharp_style_throw_expression = true:warning
+
+# IDE0029: Use coalesce expression (non-nullable types) / IDE0030: Use coalesce expression (nullable types)
+dotnet_style_coalesce_expression = true:warning
+
+# IDE0031: Use null propagation
+dotnet_style_null_propagation = true:warning
+
+# IDE0041: Use 'is null' check
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
 # Avoid this. unless absolutely necessary (IDE0003 and IDE0009)
 dotnet_style_qualification_for_event = false:warning
@@ -125,144 +166,385 @@ dotnet_style_qualification_for_property = false:warning
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
 
-dotnet_diagnostic.IDE0004.severity = warning            # IDE0004: Remove unnecessary cast
-dotnet_diagnostic.IDE0005.severity = warning            # IDE0005: Remove unnecessary using directives
-dotnet_diagnostic.IDE0011.severity = warning            # IDE0011: Add braces
-dotnet_diagnostic.IDE0017.severity = warning            # IDE0017: Simplify object initialization
-dotnet_diagnostic.IDE0018.severity = warning            # IDE0018: Inline variable declaration
-dotnet_diagnostic.IDE0019.severity = warning            # IDE0019: Use pattern matching to avoid 'as' followed by a 'null' check
-dotnet_diagnostic.IDE0020.severity = warning            # IDE0020: IDE0038: Use pattern matching to avoid 'is' check followed by a cast
-dotnet_diagnostic.IDE0028.severity = warning            # IDE0028: Simplify collection initialization
-dotnet_diagnostic.IDE0031.severity = warning            # IDE0031: Use null propagation
-dotnet_style_null_propagation = true:warning            # IDE0031: Use null propagation
-dotnet_diagnostic.IDE0032.severity = warning            # IDE0032: Use auto-implemented property
-dotnet_diagnostic.IDE0034.severity = warning            # IDE0034: Simplify 'default' expression
-dotnet_diagnostic.IDE0035.severity = warning            # IDE0035: Remove unreachable code
-dotnet_diagnostic.IDE0036.severity = warning            # IDE0036: Order modifiers
-dotnet_diagnostic.IDE0039.severity = warning            # IDE0039: Use local function instead of lambda
-dotnet_diagnostic.IDE0040.severity = warning            # IDE0040: Add accessibility modifiers
-dotnet_diagnostic.IDE0041.severity = warning            # IDE0041: Use 'is null' check
-dotnet_diagnostic.IDE0043.severity = warning            # IDE0043: Format string contains invalid placeholder
-dotnet_diagnostic.IDE0044.severity = warning            # IDE0044: Make field readonly
-dotnet_diagnostic.IDE0045.severity = warning            # IDE0045: Use conditional expression for assignment
-dotnet_diagnostic.IDE0046.severity = warning            # IDE0046: Use conditional expression for return
-dotnet_diagnostic.IDE0047.severity = warning            # IDE0047: Parentheses preferences
-dotnet_diagnostic.IDE0048.severity = warning            # IDE0048: Parentheses preferences
-dotnet_diagnostic.IDE0051.severity = warning            # IDE0051: Remove unused private member
-dotnet_diagnostic.IDE0052.severity = warning            # IDE0052: Remove unread private member
-dotnet_diagnostic.IDE0054.severity = warning            # IDE0054: Use compound assignment
-dotnet_diagnostic.IDE0055.severity = warning            # IDE0055: Fix formatting
-dotnet_diagnostic.IDE0056.severity = suggestion         # IDE0056: Use index operator
-dotnet_diagnostic.IDE0057.severity = suggestion         # IDE0057: Use range operator
-dotnet_diagnostic.IDE0059.severity = warning            # IDE0059: Unnecessary assignment to a value
-dotnet_diagnostic.IDE0060.severity = warning            # IDE0060: Remove unused parameter
-dotnet_diagnostic.IDE0062.severity = warning            # IDE0062: Make local function static
-dotnet_diagnostic.IDE0063.severity = warning            # IDE0063: Use simple 'using' statement
-dotnet_diagnostic.IDE0065.severity = warning            # IDE0065: 'using' directive placement
-dotnet_diagnostic.IDE0066.severity = warning            # IDE0066: Use switch expression
-dotnet_diagnostic.IDE0071.severity = warning            # IDE0071: Simplify interpolation
-dotnet_diagnostic.IDE0073.severity = warning            # IDE0073: File header
-dotnet_diagnostic.IDE0074.severity = warning            # IDE0074: Use coalesce compound assignment
-dotnet_diagnostic.IDE0075.severity = warning            # IDE0075: Simplify conditional expression
-dotnet_diagnostic.IDE0078.severity = warning            # IDE0078: Use pattern matching
-dotnet_diagnostic.IDE0082.severity = warning            # IDE0082: Convert typeof to nameof
-dotnet_diagnostic.IDE0083.severity = warning            # IDE0083: Use pattern matching (not operator)
-dotnet_diagnostic.IDE0090.severity = warning            # IDE0090: Use 'new(...)'
-dotnet_diagnostic.IDE0100.severity = warning            # IDE0100: Remove unnecessary equality operator
-dotnet_diagnostic.IDE0120.severity = warning            # IDE0120: Simplify LINQ expression
-dotnet_diagnostic.IDE0150.severity = warning            # IDE0150: Prefer 'null' check over type check
-dotnet_diagnostic.IDE0161.severity = warning            # IDE0160: IDE0161: Namespace declaration preferences
-dotnet_diagnostic.IDE0170.severity = warning            # IDE0170: Prefer extended property pattern
-dotnet_diagnostic.IDE0220.severity = warning            # IDE0220: Add explicit cast
-dotnet_diagnostic.IDE0240.severity = warning            # IDE0240: Remove redundant nullable directive
-dotnet_diagnostic.IDE0241.severity = warning            # IDE0241: Remove unnecessary nullable directive
-dotnet_diagnostic.IDE0250.severity = warning            # IDE0250: Struct can be made 'readonly'
-dotnet_diagnostic.IDE0251.severity = warning            # IDE0251: Member can be made 'readonly'
-dotnet_diagnostic.IDE0260.severity = warning            # IDE0260: Use pattern matching
-dotnet_diagnostic.IDE0270.severity = warning            # IDE0270: Use coalesce expression
-dotnet_diagnostic.IDE0280.severity = warning            # IDE0280: Use 'nameof'
-dotnet_diagnostic.IDE1005.severity = warning            # IDE1005: Use conditional delegate call
-dotnet_diagnostic.IDE1006.severity = warning            # IDE1006: Naming rule violation
-dotnet_diagnostic.IDE2000.severity = warning            # IDE2000: Avoid multiple blank lines
+# IDE0004: Remove unnecessary cast
+dotnet_diagnostic.IDE0004.severity = warning
+
+# IDE0005: Remove unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = warning
+
+# IDE0017: Simplify object initialization
+dotnet_diagnostic.IDE0017.severity = warning
+
+# IDE0018: Inline variable declaration
+dotnet_diagnostic.IDE0018.severity = warning
+
+# IDE0019: Use pattern matching to avoid 'as' followed by a 'null' check
+dotnet_diagnostic.IDE0019.severity = warning
+
+# IDE0020: IDE0038: Use pattern matching to avoid 'is' check followed by a cast
+dotnet_diagnostic.IDE0020.severity = warning
+
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = warning
+
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = warning
+
+# IDE0031: Use null propagation
+dotnet_style_null_propagation = true:warning
+
+# IDE0032: Use auto-implemented property
+dotnet_diagnostic.IDE0032.severity = warning
+
+# IDE0034: Simplify 'default' expression
+dotnet_diagnostic.IDE0034.severity = warning
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0039: Use local function instead of lambda
+dotnet_diagnostic.IDE0039.severity = warning
+
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
+
+# IDE0041: Use 'is null' check
+dotnet_diagnostic.IDE0041.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0045: Use conditional expression for assignment
+dotnet_diagnostic.IDE0045.severity = warning
+
+# IDE0046: Use conditional expression for return
+dotnet_diagnostic.IDE0046.severity = warning
+
+# IDE0047: Parentheses preferences
+dotnet_diagnostic.IDE0047.severity = warning
+
+# IDE0048: Parentheses preferences
+dotnet_diagnostic.IDE0048.severity = warning
+
+# IDE0051: Remove unused private member
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
+
+# IDE0054: Use compound assignment
+dotnet_diagnostic.IDE0054.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# IDE0056: Use index operator
+dotnet_diagnostic.IDE0056.severity = suggestion
+
+# IDE0057: Use range operator
+dotnet_diagnostic.IDE0057.severity = suggestion
+
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
+
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
+
+# IDE0062: Make local function static
+dotnet_diagnostic.IDE0062.severity = warning
+
+# IDE0063: Use simple 'using' statement
+dotnet_diagnostic.IDE0063.severity = warning
+
+# IDE0065: 'using' directive placement
+dotnet_diagnostic.IDE0065.severity = warning
+
+# IDE0066: Use switch expression
+dotnet_diagnostic.IDE0066.severity = warning
+
+# IDE0071: Simplify interpolation
+dotnet_diagnostic.IDE0071.severity = warning
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+
+# IDE0074: Use coalesce compound assignment
+dotnet_diagnostic.IDE0074.severity = warning
+
+# IDE0075: Simplify conditional expression
+dotnet_diagnostic.IDE0075.severity = warning
+
+# IDE0078: Use pattern matching
+dotnet_diagnostic.IDE0078.severity = warning
+
+# IDE0082: Convert typeof to nameof
+dotnet_diagnostic.IDE0082.severity = warning
+
+# IDE0083: Use pattern matching (not operator)
+dotnet_diagnostic.IDE0083.severity = warning
+
+# IDE0090: Use 'new(...)'
+dotnet_diagnostic.IDE0090.severity = warning
+
+# IDE0100: Remove unnecessary equality operator
+dotnet_diagnostic.IDE0100.severity = warning
+
+# IDE0120: Simplify LINQ expression
+dotnet_diagnostic.IDE0120.severity = warning
+
+# IDE0150: Prefer 'null' check over type check
+dotnet_diagnostic.IDE0150.severity = warning
+
+# IDE0160: IDE0161: Namespace declaration preferences
+dotnet_diagnostic.IDE0161.severity = warning
+
+# IDE0170: Prefer extended property pattern
+dotnet_diagnostic.IDE0170.severity = warning
+
+# IDE0220: Add explicit cast
+dotnet_diagnostic.IDE0220.severity = warning
+
+# IDE0240: Remove redundant nullable directive
+dotnet_diagnostic.IDE0240.severity = warning
+
+# IDE0241: Remove unnecessary nullable directive
+dotnet_diagnostic.IDE0241.severity = warning
+
+# IDE0250: Struct can be made 'readonly'
+dotnet_diagnostic.IDE0250.severity = warning
+
+# IDE0251: Member can be made 'readonly'
+dotnet_diagnostic.IDE0251.severity = warning
+
+# IDE0260: Use pattern matching
+dotnet_diagnostic.IDE0260.severity = warning
+
+# IDE0270: Use coalesce expression
+dotnet_diagnostic.IDE0270.severity = warning
+
+# IDE0280: Use 'nameof'
+dotnet_diagnostic.IDE0280.severity = warning
+
+# IDE1005: Use conditional delegate call
+dotnet_diagnostic.IDE1005.severity = warning
+
+# IDE1006: Naming rule violation
+dotnet_diagnostic.IDE1006.severity = warning
+
+# IDE2000: Avoid multiple blank lines
+dotnet_diagnostic.IDE2000.severity = warning
 dotnet_diagnostic.IDE2002.severity = warning
 dotnet_diagnostic.IDE2003.severity = warning
 dotnet_diagnostic.IDE2004.severity = warning
 dotnet_diagnostic.IDE2005.severity = warning
 dotnet_diagnostic.IDE2006.severity = warning
 
-dotnet_diagnostic.CA1000.severity = warning             # CA1000: Do not declare static members on generic types
-dotnet_diagnostic.CA1001.severity = warning             # CA1001: Types that own disposable fields should be disposable
-dotnet_diagnostic.CA1010.severity = warning             # CA1010: Collections should implement generic interface
-dotnet_diagnostic.CA1012.severity = warning             # CA1012: Abstract types should not have public constructors
-dotnet_diagnostic.CA1304.severity = warning             # CA1304: Specify CultureInfo
-dotnet_diagnostic.CA1305.severity = warning             # CA1305: Specify IFormatProvider
-dotnet_diagnostic.CA1309.severity = warning             # CA1309: Use ordinal StringComparison
-dotnet_diagnostic.CA1310.severity = warning             # CA1310: Specify StringComparison for correctness
-dotnet_diagnostic.CA1311.severity = warning             # CA1311: Specify a culture or use an invariant version
-dotnet_diagnostic.CA1507.severity = warning             # CA1507: Use nameof in place of string
-dotnet_diagnostic.CA1510.severity = none                # CA1510: Use ArgumentNullException throw helper
-dotnet_diagnostic.CA1708.severity = warning             # CA1708: Identifiers should differ by more than case
-dotnet_diagnostic.CA1710.severity = warning             # CA1710: Identifiers should have correct suffix
-dotnet_diagnostic.CA1711.severity = warning             # CA1711: Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1712.severity = warning             # CA1712: Do not prefix enum values with type name
-dotnet_diagnostic.CA1725.severity = warning             # CA1725: Parameter names should match base declaration
-dotnet_diagnostic.CA1805.severity = warning             # CA1805: Do not initialize unnecessarily
-dotnet_diagnostic.CA1806.severity = warning             # CA1806: Do not ignore method results
-dotnet_diagnostic.CA1829.severity = warning             # CA1829: Use Length/Count property instead of Count() when available
-dotnet_diagnostic.CA1825.severity = warning             # CA1825: Avoid zero-length array allocations
-dotnet_diagnostic.CA1827.severity = warning             # CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1836.severity = warning             # CA1836: Prefer IsEmpty over Count
-dotnet_diagnostic.CA1840.severity = warning             # CA1840: Use 'Environment.CurrentManagedThreadId'
-dotnet_diagnostic.CA1852.severity = warning             # CA1852: Seal internal types
-dotnet_code_quality.CA1852.ignore_internalsvisibleto = true
-dotnet_diagnostic.CA1854.severity = warning             # CA1854: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
-# Disabled as it's making the code complex to deal with when multi targeting
-dotnet_diagnostic.CA1863.severity = none                # CA1863: Use 'CompositeFormat'
-dotnet_diagnostic.CA2016.severity = warning             # CA2016: Forward the 'CancellationToken' parameter to methods
-dotnet_diagnostic.CA2208.severity = warning             # CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2211.severity = warning             # CA2211: Non-constant fields should not be visible
-dotnet_diagnostic.CA2215.severity = warning             # CA2215: Dispose methods should call base class dispose
-dotnet_diagnostic.CA2219.severity = warning             # CA2219: Do not raise exceptions in finally clauses
-dotnet_diagnostic.CA2241.severity = warning             # CA2241: Provide correct arguments to formatting methods
-dotnet_diagnostic.CA2242.severity = warning             # CA2242: Test for NaN correctly
-dotnet_diagnostic.CA2244.severity = warning             # CA2244: Do not duplicate indexed element initializations
-dotnet_diagnostic.CA2245.severity = warning             # CA2245: Do not assign a property to itself
-dotnet_diagnostic.CA2248.severity = warning             # CA2248: Provide correct enum argument to Enum.HasFlag
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.CA1000.severity = warning
 
-dotnet_public_api_analyzer.require_api_files = true     # RS0016: Only enable if API files are present
-dotnet_diagnostic.RS0041.severity = none                # RS0041: Do not use 'Obsolete' attribute
+# CA1001: Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1001.severity = warning
+
+# CA1010: Collections should implement generic interface
+dotnet_diagnostic.CA1010.severity = warning
+
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = warning
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = warning
+
+# CA1309: Use ordinal StringComparison
+dotnet_diagnostic.CA1309.severity = warning
+
+# CA1310: Specify StringComparison for correctness
+dotnet_diagnostic.CA1310.severity = warning
+
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = warning
+
+# CA1507: Use nameof in place of string
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = none
+
+# CA1708: Identifiers should differ by more than case
+dotnet_diagnostic.CA1708.severity = warning
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.CA1710.severity = warning
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = warning
+
+# CA1712: Do not prefix enum values with type name
+dotnet_diagnostic.CA1712.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = warning
+
+# CA1805: Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = warning
+
+# CA1806: Do not ignore method results
+dotnet_diagnostic.CA1806.severity = warning
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = warning
+
+# CA1825: Avoid zero-length array allocations
+dotnet_diagnostic.CA1825.severity = warning
+
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = warning
+
+# CA1836: Prefer IsEmpty over Count
+dotnet_diagnostic.CA1836.severity = warning
+
+# CA1840: Use 'Environment.CurrentManagedThreadId'
+dotnet_diagnostic.CA1840.severity = warning
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = warning
+dotnet_code_quality.CA1852.ignore_internalsvisibleto = true
+
+# CA1854: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+dotnet_diagnostic.CA1854.severity = warning
+
+# Disabled as it's making the code complex to deal with when multi targeting
+# CA1863: Use 'CompositeFormat'
+dotnet_diagnostic.CA1863.severity = none
+
+# CA2016: Forward the 'CancellationToken' parameter to methods
+dotnet_diagnostic.CA2016.severity = warning
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = warning
+
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.CA2211.severity = warning
+
+# CA2215: Dispose methods should call base class dispose
+dotnet_diagnostic.CA2215.severity = warning
+
+# CA2219: Do not raise exceptions in finally clauses
+dotnet_diagnostic.CA2219.severity = warning
+
+# CA2241: Provide correct arguments to formatting methods
+dotnet_diagnostic.CA2241.severity = warning
+
+# CA2242: Test for NaN correctly
+dotnet_diagnostic.CA2242.severity = warning
+
+# CA2244: Do not duplicate indexed element initializations
+dotnet_diagnostic.CA2244.severity = warning
+
+# CA2245: Do not assign a property to itself
+dotnet_diagnostic.CA2245.severity = warning
+
+# CA2248: Provide correct enum argument to Enum.HasFlag
+dotnet_diagnostic.CA2248.severity = warning
+
+# RS0016: Only enable if API files are present
+dotnet_public_api_analyzer.require_api_files = true
+
+# RS0041: Do not use 'Obsolete' attribute
+dotnet_diagnostic.RS0041.severity = none
 
 # Disabled due to bug https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687
-dotnet_diagnostic.SA1010.severity = none                # SA1010: Opening square brackets should be spaced correctly
-dotnet_diagnostic.SA1101.severity = none                # SA1101: Prefix local calls with this
-dotnet_diagnostic.SA1115.severity = none                # SA1115: Parameter should follow comma
-dotnet_diagnostic.SA1117.severity = none                # SA1117: Parameters should be on same line or separate lines
-dotnet_diagnostic.SA1118.severity = none                # SA1118: Parameter should not span multiple lines
-dotnet_diagnostic.SA1124.severity = none                # SA1124: Do not use regions
-dotnet_diagnostic.SA1201.severity = none                # SA1201: Elements should appear in the correct order
-dotnet_diagnostic.SA1202.severity = none                # SA1202: Elements should be ordered by access
-dotnet_diagnostic.SA1204.severity = none                # SA1204: Static elements should appear before instance elements
-dotnet_diagnostic.SA1308.severity = none                # SA1308: Variable names should not be prefixed
-dotnet_diagnostic.SA1309.severity = none                # SA1309: Field names should not begin with underscore
-dotnet_diagnostic.SA1313.severity = none                # SA1313: Parameter names should begin with lower-case letter
-dotnet_diagnostic.SA1402.severity = none                # SA1402: File may only contain a single type
-dotnet_diagnostic.SA1515.severity = none                # SA1515: Single-line comment should be preceded by blank line
-dotnet_diagnostic.SA1611.severity = none                # SA1611: Element parameters should be documented
-dotnet_diagnostic.SA1615.severity = none                # SA1615: Element return value should be documented
-dotnet_diagnostic.SA1633.severity = none                # SA1633: File should have header
-dotnet_diagnostic.SA1649.severity = none                # SA1649: File name should match first type name
+# SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = none
 
-dotnet_diagnostic.VSTHRD002.severity = none             # VSTHRD002 Avoid problematic synchronous waits
-dotnet_diagnostic.VSTHRD003.severity = none             # VSTHRD003: Avoid awaiting foreign Tasks
-dotnet_diagnostic.VSTHRD105.severity = none             # VSTHRD105: Avoid method overloads that assume TaskScheduler.Current
+# SA1101: Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
 
-dotnet_diagnostic.MSTESTEXP.severity = none             # MSTESTEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-dotnet_diagnostic.TPEXP.severity = none                 # TPEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+# SA1115: Parameter should follow comma
+dotnet_diagnostic.SA1115.severity = none
 
-dotnet_diagnostic.SA1108.severity = none                # SA1108: Block statements must not contain embedded comments
-dotnet_diagnostic.SA1600.severity = none                # SA1600: Elements should be documented
-dotnet_diagnostic.SA1601.severity = none                # SA1601: Partial elements should be documented
-dotnet_diagnostic.SA1602.severity = none                # SA1602: Enumeration items should be documented
+# SA1117: Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = none
+
+# SA1118: Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = none
+
+# SA1124: Do not use regions
+dotnet_diagnostic.SA1124.severity = none
+
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = none
+
+# SA1202: Elements should be ordered by access
+dotnet_diagnostic.SA1202.severity = none
+
+# SA1204: Static elements should appear before instance elements
+dotnet_diagnostic.SA1204.severity = none
+
+# SA1308: Variable names should not be prefixed
+dotnet_diagnostic.SA1308.severity = none
+
+# SA1309: Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+# SA1313: Parameter names should begin with lower-case letter
+dotnet_diagnostic.SA1313.severity = none
+
+# SA1402: File may only contain a single type
+dotnet_diagnostic.SA1402.severity = none
+
+# SA1515: Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = none
+
+# SA1611: Element parameters should be documented
+dotnet_diagnostic.SA1611.severity = none
+
+# SA1615: Element return value should be documented
+dotnet_diagnostic.SA1615.severity = none
+
+# SA1633: File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# SA1649: File name should match first type name
+dotnet_diagnostic.SA1649.severity = none
+
+# VSTHRD002 Avoid problematic synchronous waits
+dotnet_diagnostic.VSTHRD002.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# VSTHRD105: Avoid method overloads that assume TaskScheduler.Current
+dotnet_diagnostic.VSTHRD105.severity = none
+
+# MSTESTEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+dotnet_diagnostic.MSTESTEXP.severity = none
+
+# TPEXP: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+dotnet_diagnostic.TPEXP.severity = none
+
+# SA1108: Block statements must not contain embedded comments
+dotnet_diagnostic.SA1108.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1601: Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = none
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = none
 
 #### Naming styles ####
 
@@ -347,8 +629,11 @@ dotnet_naming_style.s_underscore_camel_case.capitalization = camel_case
 #### C# Coding Conventions ####
 
 # Code block preferences
-csharp_prefer_braces = true:silent                                                              # IDE0011: Add braces
-csharp_prefer_simple_using_statement = true:warning                                             # IDE0063: Use simple using statement
+# IDE0011: Add braces
+csharp_prefer_braces = true:silent
+
+# IDE0063: Use simple using statement
+csharp_prefer_simple_using_statement = true:warning
 
 # Wrap options
 csharp_preserve_single_line_blocks = true:none
@@ -356,24 +641,53 @@ csharp_preserve_single_line_statements = false:none
 
 # Code style defaults
 csharp_indent_labels = one_less_than_current
-csharp_prefer_static_local_function = true:warning                                              # IDE0062: Make local function static
-csharp_style_deconstructed_variable_declaration = true:suggestion                               # IDE0042: Deconstruct variable declaration
-csharp_style_implicit_object_creation_when_type_is_apparent = true:warning                      # IDE0090: Simplify new expression
-csharp_style_namespace_declarations = file_scoped:warning                                       # IDE0160: Use block-scoped namespace / IDE0161: Use file-scoped namespace
+# IDE0062: Make local function static
+csharp_prefer_static_local_function = true:warning
+
+# IDE0042: Deconstruct variable declaration
+csharp_style_deconstructed_variable_declaration = true:suggestion
+
+# IDE0090: Simplify new expression
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+
+# IDE0160: Use block-scoped namespace / IDE0161: Use file-scoped namespace
+csharp_style_namespace_declarations = file_scoped:warning
+
 csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_method_group_conversion = true:silent
 csharp_style_prefer_null_check_over_type_check = true:warning
-csharp_style_prefer_readonly_struct = true:suggestion                                           # IDE0250: Struct can be made 'readonly'
-csharp_style_prefer_readonly_struct_member = true:suggestion                                    # IDE0251: Member can be made 'readonly'
-csharp_style_prefer_switch_expression = true:warning                                            # IDE0066
+
+# IDE0250: Struct can be made 'readonly'
+csharp_style_prefer_readonly_struct = true:suggestion
+
+# IDE0251: Member can be made 'readonly'
+csharp_style_prefer_readonly_struct_member = true:suggestion
+
+# IDE0066: Use switch expression
+csharp_style_prefer_switch_expression = true:warning
+
 csharp_style_prefer_top_level_statements = true:silent
-csharp_style_prefer_tuple_swap = true:suggestion                                                # IDE0180: Use tuple to swap values
-csharp_style_prefer_utf8_string_literals = true:suggestion                                      # IDE0230: Use UTF-8 string literal
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion                   # IDE0059: Remove unnecessary value assignment
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent             # IDE0058: Remove unnecessary expression value
-csharp_style_prefer_primary_constructors = false                                                # IDE0290: Use primary constructor
-dotnet_style_prefer_collection_expression = false                                               # IDE0300: Simplify collection initialization
-csharp_using_directive_placement = outside_namespace:warning                                    # IDE0065: using directive placement
+
+# IDE0180: Use tuple to swap values
+csharp_style_prefer_tuple_swap = true:suggestion
+
+# IDE0230: Use UTF-8 string literal
+csharp_style_prefer_utf8_string_literals = true:suggestion
+
+# IDE0059: Remove unnecessary value assignment
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+
+# IDE0058: Remove unnecessary expression value
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# IDE0290: Use primary constructor
+csharp_style_prefer_primary_constructors = false
+
+# IDE0300: Simplify collection initialization
+dotnet_style_prefer_collection_expression = false
+
+# IDE0065: using directive placement
+csharp_using_directive_placement = outside_namespace:warning
 
 # Indentation preferences
 csharp_indent_block_contents = true
@@ -385,27 +699,58 @@ csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
 # Expression-bodied members
-csharp_style_expression_bodied_constructors = true:silent                                       # IDE0021: Use expression body for constructors
-csharp_style_expression_bodied_methods = true:warning                                           # IDE0022: Use expression body for methods
-csharp_style_expression_bodied_operators = true:warning                                         # IDE0023: Use expression body for conversion operators / IDE0024: Use expression body for operators
-csharp_style_expression_bodied_properties = true:warning                                        # IDE0025: Use expression body for properties
-csharp_style_expression_bodied_indexers = true:warning                                          # IDE0026: Use expression body for indexers
-csharp_style_expression_bodied_accessors = true:warning                                         # IDE0027: Use expression body for accessors
-csharp_style_expression_bodied_lambdas = true:warning                                           # IDE0053: Use expression body for lambdas
-csharp_style_expression_bodied_local_functions = true:warning                                   # IDE0061: Use expression body for local functions
+# IDE0021: Use expression body for constructors
+csharp_style_expression_bodied_constructors = true:silent
+
+# IDE0022: Use expression body for methods
+csharp_style_expression_bodied_methods = true:warning
+
+# IDE0023: Use expression body for conversion operators / IDE0024: Use expression body for operators
+csharp_style_expression_bodied_operators = true:warning
+
+# IDE0025: Use expression body for properties
+csharp_style_expression_bodied_properties = true:warning
+
+# IDE0026: Use expression body for indexers
+csharp_style_expression_bodied_indexers = true:warning
+
+# IDE0027: Use expression body for accessors
+csharp_style_expression_bodied_accessors = true:warning
+
+# IDE0053: Use expression body for lambdas
+csharp_style_expression_bodied_lambdas = true:warning
+
+# IDE0061: Use expression body for local functions
+csharp_style_expression_bodied_local_functions = true:warning
 
 # Expression-level preferences
-csharp_prefer_simple_default_expression = true:warning                                          # IDE0034: Simplify default expression
+# IDE0034: Simplify default expression
+csharp_prefer_simple_default_expression = true:warning
 
 # Pattern matching
-csharp_style_prefer_pattern_matching = true:silent                                              # IDE0078: Use pattern matching
-csharp_style_inlined_variable_declaration = true:warning                                        # IDE0018: Inline variable declaration
-csharp_style_pattern_matching_over_as_with_null_check = true:warning                            # IDE0019: Use pattern matching to avoid as followed by a null check
-csharp_style_pattern_matching_over_is_with_cast_check = true:warning                            # IDE0020: Use pattern matching to avoid is check followed by a cast (with variable) / IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
-csharp_style_prefer_switch_expression = true:warning                                            # IDE0066: Use switch expression
-csharp_style_prefer_pattern_matching = true:warning                                             # IDE0078: Use pattern matching
-csharp_style_prefer_not_pattern = true:warning                                                  # IDE0083: Use pattern matching (not operator)
-csharp_style_prefer_extended_property_pattern = true:warning                                    # IDE0170: Simplify property pattern
+# IDE0078: Use pattern matching
+csharp_style_prefer_pattern_matching = true:silent
+
+# IDE0018: Inline variable declaration
+csharp_style_inlined_variable_declaration = true:warning
+
+# IDE0019: Use pattern matching to avoid as followed by a null check
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable) / IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+
+# IDE0066: Use switch expression
+csharp_style_prefer_switch_expression = true:warning
+
+# IDE0078: Use pattern matching
+csharp_style_prefer_pattern_matching = true:warning
+
+# IDE0083: Use pattern matching (not operator)
+csharp_style_prefer_not_pattern = true:warning
+
+# IDE0170: Simplify property pattern
+csharp_style_prefer_extended_property_pattern = true:warning
 
 # Space preferences
 csharp_space_after_cast = false
@@ -441,17 +786,23 @@ csharp_new_line_before_open_brace = all
 csharp_new_line_between_query_expression_clauses = true
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = false:warning                                             # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
-csharp_style_var_when_type_is_apparent = true:warning                                           # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
-csharp_style_var_elsewhere = false:warning                                                      # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
+# IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false:warning
 
 # Modifiers order
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
 
 # Other features
-csharp_style_pattern_local_over_anonymous_function = false:none                                 # IDE0039: Use local function instead of lambda
-csharp_style_prefer_index_operator = true:warning                                               # IDE0056: Use index operator
-csharp_style_prefer_range_operator = true:warning                                               # IDE0057: Use range operator
+# IDE0039: Use local function instead of lambda
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# IDE0056: Use index operator
+csharp_style_prefer_index_operator = true:warning
+
+# IDE0057: Use range operator
+csharp_style_prefer_range_operator = true:warning
 
 # Experimental features
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent


### PR DESCRIPTION
https://spec.editorconfig.org/#no-inline-comments

> *Changed in version 0.15.0.*
>
> A `;` or `#` anywhere other than at the beginning of a line does not start a comment, but is part of the text of that line.
