### PR TITLE
Decrease default logging level to Debug

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -291,7 +291,7 @@ public sealed class TestApplication : ITestApplication
             return new(logLevel, result);
         }
 
-        logLevel = LogLevel.Trace;
+        logLevel = LogLevel.Debug;
 
         if (result.TryGetOptionArgumentList(PlatformCommandLineProvider.DiagnosticVerbosityOptionKey, out string[]? verbosity))
         {


### PR DESCRIPTION
I feel like Trace logging shouldn't be the default, esp that it can have a perf impact (https://github.com/microsoft/testfx/issues/5282).

Also:

https://github.com/microsoft/testfx/blob/66b23c38620c1ad74ce3f42d3555defdd2703177/src/Platform/Microsoft.Testing.Platform/Logging/LogLevel.cs#L11-L15
