### PR TITLE
Kill testhost if writing hang dump fails

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -379,42 +379,48 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
 
         await _outputDisplay.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.CreatingDumpFile, finalDumpFileName)));
 
+        try
+        {
 #if NETCOREAPP
-        DiagnosticsClient diagnosticsClient = new(_testHostProcessInformation.PID);
-        DumpType dumpType = _dumpType.ToLowerInvariant().Trim() switch
-        {
-            "mini" => DumpType.Normal,
-            "heap" => DumpType.WithHeap,
-            "triage" => DumpType.Triage,
-            "full" => DumpType.Full,
-            _ => throw ApplicationStateGuard.Unreachable(),
-        };
-
-        // Wrap the dump path into "" when it has space in it, this is a workaround for this runtime issue: https://github.com/dotnet/diagnostics/issues/5020
-        // It only affects windows. Otherwise the dump creation fails with: [createdump] The pid argument is no longer supported
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && finalDumpFileName.Contains(' '))
-        {
-            finalDumpFileName = $"\"{finalDumpFileName}\"";
-        }
-
-        diagnosticsClient.WriteDump(dumpType, finalDumpFileName, true);
+            DiagnosticsClient diagnosticsClient = new(_testHostProcessInformation.PID);
+            DumpType dumpType = _dumpType.ToLowerInvariant().Trim() switch
+            {
+                "mini" => DumpType.Normal,
+                "heap" => DumpType.WithHeap,
+                "triage" => DumpType.Triage,
+                "full" => DumpType.Full,
+                _ => throw ApplicationStateGuard.Unreachable(),
+            };
+    
+            // Wrap the dump path into "" when it has space in it, this is a workaround for this runtime issue: https://github.com/dotnet/diagnostics/issues/5020
+            // It only affects windows. Otherwise the dump creation fails with: [createdump] The pid argument is no longer supported
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && finalDumpFileName.Contains(' '))
+            {
+                finalDumpFileName = $"\"{finalDumpFileName}\"";
+            }
+    
+            diagnosticsClient.WriteDump(dumpType, finalDumpFileName, true);
 #else
-        MiniDumpWriteDump.MiniDumpTypeOption miniDumpTypeOption = _dumpType.ToLowerInvariant().Trim() switch
-        {
-            "mini" => MiniDumpWriteDump.MiniDumpTypeOption.Mini,
-            "heap" => MiniDumpWriteDump.MiniDumpTypeOption.Heap,
-            "full" => MiniDumpWriteDump.MiniDumpTypeOption.Full,
-            _ => throw ApplicationStateGuard.Unreachable(),
-        };
-
-        MiniDumpWriteDump.CollectDumpUsingMiniDumpWriteDump(_testHostProcessInformation.PID, finalDumpFileName, miniDumpTypeOption);
+            MiniDumpWriteDump.MiniDumpTypeOption miniDumpTypeOption = _dumpType.ToLowerInvariant().Trim() switch
+            {
+                "mini" => MiniDumpWriteDump.MiniDumpTypeOption.Mini,
+                "heap" => MiniDumpWriteDump.MiniDumpTypeOption.Heap,
+                "full" => MiniDumpWriteDump.MiniDumpTypeOption.Full,
+                _ => throw ApplicationStateGuard.Unreachable(),
+            };
+    
+            MiniDumpWriteDump.CollectDumpUsingMiniDumpWriteDump(_testHostProcessInformation.PID, finalDumpFileName, miniDumpTypeOption);
 #endif
 
-        NotifyCrashDumpServiceIfEnabled();
-        using IProcess process = _processHandler.GetProcessById(_testHostProcessInformation.PID);
-        process.Kill();
-        await process.WaitForExitAsync();
-        _dumpFileTaken = finalDumpFileName;
+            _dumpFileTaken = finalDumpFileName;
+        }
+        finally
+        {
+            NotifyCrashDumpServiceIfEnabled();
+            using IProcess process = _processHandler.GetProcessById(_testHostProcessInformation.PID);
+            process.Kill();
+            await process.WaitForExitAsync();
+        }
     }
 
     private static void NotifyCrashDumpServiceIfEnabled()

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -391,7 +391,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
                 "full" => DumpType.Full,
                 _ => throw ApplicationStateGuard.Unreachable(),
             };
-    
+
             // Wrap the dump path into "" when it has space in it, this is a workaround for this runtime issue: https://github.com/dotnet/diagnostics/issues/5020
             // It only affects windows. Otherwise the dump creation fails with: [createdump] The pid argument is no longer supported
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && finalDumpFileName.Contains(' '))
@@ -408,7 +408,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
                 "full" => MiniDumpWriteDump.MiniDumpTypeOption.Full,
                 _ => throw ApplicationStateGuard.Unreachable(),
             };
-    
+
             MiniDumpWriteDump.CollectDumpUsingMiniDumpWriteDump(_testHostProcessInformation.PID, finalDumpFileName, miniDumpTypeOption);
 #endif
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -398,7 +398,6 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
             {
                 finalDumpFileName = $"\"{finalDumpFileName}\"";
             }
-    
             diagnosticsClient.WriteDump(dumpType, finalDumpFileName, true);
 #else
             MiniDumpWriteDump.MiniDumpTypeOption miniDumpTypeOption = _dumpType.ToLowerInvariant().Trim() switch

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -398,6 +398,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
             {
                 finalDumpFileName = $"\"{finalDumpFileName}\"";
             }
+
             diagnosticsClient.WriteDump(dumpType, finalDumpFileName, true);
 #else
             MiniDumpWriteDump.MiniDumpTypeOption miniDumpTypeOption = _dumpType.ToLowerInvariant().Trim() switch


### PR DESCRIPTION
Hide whitespaces in diff for easier review.

This change basically still kills the test host even if writing the dump file fails, so that the process isn't stuck