### PR TITLE
Consider `--results-directory` before configuration

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
@@ -21,7 +21,6 @@ internal sealed class AggregatedConfiguration(
     private readonly CommandLineParseResult _commandLineParseResult = commandLineParseResult;
     private string? _resultsDirectory;
     private string? _currentWorkingDirectory;
-    private string? _testHostWorkingDirectory;
 
     public string? this[string key]
     {
@@ -33,15 +32,10 @@ internal sealed class AggregatedConfiguration(
                 return _resultsDirectory;
             }
 
-            if (key == PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)
+            if (key is PlatformConfigurationConstants.PlatformCurrentWorkingDirectory or PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)
             {
                 _currentWorkingDirectory = GetCurrentWorkingDirectoryCore();
                 return _currentWorkingDirectory;
-            }
-
-            if (key == PlatformConfigurationConstants.PlatformTestHostWorkingDirectory && _testHostWorkingDirectory is not null)
-            {
-                return _testHostWorkingDirectory;
             }
 
             // Fallback to calculating from configuration providers.
@@ -64,9 +58,6 @@ internal sealed class AggregatedConfiguration(
 
     public /* for testing */ void SetCurrentWorkingDirectory(string workingDirectory) =>
         _currentWorkingDirectory = Guard.NotNull(workingDirectory);
-
-    public void SetTestHostWorkingDirectory(string workingDirectory) =>
-        _testHostWorkingDirectory = Guard.NotNull(workingDirectory);
 
     public async Task CheckTestResultsDirectoryOverrideAndCreateItAsync(IFileLoggerProvider? fileLoggerProvider)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
@@ -8,13 +8,18 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Platform.Configurations;
 
-internal sealed class AggregatedConfiguration(IConfigurationProvider[] configurationProviders, ITestApplicationModuleInfo testApplicationModuleInfo, IFileSystem fileSystem) : IConfiguration
+internal sealed class AggregatedConfiguration(
+    IConfigurationProvider[] configurationProviders,
+    ITestApplicationModuleInfo testApplicationModuleInfo,
+    IFileSystem fileSystem,
+    CommandLineParseResult commandLineParseResult) : IConfiguration
 {
     public const string DefaultTestResultFolderName = "TestResults";
     private readonly IConfigurationProvider[] _configurationProviders = configurationProviders;
     private readonly ITestApplicationModuleInfo _testApplicationModuleInfo = testApplicationModuleInfo;
     private readonly IFileSystem _fileSystem = fileSystem;
-    private string? _resultDirectory;
+    private readonly CommandLineParseResult _commandLineParseResult = commandLineParseResult;
+    private string? _resultsDirectory;
     private string? _currentWorkingDirectory;
     private string? _testHostWorkingDirectory;
 
@@ -22,13 +27,15 @@ internal sealed class AggregatedConfiguration(IConfigurationProvider[] configura
     {
         get
         {
-            if (key == PlatformConfigurationConstants.PlatformResultDirectory && _resultDirectory is not null)
+            if (key == PlatformConfigurationConstants.PlatformResultDirectory)
             {
-                return _resultDirectory;
+                _resultsDirectory = GetResultsDirectoryCore(_commandLineParseResult);
+                return _resultsDirectory;
             }
 
-            if (key == PlatformConfigurationConstants.PlatformCurrentWorkingDirectory && _currentWorkingDirectory is not null)
+            if (key == PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)
             {
+                _currentWorkingDirectory = GetCurrentWorkingDirectoryCore();
                 return _currentWorkingDirectory;
             }
 
@@ -37,20 +44,23 @@ internal sealed class AggregatedConfiguration(IConfigurationProvider[] configura
                 return _testHostWorkingDirectory;
             }
 
-            foreach (IConfigurationProvider source in _configurationProviders)
-            {
-                if (source.TryGet(key, out string? value))
-                {
-                    return value;
-                }
-            }
-
-            return null;
+            // Fallback to calculating from configuration providers.
+            return CalculateFromConfigurationProviders(key);
         }
     }
 
-    public /* for testing */ void SetResultDirectory(string resultDirectory) =>
-        _resultDirectory = Guard.NotNull(resultDirectory);
+    private string? CalculateFromConfigurationProviders(string key)
+    {
+        foreach (IConfigurationProvider source in _configurationProviders)
+        {
+            if (source.TryGet(key, out string? value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
 
     public /* for testing */ void SetCurrentWorkingDirectory(string workingDirectory) =>
         _currentWorkingDirectory = Guard.NotNull(workingDirectory);
@@ -58,34 +68,49 @@ internal sealed class AggregatedConfiguration(IConfigurationProvider[] configura
     public void SetTestHostWorkingDirectory(string workingDirectory) =>
         _testHostWorkingDirectory = Guard.NotNull(workingDirectory);
 
-    public async Task CheckTestResultsDirectoryOverrideAndCreateItAsync(ICommandLineOptions commandLineOptions, IFileLoggerProvider? fileLoggerProvider)
+    public async Task CheckTestResultsDirectoryOverrideAndCreateItAsync(IFileLoggerProvider? fileLoggerProvider)
     {
-        // Load Configuration
-        _currentWorkingDirectory = _testApplicationModuleInfo.GetCurrentTestApplicationDirectory();
-
-        string? resultDirectory = this[PlatformConfigurationConstants.PlatformResultDirectory];
-        if (resultDirectory is null)
-        {
-            if (commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.ResultDirectoryOptionKey, out string[]? resultDirectoryArg))
-            {
-                _resultDirectory = resultDirectoryArg[0];
-            }
-        }
-        else
-        {
-            _resultDirectory = resultDirectory;
-        }
-
-        _resultDirectory ??= Path.Combine(_currentWorkingDirectory, DefaultTestResultFolderName);
-
-        _resultDirectory = _fileSystem.CreateDirectory(_resultDirectory);
+        _resultsDirectory = _fileSystem.CreateDirectory(this[PlatformConfigurationConstants.PlatformResultDirectory]!);
 
         // In case of the result directory is overridden by the config file we move logs to it.
         // This can happen in case of VSTest mode where the result directory is set to a different location.
         // This behavior is non documented and we reserve the right to change it in the future.
         if (fileLoggerProvider is not null)
         {
-            await fileLoggerProvider.CheckLogFolderAndMoveToTheNewIfNeededAsync(_resultDirectory);
+            await fileLoggerProvider.CheckLogFolderAndMoveToTheNewIfNeededAsync(_resultsDirectory);
         }
     }
+
+    private string GetResultsDirectoryCore(CommandLineParseResult commandLineParseResult)
+    {
+        // We already calculated it before, or was set by unit tests via SetCurrentWorkingDirectory.
+        if (_resultsDirectory is not null)
+        {
+            return _resultsDirectory;
+        }
+
+        // NOTE: It's important to consider the `--results-directory` option before the configurations.
+        // It makes more sense to respect it first, and is also relevant for Retry extension.
+        // Consider user is setting ResultsDirectory in configuration file.
+        // When tests are retried, we re-run the executable again, but we pass --results-directory containing the folder where the current retry attempt
+        // results should be stored. But we will also still pass configuration file (e.g, runsettings via --settings) that the user originally specified.
+        // In that case, we will want to respect --results-directory.
+        if (commandLineParseResult.TryGetOptionArgumentList(PlatformCommandLineProvider.ResultDirectoryOptionKey, out string[]? resultDirectoryArg))
+        {
+            return resultDirectoryArg[0];
+        }
+
+        // If not specified by command line, then use the configuration providers.
+        // And finally fallback to DefaultTestResultFolderName relative to the current working directory.
+        return CalculateFromConfigurationProviders(PlatformConfigurationConstants.PlatformResultDirectory)
+            ?? Path.Combine(this[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory]!, DefaultTestResultFolderName);
+    }
+
+    private string GetCurrentWorkingDirectoryCore()
+         // If the value is already set, use that.
+         => _currentWorkingDirectory
+            // If first time calculating it, prefer the value from configuration,
+            ?? CalculateFromConfigurationProviders(PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)
+            // then fallback to the actual working directory.
+            ?? _testApplicationModuleInfo.GetCurrentTestApplicationDirectory();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationExtensions.cs
@@ -35,6 +35,7 @@ public static class ConfigurationExtensions
     /// </summary>
     /// <param name="configuration">The configuration.</param>
     /// <returns>The test host working directory.</returns>
+    [Obsolete("This API is obsolete and will be removed in v2. Use GetCurrentWorkingDirectory instead.", error: true)]
     // TODO: This is only used in unit tests. Should that be removed (maybe in v2)?
     public static string GetTestHostWorkingDirectory(this IConfiguration configuration)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationExtensions.cs
@@ -35,6 +35,7 @@ public static class ConfigurationExtensions
     /// </summary>
     /// <param name="configuration">The configuration.</param>
     /// <returns>The test host working directory.</returns>
+    // TODO: This is only used in unit tests. Should that be removed (maybe in v2)?
     public static string GetTestHostWorkingDirectory(this IConfiguration configuration)
     {
         string? workingDirectory = configuration[PlatformConfigurationConstants.PlatformTestHostWorkingDirectory];

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationManager.cs
@@ -58,6 +58,6 @@ internal sealed class ConfigurationManager(IFileSystem fileSystem, ITestApplicat
 
         return defaultJsonConfiguration is null
             ? throw new InvalidOperationException(PlatformResources.ConfigurationManagerCannotFindDefaultJsonConfigurationErrorMessage)
-            : new AggregatedConfiguration(configurationProviders.OrderBy(x => x.Order).Select(x => x.ConfigurationProvider).ToArray(), _testApplicationModuleInfo, _fileSystem);
+            : new AggregatedConfiguration(configurationProviders.OrderBy(x => x.Order).Select(x => x.ConfigurationProvider).ToArray(), _testApplicationModuleInfo, _fileSystem, commandLineParseResult);
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -287,7 +287,7 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         // here we ensure to override the result directory if user passed the argument --results-directory in command line.
         // After this check users can get the result directory using IConfiguration["platformOptions:resultDirectory"] or the
         // extension method helper serviceProvider.GetConfiguration()
-        await configuration.CheckTestResultsDirectoryOverrideAndCreateItAsync(commandLineOptions, loggingState.FileLoggerProvider);
+        await configuration.CheckTestResultsDirectoryOverrideAndCreateItAsync(loggingState.FileLoggerProvider);
 
         // Display banner now because we need capture the output in case of MSBuild integration and we want to forward
         // to file disc also the banner, so at this point we need to have all services and configuration(result directory) built.

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -433,7 +433,6 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         // Out of the test host controller extension the current working directory is the test host working directory.
         string? currentWorkingDirectory = configuration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory];
         ApplicationStateGuard.Ensure(currentWorkingDirectory is not null);
-        configuration.SetTestHostWorkingDirectory(currentWorkingDirectory);
 
         testHostControllerInfo.IsCurrentProcessTestHostController = false;
 

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
@@ -85,7 +85,6 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
         var aggregatedConfiguration = (AggregatedConfiguration)serviceProvider.GetConfiguration();
         string? currentWorkingDirectory = aggregatedConfiguration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory];
         ApplicationStateGuard.Ensure(currentWorkingDirectory is not null);
-        aggregatedConfiguration.SetTestHostWorkingDirectory(currentWorkingDirectory);
 
         List<(ITestHostEnvironmentVariableProvider TestHostEnvironmentVariableProvider, int RegistrationOrder)> environmentVariableProviders = [];
         foreach (Func<IServiceProvider, ITestHostEnvironmentVariableProvider> environmentVariableProviderFactory in _environmentVariableProviderFactories)

--- a/test/UnitTests/MSTest.Engine.UnitTests/Adapter_ExecuteRequestAsyncTests.cs
+++ b/test/UnitTests/MSTest.Engine.UnitTests/Adapter_ExecuteRequestAsyncTests.cs
@@ -116,7 +116,7 @@ public class Adapter_ExecuteRequestAsyncTests : TestBase
             ServiceProvider.AddService(new FakeClock());
             ServiceProvider.AddService(new SystemTask());
 #pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            ServiceProvider.AddService(new AggregatedConfiguration(Array.Empty<IConfigurationProvider>(), new CurrentTestApplicationModuleInfo(new SystemEnvironment(), new SystemProcessHandler()), new SystemFileSystem()));
+            ServiceProvider.AddService(new AggregatedConfiguration(Array.Empty<IConfigurationProvider>(), new CurrentTestApplicationModuleInfo(new SystemEnvironment(), new SystemProcessHandler()), new SystemFileSystem(), new(null, [], [])));
 #pragma warning restore TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -23,7 +23,7 @@ public sealed class AggregatedConfigurationTests
     [DataRow(PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)]
     public void IndexerTest_DirectoryNotSetAndNoConfigurationProviders_DirectoryIsNull(string key)
-        => Assert.IsNull(new AggregatedConfiguration([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object)[key]);
+        => Assert.IsNull(new AggregatedConfiguration([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []))[key]);
 
     [TestMethod]
     [DataRow(PlatformConfigurationConstants.PlatformResultDirectory)]
@@ -33,7 +33,7 @@ public sealed class AggregatedConfigurationTests
     {
         Mock<IConfigurationProvider> mockProvider = new();
 
-        AggregatedConfiguration aggregatedConfiguration = new([mockProvider.Object], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([mockProvider.Object], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []));
         Assert.IsNull(aggregatedConfiguration[key]);
     }
 
@@ -43,23 +43,21 @@ public sealed class AggregatedConfigurationTests
     [DataRow(PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)]
     public void IndexerTest_DirectoryNotSetButConfigurationProvidersPresent_DirectoryIsNotNull(string key)
     {
-        AggregatedConfiguration aggregatedConfiguration = new([new FakeConfigurationProvider(ExpectedPath)], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([new FakeConfigurationProvider(ExpectedPath)], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []));
         Assert.AreEqual(ExpectedPath, aggregatedConfiguration[key]);
     }
 
     [TestMethod]
     public void IndexerTest_ResultDirectorySet_DirectoryIsNotNull()
     {
-        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object);
-
-        aggregatedConfiguration.SetResultDirectory(ExpectedPath);
+        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
         Assert.AreEqual(ExpectedPath, aggregatedConfiguration[PlatformConfigurationConstants.PlatformResultDirectory]);
     }
 
     [TestMethod]
     public void IndexerTest_CurrentWorkingDirectorySet_DirectoryIsNotNull()
     {
-        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []));
 
         aggregatedConfiguration.SetCurrentWorkingDirectory(ExpectedPath);
         Assert.AreEqual(ExpectedPath, aggregatedConfiguration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory]);
@@ -68,7 +66,7 @@ public sealed class AggregatedConfigurationTests
     [TestMethod]
     public void IndexerTest_TestHostWorkingDirectorySet_DirectoryIsNotNull()
     {
-        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []));
 
         aggregatedConfiguration.SetTestHostWorkingDirectory(ExpectedPath);
         Assert.AreEqual(ExpectedPath, aggregatedConfiguration[PlatformConfigurationConstants.PlatformTestHostWorkingDirectory]);
@@ -87,9 +85,8 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object);
-        await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(
-            new FakeCommandLineOptions(ExpectedPath), mockFileLogger.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         mockFileSystem.Verify(x => x.CreateDirectory(ExpectedPath), Times.Once);
         mockFileLogger.Verify(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(ExpectedPath), Times.Once);
@@ -110,9 +107,8 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object);
-        aggregatedConfiguration.SetResultDirectory(ExpectedPath);
-        await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(new FakeCommandLineOptions(ExpectedPath), mockFileLogger.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         mockFileSystem.Verify(x => x.CreateDirectory(ExpectedPath), Times.Once);
         mockFileLogger.Verify(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(ExpectedPath), Times.Once);
@@ -133,9 +129,8 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object);
-        await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(
-            new FakeCommandLineOptions(ExpectedPath, bypass: true), mockFileLogger.Object);
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         string expectedPath = "a" + Path.DirectorySeparatorChar + "b" + Path.DirectorySeparatorChar + "TestResults";
         mockFileSystem.Verify(x => x.CreateDirectory(expectedPath), Times.Once);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -74,15 +74,6 @@ public sealed class AggregatedConfigurationTests
     }
 
     [TestMethod]
-    public void IndexerTest_TestHostWorkingDirectorySet_DirectoryIsNotNull()
-    {
-        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []));
-
-        aggregatedConfiguration.SetTestHostWorkingDirectory(ExpectedPath);
-        Assert.AreEqual(ExpectedPath, aggregatedConfiguration[PlatformConfigurationConstants.PlatformTestHostWorkingDirectory]);
-    }
-
-    [TestMethod]
     public async ValueTask CheckTestResultsDirectoryOverrideAndCreateItAsync_ResultsDirectoryIsNull_GetDirectoryFromCommandLineProvider()
     {
         Mock<ITestApplicationModuleInfo> mockTestApplicationModuleInfo = new();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -22,11 +22,21 @@ public sealed class AggregatedConfigurationTests
     [DataRow(PlatformConfigurationConstants.PlatformResultDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)]
-    public void IndexerTest_DirectoryNotSetAndNoConfigurationProviders_DirectoryIsNull(string key)
-        => Assert.IsNull(new AggregatedConfiguration([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []))[key]);
+    public void IndexerTest_DirectoryNotSetAndNoConfigurationProviders(string key)
+    {
+        _testApplicationModuleInfoMock.Setup(x => x.GetCurrentTestApplicationDirectory()).Returns("TestAppDir");
+        string? expected = key switch
+        {
+            PlatformConfigurationConstants.PlatformResultDirectory => Path.Combine("TestAppDir", "TestResults"),
+            PlatformConfigurationConstants.PlatformCurrentWorkingDirectory => "TestAppDir",
+            PlatformConfigurationConstants.PlatformTestHostWorkingDirectory => null,
+            _ => throw ApplicationStateGuard.Unreachable(),
+        };
+
+        Assert.AreEqual(expected, new AggregatedConfiguration([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [], []))[key]);
+    }
 
     [TestMethod]
-    [DataRow(PlatformConfigurationConstants.PlatformResultDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)]
     public void IndexerTest_DirectoryNotSetButConfigurationProvidersPresent_DirectoryIsNull(string key)
@@ -129,7 +139,7 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("results-directory", [ExpectedPath])], []));
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [], []));
         await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         string expectedPath = "a" + Path.DirectorySeparatorChar + "b" + Path.DirectorySeparatorChar + "TestResults";
