### PR TITLE
Don't publish RTM build

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -52,6 +52,10 @@ variables:
     - name: _ReleaseVersionKind
       value: release
 
+  # Final builds should not go into internal package feeds so we can keep re-building them until we are ready to ship.
+  - name: _Publish
+    value: {{ not parameters.isRTM }}
+
   - group: DotNet-Symbol-Server-Pats
 
 resources:
@@ -135,6 +139,7 @@ extends:
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                 /p:ProductsToBuild=$(_Products)
                 /p:Test=false
+                /p:Publish=$(_Publish)
               name: Build
               displayName: Build
 


### PR DESCRIPTION
Final RTM builds have version without any suffix. Nuget feeds don't allow overwriting versions so we have only 1 chance to get the build right. Disable publishing to internal feeds so we can re-build the RTM build from as many versions of code as we can, until we decide to push it to nuget.org.