### PR TITLE
fix nullability in TestableMSTestAdapterSettings

### DIFF
--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
@@ -379,9 +379,9 @@ public class TestableMSTestAdapterSettings : MSTestAdapterSettings
 
     public TestableMSTestAdapterSettings(List<RecursiveDirectoryPath> expectedResult) => SearchDirectories.AddRange(expectedResult);
 
-    public Func<string, bool> DoesDirectoryExistSetter { get; set; } = null!;
+    public Func<string, bool>? DoesDirectoryExistSetter { get; set; }
 
-    public Func<string, string> ExpandEnvironmentVariablesSetter { get; set; } = null!;
+    public Func<string, string>? ExpandEnvironmentVariablesSetter { get; set; }
 
     protected override bool DoesDirectoryExist(string path) => DoesDirectoryExistSetter?.Invoke(path) ?? base.DoesDirectoryExist(path);
 


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

since based on the code paths both can be null. so the null suppression `null!` is both not required and incorrect