### PR TITLE
Use new version of .NET SDK and re-enable new dotnet test experience

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,6 @@ stages:
               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
-
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
           - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,12 +98,12 @@ stages:
           # Because the build step is using -ci flag, restore is done in a local .packages directory.
           # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
           # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-           - script: $(Build.SourcesDirectory)/.dotnet/dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
-             name: Test
-             displayName: Test
-             env:
-               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+          - script: $(Build.SourcesDirectory)/.dotnet/dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
+            name: Test
+            displayName: Test
+            env:
+              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
@@ -162,12 +162,12 @@ stages:
           # Because the build step is using -ci flag, restore is done in a local .packages directory.
           # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
           # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-           - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
-             name: Test
-             displayName: Test
-             env:
-               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+          - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
+            name: Test
+            displayName: Test
+            env:
+              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
           - script: |
               chmod +x ./test.sh
@@ -225,12 +225,12 @@ stages:
           # Because the build step is using -ci flag, restore is done in a local .packages directory.
           # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
           # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-           - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
-             name: Test
-             displayName: Test
-             env:
-               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+          - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
+            name: Test
+            displayName: Test
+            env:
+              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,7 @@ stages:
               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
+
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
           - task: PublishBuildArtifacts@1
@@ -169,12 +170,6 @@ stages:
               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
-          - script: |
-              chmod +x ./test.sh
-              ./test.sh --configuration $(_BuildConfig) --ci --test --integrationTest --nobl
-            name: Test
-            displayName: Test
-          
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
           - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,25 +92,18 @@ stages:
             /p:FastAcceptanceTest=true
           name: Build
           displayName: Build
-          
+
         - ${{ if eq(parameters.SkipTests, False) }}:
 
           # Because the build step is using -ci flag, restore is done in a local .packages directory.
           # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
           # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-          # - script: $(Build.SourcesDirectory)/.dotnet/dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
-          #   name: Test
-          #   displayName: Test
-          #   env:
-          #     DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-          #     NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-
-          - script: Test.cmd
-              -configuration $(_BuildConfig)
-              -ci
-              -nobl
-            name: Test
-            displayName: Test
+           - script: $(Build.SourcesDirectory)/.dotnet/dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
+             name: Test
+             displayName: Test
+             env:
+               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
 
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
@@ -169,13 +162,13 @@ stages:
           # Because the build step is using -ci flag, restore is done in a local .packages directory.
           # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
           # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-          # - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
-          #   name: Test
-          #   displayName: Test
-          #   env:
-          #     DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-          #     NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-          
+           - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
+             name: Test
+             displayName: Test
+             env:
+               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+
           - script: |
               chmod +x ./test.sh
               ./test.sh --configuration $(_BuildConfig) --ci --test --integrationTest --nobl
@@ -232,19 +225,13 @@ stages:
           # Because the build step is using -ci flag, restore is done in a local .packages directory.
           # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
           # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-          # - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
-          #   name: Test
-          #   displayName: Test
-          #   env:
-          #     DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-          #     NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              
-          - script: |
-              chmod +x ./test.sh
-              ./test.sh --configuration $(_BuildConfig) --ci --test --integrationTest --nobl
-            name: Test
-            displayName: Test
-          
+           - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\TestStep.binlog
+             name: Test
+             displayName: Test
+             env:
+               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
           - task: PublishBuildArtifacts@1

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.100-preview.3.25167.3",
+    "dotnet": "10.0.100-preview.4.25172.1",
     "runtimes": {
       "dotnet": [
         "3.1.32",
@@ -23,7 +23,7 @@
     }
   },
   "sdk": {
-    "version": "10.0.100-preview.3.25167.3",
+    "version": "10.0.100-preview.4.25172.1",
     "allowPrerelease": true,
     "rollForward": "latestFeature"
   },


### PR DESCRIPTION
We previously made changes in the protocol used by dotnet test to add `InstanceId` which was breaking. So, we temporarily switched back to Arcade's way of testing. Now that we have an updated version of SDK that knows the new protocol, I'm switching back to `dotnet test`.