@@ -159,38 +169,6 @@ internal sealed class FakeConfigurationProvider : IConfigurationProvider
                 value = _path;
                 return true;
 
-            default:
-                return false;
-        }
-    }
-}
-
-internal sealed class FakeCommandLineOptions : ICommandLineOptions
-{
-    private readonly string _path;
-    private readonly bool _bypass;
-
-    public FakeCommandLineOptions(string path, bool bypass = false)
-    {
-        _path = path;
-        _bypass = bypass;
-    }
-
-    public bool IsOptionSet(string optionName) => throw new NotImplementedException();
-
-    public bool TryGetOptionArgumentList(string optionName, [NotNullWhen(true)] out string[]? arguments)
-    {
-        arguments = null;
-        if (_bypass)
-        {
-            return false;
-        }
-
-        switch (optionName)
-        {
-            case PlatformCommandLineProvider.ResultDirectoryOptionKey:
-                arguments = [_path];
-                return true;
             default:
                 return false;
         }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -50,7 +50,7 @@ public sealed class AggregatedConfigurationTests
     [TestMethod]
     public void IndexerTest_ResultDirectorySet_DirectoryIsNotNull()
     {
-        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        AggregatedConfiguration aggregatedConfiguration = new([], _testApplicationModuleInfoMock.Object, _fileSystemMock.Object, new(null, [new CommandLineParseOption("results-directory", [ExpectedPath])], []));
         Assert.AreEqual(ExpectedPath, aggregatedConfiguration[PlatformConfigurationConstants.PlatformResultDirectory]);
     }
 
@@ -85,7 +85,7 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("results-directory", [ExpectedPath])], []));
         await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         mockFileSystem.Verify(x => x.CreateDirectory(ExpectedPath), Times.Once);
