### PR TITLE
Increase DotnetCli.RunAsync timeout from 50s to 60s

### DIFF
--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -54,7 +54,7 @@ public static class DotnetCli
         Dictionary<string, string?>? environmentVariables = null,
         bool failIfReturnValueIsNotZero = true,
         bool disableTelemetry = true,
-        int timeoutInSeconds = 50,
+        int timeoutInSeconds = 60,
         int retryCount = 5,
         bool disableCodeCoverage = true,
         bool warnAsError = true,


### PR DESCRIPTION
Tests often timeout in `DotnetCli.RunAsync`. Let's see if increasing the timeout can improve stability.