### PR TITLE
VSTestBridge: Add traits as TestMetadataProperty

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -46,7 +46,6 @@ internal static class ObjectModelConverters
     private static void CopyVSTestProperties(IEnumerable<TestProperty> testProperties, TestNode testNode, TestCase testCase, Func<TestProperty, object?> getPropertyValue,
         bool isTrxEnabled, IClientInfo client)
     {
-        List<KeyValuePair<string, string>>? testNodeTraits = null;
         foreach (TestProperty property in testProperties)
         {
             testNode.Properties.Add(new VSTestProperty(property, testCase));
@@ -90,37 +89,28 @@ internal static class ObjectModelConverters
                 {
                     testNode.Properties.Add(new SerializableNamedArrayStringProperty("vstest.TestCase.Hierarchy", testCaseHierarchy));
                 }
+            }
 
-                // ID is defined on TraitCollection but is internal so again we copy the string here.
-                else if (property.Id == "TestObject.Traits"
-                    && getPropertyValue(property) is KeyValuePair<string, string>[] traits && traits.Length > 0)
+            // ID is defined on TraitCollection but is internal so again we copy the string here.
+            if (property.Id == "TestObject.Traits"
+                && getPropertyValue(property) is KeyValuePair<string, string>[] traits && traits.Length > 0)
+            {
+                foreach (KeyValuePair<string, string> trait in traits)
                 {
-#pragma warning disable SA1010 // Opening square brackets should be spaced correctly
-                    testNodeTraits ??= [];
-#pragma warning restore SA1010 // Opening square brackets should be spaced correctly
-                    testNodeTraits.AddRange(traits);
-                }
-
-                // TPv2 is doing some special handling for MSTest... we should probably do the same.
-                // See https://github.com/microsoft/vstest/blob/main/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs#L66-L70
-                else if (property.Id == "MSTestDiscoverer.TestCategory"
-                    && getPropertyValue(property) is string[] mstestCategories && mstestCategories.Length > 0)
-                {
-#pragma warning disable SA1010 // Opening square brackets should be spaced correctly
-                    testNodeTraits ??= [];
-#pragma warning restore SA1010 // Opening square brackets should be spaced correctly
-                    foreach (string category in mstestCategories)
-                    {
-                        testNodeTraits.Add(new(category, string.Empty));
-                    }
+                    testNode.Properties.Add(new TestMetadataProperty(trait.Key, trait.Value));
                 }
             }
-        }
 
-        // Add all the traits and categories we collected from different properties.
-        if (testNodeTraits != null)
-        {
-            testNode.Properties.Add(new SerializableNamedKeyValuePairsStringProperty("traits", testNodeTraits.ToArray()));
+            // TPv2 is doing some special handling for MSTest... we should probably do the same.
+            // See https://github.com/microsoft/vstest/blob/main/src/Microsoft.TestPlatform.Extensions.TrxLogger/Utility/Converter.cs#L66-L70
+            else if (property.Id == "MSTestDiscoverer.TestCategory"
+                && getPropertyValue(property) is string[] mstestCategories && mstestCategories.Length > 0)
+            {
+                foreach (string category in mstestCategories)
+                {
+                    testNode.Properties.Add(new TestMetadataProperty(category, string.Empty));
+                }
+            }
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
@@ -374,20 +374,6 @@ public record StandardErrorProperty(string StandardError) : IProperty;
 
 internal sealed record SerializableKeyValuePairStringProperty(string Key, string Value) : KeyValuePairStringProperty(Key, Value);
 
-internal sealed record SerializableNamedKeyValuePairsStringProperty(string Name, KeyValuePair<string, string>[] Pairs) : IProperty
-{
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "https://github.com/dotnet/roslyn/issues/52421")]
-    private bool PrintMembers(StringBuilder builder)
-    {
-        builder.Append("Name = ");
-        builder.Append(Name);
-        builder.Append(", Pairs = [");
-        builder.AppendJoin(", ", Pairs.Select(x => x.ToString()));
-        builder.Append(']');
-        return true;
-    }
-}
-
 internal sealed record SerializableNamedArrayStringProperty(string Name, string[] Values) : IProperty
 {
     [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "https://github.com/dotnet/roslyn/issues/52421")]

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
@@ -152,12 +152,6 @@ internal sealed class Json
                     continue;
                 }
 
