### PR TITLE
Ensure TestMethodAttribute.Execute is run on the correct execution context

### DIFF
--- a/MSTest.slnf
+++ b/MSTest.slnf
@@ -50,6 +50,7 @@
       "test\\UnitTests\\MSTest.Analyzers.UnitTests\\MSTest.Analyzers.UnitTests.csproj",
       "test\\UnitTests\\MSTestAdapter.PlatformServices.UnitTests\\MSTestAdapter.PlatformServices.UnitTests.csproj",
       "test\\UnitTests\\MSTestAdapter.UnitTests\\MSTestAdapter.UnitTests.csproj",
+      "test\\UnitTests\\MSTest.SelfRealExamples.UnitTests\\MSTest.SelfRealExamples.UnitTests.csproj",
       "test\\UnitTests\\TestFramework.UnitTests\\TestFramework.UnitTests.csproj",
       "test\\Utilities\\Automation.CLI\\Automation.CLI.csproj",
       "test\\Utilities\\Microsoft.Testing.TestInfrastructure\\Microsoft.Testing.TestInfrastructure.csproj",

--- a/TestFx.sln
+++ b/TestFx.sln
@@ -224,6 +224,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSTest.SourceGeneration.Uni
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Testing.Extensions.AzureDevOpsReport", "src\Platform\Microsoft.Testing.Extensions.AzureDevOpsReport\Microsoft.Testing.Extensions.AzureDevOpsReport.csproj", "{F608D3A3-125B-CD88-1D51-8714ED142029}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSTest.SelfRealExamples.UnitTests", "test\UnitTests\MSTest.SelfRealExamples.UnitTests\MSTest.SelfRealExamples.UnitTests.csproj", "{E5DE7057-7304-439A-94D7-D1609CC40631}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -530,6 +532,10 @@ Global
 		{F608D3A3-125B-CD88-1D51-8714ED142029}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F608D3A3-125B-CD88-1D51-8714ED142029}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F608D3A3-125B-CD88-1D51-8714ED142029}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5DE7057-7304-439A-94D7-D1609CC40631}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5DE7057-7304-439A-94D7-D1609CC40631}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5DE7057-7304-439A-94D7-D1609CC40631}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5DE7057-7304-439A-94D7-D1609CC40631}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -622,6 +628,7 @@ Global
 		{2C0DFAC0-5D58-D172-ECE4-CBB78AD03435} = {BB874DF1-44FE-415A-B634-A6B829107890}
 		{E6C0466E-BE8D-C04F-149A-FD98438F1413} = {BB874DF1-44FE-415A-B634-A6B829107890}
 		{F608D3A3-125B-CD88-1D51-8714ED142029} = {6AEE1440-FDF0-4729-8196-B24D0E333550}
+		{E5DE7057-7304-439A-94D7-D1609CC40631} = {BB874DF1-44FE-415A-B634-A6B829107890}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {31E0F4D5-975A-41CC-933E-545B2201FAF9}

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TestMethodAttribute.cs
@@ -67,7 +67,6 @@ public class TestMethodAttribute : Attribute
     /// <param name="testMethod">The test method to execute.</param>
     /// <returns>An array of TestResult objects that represent the outcome(s) of the test.</returns>
     /// <remarks>Extensions can override this method to customize running a TestMethod.</remarks>
-    // TODO: Double check whether this breaks async local propagation between test init, test, test cleanup
     internal virtual async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
         => UseAsync
         ? [await testMethod.InvokeAsync(null)]

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/MSTest.SelfRealExamples.UnitTests.csproj
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/MSTest.SelfRealExamples.UnitTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net472;net9.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.AzureDevOpsReport\Microsoft.Testing.Extensions.AzureDevOpsReport.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="DiagnoseCapabilities" />
+    <ProjectCapability Include="TestingPlatformServer" />
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
+
+</Project>

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.Testing.Platform.Builder;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[assembly: Parallelize(Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel, Workers = 0)]
+
 ITestApplicationBuilder testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/Program.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+ITestApplicationBuilder testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+
+testApplicationBuilder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
+testApplicationBuilder.AddTrxReportProvider();
+testApplicationBuilder.AddAppInsightsTelemetryProvider();
+testApplicationBuilder.AddCodeCoverageProvider();
+testApplicationBuilder.AddAzureDevOpsProvider();
+using ITestApplication testApplication = await testApplicationBuilder.BuildAsync();
+return await testApplication.RunAsync();

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/TestExecutionContextPropagationFromTestMethodAttributeToTestMethod.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/TestExecutionContextPropagationFromTestMethodAttributeToTestMethod.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MSTest.SelfRealExamples.UnitTests;
+
+[TestClass]
+public sealed class TestExecutionContextPropagationFromTestMethodAttributeToTestMethod
+{
+    private static readonly AsyncLocal<object> State = new();
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext testContext)
+    {
+    }
+
+    [MyTestMethod]
+    public void TestAsyncLocalValueIsPreserved()
+        => Assert.AreEqual("In Execute", State.Value);
+
+    private sealed class MyTestMethodAttribute : TestMethodAttribute
+    {
+        public override TestResult[] Execute(ITestMethod testMethod)
+        {
+            State.Value = "In Execute";
+            return base.Execute(testMethod);
+        }
+    }
+}


### PR DESCRIPTION
One more execution context bug :)

Also adding a new test project that's kinda in-between unit tests and integration tests. It's similar to Playground but intended to contain real tests. It can only test "positive" cases.

Fixes #5687