### PR TITLE
Delete dead code in ExceptionHelper

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/ExceptionHelper.cs
@@ -83,7 +83,7 @@ internal static class ExceptionHelper
             first = false;
         }
 
-        return CreateStackTraceInformation(ex, true, result.ToString());
+        return CreateStackTraceInformation(result.ToString());
     }
 
     /// <summary>
@@ -173,28 +173,14 @@ internal static class ExceptionHelper
     /// <summary>
     /// Create stack trace information.
     /// </summary>
-    /// <param name="ex">
-    /// The exception.
-    /// </param>
-    /// <param name="checkInnerExceptions">
-    /// Whether the inner exception needs to be checked too.
-    /// </param>
     /// <param name="stackTraceString">
     /// The stack Trace String.
     /// </param>
     /// <returns>
     /// The <see cref="StackTraceInformation"/>.
     /// </returns>
-    internal static StackTraceInformation? CreateStackTraceInformation(
-        Exception ex,
-        bool checkInnerExceptions,
-        string stackTraceString)
+    internal static StackTraceInformation? CreateStackTraceInformation(string stackTraceString)
     {
-        if (checkInnerExceptions && ex.InnerException != null)
-        {
-            return CreateStackTraceInformation(ex.InnerException, checkInnerExceptions, stackTraceString);
-        }
-
         string stackTrace = TrimStackTrace(stackTraceString);
 
         return !StringEx.IsNullOrEmpty(stackTrace) ? new StackTraceInformation(stackTrace, null, 0, 0) : null;

--- a/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/ExceptionExtensions.cs
@@ -54,7 +54,7 @@ internal static class ExceptionExtensions
     /// <param name="exception">An <see cref="Exception"/> instance.</param>
     /// <returns>StackTraceInformation for the exception.</returns>
     internal static StackTraceInformation? TryGetStackTraceInformation(this Exception exception) => !StringEx.IsNullOrEmpty(exception.StackTrace)
-            ? ExceptionHelper.CreateStackTraceInformation(exception, false, exception.StackTrace)
+            ? ExceptionHelper.CreateStackTraceInformation(exception.StackTrace)
             : null;
 
     /// <summary>


### PR DESCRIPTION
The recursion part of `CreateStackTraceInformation` that is around inner exception wasn't doing anything. At the end, we were always just operating on the originally given stack trace.

Given that this dead code has been like this forever, I'm deleting it.