### PR TITLE
Ship props/targets of MSTest.TestFramework and MSTest.TestAdapter in both build and buildTransitive

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -20,8 +20,8 @@ function Confirm-NugetPackages {
     Write-Verbose "Starting Confirm-NugetPackages."
     $expectedNumOfFiles = @{
         "MSTest.Sdk"                                  = 15
-        "MSTest.TestFramework"                        = 150
-        "MSTest.TestAdapter"                          = 77
+        "MSTest.TestFramework"                        = 154
+        "MSTest.TestAdapter"                          = 93
         "MSTest"                                      = 14
         "MSTest.Analyzers"                            = 56
     }

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec
@@ -55,9 +55,7 @@
     <file src="net6.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net6.0\MSTest.TestAdapter.props" />
     <file src="net6.0\buildTransitive\common\MSTest.TestAdapter.targets" target="buildTransitive\net6.0\MSTest.TestAdapter.targets" />
     <file src="net6.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net6.0\" />
-    <file src="$ArtifactsBinDir$MSTestAdapter.PlatformServices\$Configuration$\net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net6.0\winui\" />
     <file src="net6.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net6.0\" />
-    <file src="net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net6.0\winui" />
     <file src="net6.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net6.0\" />
     <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net6.0\MSTest.TestAdapter.props" target="build\net6.0\" />
     <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net6.0\MSTest.TestAdapter.targets" target="build\net6.0\" />

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec
@@ -40,20 +40,27 @@
     <file src="netstandard2.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\netstandard2.0\" />
-
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netstandard2.0\MSTest.TestAdapter.props" target="build\netstandard2.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netstandard2.0\MSTest.TestAdapter.targets" target="build\netstandard2.0\" />
     <!-- netcoreapp3.1 -->
     <file src="netcoreapp3.1\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\netcoreapp3.1\" />
     <file src="netcoreapp3.1\buildTransitive\common\MSTest.TestAdapter.targets" target="buildTransitive\netcoreapp3.1\" />
     <file src="netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\netcoreapp3.1\" />
     <file src="netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\netcoreapp3.1\" />
     <file src="netcoreapp3.1\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\netcoreapp3.1\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netcoreapp3.1\MSTest.TestAdapter.props" target="build\netcoreapp3.1\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netcoreapp3.1\MSTest.TestAdapter.targets" target="build\netcoreapp3.1\" />
 
     <!-- net6.0 -->
     <file src="net6.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net6.0\MSTest.TestAdapter.props" />
     <file src="net6.0\buildTransitive\common\MSTest.TestAdapter.targets" target="buildTransitive\net6.0\MSTest.TestAdapter.targets" />
     <file src="net6.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net6.0\" />
+    <file src="$ArtifactsBinDir$MSTestAdapter.PlatformServices\$Configuration$\net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net6.0\winui\" />
     <file src="net6.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net6.0\" />
+    <file src="net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net6.0\winui" />
     <file src="net6.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net6.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net6.0\MSTest.TestAdapter.props" target="build\net6.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net6.0\MSTest.TestAdapter.targets" target="build\net6.0\" />
 
     <!-- net7.0 -->
     <file src="net7.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net7.0\MSTest.TestAdapter.props" />
@@ -61,6 +68,8 @@
     <file src="net7.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net7.0\" />
     <file src="net7.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net7.0\" />
     <file src="net7.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net7.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net7.0\MSTest.TestAdapter.props" target="build\net7.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net7.0\MSTest.TestAdapter.targets" target="build\net7.0\" />
 
     <!-- net8.0 -->
     <file src="net8.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net8.0\MSTest.TestAdapter.props" />
@@ -68,6 +77,8 @@
     <file src="net8.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net8.0\" />
     <file src="net8.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net8.0\" />
     <file src="net8.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net8.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net8.0\MSTest.TestAdapter.props" target="build\net8.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net8.0\MSTest.TestAdapter.targets" target="build\net8.0\" />
 
     <!-- net9.0 -->
     <file src="net9.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net9.0\MSTest.TestAdapter.props" />
@@ -75,6 +86,8 @@
     <file src="net9.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net9.0\" />
     <file src="net9.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net9.0\" />
     <file src="net9.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net9.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net9.0\MSTest.TestAdapter.props" target="build\net9.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net9.0\MSTest.TestAdapter.targets" target="build\net9.0\" />
 
     <!-- Localization -->
     <!-- All TFMs share the same resx + TestAdapter depends on PlatformServices + TestFramework so all resources are available -->

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -48,6 +48,8 @@
     <file src="netstandard2.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\netstandard2.0\" />
     <file src="netstandard2.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\netstandard2.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netstandard2.0\MSTest.TestAdapter.props" target="build\netstandard2.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netstandard2.0\MSTest.TestAdapter.targets" target="build\netstandard2.0\" />
 
     <!-- uap10.0 -->
     <file src="uap10.0.16299\buildTransitive\uwp\MSTest.TestAdapter.props" target="buildTransitive\uap10.0\MSTest.TestAdapter.props" />
@@ -55,6 +57,8 @@
     <file src="$ArtifactsBinDir$MSTestAdapter.PlatformServices\$Configuration$\uap10.0.16299\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\uap10.0\" />
     <file src="uap10.0.16299\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\uap10.0\" />
     <file src="uap10.0.16299\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\uap10.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\uap10.0\MSTest.TestAdapter.props" target="build\uap10.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\uap10.0\MSTest.TestAdapter.targets" target="build\uap10.0\" />
 
     <!-- netcoreapp3.1 -->
     <file src="netcoreapp3.1\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\netcoreapp3.1\" />
@@ -62,6 +66,8 @@
     <file src="netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\netcoreapp3.1\" />
     <file src="netcoreapp3.1\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\netcoreapp3.1\" />
     <file src="netcoreapp3.1\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\netcoreapp3.1\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netcoreapp3.1\MSTest.TestAdapter.props" target="build\netcoreapp3.1\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\netcoreapp3.1\MSTest.TestAdapter.targets" target="build\netcoreapp3.1\" />
 
     <!-- net6.0 -->
     <file src="net6.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net6.0\MSTest.TestAdapter.props" />
@@ -71,6 +77,8 @@
     <file src="net6.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net6.0\" />
     <file src="net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net6.0\winui" />
     <file src="net6.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net6.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net6.0\MSTest.TestAdapter.props" target="build\net6.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net6.0\MSTest.TestAdapter.targets" target="build\net6.0\" />
 
     <!-- net7.0 -->
     <file src="net7.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net7.0\MSTest.TestAdapter.props" />
@@ -78,6 +86,8 @@
     <file src="net7.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net7.0\" />
     <file src="net7.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net7.0\" />
     <file src="net7.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net7.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net7.0\MSTest.TestAdapter.props" target="build\net7.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net7.0\MSTest.TestAdapter.targets" target="build\net7.0\" />
 
     <!-- net8.0 -->
     <file src="net8.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net8.0\MSTest.TestAdapter.props" />
@@ -85,6 +95,8 @@
     <file src="net8.0\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net8.0\" />
     <file src="net8.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net8.0\" />
     <file src="net8.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net8.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net8.0\MSTest.TestAdapter.props" target="build\net8.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net8.0\MSTest.TestAdapter.targets" target="build\net8.0\" />
 
     <!-- net9.0 -->
     <file src="net9.0\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net9.0\MSTest.TestAdapter.props" />
@@ -94,6 +106,8 @@
     <file src="net9.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net9.0\" />
     <file src="net9.0-windows10.0.17763.0\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net9.0\uwp" />
     <file src="net9.0\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net9.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net9.0\MSTest.TestAdapter.props" target="build\net9.0\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net9.0\MSTest.TestAdapter.targets" target="build\net9.0\" />
 
     <!-- net462 -->
     <file src="net462\buildTransitive\common\MSTest.TestAdapter.props" target="buildTransitive\net462\" />
@@ -101,6 +115,9 @@
     <file src="net462\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.dll" target="buildTransitive\net462\" />
     <file src="net462\Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.dll" target="buildTransitive\net462\" />
     <file src="net462\Microsoft.TestPlatform.AdapterUtilities.dll" target="buildTransitive\net462\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net462\MSTest.TestAdapter.props" target="build\net462\" />
+    <file src="$RepoRoot$src\Adapter\MSTest.TestAdapter\build\net462\MSTest.TestAdapter.targets" target="build\net462\" />
+
     <!--
       For .NET Framework, when using AppDomains (default) with VSTest, VSTest uses a custom assembly resolver that only
       considers VS folders and MSTest.TestAdapter NuGet folder to look for deps, resulting in TestFramework.dll not

--- a/src/Adapter/MSTest.TestAdapter/build/net462/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/net462/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net462\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net462/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/net462/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net462\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net6.0/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/net6.0/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net6.0\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net6.0/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/net6.0/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net6.0\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net7.0/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/net7.0/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net7.0\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net7.0/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/net7.0/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net7.0\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net8.0/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/net8.0/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net8.0\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net8.0/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/net8.0/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net8.0\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net9.0/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/net9.0/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net9.0\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/net9.0/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/net9.0/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net9.0\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/netcoreapp3.1/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/netcoreapp3.1/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\netcoreapp3.1\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/netcoreapp3.1/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/netcoreapp3.1/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\netcoreapp3.1\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/netstandard2.0/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/netstandard2.0/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\netstandard2.0\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/netstandard2.0/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/netstandard2.0/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\netstandard2.0\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/uap10.0/MSTest.TestAdapter.props
+++ b/src/Adapter/MSTest.TestAdapter/build/uap10.0/MSTest.TestAdapter.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\uap10.0\MSTest.TestAdapter.props" />
+</Project>

--- a/src/Adapter/MSTest.TestAdapter/build/uap10.0/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/build/uap10.0/MSTest.TestAdapter.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\uap10.0\MSTest.TestAdapter.targets" />
+</Project>

--- a/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.NonWindows.nuspec
+++ b/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.NonWindows.nuspec
@@ -48,6 +48,7 @@
     <file src="net6.0/**/Microsoft.VisualStudio.TestPlatform.TestFramework.resources.dll" target="lib/net6.0/" />
     <file src="net6.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive/net6.0/" />
     <file src="net6.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive/net6.0/" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net6.0\MSTest.TestFramework.targets" target="build\net6.0\" />
 
     <!-- net7.0 -->
     <file src="net7.0/buildTransitive/winui+uwp/MSTest.TestFramework.targets" target="buildTransitive/net7.0/" />
@@ -56,6 +57,7 @@
     <file src="net7.0/**/Microsoft.VisualStudio.TestPlatform.TestFramework.resources.dll" target="lib/net7.0/" />
     <file src="net7.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive/net7.0/" />
     <file src="net7.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive/net7.0/" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net7.0\MSTest.TestFramework.targets" target="build\net7.0\" />
 
     <!-- net8.0 -->
     <file src="net8.0/buildTransitive/winui+uwp/MSTest.TestFramework.targets" target="buildTransitive/net8.0/" />
@@ -64,6 +66,7 @@
     <file src="net8.0/**/Microsoft.VisualStudio.TestPlatform.TestFramework.resources.dll" target="lib/net8.0/" />
     <file src="net8.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive/net8.0/" />
     <file src="net8.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive/net8.0/" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net8.0\MSTest.TestFramework.targets" target="build\net8.0\" />
 
     <!-- net9.0 -->
     <file src="net9.0/buildTransitive/winui+uwp/MSTest.TestFramework.targets" target="buildTransitive/net9.0/" />
@@ -72,6 +75,7 @@
     <file src="net9.0/**/Microsoft.VisualStudio.TestPlatform.TestFramework.resources.dll" target="lib/net9.0/" />
     <file src="net9.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive/net9.0/" />
     <file src="net9.0/Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive/net9.0/" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net9.0\MSTest.TestFramework.targets" target="build\net9.0\" />
 
     <!-- Source code -->
     <file src="$srcroot$/**/*.cs" target="src" />

--- a/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.nuspec
+++ b/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.nuspec
@@ -70,6 +70,7 @@
     <file src="net6.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive\net6.0\" />
     <file src="net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive\net6.0\winui\" />
     <file src="net6.0-windows10.0.18362.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive\net6.0\winui\" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net6.0\MSTest.TestFramework.targets" target="build\net6.0\" />
 
     <!-- net7.0 -->
     <file src="net7.0\buildTransitive\winui+uwp\MSTest.TestFramework.targets" target="buildTransitive\net7.0\" />
@@ -78,6 +79,7 @@
     <file src="net7.0\**\Microsoft.VisualStudio.TestPlatform.TestFramework.resources.dll" target="lib\net7.0\" />
     <file src="net7.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive\net7.0\" />
     <file src="net7.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive\net7.0\" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net7.0\MSTest.TestFramework.targets" target="build\net7.0\" />
 
     <!-- net8.0 -->
     <file src="net8.0\buildTransitive\winui+uwp\MSTest.TestFramework.targets" target="buildTransitive\net8.0\" />
@@ -86,6 +88,7 @@
     <file src="net8.0\**\Microsoft.VisualStudio.TestPlatform.TestFramework.resources.dll" target="lib\net8.0\" />
     <file src="net8.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive\net8.0\" />
     <file src="net8.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive\net8.0\" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net8.0\MSTest.TestFramework.targets" target="build\net8.0\" />
 
     <!-- net9.0 -->
     <file src="net9.0\buildTransitive\winui+uwp\MSTest.TestFramework.targets" target="buildTransitive\net9.0\" />
@@ -96,6 +99,7 @@
     <file src="net9.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive\net9.0\" />
     <file src="net9.0-windows10.0.17763.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll" target="buildTransitive\net9.0\uwp" />
     <file src="net9.0-windows10.0.17763.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.xml" target="buildTransitive\net9.0\uwp" />
+    <file src="$RepoRoot$src\TestFramework\TestFramework.Extensions\build\net9.0\MSTest.TestFramework.targets" target="build\net9.0\" />
 
     <!-- Source code -->
     <file src="$srcroot$\**\*.cs" target="src" />

--- a/src/TestFramework/TestFramework.Extensions/build/net6.0/MSTest.TestFramework.targets
+++ b/src/TestFramework/TestFramework.Extensions/build/net6.0/MSTest.TestFramework.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net6.0\MSTest.TestFramework.targets" />
+</Project>

--- a/src/TestFramework/TestFramework.Extensions/build/net7.0/MSTest.TestFramework.targets
+++ b/src/TestFramework/TestFramework.Extensions/build/net7.0/MSTest.TestFramework.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net7.0\MSTest.TestFramework.targets" />
+</Project>

--- a/src/TestFramework/TestFramework.Extensions/build/net8.0/MSTest.TestFramework.targets
+++ b/src/TestFramework/TestFramework.Extensions/build/net8.0/MSTest.TestFramework.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net8.0\MSTest.TestFramework.targets" />
+</Project>

--- a/src/TestFramework/TestFramework.Extensions/build/net9.0/MSTest.TestFramework.targets
+++ b/src/TestFramework/TestFramework.Extensions/build/net9.0/MSTest.TestFramework.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\buildTransitive\net9.0\MSTest.TestFramework.targets" />
+</Project>


### PR DESCRIPTION
Fixes #5213