### PR TITLE
Batching Method to handle acquiring the Console lock, executing delegates and then releasing the lock

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -161,7 +161,21 @@ internal sealed class AnsiTerminal : ITerminal
         }
     }
 
-    public void StartUpdate()
+    public void WithBatching(Action<ITerminal> action)
+    {
+        StartUpdate();
+
+        try
+        {
+            action(this);
+        }
+        finally
+        {
+            StopUpdate();
+        }
+    }
+
+    private void StartUpdate()
     {
         if (_isBatching)
         {
@@ -172,7 +186,7 @@ internal sealed class AnsiTerminal : ITerminal
         _isBatching = true;
     }
 
-    public void StopUpdate()
+    private void StopUpdate()
     {
         _console.Write(_stringBuilder.ToString());
         _isBatching = false;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/ITerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/ITerminal.cs
@@ -30,9 +30,7 @@ internal interface ITerminal
 
     void HideCursor();
 
-    void StartUpdate();
-
-    void StopUpdate();
+    void WithBatching(Action<ITerminal> action);
 
     void EraseProgress();
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NonAnsiTerminal.cs
@@ -79,10 +79,24 @@ internal sealed class NonAnsiTerminal : ITerminal
         // nop
     }
 
+    public void WithBatching(Action<ITerminal> action)
+    {
+        StartUpdate();
+
+        try
+        {
+            action(this);
+        }
+        finally
+        {
+            StopUpdate();
+        }
+    }
+
     // TODO: Refactor NonAnsiTerminal and AnsiTerminal such that we don't need StartUpdate/StopUpdate.
     // It's much better if we use lock C# keyword instead of manually calling Monitor.Enter/Exit
     // Using lock also ensures we don't accidentally have `await`s in between that could cause Exit to be on a different thread.
-    public void StartUpdate()
+    private void StartUpdate()
     {
         if (_isBatching)
         {
@@ -118,7 +132,7 @@ internal sealed class NonAnsiTerminal : ITerminal
         _isBatching = true;
     }
 
-    public void StopUpdate()
+    private void StopUpdate()
     {
         Monitor.Exit(SystemConsole.ConsoleOut);
         _isBatching = false;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -359,6 +359,8 @@ public sealed class TerminalTestReporterTests
             _stringBuilder.Append(lineNumber);
         }
 
+        public void WithBatching(Action<ITerminal> action) => throw new NotImplementedException();
+
         public void EraseProgress() => throw new NotImplementedException();
 
         public void HideCursor() => throw new NotImplementedException();
@@ -379,11 +381,7 @@ public sealed class TerminalTestReporterTests
 
         public void StartBusyIndicator() => throw new NotImplementedException();
 
-        public void StartUpdate() => throw new NotImplementedException();
-
         public void StopBusyIndicator() => throw new NotImplementedException();
-
-        public void StopUpdate() => throw new NotImplementedException();
     }
 
     private class StackTraceException : Exception


### PR DESCRIPTION
Alternatives proposal to #5179

This would avoid callers having to handle the acquire, try, finally, release logic. This helper method does it. Just pass a delegate of all the calls you want to batch.