### PR TITLE
Fix typo in DotnetTestDataConsumer causes only first artifact to be sent

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -130,7 +130,6 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                         });
 
                     await _dotnetTestConnection.SendMessageAsync(testFileArtifactMessages);
-                    break;
                 }
 
                 break;


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->