### PR TITLE
Fix dotnet_root passing, and unignore tests

### DIFF
--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/DeploymentTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/DeploymentTests.cs
@@ -21,8 +21,7 @@ public class DeploymentTests : CLITestBase
     public void ValidateTestSourceDependencyDeployment_net462()
         => ValidateTestSourceDependencyDeployment("net462");
 
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Disabled as it's not working on CIA fatal error occurred. The required library hostfxr.dll could not be found.")]
-    private void ValidateTestSourceDependencyDeployment_netcoreapp31()
+    public void ValidateTestSourceDependencyDeployment_netcoreapp31()
         => ValidateTestSourceDependencyDeployment("netcoreapp3.1");
 
     private void ValidateTestSourceDependencyDeployment(string targetFramework)
@@ -49,8 +48,7 @@ public class DeploymentTests : CLITestBase
     public void ValidateDirectoryDeployment_net462()
         => ValidateDirectoryDeployment("net462");
 
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Disabled as it's not working on CIA fatal error occurred. The required library hostfxr.dll could not be found.")]
-    private void ValidateDirectoryDeployment_netcoreapp31()
+    public void ValidateDirectoryDeployment_netcoreapp31()
         => ValidateDirectoryDeployment("netcoreapp3.1");
 
     public void ValidateDirectoryDeployment(string targetFramework)
@@ -62,8 +60,7 @@ public class DeploymentTests : CLITestBase
     public void ValidateFileDeployment_net462()
         => ValidateFileDeployment("net462");
 
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Disabled as it's not working on CIA fatal error occurred. The required library hostfxr.dll could not be found.")]
-    private void ValidateFileDeployment_netcoreapp31()
+    public void ValidateFileDeployment_netcoreapp31()
         => ValidateFileDeployment("netcoreapp3.1");
 
     public void ValidateFileDeployment(string targetFramework)

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/SuiteLifeCycleTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/SuiteLifeCycleTests.cs
@@ -12,8 +12,7 @@ public class SuiteLifeCycleTests : CLITestBase
     private const string TestAssetName = "SuiteLifeCycleTestProject";
     private static readonly string[] WindowsLineReturn = ["\r\n"];
 
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Disabled as it's not working on CI. A fatal error occurred. The required library hostfxr.dll could not be found.")]
-    private void ValidateTestRunLifecycle_net6() => ValidateTestRunLifecycle("net6.0");
+    public void ValidateTestRunLifecycle_net6() => ValidateTestRunLifecycle("net6.0");
 
     public void ValidateTestRunLifecycle_net462() => ValidateTestRunLifecycle("net462");
 

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/TimeoutTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/TimeoutTests.cs
@@ -13,8 +13,7 @@ public class TimeoutTests : CLITestBase
 
     public void ValidateTimeoutTests_net462() => ValidateTimeoutTests("net462");
 
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Disabled as it's not working on CIA fatal error occurred. The required library hostfxr.dll could not be found.")]
-    private void ValidateTimeoutTests_netcoreapp31() => ValidateTimeoutTests("netcoreapp3.1");
+    public void ValidateTimeoutTests_netcoreapp31() => ValidateTimeoutTests("netcoreapp3.1");
 
     private void ValidateTimeoutTests(string targetFramework)
     {

--- a/test/Utilities/Automation.CLI/CLITestBase.e2e.cs
+++ b/test/Utilities/Automation.CLI/CLITestBase.e2e.cs
@@ -331,9 +331,10 @@ public partial class CLITestBase : TestContainer
         var currentDirectory = new DirectoryInfo(Directory.GetCurrentDirectory());
         do
         {
-            if (currentDirectory.EnumerateDirectories(".dotnet").Any())
+            string folderName = ".dotnet";
+            if (currentDirectory.EnumerateDirectories(folderName).Any())
             {
-                return currentDirectory.FullName;
+                return Path.Combine(currentDirectory.FullName, folderName);
             }
         }
         while ((currentDirectory = currentDirectory.Parent) != null);


### PR DESCRIPTION
Return path to .dotnet when setting DOTNET_ROOT to properly propagate the where locally installed dotnet is.

Fix #5110 