### PR TITLE
add disable CS0618  to MSTestSettingsTests

### DIFF
--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestSettingsTests.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Moq;
 
 using TestFramework.ForTestingMSTest;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests;
 


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

removes some compiler warnings. and given this test is only to test an obsolete class, the warnings add little value