@@ -107,7 +107,7 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("results-directory", [ExpectedPath])], []));
         await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         mockFileSystem.Verify(x => x.CreateDirectory(ExpectedPath), Times.Once);
@@ -129,7 +129,7 @@ public sealed class AggregatedConfigurationTests
         Mock<IFileLoggerProvider> mockFileLogger = new();
         mockFileLogger.Setup(x => x.CheckLogFolderAndMoveToTheNewIfNeededAsync(It.IsAny<string>())).Callback(() => { });
 
-        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("--results-directory", [ExpectedPath])], []));
+        AggregatedConfiguration aggregatedConfiguration = new([], mockTestApplicationModuleInfo.Object, mockFileSystem.Object, new(null, [new CommandLineParseOption("results-directory", [ExpectedPath])], []));
         await aggregatedConfiguration.CheckTestResultsDirectoryOverrideAndCreateItAsync(mockFileLogger.Object);
 
         string expectedPath = "a" + Path.DirectorySeparatorChar + "b" + Path.DirectorySeparatorChar + "TestResults";

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -29,7 +29,7 @@ public sealed class AggregatedConfigurationTests
         {
             PlatformConfigurationConstants.PlatformResultDirectory => Path.Combine("TestAppDir", "TestResults"),
             PlatformConfigurationConstants.PlatformCurrentWorkingDirectory => "TestAppDir",
-            PlatformConfigurationConstants.PlatformTestHostWorkingDirectory => null,
+            PlatformConfigurationConstants.PlatformTestHostWorkingDirectory => "TestAppDir",
             _ => throw ApplicationStateGuard.Unreachable(),
         };
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationExtensionsTests.cs
@@ -14,14 +14,12 @@ public sealed class ConfigurationExtensionsTests
     {
         PlatformConfigurationConstants.PlatformResultDirectory => configuration.GetTestResultDirectory(),
         PlatformConfigurationConstants.PlatformCurrentWorkingDirectory => configuration.GetCurrentWorkingDirectory(),
-        PlatformConfigurationConstants.PlatformTestHostWorkingDirectory => configuration.GetTestHostWorkingDirectory(),
         _ => throw new ArgumentException("Unsupported key."),
     };
 
     [TestMethod]
     [DataRow(PlatformConfigurationConstants.PlatformResultDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)]
