### PR TITLE
Add quotes around MSBuild property when performing comparison

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -4,7 +4,7 @@
   <!-- Setup the task folder -->
   <PropertyGroup>
     <!-- Constants -->
-    <MicrosoftTestingPlatformMSBuildTaskFolder Condition=" $(MicrosoftTestingPlatformMSBuildTaskFolder) == '' ">$(MSBuildThisFileDirectory)..\_MSBuildTasks\netstandard2.0\</MicrosoftTestingPlatformMSBuildTaskFolder>
+    <MicrosoftTestingPlatformMSBuildTaskFolder Condition=" '$(MicrosoftTestingPlatformMSBuildTaskFolder)' == '' ">$(MSBuildThisFileDirectory)..\_MSBuildTasks\netstandard2.0\</MicrosoftTestingPlatformMSBuildTaskFolder>
   </PropertyGroup>
 
 


### PR DESCRIPTION
@rainersigwald We didn't see any issue, but that's how all comparisons we see look like. Is there known behavior difference? Or is it the same? It depends?