### PR TITLE
Add public api files

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/MSTest.Analyzers.CodeFixes.csproj
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/MSTest.Analyzers.CodeFixes.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/PublicAPI.Shipped.txt
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/PublicAPI.Unshipped.txt
@@ -1,0 +1,116 @@
+#nullable enable
+MSTest.Analyzers.AddTestClassFixer
+MSTest.Analyzers.AddTestClassFixer.AddTestClassFixer() -> void
+MSTest.Analyzers.AssemblyCleanupShouldBeValidFixer
+MSTest.Analyzers.AssemblyCleanupShouldBeValidFixer.AssemblyCleanupShouldBeValidFixer() -> void
+MSTest.Analyzers.AssemblyInitializeShouldBeValidFixer
+MSTest.Analyzers.AssemblyInitializeShouldBeValidFixer.AssemblyInitializeShouldBeValidFixer() -> void
+MSTest.Analyzers.AssertionArgsShouldAvoidConditionalAccessFixer
+MSTest.Analyzers.AssertionArgsShouldAvoidConditionalAccessFixer.AssertionArgsShouldAvoidConditionalAccessFixer() -> void
+MSTest.Analyzers.AssertionArgsShouldBePassedInCorrectOrderFixer
+MSTest.Analyzers.AssertionArgsShouldBePassedInCorrectOrderFixer.AssertionArgsShouldBePassedInCorrectOrderFixer() -> void
+MSTest.Analyzers.AvoidAssertAreSameWithValueTypesFixer
+MSTest.Analyzers.AvoidAssertAreSameWithValueTypesFixer.AvoidAssertAreSameWithValueTypesFixer() -> void
+MSTest.Analyzers.AvoidExpectedExceptionAttributeFixer
+MSTest.Analyzers.AvoidExpectedExceptionAttributeFixer.AvoidExpectedExceptionAttributeFixer() -> void
+MSTest.Analyzers.ClassCleanupShouldBeValidFixer
+MSTest.Analyzers.ClassCleanupShouldBeValidFixer.ClassCleanupShouldBeValidFixer() -> void
+MSTest.Analyzers.ClassInitializeShouldBeValidFixer
+MSTest.Analyzers.ClassInitializeShouldBeValidFixer.ClassInitializeShouldBeValidFixer() -> void
+MSTest.Analyzers.PreferAssertFailOverAlwaysFalseConditionsFixer
+MSTest.Analyzers.PreferAssertFailOverAlwaysFalseConditionsFixer.PreferAssertFailOverAlwaysFalseConditionsFixer() -> void
+MSTest.Analyzers.PreferConstructorOverTestInitializeFixer
+MSTest.Analyzers.PreferConstructorOverTestInitializeFixer.PreferConstructorOverTestInitializeFixer() -> void
+MSTest.Analyzers.PreferDisposeOverTestCleanupFixer
+MSTest.Analyzers.PreferDisposeOverTestCleanupFixer.PreferDisposeOverTestCleanupFixer() -> void
+MSTest.Analyzers.PreferTestCleanupOverDisposeFixer
+MSTest.Analyzers.PreferTestCleanupOverDisposeFixer.PreferTestCleanupOverDisposeFixer() -> void
+MSTest.Analyzers.PreferTestInitializeOverConstructorFixer
+MSTest.Analyzers.PreferTestInitializeOverConstructorFixer.PreferTestInitializeOverConstructorFixer() -> void
+MSTest.Analyzers.PublicMethodShouldBeTestMethodFixer
+MSTest.Analyzers.PublicMethodShouldBeTestMethodFixer.PublicMethodShouldBeTestMethodFixer() -> void
+MSTest.Analyzers.TestClassShouldBeValidFixer
+MSTest.Analyzers.TestClassShouldBeValidFixer.TestClassShouldBeValidFixer() -> void
+MSTest.Analyzers.TestCleanupShouldBeValidFixer
+MSTest.Analyzers.TestCleanupShouldBeValidFixer.TestCleanupShouldBeValidFixer() -> void
+MSTest.Analyzers.TestContextShouldBeValidFixer
+MSTest.Analyzers.TestContextShouldBeValidFixer.TestContextShouldBeValidFixer() -> void
+MSTest.Analyzers.TestInitializeShouldBeValidFixer
+MSTest.Analyzers.TestInitializeShouldBeValidFixer.TestInitializeShouldBeValidFixer() -> void
+MSTest.Analyzers.TestMethodShouldBeValidCodeFixProvider
+MSTest.Analyzers.TestMethodShouldBeValidCodeFixProvider.TestMethodShouldBeValidCodeFixProvider() -> void
+MSTest.Analyzers.UseAttributeOnTestMethodFixer
+MSTest.Analyzers.UseAttributeOnTestMethodFixer.UseAttributeOnTestMethodFixer() -> void
+MSTest.Analyzers.UseNewerAssertThrowsFixer
+MSTest.Analyzers.UseNewerAssertThrowsFixer.UseNewerAssertThrowsFixer() -> void
+MSTest.Analyzers.UseProperAssertMethodsFixer
+MSTest.Analyzers.UseProperAssertMethodsFixer.UseProperAssertMethodsFixer() -> void
+override MSTest.Analyzers.AddTestClassFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.AddTestClassFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.AssemblyCleanupShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.AssemblyCleanupShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.AssemblyInitializeShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.AssemblyInitializeShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.AssertionArgsShouldAvoidConditionalAccessFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.AssertionArgsShouldAvoidConditionalAccessFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.AssertionArgsShouldBePassedInCorrectOrderFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.AssertionArgsShouldBePassedInCorrectOrderFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.AvoidAssertAreSameWithValueTypesFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.AvoidAssertAreSameWithValueTypesFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.AvoidExpectedExceptionAttributeFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.ClassCleanupShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.ClassCleanupShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.ClassInitializeShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.ClassInitializeShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.PreferAssertFailOverAlwaysFalseConditionsFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.PreferAssertFailOverAlwaysFalseConditionsFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.PreferConstructorOverTestInitializeFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override MSTest.Analyzers.PreferConstructorOverTestInitializeFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.PreferConstructorOverTestInitializeFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.PreferDisposeOverTestCleanupFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override MSTest.Analyzers.PreferDisposeOverTestCleanupFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.PreferDisposeOverTestCleanupFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.PreferTestCleanupOverDisposeFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override MSTest.Analyzers.PreferTestCleanupOverDisposeFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.PreferTestCleanupOverDisposeFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.PreferTestInitializeOverConstructorFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override MSTest.Analyzers.PreferTestInitializeOverConstructorFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.PreferTestInitializeOverConstructorFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.PublicMethodShouldBeTestMethodFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override MSTest.Analyzers.PublicMethodShouldBeTestMethodFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.PublicMethodShouldBeTestMethodFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.TestClassShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.TestClassShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.TestCleanupShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.TestCleanupShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.TestContextShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.TestContextShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.TestInitializeShouldBeValidFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.TestInitializeShouldBeValidFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.TestMethodShouldBeValidCodeFixProvider.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override MSTest.Analyzers.TestMethodShouldBeValidCodeFixProvider.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.TestMethodShouldBeValidCodeFixProvider.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.UseAttributeOnTestMethodFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.UseNewerAssertThrowsFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.UseNewerAssertThrowsFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override MSTest.Analyzers.UseProperAssertMethodsFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override MSTest.Analyzers.UseProperAssertMethodsFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override sealed MSTest.Analyzers.AddTestClassFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AssemblyCleanupShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AssemblyInitializeShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AssertionArgsShouldAvoidConditionalAccessFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AssertionArgsShouldBePassedInCorrectOrderFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AvoidAssertAreSameWithValueTypesFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AvoidExpectedExceptionAttributeFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.AvoidExpectedExceptionAttributeFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override sealed MSTest.Analyzers.ClassCleanupShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.ClassInitializeShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.PreferAssertFailOverAlwaysFalseConditionsFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.TestClassShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.TestCleanupShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.TestContextShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.TestInitializeShouldBeValidFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.UseAttributeOnTestMethodFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.UseAttributeOnTestMethodFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
+override sealed MSTest.Analyzers.UseNewerAssertThrowsFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.UseProperAssertMethodsFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>

