### PR TITLE
fix nullability in FileLoggerProvider

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLoggerProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLoggerProvider.cs
@@ -47,8 +47,7 @@ internal sealed class FileLoggerProvider(
         // If custom directory is provided for the log file, we don't WANT to move the log file
         // We won't betray the users expectations.
         if (_customDirectory
-            || testResultDirectory == Path.GetDirectoryName(FileLogger.FileName)
-            || FileLogger is null)
+            || testResultDirectory == Path.GetDirectoryName(FileLogger.FileName))
         {
             return;
         }
@@ -73,15 +72,10 @@ internal sealed class FileLoggerProvider(
         => new FileLoggerCategory(FileLogger, categoryName);
 
     public void Dispose()
-        => FileLogger?.Dispose();
+        => FileLogger.Dispose();
 
 #if NETCOREAPP
-    public async ValueTask DisposeAsync()
-    {
-        if (FileLogger is not null)
-        {
-            await FileLogger.DisposeAsync();
-        }
-    }
+    public ValueTask DisposeAsync()
+        => FileLogger.DisposeAsync();
 #endif
 }

--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLoggerProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLoggerProvider.cs
@@ -75,7 +75,7 @@ internal sealed class FileLoggerProvider(
         => FileLogger.Dispose();
 
 #if NETCOREAPP
-    public ValueTask DisposeAsync()
-        => FileLogger.DisposeAsync();
+    public async ValueTask DisposeAsync()
+        => await FileLogger.DisposeAsync();
 #endif
 }


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

since `FileLogger` is never assigned to null