### PR TITLE
fix nullability of argument in GetProcessExitCodeAsync_IgnoreExitCodes

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
@@ -190,7 +190,7 @@ public sealed class TestApplicationResultTests
     [DataRow(null, ExitCodes.ZeroTests)]
     [DataRow("", ExitCodes.ZeroTests)]
     [TestMethod]
-    public void GetProcessExitCodeAsync_IgnoreExitCodes(string argument, int expectedExitCode)
+    public void GetProcessExitCodeAsync_IgnoreExitCodes(string? argument, int expectedExitCode)
     {
         Mock<IEnvironment> environment = new();
         environment.Setup(x => x.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_EXITCODE_IGNORE)).Returns(argument);


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

since one of the DataRows pass in a null, and we do null checks in the test on that parameter