-    [DataRow(PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)]
     public void ConfigurationExtensions_TestedMethod_ReturnsExpectedPath(string key)
     {
         string expectedPath = Path.Combine("a", "b", "c");
@@ -37,7 +35,6 @@ public sealed class ConfigurationExtensionsTests
     [TestMethod]
     [DataRow(PlatformConfigurationConstants.PlatformResultDirectory)]
     [DataRow(PlatformConfigurationConstants.PlatformCurrentWorkingDirectory)]
-    [DataRow(PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)]
     public void ConfigurationExtensions_TestedMethod_ThrowsArgumentNullException(string key)
     {
         Mock<IConfiguration> configuration = new();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
@@ -20,7 +20,7 @@ public sealed class TestApplicationBuilderTests
     public TestApplicationBuilderTests()
     {
         CurrentTestApplicationModuleInfo testApplicationModuleInfo = new(new SystemEnvironment(), new SystemProcessHandler());
-        AggregatedConfiguration configuration = new([], testApplicationModuleInfo, new SystemFileSystem());
+        AggregatedConfiguration configuration = new([], testApplicationModuleInfo, new SystemFileSystem(), new(null, [], []));
         configuration.SetCurrentWorkingDirectory(string.Empty);
         configuration.SetCurrentWorkingDirectory(string.Empty);
         _serviceProvider.AddService(configuration);


### PR DESCRIPTION
Fixes #5189