### PR TITLE
Remove SessionUid from FileArtifactProperty

### DIFF
--- a/src/Adapter/MSTest.Engine/Engine/TestExecutionContext.cs
+++ b/src/Adapter/MSTest.Engine/Engine/TestExecutionContext.cs
@@ -5,7 +5,6 @@ using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Framework.Configurations;
 using Microsoft.Testing.Framework.Helpers;
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.TestHost;
 
 using PlatformTestNode = Microsoft.Testing.Platform.Extensions.Messages.TestNode;
 
@@ -16,16 +15,14 @@ internal sealed class TestExecutionContext : ITestExecutionContext
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly PlatformTestNode _platformTestNode;
     private readonly ITrxReportCapability? _trxReportCapability;
-    private readonly SessionUid _sessionUid;
     private readonly CancellationToken _originalCancellationToken;
 
     public TestExecutionContext(IConfiguration configuration, TestNode testNode, PlatformTestNode platformTestNode,
-        ITrxReportCapability? trxReportCapability, SessionUid sessionUid, CancellationToken cancellationToken)
+        ITrxReportCapability? trxReportCapability, CancellationToken cancellationToken)
     {
         Configuration = configuration;
         _platformTestNode = platformTestNode;
         _trxReportCapability = trxReportCapability;
-        _sessionUid = sessionUid;
         TestInfo = new TestInfo(testNode);
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         _originalCancellationToken = cancellationToken;
@@ -76,7 +73,7 @@ internal sealed class TestExecutionContext : ITestExecutionContext
 
     public Task AddTestAttachmentAsync(FileInfo file, string displayName, string? description = null)
     {
-        _platformTestNode.Properties.Add(new FileArtifactProperty(_sessionUid, file, displayName, description));
+        _platformTestNode.Properties.Add(new FileArtifactProperty(file, displayName, description));
         return Task.CompletedTask;
     }
 

--- a/src/Adapter/MSTest.Engine/Engine/ThreadPoolTestNodeRunner.cs
+++ b/src/Adapter/MSTest.Engine/Engine/ThreadPoolTestNodeRunner.cs
@@ -215,7 +215,7 @@ internal sealed class ThreadPoolTestNodeRunner : IDisposable
             platformTestNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(platformTestNode.Uid.Value[..platformTestNode.Uid.Value.LastIndexOf('.')]));
         }
 
