### PR TITLE
Move StartUpdate call into try, so we unlock when failing

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
@@ -48,9 +48,9 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
                 lock (_lock)
                 {
                     OnProgressStartUpdate?.Invoke(this, EventArgs.Empty);
-                    _terminal.StartUpdate();
                     try
                     {
+                        _terminal.StartUpdate();
                         _terminal.RenderProgress(_progressItems);
                     }
                     finally


### PR DESCRIPTION
If StartUpdate throws we want to call StopUpdate in finally to release the monitor.