### PR TITLE
Consume MTP.MSBuild from source when using internal test framework

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -26,7 +26,7 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.HangDump\Microsoft.Testing.Extensions.HangDump.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Retry\Microsoft.Testing.Extensions.Retry.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Condition="'$(UseInternalTestFramework)' == 'true' OR '$(UseMSTestFromSource)' == 'true'" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Condition="'$(UseMSTestFromSource)' == 'true'" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" GeneratePathProperty="True" />
   </ItemGroup>
 


### PR DESCRIPTION
Hopefully fixes main official build this time :)