--- a/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
+++ b/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
@@ -22,6 +22,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\MSTest.Analyzers\MSTest.Analyzers.csproj" />
   </ItemGroup>

--- a/src/Analyzers/MSTest.Analyzers.Package/PublicAPI.Shipped.txt
+++ b/src/Analyzers/MSTest.Analyzers.Package/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.Analyzers.Package/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.Analyzers.Package/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.GlobalConfigsGenerator/MSTest.GlobalConfigsGenerator.csproj
+++ b/src/Analyzers/MSTest.GlobalConfigsGenerator/MSTest.GlobalConfigsGenerator.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(RepoRoot)/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownCustomTags.cs" />
   </ItemGroup>
 

--- a/src/Analyzers/MSTest.GlobalConfigsGenerator/PublicAPI.Shipped.txt
+++ b/src/Analyzers/MSTest.GlobalConfigsGenerator/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.GlobalConfigsGenerator/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.GlobalConfigsGenerator/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.Internal.Analyzers/MSTest.Internal.Analyzers.csproj
+++ b/src/Analyzers/MSTest.Internal.Analyzers/MSTest.Internal.Analyzers.csproj
@@ -11,6 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />
   </ItemGroup>

--- a/src/Analyzers/MSTest.Internal.Analyzers/PublicAPI.Shipped.txt
+++ b/src/Analyzers/MSTest.Internal.Analyzers/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.Internal.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.Internal.Analyzers/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+#nullable enable
+MSTest.Internal.Analyzers.MSTestObsoleteTypesSuppressor
+MSTest.Internal.Analyzers.MSTestObsoleteTypesSuppressor.MSTestObsoleteTypesSuppressor() -> void
+override MSTest.Internal.Analyzers.MSTestObsoleteTypesSuppressor.ReportSuppressions(Microsoft.CodeAnalysis.Diagnostics.SuppressionAnalysisContext context) -> void
+override MSTest.Internal.Analyzers.MSTestObsoleteTypesSuppressor.SupportedSuppressions.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SuppressionDescriptor!>

