### PR TITLE
Move System.Threading.Tasks.Extensions to TestFramework

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec
@@ -6,7 +6,6 @@
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
-        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -63,7 +63,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.AdapterUtilities" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -3,10 +3,13 @@
   <metadata>
     $CommonMetadataElements$
     <dependencies>
-      <!-- WARNING! MSTest.TestAdapter shouldn't have dependencies unless they are used by MTP only -->
-      <!-- If you add a dependency here, and user decided to upgrade it in their own project, it won't be considered -->
-      <!-- by GenerateBindingRedirects target (because adapter isn't add as "Reference" item) -->
-      <!-- This can then cause the assembly to fail loading. -->
+      <!-- 
+        WARNING! MSTest.TestAdapter shouldn't have dependencies unless they are used by MTP only.
+        MSTest.TestAdapter dll is not referenced by the test project, unless it uses MTP. So the dependency 
+        won't be considered by GenerateBindingRedirects target. When user references the same package and
+        upgrades it to version that is newer than what we reference, they will get assembly load failures, because
+        the assembly version is mismatched, and there is not binding redirect to correct it.
+      -->
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -3,18 +3,19 @@
   <metadata>
     $CommonMetadataElements$
     <dependencies>
+      <!-- WARNING! MSTest.TestAdapter shouldn't have dependencies unless they are used by MTP only -->
+      <!-- If you add a dependency here, and user decided to upgrade it in their own project, it won't be considered -->
+      <!-- by GenerateBindingRedirects target (because adapter isn't add as "Reference" item) -->
+      <!-- This can then cause the assembly to fail loading. -->
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
-        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="net462">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
-        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />

--- a/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.NonWindows.nuspec
+++ b/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.NonWindows.nuspec
@@ -5,7 +5,12 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+
+        <!-- This dependency is used only in adapter, but we have to add it to test framework. -->
+        <!-- See comment in MSTest.TestAdapter.nuspec for info. -->
+        <!-- START: Moved from MSTest.TestAdapter -->
         <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
+        <!-- END: Moved from MSTest.TestAdapter -->
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="MSTest.Analyzers" version="$Version$" />

--- a/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.NonWindows.nuspec
+++ b/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.NonWindows.nuspec
@@ -5,6 +5,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="MSTest.Analyzers" version="$Version$" />

--- a/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.nuspec
+++ b/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.nuspec
@@ -5,12 +5,15 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="net462">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="uap10.0">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+        <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="MSTest.Analyzers" version="$Version$" />

--- a/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.nuspec
+++ b/src/TestFramework/TestFramework.Extensions/MSTest.TestFramework.nuspec
@@ -5,11 +5,21 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+
+        <!-- This dependency is used only in adapter, but we have to add it to test framework. -->
+        <!-- See comment in MSTest.TestAdapter.nuspec for info. -->
+        <!-- START: Moved from MSTest.TestAdapter -->
         <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
+        <!-- END: Moved from MSTest.TestAdapter -->
       </group>
       <group targetFramework="net462">
         <dependency id="MSTest.Analyzers" version="$Version$" />
+
+        <!-- This dependency is used only in adapter, but we have to add it to test framework. -->
+        <!-- See comment in MSTest.TestAdapter.nuspec for info. -->
+        <!-- START: Moved from MSTest.TestAdapter -->
         <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
+        <!-- END: Moved from MSTest.TestAdapter -->
       </group>
       <group targetFramework="uap10.0">
         <dependency id="MSTest.Analyzers" version="$Version$" />

--- a/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
+++ b/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
@@ -59,7 +59,12 @@
 
   <ItemGroup>
     <PackageReference Condition=" '$(TargetFramework)' == '$(WinUiMinimum)' " Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
+
+    <!-- This dependency is used only in adapter, but we have to add it to test framework. -->
+    <!-- See comment in MSTest.TestAdapter.nuspec for info. -->
+    <!-- START: Moved from MSTest.TestAdapter -->
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
+    <!-- END: Moved from MSTest.TestAdapter -->
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkMinimum)' ">

--- a/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
+++ b/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup>
     <PackageReference Condition=" '$(TargetFramework)' == '$(WinUiMinimum)' " Include="Microsoft.WindowsAppSDK" Version="$(MicrosoftWindowsAppSDKVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkMinimum)' ">
@@ -77,6 +78,7 @@
 
   <ItemGroup Label="NuGet">
     <NuspecProperty Include="RepoRoot=$(RepoRoot)" />
+    <NuspecProperty Include="SystemThreadingTasksExtensionsVersion=$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Scenario:

A test project uses MSTest 3.8.3, and upgrades `System.Threading.Tasks.Extensions` to 4.6.0 or later.
MSTest.TestAdapter already depends on 4.5.4.

Because the user is using a newer version, the requested assembly version by MSTest.TestAdapter won't be found.
**Normally**, binding redirects should be generated and are considered by VSTest. However, the tooling only consider assemblies in `Reference` item for binding redirect generation. As MSTest.TestAdapter NuGet package is kinda special and the adapter dll isn't added to `Reference` item, binding redirect is not generated.