### PR TITLE
Run the whole ExecuteInternal logic under the right execution context

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -558,7 +558,7 @@ public class TestMethodInfo : ITestMethod
         // Pulling it out so extension writers can abort custom cleanups if need be. Having this in a finally block
         // does not allow a thread abort exception to be raised within the block but throws one after finally is executed
         // crashing the process. This was blocking writing an extension for Dynamic Timeout in VSO.
-        RunTestCleanupMethod(result, ref executionContext, timeoutTokenSource);
+        RunTestCleanupMethod(result, executionContext, timeoutTokenSource);
 
         return testRunnerException != null ? throw testRunnerException : result;
     }

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -706,7 +706,7 @@ public class TestMethodInfo : ITestMethod
     /// <param name="executionContext">The execution context to run on.</param>
     /// <param name="timeoutTokenSource">The timeout token source.</param>
     [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Requirement is to handle all kinds of user exceptions and message appropriately.")]
-    private void RunTestCleanupMethod(TestResult result, ref ExecutionContext? executionContext, CancellationTokenSource? timeoutTokenSource)
+    private void RunTestCleanupMethod(TestResult result, ExecutionContext? executionContext, CancellationTokenSource? timeoutTokenSource)
     {
         DebugEx.Assert(result != null, "result != null");
 
@@ -1129,7 +1129,7 @@ public class TestMethodInfo : ITestMethod
 
             // It's possible that some failures happened and that the cleanup wasn't executed, so we need to run it here.
             // The method already checks if the cleanup was already executed.
-            RunTestCleanupMethod(result, ref executionContext, null);
+            RunTestCleanupMethod(result, executionContext, null);
             return result;
         }
 
@@ -1153,7 +1153,7 @@ public class TestMethodInfo : ITestMethod
 
         // We don't know when the cancellation happened so it's possible that the cleanup wasn't executed, so we need to run it here.
         // The method already checks if the cleanup was already executed.
-        RunTestCleanupMethod(timeoutResult, ref executionContext, null);
+        RunTestCleanupMethod(timeoutResult, executionContext, null);
         return timeoutResult;
 
         // Local functions

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/GenericTestMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/GenericTestMethodTests.cs
@@ -38,22 +38,18 @@ public class GenericTestMethodTests : AcceptanceTestBase<GenericTestMethodTests.
             failed ParameterizedMethodSimple \(null\) \(\d+ms\)
               Test method TestClass\.ParameterizedMethodSimple threw exception: 
               System\.InvalidOperationException: The type of the generic parameter 'T' could not be inferred\.
-                .+?
             failed ParameterizedMethodTwoGenericParametersAndFourMethodParameters \(1,"Hello world",2,3\) \(\d+ms\)
               Test method TestClass\.ParameterizedMethodTwoGenericParametersAndFourMethodParameters threw exception: 
               System\.InvalidOperationException: Found two conflicting types for generic parameter 'T2'\. The conflicting types are 'System\.Byte' and 'System\.Int32'\.
-                .+?
             failed ParameterizedMethodTwoGenericParametersAndFourMethodParameters \(null,"Hello world","Hello again",3\) \(\d+ms\)
               Assert\.Fail failed\. Test method 'ParameterizedMethodTwoGenericParametersAndFourMethodParameters' did run with parameters '<null>', 'Hello world', 'Hello again', '3' and generic types 'System\.Int32', 'System\.String'\.
                 .+?
             failed ParameterizedMethodTwoGenericParametersAndFourMethodParameters \("Hello hello","Hello world",null,null\) \(\d+ms\)
               Test method TestClass\.ParameterizedMethodTwoGenericParametersAndFourMethodParameters threw exception: 
               System\.InvalidOperationException: The type of the generic parameter 'T1' could not be inferred\.
-                .+?
             failed ParameterizedMethodTwoGenericParametersAndFourMethodParameters \(null,null,null,null\) \(\d+ms\)
               Test method TestClass\.ParameterizedMethodTwoGenericParametersAndFourMethodParameters threw exception: 
               System\.InvalidOperationException: The type of the generic parameter 'T1' could not be inferred\.
-                .+?
             failed ParameterizedMethodSimpleParams \(1\) \(\d+ms\)
               Cannot create an instance of T\[] because Type\.ContainsGenericParameters is true\.
                 .+?

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestContextTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestContextTests.cs
@@ -88,6 +88,7 @@ public sealed class TestContextTests : AcceptanceTestBase<TestContextTests.TestA
     <OutputType>Exe</OutputType>
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
 
     <!--
         This property is not required by users and is only set to simplify our testing infrastructure. When testing out in local or ci,
@@ -106,6 +107,7 @@ public sealed class TestContextTests : AcceptanceTestBase<TestContextTests.TestA
 #file UnitTest1.cs
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [TestClass]
@@ -148,13 +150,22 @@ public class TestContextCtor
 public class TestContextCtorAndProperty
 {
     private TestContext _testContext;
+    private static AsyncLocal<string> s_asyncLocal = new();
 
     public TestContextCtorAndProperty(TestContext testContext)
     {
         _testContext = testContext;
     }
 
-    public TestContext TestContext { get; set; }
+    public TestContext TestContext
+    {
+        get => field;
+        set
+        {
+            field = value;
+            s_asyncLocal.Value = "TestContext is set";
+        }
+    }
 
     [TestMethod]
     public void TestMethod()
@@ -163,6 +174,7 @@ public class TestContextCtorAndProperty
         TestContext.WriteLine("Method TestContextCtorAndProperty.TestMethod() was called");
         Assert.IsNotNull(_testContext);
         Assert.IsNotNull(TestContext);
+        Assert.AreEqual("TestContext is set", s_asyncLocal.Value);
     }
 }
 


### PR DESCRIPTION
Fixes #5622
Fixes #5630