### PR TITLE
Fix fallback path for getting method info if InvalidManagedNameException is thrown

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TypeCache.cs
@@ -738,7 +738,7 @@ internal sealed class TypeCache : MarshalByRefObject
         {
             Type[] parameters = [.. methodBase.GetParameters().Select(i => i.ParameterType)];
             // TODO: Should we pass true for includeNonPublic?
-            testMethodInfo = PlatformServiceProvider.Instance.ReflectionOperations.GetRuntimeMethod(methodBase.DeclaringType!, methodBase.Name, parameters, includeNonPublic: false);
+            testMethodInfo = PlatformServiceProvider.Instance.ReflectionOperations.GetRuntimeMethod(methodBase.DeclaringType!, methodBase.Name, parameters, includeNonPublic: true);
         }
 
         return testMethodInfo is null


### PR DESCRIPTION
I never seen a case where `InvalidManagedNameException` is thrown in MSTest, but let's have the fallback path consistent with the main logic.

Fixes #4508