-                if (property is SerializableNamedKeyValuePairsStringProperty namedKvpStringProperty)
-                {
-                    properties.Add((namedKvpStringProperty.Name, namedKvpStringProperty.Pairs));
-                    continue;
-                }
-
                 if (property is TestFileLocationProperty fileLocationProperty)
                 {
                     properties.Add(("location.file", fileLocationProperty.FilePath));

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
@@ -213,26 +213,6 @@ internal static class SerializerUtilities
                         continue;
                     }
 
-                    if (property is SerializableNamedKeyValuePairsStringProperty namedKvpStringProperty)
-                    {
-#if NETCOREAPP
-                        properties[namedKvpStringProperty.Name] = namedKvpStringProperty.Pairs;
-#else
-                        JsonArray collection = [];
-                        foreach ((string? key, string? value) in namedKvpStringProperty.Pairs)
-                        {
-                            JsonObject o = new()
-                            {
-                                { key, value },
-                            };
-                            collection.Add(o);
-                        }
-
-                        properties[namedKvpStringProperty.Name] = collection;
-#endif
-                        continue;
-                    }
-
                     if (property is TestFileLocationProperty fileLocationProperty)
                     {
                         properties["location.file"] = fileLocationProperty.FilePath;

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
@@ -79,11 +79,10 @@ public sealed class ObjectModelConvertersTests
 
         var testNode = testResult.ToTestNode(false, VSTestClient);
 
-        SerializableNamedKeyValuePairsStringProperty[] errorTestNodeStateProperties = testNode.Properties.OfType<SerializableNamedKeyValuePairsStringProperty>().ToArray();
-        Assert.AreEqual(1, errorTestNodeStateProperties.Length);
-        Assert.AreEqual("traits", errorTestNodeStateProperties[0].Name);
-        Assert.AreEqual(1, errorTestNodeStateProperties[0].Pairs.Length);
-        Assert.AreEqual("category1", errorTestNodeStateProperties[0].Pairs[0].Key);
+        TestMetadataProperty[] testMetadatas = testNode.Properties.OfType<TestMetadataProperty>().ToArray();
+        Assert.AreEqual(1, testMetadatas.Length);
+        Assert.AreEqual("category1", testMetadatas[0].Key);
+        Assert.AreEqual(string.Empty, testMetadatas[0].Value);
     }
 
     [TestMethod]
@@ -259,12 +258,10 @@ public sealed class ObjectModelConvertersTests
 
         var testNode = testResult.ToTestNode(false, VSTestClient);
 
-        SerializableNamedKeyValuePairsStringProperty[] errorTestNodeStateProperties = testNode.Properties.OfType<SerializableNamedKeyValuePairsStringProperty>().ToArray();
-        Assert.AreEqual(1, errorTestNodeStateProperties.Length);
-        Assert.AreEqual("traits", errorTestNodeStateProperties[0].Name);
-        Assert.AreEqual(1, errorTestNodeStateProperties[0].Pairs.Length);
-        Assert.AreEqual("key", errorTestNodeStateProperties[0].Pairs[0].Key);
-        Assert.AreEqual("value", errorTestNodeStateProperties[0].Pairs[0].Value);
+        TestMetadataProperty[] testMetadatas = testNode.Properties.OfType<TestMetadataProperty>().ToArray();
+        Assert.AreEqual(1, testMetadatas.Length);
+        Assert.AreEqual("key", testMetadatas[0].Key);
+        Assert.AreEqual("value", testMetadatas[0].Value);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
@@ -209,10 +209,10 @@ public sealed class TestNodePropertiesTests
             new TestMethodIdentifierProperty("assembly", "namespace", "type", "method", ["string"], "bool").ToString());
 
     [TestMethod]