-        TestExecutionContext testExecutionContext = new(_configuration, testNode, platformTestNode, _trxReportCapability, _sessionUid, _cancellationToken);
+        TestExecutionContext testExecutionContext = new(_configuration, testNode, platformTestNode, _trxReportCapability, _cancellationToken);
         try
         {
             // If we're already enqueued we cancel the test before the start

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FrameworkHandlerAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FrameworkHandlerAdapter.cs
@@ -126,7 +126,7 @@ internal sealed class FrameworkHandlerAdapter : IFrameworkHandle
         _frameworkHandle?.RecordResult(testResult);
 
         // Publish node state change to Microsoft Testing Platform
-        var testNode = testResult.ToTestNode(_isTrxEnabled, _clientInfo, _session.SessionUid);
+        var testNode = testResult.ToTestNode(_isTrxEnabled, _clientInfo);
 
         var testNodeChange = new TestNodeUpdateMessage(_session.SessionUid, testNode);
         _messageBus.PublishAsync(_adapterExtensionBase, testNodeChange).Await();

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -117,7 +117,7 @@ internal static class ObjectModelConverters
     /// <summary>
     /// Converts a VSTest <see cref="TestResult"/> to a Microsoft Testing Platform <see cref="TestNode"/>.
     /// </summary>
-    public static TestNode ToTestNode(this TestResult testResult, bool isTrxEnabled, IClientInfo client, SessionUid sessionUid)
+    public static TestNode ToTestNode(this TestResult testResult, bool isTrxEnabled, IClientInfo client)
     {
         var testNode = testResult.TestCase.ToTestNode(isTrxEnabled, client, testResult.DisplayName);
         CopyVSTestProperties(testResult.Properties, testNode, testResult.TestCase, testResult.GetPropertyValue, isTrxEnabled, client);
@@ -173,7 +173,7 @@ internal static class ObjectModelConverters
         {
             foreach (UriDataAttachment attachment in attachmentSet.Attachments)
             {
-                testNode.Properties.Add(new FileArtifactProperty(sessionUid, new FileInfo(attachment.Uri.LocalPath), attachmentSet.DisplayName, attachment.Description));
+                testNode.Properties.Add(new FileArtifactProperty(new FileInfo(attachment.Uri.LocalPath), attachmentSet.DisplayName, attachment.Description));
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.TestHost;
-
 namespace Microsoft.Testing.Platform.Extensions.Messages;
 
 /// <summary>
@@ -377,11 +375,10 @@ public record StandardErrorProperty(string StandardError) : IProperty;
 /// <summary>
 /// Property that represents multiple artifacts/attachments to associate with a test node.
 /// </summary>
-/// <param name="SessionUid">The session UID.</param>
 /// <param name="FileInfo">The file information.</param>
 /// <param name="DisplayName">The display name.</param>
 /// <param name="Description">The description.</param>
-public record FileArtifactProperty(SessionUid SessionUid, FileInfo FileInfo, string DisplayName, string? Description = null) : IProperty;
+public record FileArtifactProperty(FileInfo FileInfo, string DisplayName, string? Description = null) : IProperty;
 
 internal sealed record SerializableKeyValuePairStringProperty(string Key, string Value) : KeyValuePairStringProperty(Key, Value);
 

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,16 +1,14 @@
 #nullable enable
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty
-Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.Deconstruct(out Microsoft.Testing.Platform.TestHost.SessionUid SessionUid, out System.IO.FileInfo! FileInfo, out string! DisplayName, out string? Description) -> void
+Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.Deconstruct(out System.IO.FileInfo! FileInfo, out string! DisplayName, out string? Description) -> void
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.Description.get -> string?
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.Description.init -> void
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.DisplayName.get -> string!
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.DisplayName.init -> void
+Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.FileArtifactProperty(Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty! original) -> void
+Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.FileArtifactProperty(System.IO.FileInfo! FileInfo, string! DisplayName, string? Description = null) -> void
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.FileInfo.get -> System.IO.FileInfo!
 Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.FileInfo.init -> void
-Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.SessionUid.get -> Microsoft.Testing.Platform.TestHost.SessionUid
-Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.SessionUid.init -> void
-Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.FileArtifactProperty(Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty! original) -> void
-Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.FileArtifactProperty(Microsoft.Testing.Platform.TestHost.SessionUid SessionUid, System.IO.FileInfo! FileInfo, string! DisplayName, string? Description = null) -> void
 override Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.Equals(object? obj) -> bool
 override Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.GetHashCode() -> int
 override Microsoft.Testing.Platform.Extensions.Messages.FileArtifactProperty.ToString() -> string!

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -126,7 +126,7 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                             artifact.Description ?? string.Empty,
                             testNodeUpdateMessage.TestNode.Uid.Value,
                             testNodeUpdateMessage.TestNode.DisplayName,
-                            artifact.SessionUid.Value),
+                            testNodeUpdateMessage.SessionUid.Value),
                         });
 
                     await _dotnetTestConnection.SendMessageAsync(testFileArtifactMessages);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -381,7 +381,7 @@ public class TrxTests
         // Arrange
         using MemoryFileStream memoryStream = new();
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(1, 0,
-            new(new PassedTestNodeStateProperty(), new FileArtifactProperty(new SessionUid("1"), new FileInfo("fileName"), "TestMethod", "description")), memoryStream);
+            new(new PassedTestNodeStateProperty(), new FileArtifactProperty(new FileInfo("fileName"), "TestMethod", "description")), memoryStream);
 
         // Act
         (string fileName, string? warning) = await trxReportEngine.GenerateReportAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