--- a/src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj
@@ -33,6 +33,8 @@ This package provides the C# source generators for MSTest test framework.]]>
 
   <ItemGroup>
     <AdditionalFiles Include="BannedSymbols.txt" />
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Analyzers/MSTest.SourceGeneration/PublicAPI.Shipped.txt
+++ b/src/Analyzers/MSTest.SourceGeneration/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Analyzers/MSTest.SourceGeneration/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.SourceGeneration/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.MSBuild.UnitTests" Key="$(VsPublicKey)" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+#nullable enable
+Microsoft.Testing.Platform.MSBuild.MSBuildExtensions
+Microsoft.Testing.Platform.MSBuild.TestingPlatformBuilderHook
+static Microsoft.Testing.Platform.MSBuild.MSBuildExtensions.AddMSBuild(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void
+static Microsoft.Testing.Platform.MSBuild.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
@@ -45,11 +45,16 @@ This package provides MSBuild integration of the platform, its extensions and co
 
   <Target Name="IncludeProjectReferenceDlls" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))" PackagePath="lib\$(TargetFramework)\%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('CopyToBuildOutput', 'true'))" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
-      <BuildOutputInPackage Include="@(RuntimeTargetsCopyLocalItems->HasMetadata('NuGetPackageId'))" TargetPath="%(RuntimeCopyLocalPaths.DestinationSubPath)" />
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" PackagePath="lib\$(TargetFramework)\%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('CopyToBuildOutput', 'true'))" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
+      <BuildOutputInPackage Include="@(RuntimeTargetsCopyLocalItems-&gt;HasMetadata('NuGetPackageId'))" TargetPath="%(RuntimeCopyLocalPaths.DestinationSubPath)" />
     </ItemGroup>
   </Target>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Microsoft.Testing.Extensions.MSBuild\MSBuildConstants.cs" Link="MSBuildConstants.cs" />

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/PublicAPI.Unshipped.txt
@@ -1,0 +1,84 @@
+#nullable enable
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.AssemblyName.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.AssemblyName.set -> void
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.ConfigurationFileTask() -> void
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.FinalTestingPlatformConfigurationFile.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.FinalTestingPlatformConfigurationFile.set -> void
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.MSBuildProjectDirectory.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.MSBuildProjectDirectory.set -> void
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.OutputPath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.OutputPath.set -> void
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.TestingPlatformConfigurationFileSource.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.TestingPlatformConfigurationFileSource.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.AssemblyName.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.AssemblyName.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.Dispose() -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.DotnetHostPath.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.DotnetHostPath.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.InvokeTestingPlatformTask() -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.IsExecutable.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.IsExecutable.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.NativeExecutableExtension.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.NativeExecutableExtension.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ProjectFullPath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ProjectFullPath.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetDir.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetDir.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetFramework.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetFramework.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetFrameworkIdentifier.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetFrameworkIdentifier.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetPath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TargetPath.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestArchitecture.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestArchitecture.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestingPlatformCaptureOutput.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestingPlatformCaptureOutput.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestingPlatformCommandLineArguments.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestingPlatformCommandLineArguments.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestingPlatformShowTestsFailure.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.TestingPlatformShowTestsFailure.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.UseAppHost.get -> Microsoft.Build.Framework.ITaskItem?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.UseAppHost.set -> void
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.VSTestCLIRunSettings.get -> Microsoft.Build.Framework.ITaskItem![]?
+Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.VSTestCLIRunSettings.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.Language.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.Language.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.RootNamespace.get -> string?
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.RootNamespace.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.TestingPlatformEntryPointGeneratedFilePath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.TestingPlatformEntryPointGeneratedFilePath.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.TestingPlatformEntryPointSourcePath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.TestingPlatformEntryPointSourcePath.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.TestingPlatformEntryPointTask() -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.Language.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.Language.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.RootNamespace.get -> string?
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.RootNamespace.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.SelfRegisteredExtensionsBuilderHook.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.SelfRegisteredExtensionsBuilderHook.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.SelfRegisteredExtensionsGeneratedFilePath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.SelfRegisteredExtensionsGeneratedFilePath.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.SelfRegisteredExtensionsSourcePath.get -> Microsoft.Build.Framework.ITaskItem!
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.SelfRegisteredExtensionsSourcePath.set -> void
+Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.TestingPlatformSelfRegisteredExtensions() -> void
+override Microsoft.Testing.Platform.MSBuild.ConfigurationFileTask.Execute() -> bool
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.Execute() -> bool
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.GenerateCommandLineCommands() -> string!
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.GenerateFullPathToTool() -> string?
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.HandleTaskExecutionErrors() -> bool
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.LogEventsFromTextOutput(string! singleLine, Microsoft.Build.Framework.MessageImportance messageImportance) -> void
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.LogToolCommand(string! message) -> void
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ProcessStarted() -> void
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.StandardErrorLoggingImportance.get -> Microsoft.Build.Framework.MessageImportance
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.StandardOutputLoggingImportance.get -> Microsoft.Build.Framework.MessageImportance
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ToolExe.get -> string!
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ToolExe.set -> void
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ToolName.get -> string!
+override Microsoft.Testing.Platform.MSBuild.InvokeTestingPlatformTask.ValidateParameters() -> bool
+override Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask.Execute() -> bool
+override Microsoft.Testing.Platform.MSBuild.TestingPlatformSelfRegisteredExtensions.Execute() -> bool


### PR DESCRIPTION
Add public api files to projects that were missing the. We are trying to keep the public apis minimal, to avoid users accidentally depending on api that we don't want to keep backwards compatible.