### PR TITLE
Unblock run when cancellation was requested 

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestExecutionManager.cs
@@ -471,7 +471,11 @@ public class TestExecutionManager
 
                 try
                 {
-                    await Task.WhenAll(tasks);
+                    // Ensure we can abandon currently running tasks on cancellation, rather than waiting for them to complete.
+                    // They will still run on background but we won't await them.
+                    var runCancelled = new TaskCompletionSource<object>();
+                    _testRunCancellationToken?.Register(() => runCancelled.TrySetCanceled());
+                    await Task.WhenAny(Task.WhenAll(tasks), runCancelled.Task);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Ensure that we can complete the run when non-graceful cancellation is requested (e.b. ctrl+C on commandline), by making sure that the test runner does not wait for all currently running tests to finish.