### PR TITLE
Avoid loading System.Threading.Tasks.Extensions when not needed

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -432,32 +432,10 @@ public class TestMethodInfo : ITestMethod
 
                         if (executionContext is null)
                         {
-                            object? invokeResult = TestMethod.GetInvokeResult(_classInstance, arguments);
-                            if (invokeResult is null)
+                            Task? invokeResult = TestMethod.GetInvokeResultAsync(_classInstance, arguments);
+                            if (invokeResult is not null)
                             {
-                                // Do nothing.
-                                // Don't remove this if condition as we don't want to go in the "else" in this case.
-                            }
-                            else if (invokeResult is Task task)
-                            {
-                                await task;
-                            }
-                            else
-                            {
-                                await TryAwaitValueTaskAsync(invokeResult);
-
-                                // Avoid loading System.Threading.Tasks.Extensions if not needed.
-                                // Note: .NET runtime will load all types once it's entering the method.
-                                // So, moving this out of the method will load System.Threading.Tasks.Extensions
-                                // Even when invokeResult is null or Task.
-                                [MethodImpl(MethodImplOptions.NoInlining)]
-                                static async Task TryAwaitValueTaskAsync(object invokeResult)
-                                {
-                                    if (invokeResult is ValueTask valueTask)
-                                    {
-                                        await valueTask;
-                                    }
-                                }
+                                await invokeResult;
                             }
                         }
                         else