-    public void SerializableNamedKeyValuePairsStringProperty_ToStringIsCorrect()
+    public void TestMetadataProperty_ToStringIsCorrect()
         => Assert.AreEqual(
-            "SerializableNamedKeyValuePairsStringProperty { Name = some name, Pairs = [[key, value]] }",
-            new SerializableNamedKeyValuePairsStringProperty("some name", [new("key", "value")]).ToString());
+            "TestMetadataProperty { Key = some name, Value = some value }",
+            new TestMetadataProperty("some name", "some value").ToString());
 
     [TestMethod]
     public void SerializableNamedArrayStringProperty_ToStringIsCorrect()

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -176,7 +176,7 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(TestNode))
         {
-            Assert.AreEqual("""{"uid":"uid","display-name":"DisplayName","tuples-key":[{"a":"1"},{"b":"2"}],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""}""".Replace(" ", string.Empty), instanceSerialized, because);
+            Assert.AreEqual("""{"uid":"uid","display-name":"DisplayName","testmetadata-key":["testmetadata-value"],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""}""".Replace(" ", string.Empty), instanceSerialized, because);
             return;
         }
 
@@ -188,7 +188,7 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(TestNodeUpdateMessage))
         {
-            Assert.AreEqual("""{"node":{"uid":"uid","display-name":"DisplayName","tuples-key":[{"a":"1"},{"b":"2"}],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""},"parent":"parent-uid"}""".Replace(" ", string.Empty), instanceSerialized, because);
+            Assert.AreEqual("""{"node":{"uid":"uid","display-name":"DisplayName","testmetadata-key":["testmetadata-value"],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""},"parent":"parent-uid"}""".Replace(" ", string.Empty), instanceSerialized, because);
             return;
         }
 
@@ -463,7 +463,7 @@ public sealed class FormatterUtilitiesTests
             testNode.Properties.Add(new StandardOutputProperty("textProperty"));
             testNode.Properties.Add(new StandardErrorProperty("textProperty2"));
             testNode.Properties.Add(new SerializableNamedArrayStringProperty("array-key", ["1", "2"]));
-            testNode.Properties.Add(new SerializableNamedKeyValuePairsStringProperty("tuples-key", [new KeyValuePair<string, string>("a", "1"), new KeyValuePair<string, string>("b", "2"),]));
+            testNode.Properties.Add(new TestMetadataProperty("testmetadata-key", "testmetadata-value"));
 
             return testNode;
         }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -176,7 +176,7 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(TestNode))
         {
-            Assert.AreEqual("""{"uid":"uid","display-name":"DisplayName","testmetadata-key":["testmetadata-value"],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""}""".Replace(" ", string.Empty), instanceSerialized, because);
+            Assert.AreEqual("""{"uid":"uid","display-name":"DisplayName","traits":[{"testmetadata-key":"testmetadata-value"}],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""}""".Replace(" ", string.Empty), instanceSerialized, because);
             return;
         }
 
@@ -188,7 +188,7 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(TestNodeUpdateMessage))
         {
-            Assert.AreEqual("""{"node":{"uid":"uid","display-name":"DisplayName","testmetadata-key":["testmetadata-value"],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""},"parent":"parent-uid"}""".Replace(" ", string.Empty), instanceSerialized, because);
+            Assert.AreEqual("""{"node":{"uid":"uid","display-name":"DisplayName","traits":[{"testmetadata-key":"testmetadata-value"}],"array-key":["1","2"],"standardError":"textProperty2","standardOutput":"textProperty","time.start-utc":"2023-01-01T01:01:01.0000000+00:00","time.stop-utc":"2023-01-01T01:01:01.0000000+00:00","time.duration-ms":0,"location.namespace":"namespace","location.type":"typeName","location.method":"methodName(param1,param2)","location.file":"filePath","location.line-start":1,"location.line-end":2,"key":"value","node-type":"action","execution-state":"failed","error.message":"sample","error.stacktrace":"","assert.actual":"","assert.expected":""},"parent":"parent-uid"}""".Replace(" ", string.Empty), instanceSerialized, because);
             return;
         }
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.VSTestBridge\Microsoft.Testing.Extensions.VSTestBridge.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Partially addressing #5265

From the original issue:

> Ideally, in order to reduce memory consumption, these properties should not always be emitted by the test framework and we should have a capability like we have for TRX that would allow clients or extensions to declare they are interested about such properties so that test framework can conditionally emit them.

This is something I'm not doing yet in this PR. So will keep the issue open to address it.