### PR TITLE
Fix parameterized UI tests for WinUI

### DIFF
--- a/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
@@ -84,7 +84,7 @@ public class UITestMethodAttribute : TestMethodAttribute
                 {
                     try
                     {
-                        result = testMethod.Invoke([]);
+                        result = testMethod.Invoke(null);
                         taskCompletionSource.SetResult(null);
                     }
                     catch (Exception e)


### PR DESCRIPTION
We should pass `null` so that we fallback to `Arguments` which has the right thing for parameterized tests:

https://github.com/microsoft/testfx/blob/d991da75ccb71e4181424ae6435d3136f9d43062/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs#L149

Fixes #740

It looks like we don't have the test infra that allows to test this, as we need vstest.console.exe that comes with VS. It should be possible to test it, but requires a bit of test infra work.