@@ -469,32 +447,10 @@ public class TestMethodInfo : ITestMethod
                             {
                                 try
                                 {
-                                    object? invokeResult = TestMethod.GetInvokeResult(_classInstance, arguments);
-                                    if (invokeResult is null)
+                                    Task? invokeResult = TestMethod.GetInvokeResultAsync(_classInstance, arguments);
+                                    if (invokeResult is not null)
                                     {
-                                        // Do nothing.
-                                        // Don't remove this if condition as we don't want to go in the "else" in this case.
-                                    }
-                                    else if (invokeResult is Task task)
-                                    {
-                                        await task;
-                                    }
-                                    else
-                                    {
-                                        await TryAwaitValueTaskAsync(invokeResult);
-
-                                        // Avoid loading System.Threading.Tasks.Extensions if not needed.
-                                        // Note: .NET runtime will load all types once it's entering the method.
-                                        // So, moving this out of the method will load System.Threading.Tasks.Extensions
-                                        // Even when invokeResult is null or Task.
-                                        [MethodImpl(MethodImplOptions.NoInlining)]
-                                        static async Task TryAwaitValueTaskAsync(object invokeResult)
-                                        {
-                                            if (invokeResult is ValueTask valueTask)
-                                            {
-                                                await valueTask;
-                                            }
-                                        }
+                                        await invokeResult;
                                     }
                                 }
                                 catch (Exception e)

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -433,13 +433,28 @@ public class TestMethodInfo : ITestMethod
                         if (executionContext is null)
                         {
                             object? invokeResult = TestMethod.GetInvokeResult(_classInstance, arguments);
-                            if (invokeResult is Task task)
+                            if (invokeResult is null)
+                            {
+                                // Do nothing.
+                                // Don't remove this if condition as we don't want to go in the "else" in this case.
+                            }
+                            else if (invokeResult is Task task)
                             {
                                 await task;
                             }
-                            else if (invokeResult is ValueTask valueTask)
+                            else
                             {
-                                await valueTask;
+                                await TryAwaitValueTaskAsync(invokeResult);
+
+                                // Avoid loading System.Threading.Tasks.Extensions if not needed.
+                                [MethodImpl(MethodImplOptions.NoInlining)]
+                                static async Task TryAwaitValueTaskAsync(object invokeResult)
+                                {
+                                    if (invokeResult is ValueTask valueTask)
+                                    {
+                                        await valueTask;
+                                    }
+                                }
                             }
                         }
                         else
@@ -452,13 +467,28 @@ public class TestMethodInfo : ITestMethod
                                 try
                                 {
                                     object? invokeResult = TestMethod.GetInvokeResult(_classInstance, arguments);
-                                    if (invokeResult is Task task)
+                                    if (invokeResult is null)
+                                    {
+                                        // Do nothing.
+                                        // Don't remove this if condition as we don't want to go in the "else" in this case.
+                                    }
+                                    else if (invokeResult is Task task)
                                     {
                                         await task;
                                     }
-                                    else if (invokeResult is ValueTask valueTask)
+                                    else
                                     {
-                                        await valueTask;
+                                        await TryAwaitValueTaskAsync(invokeResult);
+
+                                        // Avoid loading System.Threading.Tasks.Extensions if not needed.
+                                        [MethodImpl(MethodImplOptions.NoInlining)]
+                                        static async Task TryAwaitValueTaskAsync(object invokeResult)
+                                        {
+                                            if (invokeResult is ValueTask valueTask)
+                                            {
+                                                await valueTask;
+                                            }
+                                        }
                                     }
                                 }
                                 catch (Exception e)

--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -447,6 +447,9 @@ public class TestMethodInfo : ITestMethod
                                 await TryAwaitValueTaskAsync(invokeResult);
 
                                 // Avoid loading System.Threading.Tasks.Extensions if not needed.
+                                // Note: .NET runtime will load all types once it's entering the method.
+                                // So, moving this out of the method will load System.Threading.Tasks.Extensions
+                                // Even when invokeResult is null or Task.
                                 [MethodImpl(MethodImplOptions.NoInlining)]
                                 static async Task TryAwaitValueTaskAsync(object invokeResult)
                                 {
@@ -481,6 +484,9 @@ public class TestMethodInfo : ITestMethod
                                         await TryAwaitValueTaskAsync(invokeResult);
 
                                         // Avoid loading System.Threading.Tasks.Extensions if not needed.
+                                        // Note: .NET runtime will load all types once it's entering the method.
+                                        // So, moving this out of the method will load System.Threading.Tasks.Extensions
+                                        // Even when invokeResult is null or Task.
                                         [MethodImpl(MethodImplOptions.NoInlining)]
                                         static async Task TryAwaitValueTaskAsync(object invokeResult)
                                         {

--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -96,6 +96,9 @@ internal static class MethodInfoExtensions
         || method.IsValueTask();
 
     // Avoid loading System.Threading.Tasks.Extensions if not needed.
+    // Note: .NET runtime will load all types once it's entering the method.
+    // So, moving this out of the method will load System.Threading.Tasks.Extensions
+    // Even when invokeResult is null or Task.
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool IsValueTask(this MethodInfo method)
         => ReflectHelper.MatchReturnType(method, typeof(ValueTask));
@@ -212,6 +215,9 @@ internal static class MethodInfoExtensions
             TryWaitValueTask(invokeResult);
 
             // Avoid loading System.Threading.Tasks.Extensions if not needed.
+            // Note: .NET runtime will load all types once it's entering the method.
+            // So, moving this out of the method will load System.Threading.Tasks.Extensions
+            // Even when invokeResult is null or Task.
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void TryWaitValueTask(object invokeResult)
             {

--- a/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/MethodInfoExtensions.cs
@@ -212,11 +212,7 @@ internal static class MethodInfoExtensions
     internal static void InvokeAsSynchronousTask(this MethodInfo methodInfo, object? classInstance, params object?[]? arguments)
     {
         Task? invokeResult = methodInfo.GetInvokeResultAsync(classInstance, arguments);
-
-        if (invokeResult is not null)
-        {
-            invokeResult.GetAwaiter().GetResult();
-        }
+        invokeResult?.GetAwaiter().GetResult();
     }
 
     private static void InferGenerics(Type parameterType, Type argumentType, List<(Type ParameterType, Type Substitution)> result)


### PR DESCRIPTION
This works-around cases where binding redirects are not properly generated in consumer projects, either due to missing Microsoft.NET.Test.Sdk dependency, or due to reasons not yet known.