### PR TITLE
Fix alpha branding on devops extension in rtm build

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
@@ -6,6 +6,7 @@
     <!-- Stay on 1.0.0 alpha while we are dogfooding this extension to see if it is useful. -->
     <VersionPrefix>1.0.0</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <!-- NuGet properties -->


### PR DESCRIPTION
RTM produced 1.0.0 not 1.0.0-alphaxxx.