### PR TITLE
Update InvokeTestingPlatformTask to prefer running Exe over `dotnet exec dll`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -373,6 +373,18 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <inheritdoc />
     public override bool Execute()
     {
+        var list = new List<string>();
+        foreach (DictionaryEntry entry in new SystemEnvironment().GetEnvironmentVariables())
+        {
+            if (entry.Key is string key && key.StartsWith("DOTNET_ROOT", StringComparison.OrdinalIgnoreCase))
+            {
+                list.Add($"{key}={entry.Value}");
+            }
+        }
+
+        // This should be done before the base.Execute() call.
+        EnvironmentVariables = list.ToArray();
+
         bool returnValue = base.Execute();
         if (_toolCommand is not null)
         {

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -93,7 +93,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <summary>
     /// Gets or sets the value of MSBuild property _NativeExecutableExtension.
     /// </summary>
-    public ITaskItem NativeExecutableExtension { get; set; }
+    public ITaskItem? NativeExecutableExtension { get; set; }
 
     // -------- END the previous properties shouldn't be used. See https://github.com/microsoft/testfx/issues/5091 --------
 
@@ -255,7 +255,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
             bool.TryParse(IsExecutable.ItemSpec, out bool isExecutable) && isExecutable &&
             bool.TryParse(UseAppHost.ItemSpec, out bool useAppHost) && useAppHost)
         {
-            string runCommand = $"{TargetDir.ItemSpec}{AssemblyName.ItemSpec}{NativeExecutableExtension.ItemSpec}";
+            string runCommand = $"{TargetDir.ItemSpec}{AssemblyName.ItemSpec}{NativeExecutableExtension?.ItemSpec}";
             if (File.Exists(runCommand))
             {
                 return runCommand;

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -244,13 +244,6 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
     private string? TryGetRunCommand()
     {
-        // if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        // {
-        //     // Currently fails on Linux and macOS.
-        //     // Not yet investigated.
-        //     return null;
-        // }
-
         // This condition specifically handles this part:
         // https://github.com/dotnet/sdk/blob/5846d648f2280b54a54e481f55de4d9eea0e6a0e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L1152-L1155
         // The more correct logic is implementing https://github.com/microsoft/testfx/issues/5091

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -248,6 +248,13 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
     private string? TryGetRunCommand()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Currently fails on Linux and macOS.
+            // Not yet investigated.
+            return null;
+        }
+
         // This condition specifically handles this part:
         // https://github.com/dotnet/sdk/blob/5846d648f2280b54a54e481f55de4d9eea0e6a0e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L1152-L1155
         // The more correct logic is implementing https://github.com/microsoft/testfx/issues/5091

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -380,7 +380,6 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
         //// This should be done before the base.Execute() call.
         // EnvironmentVariables = list.ToArray();
-
         bool returnValue = base.Execute();
         if (_toolCommand is not null)
         {

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -369,17 +369,17 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <inheritdoc />
     public override bool Execute()
     {
-        var list = new List<string>();
-        foreach (DictionaryEntry entry in new SystemEnvironment().GetEnvironmentVariables())
-        {
-            if (entry.Key is string key && key.StartsWith("DOTNET_ROOT", StringComparison.OrdinalIgnoreCase))
-            {
-                list.Add($"{key}={entry.Value}");
-            }
-        }
+        // var list = new List<string>();
+        // foreach (DictionaryEntry entry in new SystemEnvironment().GetEnvironmentVariables())
+        // {
+        //     if (entry.Key is string key && key.StartsWith("DOTNET_ROOT", StringComparison.OrdinalIgnoreCase))
+        //     {
+        //         list.Add($"{key}={entry.Value}");
+        //     }
+        // }
 
-        // This should be done before the base.Execute() call.
-        EnvironmentVariables = list.ToArray();
+        //// This should be done before the base.Execute() call.
+        // EnvironmentVariables = list.ToArray();
 
         bool returnValue = base.Execute();
         if (_toolCommand is not null)

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -93,7 +93,6 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <summary>
     /// Gets or sets the value of MSBuild property _NativeExecutableExtension.
     /// </summary>
-    [Required]
     public ITaskItem NativeExecutableExtension { get; set; }
 
     // -------- END the previous properties shouldn't be used. See https://github.com/microsoft/testfx/issues/5091 --------

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -369,17 +369,6 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <inheritdoc />
     public override bool Execute()
     {
-        // var list = new List<string>();
-        // foreach (DictionaryEntry entry in new SystemEnvironment().GetEnvironmentVariables())
-        // {
-        //     if (entry.Key is string key && key.StartsWith("DOTNET_ROOT", StringComparison.OrdinalIgnoreCase))
-        //     {
-        //         list.Add($"{key}={entry.Value}");
-        //     }
-        // }
-
-        //// This should be done before the base.Execute() call.
-        // EnvironmentVariables = list.ToArray();
         bool returnValue = base.Execute();
         if (_toolCommand is not null)
         {

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -64,6 +64,40 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     [Required]
     public ITaskItem TargetPath { get; set; }
 
+    // -------- BEGIN the following properties shouldn't be used. See https://github.com/microsoft/testfx/issues/5091 --------
+
+    /// <summary>
+    /// Gets or sets the value of MSBuild property UseAppHost.
+    /// </summary>
+    [Required]
+    public ITaskItem UseAppHost { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of MSBuild property _IsExecutable.
+    /// </summary>
+    [Required]
+    public ITaskItem IsExecutable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of MSBuild property TargetDir.
+    /// </summary>
+    [Required]
+    public ITaskItem TargetDir { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of MSBuild property AssemblyName.
+    /// </summary>
+    [Required]
+    public ITaskItem AssemblyName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of MSBuild property _NativeExecutableExtension.
+    /// </summary>
+    [Required]
+    public ITaskItem NativeExecutableExtension { get; set; }
+
+    // -------- END the previous properties shouldn't be used. See https://github.com/microsoft/testfx/issues/5091 --------
+
     /// <summary>
     /// Gets or sets the target framework.
     /// </summary>
@@ -122,6 +156,12 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     {
         get
         {
+            if (TryGetRunCommand() is string runCommand)
+            {
+                Log.LogMessage(MessageImportance.Low, $"Constructed target path via similar logic as to RunCommand: '{runCommand}'");
+                return Path.GetFileName(runCommand);
+            }
+
             // If target dll ends with .dll we're in the "dotnet" context
             if (TargetPath.ItemSpec.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
             {
@@ -146,6 +186,11 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <inheritdoc />
     protected override string? GenerateFullPathToTool()
     {
+        if (TryGetRunCommand() is string runCommand)
+        {
+            return runCommand;
+        }
+
         // If it's not netcore and we're on Windows we expect the TargetPath to be the executable, otherwise we try with mono.
         if (!IsNetCoreApp && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -201,6 +246,25 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
     private bool IsCurrentProcessArchitectureCompatible() =>
         _currentProcessArchitecture == EnumPolyfill.Parse<Architecture>(TestArchitecture.ItemSpec, ignoreCase: true);
+
+    private string? TryGetRunCommand()
+    {
+        // This condition specifically handles this part:
+        // https://github.com/dotnet/sdk/blob/5846d648f2280b54a54e481f55de4d9eea0e6a0e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L1152-L1155
+        // The more correct logic is implementing https://github.com/microsoft/testfx/issues/5091
+        if (IsNetCoreApp &&
+            bool.TryParse(IsExecutable.ItemSpec, out bool isExecutable) && isExecutable &&
+            bool.TryParse(UseAppHost.ItemSpec, out bool useAppHost) && useAppHost)
+        {
+            string runCommand = $"{TargetDir.ItemSpec}{AssemblyName.ItemSpec}{NativeExecutableExtension.ItemSpec}";
+            if (File.Exists(runCommand))
+            {
+                return runCommand;
+            }
+        }
+
+        return null;
+    }
 
     /// <inheritdoc />
     protected override string GenerateCommandLineCommands()

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -69,26 +69,22 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     /// <summary>
     /// Gets or sets the value of MSBuild property UseAppHost.
     /// </summary>
-    [Required]
-    public ITaskItem UseAppHost { get; set; }
+    public ITaskItem? UseAppHost { get; set; }
 
     /// <summary>
     /// Gets or sets the value of MSBuild property _IsExecutable.
     /// </summary>
-    [Required]
-    public ITaskItem IsExecutable { get; set; }
+    public ITaskItem? IsExecutable { get; set; }
 
     /// <summary>
     /// Gets or sets the value of MSBuild property TargetDir.
     /// </summary>
-    [Required]
-    public ITaskItem TargetDir { get; set; }
+    public ITaskItem? TargetDir { get; set; }
 
     /// <summary>
     /// Gets or sets the value of MSBuild property AssemblyName.
     /// </summary>
-    [Required]
-    public ITaskItem AssemblyName { get; set; }
+    public ITaskItem? AssemblyName { get; set; }
 
     /// <summary>
     /// Gets or sets the value of MSBuild property _NativeExecutableExtension.
@@ -259,10 +255,10 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
         // https://github.com/dotnet/sdk/blob/5846d648f2280b54a54e481f55de4d9eea0e6a0e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L1152-L1155
         // The more correct logic is implementing https://github.com/microsoft/testfx/issues/5091
         if (IsNetCoreApp &&
-            bool.TryParse(IsExecutable.ItemSpec, out bool isExecutable) && isExecutable &&
-            bool.TryParse(UseAppHost.ItemSpec, out bool useAppHost) && useAppHost)
+            bool.TryParse(IsExecutable?.ItemSpec, out bool isExecutable) && isExecutable &&
+            bool.TryParse(UseAppHost?.ItemSpec, out bool useAppHost) && useAppHost)
         {
-            string runCommand = $"{TargetDir.ItemSpec}{AssemblyName.ItemSpec}{NativeExecutableExtension?.ItemSpec}";
+            string runCommand = $"{TargetDir?.ItemSpec}{AssemblyName?.ItemSpec}{NativeExecutableExtension?.ItemSpec}";
             if (File.Exists(runCommand))
             {
                 return runCommand;

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -244,16 +244,18 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
     private string? TryGetRunCommand()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            // Currently fails on Linux and macOS.
-            // Not yet investigated.
-            return null;
-        }
+        // if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        // {
+        //     // Currently fails on Linux and macOS.
+        //     // Not yet investigated.
+        //     return null;
+        // }
 
         // This condition specifically handles this part:
         // https://github.com/dotnet/sdk/blob/5846d648f2280b54a54e481f55de4d9eea0e6a0e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.targets#L1152-L1155
         // The more correct logic is implementing https://github.com/microsoft/testfx/issues/5091
+        // What we want to do here is to avoid using 'dotnet exec' if possible, and run the executable directly instead.
+        // When running with dotnet exec, we are run under dotnet.exe process, which can break some scenarios (e.g, loading PRI in WinUI tests).
         if (IsNetCoreApp &&
             bool.TryParse(IsExecutable?.ItemSpec, out bool isExecutable) && isExecutable &&
             bool.TryParse(UseAppHost?.ItemSpec, out bool useAppHost) && useAppHost)
@@ -374,6 +376,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     public override bool Execute()
     {
         var list = new List<string>();
+        Debugger.Launch();
         foreach (DictionaryEntry entry in new SystemEnvironment().GetEnvironmentVariables())
         {
             if (entry.Key is string key && key.StartsWith("DOTNET_ROOT", StringComparison.OrdinalIgnoreCase))

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -256,6 +256,7 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
         // The more correct logic is implementing https://github.com/microsoft/testfx/issues/5091
         // What we want to do here is to avoid using 'dotnet exec' if possible, and run the executable directly instead.
         // When running with dotnet exec, we are run under dotnet.exe process, which can break some scenarios (e.g, loading PRI in WinUI tests).
+        // It seems like WinUI would try to resolve the PRI file relative to the path of the process, so relative to, e.g, C:\Program Files\dotnet
         if (IsNetCoreApp &&
             bool.TryParse(IsExecutable?.ItemSpec, out bool isExecutable) && isExecutable &&
             bool.TryParse(UseAppHost?.ItemSpec, out bool useAppHost) && useAppHost)
@@ -376,7 +377,6 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     public override bool Execute()
     {
         var list = new List<string>();
-        Debugger.Launch();
         foreach (DictionaryEntry entry in new SystemEnvironment().GetEnvironmentVariables())
         {
             if (entry.Key is string key && key.StartsWith("DOTNET_ROOT", StringComparison.OrdinalIgnoreCase))

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -358,8 +358,16 @@
       This let's terminal logger know that it should show `Testing` in the output,
       and not the additional internal details, such as target names.
     -->
+    <!-- Passing UseAppHost, IsExecutable, TargetDir, AssemblyName, and _NativeExecutableExtensions is mostly workaround -->
+    <!-- until we implement https://github.com/microsoft/testfx/issues/5091 properly -->
+    <!-- For now, we construct the correct "RunCommand" via these properties for a specific scenario that's known to be broken -->
     <CallTarget Targets="_TestRunStart" />
     <InvokeTestingPlatformTask TargetPath="$(TargetPath)"
+                               UseAppHost="$(UseAppHost)"
+                               IsExecutable="$(_IsExecutable)"
+                               TargetDir="$(TargetDir)"
+                               AssemblyName="$(AssemblyName)"
+                               NativeExecutableExtension="$(_NativeExecutableExtension)"
                                TargetFrameworkIdentifier="$(TargetFrameworkIdentifier)"
                                TargetFramework="$(TargetFramework)"
                                TestArchitecture="$(_TestArchitecture)"

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -149,7 +149,9 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         Assert.IsTrue(File.Exists(outputFileLog), $"Expected file '{outputFileLog}'");
         string logFileContent = File.ReadAllText(outputFileLog);
         Assert.IsTrue(Regex.IsMatch(logFileContent, ".*win-x86.*"), logFileContent);
-        Assert.IsTrue(Regex.IsMatch(logFileContent, @"\.dotnet\\x86\\dotnet\.exe"), logFileContent);
+
+        // This is the architecture part that's written by TerminalOutputDevice when there is no banner specified.
+        Assert.Contains($"[win-x86 - {TargetFrameworks.NetCurrent}]", logFileContent);
     }
 
     [TestMethod]
@@ -209,7 +211,8 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         string outputFileLog = Directory.GetFiles(testAsset.TargetAssetPath, "MSBuild Tests_net9.0_x64.log", SearchOption.AllDirectories).Single();
         Assert.IsTrue(File.Exists(outputFileLog), $"Expected file '{outputFileLog}'");
         string logFileContent = File.ReadAllText(outputFileLog);
-        Assert.IsTrue(Regex.IsMatch(logFileContent, @"\.dotnet\\dotnet\.exe"), logFileContent);
+        // This is the architecture part that's written by TerminalOutputDevice when there is no banner specified.
+        Assert.Contains($"[win-x64 - {TargetFrameworks.NetCurrent}]", logFileContent);
     }
 
     private static void CommonAssert(DotnetMuxerResult compilationResult, string tfm, bool testSucceeded, string testResultFolder)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -113,7 +113,10 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         var commandLine = new TestInfrastructure.CommandLine();
         string binlogFile = Path.Combine(TempDirectory.TestSuiteDirectory, $"{nameof(RunUsingTestTargetWithNetfxMSBuild)}.binlog");
         await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:Restore");
-        await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:\"Build;Test\" /bl:\"{binlogFile}\"");
+        await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:\"Build;Test\" /bl:\"{binlogFile}\"", environmentVariables: new Dictionary<string, string?>()
+        {
+            ["DOTNET_ROOT"] = Environment.GetEnvironmentVariable("DOTNET_ROOT"),
+        });
         StringAssert.Contains(commandLine.StandardOutput, "Tests succeeded");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -115,7 +115,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:Restore");
         await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:\"Build;Test\" /bl:\"{binlogFile}\"", environmentVariables: new Dictionary<string, string?>()
         {
-            ["DOTNET_ROOT"] = Environment.GetEnvironmentVariable("DOTNET_ROOT"),
+            ["DOTNET_ROOT"] = Path.Combine(RootFinder.Find(), ".dotnet"),
         });
         StringAssert.Contains(commandLine.StandardOutput, "Tests succeeded");
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -113,10 +113,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         var commandLine = new TestInfrastructure.CommandLine();
         string binlogFile = Path.Combine(TempDirectory.TestSuiteDirectory, $"{nameof(RunUsingTestTargetWithNetfxMSBuild)}.binlog");
         await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:Restore");
-        await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:\"Build;Test\" /bl:\"{binlogFile}\"", environmentVariables: new Dictionary<string, string?>()
-        {
-            ["DOTNET_ROOT"] = string.Empty,
-        });
+        await commandLine.RunAsync($"\"{msbuildExe}\" {testAsset.TargetAssetPath} /t:\"Build;Test\" /bl:\"{binlogFile}\"");
         StringAssert.Contains(commandLine.StandardOutput, "Tests succeeded");
     }
 
@@ -176,20 +173,9 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             $"test --arch {incompatibleArchitecture} -p:TestingPlatformDotnetTestSupport=True \"{testAsset.TargetAssetPath}\"",
             AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
             failIfReturnValueIsNotZero: false);
-        // The output looks like:
-        /*
-            D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : Could not find 'dotnet.exe' host for the 'arm64' architecture. [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-            D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :  [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-            D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : You can resolve the problem by installing the 'arm64' .NET. [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-            D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :  [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-            D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : The specified framework can be found at: [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-            D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :   - https://aka.ms/dotnet-download [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-         */
-        // Assert each error line separately for simplicity.
-        result.AssertOutputContains($"Could not find '{(OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet")}' host for the '{incompatibleArchitecture}' architecture.");
-        result.AssertOutputContains($"You can resolve the problem by installing the '{incompatibleArchitecture}' .NET.");
-        result.AssertOutputContains("The specified framework can be found at:");
-        result.AssertOutputContains("  - https://aka.ms/dotnet-download");
+
+        result.AssertOutputContains("error MSB6003: The specified task executable \"MSBuild Tests.exe\" could not be run. System.ComponentModel.Win32Exception (216): An error occurred trying to start process");
+        result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
     }
 
     [TestMethod]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -176,8 +176,31 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
             failIfReturnValueIsNotZero: false);
 
-        result.AssertOutputContains("error MSB6003: The specified task executable \"MSBuild Tests.exe\" could not be run. System.ComponentModel.Win32Exception (216): An error occurred trying to start process");
-        result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
+        // On Windows, we run the exe directly.
+        // On other OSes, we run with dotnet exec.
+        // This yields two different outputs, pointing to the same issue.
+        if (OperatingSystem.IsWindows())
+        {
+            result.AssertOutputContains("error MSB6003: The specified task executable \"MSBuild Tests.exe\" could not be run. System.ComponentModel.Win32Exception (216): An error occurred trying to start process");
+            result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
+        }
+        else
+        {
+            // The output looks like:
+            /*
+                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : Could not find 'dotnet.exe' host for the 'arm64' architecture. [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
+                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :  [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
+                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : You can resolve the problem by installing the 'arm64' .NET. [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
+                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :  [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
+                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : The specified framework can be found at: [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
+                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :   - https://aka.ms/dotnet-download [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
+             */
+            // Assert each error line separately for simplicity.
+            result.AssertOutputContains($"Could not find '{(OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet")}' host for the '{incompatibleArchitecture}' architecture.");
+            result.AssertOutputContains($"You can resolve the problem by installing the '{incompatibleArchitecture}' .NET.");
+            result.AssertOutputContains("The specified framework can be found at:");
+            result.AssertOutputContains("  - https://aka.ms/dotnet-download");
+        }
     }
 
     [TestMethod]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -182,27 +182,27 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         // On Windows, we run the exe directly.
         // On other OSes, we run with dotnet exec.
         // This yields two different outputs, pointing to the same issue.
+        string executableName = OperatingSystem.IsWindows() ? "MSBuild Tests.exe" : "MSBuild Tests";
+
+        result.AssertOutputContains($"error MSB6003: The specified task executable \"{executableName}\" could not be run. System.ComponentModel.Win32Exception");
+        result.AssertOutputContains("An error occurred trying to start process");
+
         if (OperatingSystem.IsWindows())
         {
-            result.AssertOutputContains("error MSB6003: The specified task executable \"MSBuild Tests.exe\" could not be run. System.ComponentModel.Win32Exception (216): An error occurred trying to start process");
             result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            result.AssertOutputContains("Bad CPU type in executable");
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            result.AssertOutputContains("Exec format error");
         }
         else
         {
-            // The output looks like:
-            /*
-                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : Could not find 'dotnet.exe' host for the 'arm64' architecture. [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :  [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : You can resolve the problem by installing the 'arm64' .NET. [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :  [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error : The specified framework can be found at: [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-                D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\tidOn\.packages\microsoft.testing.platform.msbuild\1.5.0-ci\buildMultiTargeting\Microsoft.Testing.Platform.MSBuild.targets(320,5): error :   - https://aka.ms/dotnet-download [D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\vf8vR\MSBuildTests\MSBuild Tests.csproj]
-             */
-            // Assert each error line separately for simplicity.
-            result.AssertOutputContains($"Could not find '{(OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet")}' host for the '{incompatibleArchitecture}' architecture.");
-            result.AssertOutputContains($"You can resolve the problem by installing the '{incompatibleArchitecture}' .NET.");
-            result.AssertOutputContains("The specified framework can be found at:");
-            result.AssertOutputContains("  - https://aka.ms/dotnet-download");
+            // Unexpected OS.
+            throw ApplicationStateGuard.Unreachable();
         }
     }
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/CommandLine.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/CommandLine.cs
@@ -72,7 +72,7 @@ public sealed class CommandLine : IDisposable
         IDictionary<string, string?>? environmentVariables = null,
         string? workingDirectory = null,
         bool cleanDefaultEnvironmentVariableIfCustomAreProvided = false,
-        int timeoutInSeconds = 60)
+        int timeoutInSeconds = 100000)
     {
         await s_maxOutstandingCommands_semaphore.WaitAsync();
         try

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/CommandLine.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/CommandLine.cs
@@ -72,7 +72,7 @@ public sealed class CommandLine : IDisposable
         IDictionary<string, string?>? environmentVariables = null,
         string? workingDirectory = null,
         bool cleanDefaultEnvironmentVariableIfCustomAreProvided = false,
-        int timeoutInSeconds = 100000)
+        int timeoutInSeconds = 60)
     {
         await s_maxOutstandingCommands_semaphore.WaitAsync();
         try


### PR DESCRIPTION
Manually verified this works as expected. For https://github.com/microsoft/PowerToys/pull/37001, tests run successfully when running the Exe directly but not when using `dotnet exec dll`. I wasn't able to set up projects in a similar way as PowerToys to repro the issue and have a test. But I think it makes sense to run directly, and potentially even faster. We probably have enough tests to know if this change is problematic for a main stream scenario.