@@ -48,7 +48,7 @@ public sealed class ObjectModelConvertersTests
         {
             CodeFilePath = "FilePath",
         });
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
         Assert.AreEqual("FilePath", testNode.Properties.Single<TestFileLocationProperty>().FilePath);
     }
 
@@ -61,7 +61,7 @@ public sealed class ObjectModelConvertersTests
             ErrorMessage = "SomeErrorMessage",
             ErrorStackTrace = "SomeStackTrace",
         };
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
 
         FailedTestNodeStateProperty[] failedTestNodeStateProperties = testNode.Properties.OfType<FailedTestNodeStateProperty>().ToArray();
         Assert.AreEqual(1, failedTestNodeStateProperties.Length);
@@ -77,7 +77,7 @@ public sealed class ObjectModelConvertersTests
         var testCategoryProperty = TestProperty.Register("MSTestDiscoverer.TestCategory", "Label", typeof(string[]), TestPropertyAttributes.None, typeof(TestCase));
         testResult.SetPropertyValue<string[]>(testCategoryProperty, ["category1"]);
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         TestMetadataProperty[] testMetadatas = testNode.Properties.OfType<TestMetadataProperty>().ToArray();
         Assert.AreEqual(1, testMetadatas.Length);
@@ -92,7 +92,7 @@ public sealed class ObjectModelConvertersTests
         var testCategoryProperty = TestProperty.Register("MSTestDiscoverer.TestCategory", "Label", typeof(string[]), TestPropertyAttributes.None, typeof(TestCase));
         testResult.SetPropertyValue<string[]>(testCategoryProperty, ["category1"]);
 
