### PR TITLE
Fix typo in docs for `StringAssert.That`

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/StringAssert.cs
+++ b/src/TestFramework/TestFramework/Assertions/StringAssert.cs
@@ -17,7 +17,7 @@ public sealed class StringAssert
     }
 
     /// <summary>
-    /// Gets the singleton instance of the CollectionAssert functionality.
+    /// Gets the singleton instance of the StringAssert functionality.
     /// </summary>
     /// <remarks>
     /// Users can use this to plug-in custom assertions through C# extension methods.


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->