### PR TITLE
Skip analyzing TestContext fields that are generated via primary constructor parameters

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs
@@ -205,6 +205,9 @@ public sealed class TestContextShouldBeValidAnalyzer : DiagnosticAnalyzer
                                     {
                                         // AssociatedSymbol check is to not analyze compiler-generated backing field.
                                         if (fieldSymbol.AssociatedSymbol is not null ||
+                                            // Workaround https://github.com/dotnet/roslyn/issues/70208
+                                            // https://github.com/dotnet/roslyn/blob/05e49aa98995349ffa26a19020333293ffe99670/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L47
+                                            (fieldSymbol.Name.StartsWith('<') && fieldSymbol.Name.EndsWith(">P", StringComparison.Ordinal)) ||
                                             !SymbolEqualityComparer.Default.Equals(fieldSymbol.Type, testContextSymbol))
                                         {
                                             continue;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
@@ -91,6 +91,26 @@ public sealed class TestContextShouldBeValidAnalyzerTests
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
 
+    [TestMethod]
+    public async Task WhenTestContextIsInPrimaryConstructor_NoDiagnostic()
+    {
+        string code = $$"""
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public sealed class Test1(TestContext testContext)
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                    testContext.CancellationTokenSource.Cancel();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
     [DataRow("TestContext", "private")]
     [DataRow("TestContext", "internal")]
     [DataRow("testcontext", "private")]


### PR DESCRIPTION
Fixes #5466