-        var testNode = testResult.ToTestNode(true, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(true, VSTestClient);
 
         TrxCategoriesProperty[] trxCategoriesProperty = testNode.Properties.OfType<TrxCategoriesProperty>().ToArray();
         Assert.AreEqual(1, trxCategoriesProperty.Length);
@@ -107,7 +107,7 @@ public sealed class ObjectModelConvertersTests
         var testCaseHierarchy = TestProperty.Register("TestCase.Hierarchy", "Label", typeof(string[]), TestPropertyAttributes.None, typeof(TestCase));
         testResult.SetPropertyValue<string[]>(testCaseHierarchy, ["assembly", "class", "category", "test"]);
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         SerializableNamedArrayStringProperty[] trxCategoriesProperty = testNode.Properties.OfType<SerializableNamedArrayStringProperty>().ToArray();
         Assert.AreEqual(1, trxCategoriesProperty.Length);
@@ -126,7 +126,7 @@ public sealed class ObjectModelConvertersTests
 
         testResult.SetPropertyValue<Uri>(originalExecutorUriProperty, new Uri("https://vs.com/"));
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         SerializableKeyValuePairStringProperty[] serializableKeyValuePairStringProperty = testNode.Properties.OfType<SerializableKeyValuePairStringProperty>().ToArray();
         Assert.AreEqual(3, serializableKeyValuePairStringProperty.Length);
@@ -139,7 +139,7 @@ public sealed class ObjectModelConvertersTests
     {
         TestResult testResult = new(new TestCase("assembly.class.test", new("executor://uri", UriKind.Absolute), "source.cs"));
 
-        var testNode = testResult.ToTestNode(true, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(true, TestClient);
 
         Assert.AreEqual(testNode.Properties.OfType<TrxExceptionProperty>()?.Length, 1);
         Assert.AreEqual("assembly.class", testNode.Properties.Single<TrxFullyQualifiedTypeNameProperty>().FullyQualifiedTypeName);
@@ -150,7 +150,7 @@ public sealed class ObjectModelConvertersTests
     {
         TestResult testResult = new(new TestCase("test", new("executor://uri", UriKind.Absolute), "source.cs"));
 
-        string errorMessage = Assert.ThrowsException<InvalidOperationException>(() => testResult.ToTestNode(true, TestClient, new SessionUid("SessionUid"))).Message;
+        string errorMessage = Assert.ThrowsException<InvalidOperationException>(() => testResult.ToTestNode(true, TestClient)).Message;
 
         Assert.IsTrue(errorMessage.Contains("Unable to parse fully qualified type name from test case: "));
     }
@@ -168,7 +168,7 @@ public sealed class ObjectModelConvertersTests
             EndTime = endTime,
             Duration = duration,
         };
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
         var testResultTimingProperty = new TimingProperty(new(startTime, endTime, duration), []);
 
         Assert.AreEqual<TimingProperty>(testNode.Properties.OfType<TimingProperty>()[0], testResultTimingProperty);
@@ -182,7 +182,7 @@ public sealed class ObjectModelConvertersTests
             Outcome = TestOutcome.NotFound,
             ErrorStackTrace = "SomeStackTrace",
         };
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
 
         ErrorTestNodeStateProperty[] errorTestNodeStateProperties = testNode.Properties.OfType<ErrorTestNodeStateProperty>().ToArray();
         Assert.AreEqual(1, errorTestNodeStateProperties.Length);
@@ -198,7 +198,7 @@ public sealed class ObjectModelConvertersTests
         {
             Outcome = TestOutcome.Skipped,
         };
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
 
         SkippedTestNodeStateProperty[] skipTestNodeStateProperties = testNode.Properties.OfType<SkippedTestNodeStateProperty>().ToArray();
         Assert.AreEqual(1, skipTestNodeStateProperties.Length);
@@ -211,7 +211,7 @@ public sealed class ObjectModelConvertersTests
         {
             Outcome = TestOutcome.None,
         };
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
 
         SkippedTestNodeStateProperty[] skipTestNodeStateProperties = testNode.Properties.OfType<SkippedTestNodeStateProperty>().ToArray();
         Assert.AreEqual(1, skipTestNodeStateProperties.Length);
@@ -224,7 +224,7 @@ public sealed class ObjectModelConvertersTests
         {
             Outcome = TestOutcome.Passed,
         };
-        var testNode = testResult.ToTestNode(false, TestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, TestClient);
 
         PassedTestNodeStateProperty[] passedTestNodeStateProperties = testNode.Properties.OfType<PassedTestNodeStateProperty>().ToArray();
         Assert.AreEqual(1, passedTestNodeStateProperties.Length);
@@ -238,7 +238,7 @@ public sealed class ObjectModelConvertersTests
             DisplayName = "TestName",
         };
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         SerializableKeyValuePairStringProperty[] errorTestNodeStateProperties = testNode.Properties.OfType<SerializableKeyValuePairStringProperty>().ToArray();
         Assert.AreEqual(2, errorTestNodeStateProperties.Length, "Expected 2 SerializableKeyValuePairStringProperty");
@@ -256,7 +256,7 @@ public sealed class ObjectModelConvertersTests
             Traits = { new Trait("key", "value") },
         };
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         TestMetadataProperty[] testMetadatas = testNode.Properties.OfType<TestMetadataProperty>().ToArray();
         Assert.AreEqual(1, testMetadatas.Length);
@@ -277,7 +277,7 @@ public sealed class ObjectModelConvertersTests
             },
         };
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         StandardOutputProperty[] standardOutputProperties = testNode.Properties.OfType<StandardOutputProperty>().ToArray();
         Assert.IsTrue(standardOutputProperties.Length == 1);
@@ -297,7 +297,7 @@ public sealed class ObjectModelConvertersTests
             },
         };
 
-        var testNode = testResult.ToTestNode(false, VSTestClient, new SessionUid("SessionUid"));
+        var testNode = testResult.ToTestNode(false, VSTestClient);
 
         StandardErrorProperty[] standardErrorProperties = testNode.Properties.OfType<StandardErrorProperty>().ToArray();
         Assert.IsTrue(standardErrorProperties.Length == 1);


### PR DESCRIPTION
The API isn't yet shipped so another break is okay :)

I feel like it's redundant to requires the property having SessionUid. It's already available on the `TestNodeUpdateMessage`.