### PR TITLE
Enable filtering with `TestMetadataProperty` in the treenode filter

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
@@ -416,4 +416,6 @@ public record StandardErrorProperty(string StandardError) : IProperty;
 /// <param name="Description">The description.</param>
 public record FileArtifactProperty(FileInfo FileInfo, string DisplayName, string? Description = null) : IProperty;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 internal sealed record SerializableKeyValuePairStringProperty(string Key, string Value) : KeyValuePairStringProperty(Key, Value);
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeProperties.cs
@@ -13,6 +13,7 @@ public interface IProperty;
 /// </summary>
 /// <param name="Key">Key name.</param>
 /// <param name="Value">Key value.</param>
+[Obsolete("Use TestMetadataProperty instead. This will be removed in a future version.")]
 public record KeyValuePairStringProperty(string Key, string Value) : IProperty;
 
 /// <summary>

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -550,7 +550,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
         => propertyExpr switch
         {
             PropertyExpression { PropertyName: var propExpr, Value: var valueExpr }
-                => properties.AsEnumerable().Any(prop => prop is KeyValuePairStringProperty kvpProperty && propExpr.Regex.IsMatch(kvpProperty.Key) && valueExpr.Regex.IsMatch(kvpProperty.Value)),
+                => properties.AsEnumerable().Any(prop => IsMatchingProperty(prop, propExpr, valueExpr)),
             OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subExprs }
                 => subExprs.Any(expr => MatchProperties(expr, properties)),
             OperatorExpression { Op: FilterOperator.And, SubExpressions: var subExprs }
@@ -558,5 +558,13 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
             OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subExprs }
                 => !MatchProperties(subExprs.Single(), properties),
             _ => throw ApplicationStateGuard.Unreachable(),
+        };
+
+    private static bool IsMatchingProperty(IProperty prop, ValueExpression propExpr, ValueExpression valueExpr) =>
+        prop switch
+        {
+            KeyValuePairStringProperty kvpProperty => propExpr.Regex.IsMatch(kvpProperty.Key) && valueExpr.Regex.IsMatch(kvpProperty.Value),
+            TestMetadataProperty testMetadataProperty => propExpr.Regex.IsMatch(testMetadataProperty.Key) && valueExpr.Regex.IsMatch(testMetadataProperty.Value),
+            _ => false,
         };
 }

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -563,7 +563,9 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
     private static bool IsMatchingProperty(IProperty prop, ValueExpression propExpr, ValueExpression valueExpr) =>
         prop switch
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             KeyValuePairStringProperty kvpProperty => propExpr.Regex.IsMatch(kvpProperty.Key) && valueExpr.Regex.IsMatch(kvpProperty.Value),
+#pragma warning restore CS0618 // Type or member is obsolete
             TestMetadataProperty testMetadataProperty => propExpr.Regex.IsMatch(testMetadataProperty.Key) && valueExpr.Regex.IsMatch(testMetadataProperty.Value),
             _ => false,
         };

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable CS0618 // Type or member is obsolete
 namespace Microsoft.Testing.Platform.Extensions.Messages.UnitTests;
 
 [TestClass]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Requests;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 #pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 namespace Microsoft.Testing.Platform.UnitTests;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
@@ -221,5 +221,13 @@ public sealed class TreeNodeFilterTests
     }
 
     [TestMethod]
+    public void MatchAllFilterSubpathWithPropertyExpression_WithTestMetadataProperty()
+    {
+        TreeNodeFilter filter = new("/A/**[A=B]");
+        Assert.IsTrue(filter.MatchesFilter("/A/B/C/D", new PropertyBag(new TestMetadataProperty("A", "B"))));
+        Assert.IsFalse(filter.MatchesFilter("/B/A/C/D", new PropertyBag(new TestMetadataProperty("A", "B"))));
+    }
+
+    [TestMethod]
     public void MatchAllFilterWithPropertyExpression_DoNotAllowInMiddleOfFilter() => Assert.ThrowsException<ArgumentException>(() => _ = new TreeNodeFilter("/**/Path[A=B]"));
 }


### PR DESCRIPTION
Fix: #5677