### PR TITLE
Use `PlatformVersion.Version` as the server version

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Testing.Platform.Hosts;
 
 internal sealed partial class ServerTestHost : CommonTestHost, IServerTestHost, IDisposable, IOutputDeviceDataProducer
 {
-    public const string ProtocolVersion = "1.0.0";
+    public const string ProtocolVersion = PlatformVersion.Version;
     private readonly Func<TestFrameworkBuilderData, Task<ITestFramework>> _buildTestFrameworkAsync;
 
     private readonly IMessageHandlerFactory _messageHandlerFactory;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PassiveNode.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PassiveNode.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Hosts;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
 
@@ -63,7 +62,7 @@ internal sealed class PassiveNode : IDisposable
         var requestMessage = (RequestMessage)message;
         var responseObject = new InitializeResponseArgs(
                         ProcessId: _processHandler.GetCurrentProcess().Id,
-                        ServerInfo: new ServerInfo("test-anywhere", Version: ServerTestHost.ProtocolVersion),
+                        ServerInfo: new ServerInfo("test-anywhere", Version: PlatformVersion.Version),
                         Capabilities: new ServerCapabilities(
                             new ServerTestingCapabilities(
                                 SupportsDiscovery: false,


### PR DESCRIPTION
This makes much more sense to me instead of hard-coding 1.0.0 or having to manually bump it later on.