### PR TITLE
Remove dead code in TestMethodInfo

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TestMethodInfo.cs
@@ -1103,10 +1103,6 @@ public class TestMethodInfo : ITestMethod
             }
 
             DebugEx.Assert(result is not null, "result is not null");
-
-            // It's possible that some failures happened and that the cleanup wasn't executed, so we need to run it here.
-            // The method already checks if the cleanup was already executed.
-            RunTestCleanupMethod(result, executionContext, null);
             return result;
         }
 


### PR DESCRIPTION
The deleted logic is under the following condition:

```csharp
if (PlatformServiceProvider.Instance.ThreadOperations.Execute(ExecuteAsyncAction, TimeoutInfo.Timeout, TestContext!.Context.CancellationTokenSource.Token))
```

If `ThreadOperations.Execute` returned true, that means that `ExecuteAsyncAction` completed successfully and the test didn't timeout. So, cleanup has already been executed successfully as part of `ExecuteInternalAsync`.