### PR TITLE
Fix double empty line

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -141,11 +141,10 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
     private void AppendTestRunSummary(ITerminal terminal)
     {
-        terminal.AppendLine();
-
         IEnumerable<IGrouping<bool, TestRunArtifact>> artifactGroups = _artifacts.GroupBy(a => a.OutOfProcess);
         if (artifactGroups.Any())
         {
+            // Add extra empty line when we will be writing any artifacts, to split it from previous output.
             terminal.AppendLine();
         }
 
@@ -169,6 +168,8 @@ internal sealed partial class TerminalTestReporter : IDisposable
                 terminal.AppendLine();
             }
         }
+
+        terminal.AppendLine();
 
         int totalTests = _assemblies.Values.Sum(a => a.TotalTests);
         int totalFailedTests = _assemblies.Values.Sum(a => a.FailedTests);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -145,11 +145,11 @@ public sealed class TerminalTestReporterTests
               Error output
                 Oh no!
             ␛[m
-
               Out of process file artifacts produced:
                 - ␛[90m␛]8;;file:///{folderLink}artifact1.txt␛\{folder}artifact1.txt␛]8;;␛\␛[m
               In process file artifacts produced:
                 - ␛[90m␛]8;;file:///{folderLink}artifact2.txt␛\{folder}artifact2.txt␛]8;;␛\␛[m
+            
             ␛[91mTest run summary: Failed!␛[90m - ␛[m␛[90m␛]8;;file:///{folderLinkNoSlash}␛\{folder}assembly.dll␛]8;;␛\␛[m (net8.0|x64)
             ␛[m  total: 5
             ␛[91m  failed: 3


### PR DESCRIPTION
Screenshot from dotnet test, but it is the same issue and code, empty line was doubled when we wrote artifacts, because we wrote it before writing artifacts and not after. 

![image](https://github.com/user-attachments/assets/8b1224ce-4172-4641-8b1b-cc1541b35086)