### PR TITLE
Consistent command-line options provider properties

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.CommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.CommandLine.cs
@@ -5,7 +5,6 @@ using Microsoft.Testing.Extensions.TestReports.Resources;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
-using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Tools;
 
 namespace Microsoft.Testing.Extensions.TrxReport.Abstractions;
@@ -17,25 +16,19 @@ internal sealed class TrxCompareToolCommandLine : IToolCommandLineOptionsProvide
     private readonly IExtension _extension;
 
     public TrxCompareToolCommandLine(IExtension extension)
-    {
-        _extension = extension;
-        Uid = _extension.Uid;
-        Version = _extension.Version;
-        DisplayName = _extension.DisplayName;
-        Description = _extension.Description;
-    }
+        => _extension = extension;
 
     /// <inheritdoc />
-    public string Uid { get; }
+    public string Uid => _extension.Uid;
 
     /// <inheritdoc />
-    public string Version { get; } = AppVersion.DefaultSemVer;
+    public string Version => _extension.Version;
 
     /// <inheritdoc />
-    public string DisplayName { get; }
+    public string DisplayName => _extension.DisplayName;
 
     /// <inheritdoc />
-    public string Description { get; }
+    public string Description => _extension.Description;
 
     /// <inheritdoc />
     public string ToolName { get; } = TrxCompareTool.ToolName;

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/TreeNodeFilterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/TreeNodeFilterCommandLineOptionsProvider.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
-using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Resources;
 
 namespace Microsoft.Testing.Platform.CommandLine;
@@ -16,7 +15,7 @@ internal sealed class TreeNodeFilterCommandLineOptionsProvider(IExtension extens
     public string Uid { get; } = extension.Uid;
 
     /// <inheritdoc />
-    public string Version { get; } = AppVersion.DefaultSemVer;
+    public string Version { get; } = extension.Version;
 
     /// <inheritdoc />
     public string DisplayName { get; } = extension.DisplayName;


### PR DESCRIPTION
Partially addresses #4294.
In future, we will probably want everything to be aligned by the platform and remove the `IExtension` parameter, and obsolete the relevant public APIs that accepts `IExtension`.

I'm going for the easier approach for now.