### PR TITLE
Fix TraceListenerManager thread safety issue

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
@@ -65,8 +65,7 @@ internal sealed class ClassCleanupManager
 
     internal static void ForceCleanup(TypeCache typeCache, IDictionary<string, object?> sourceLevelParameters, IMessageLogger logger)
     {
-        using var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture, "context");
-        TestContext testContext = new TestContextImplementation(null, writer, sourceLevelParameters, logger, testRunCancellationToken: null);
+        TestContext testContext = new TestContextImplementation(null, sourceLevelParameters, logger, testRunCancellationToken: null);
         IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;
         foreach (TestClassInfo classInfo in classInfoCache)
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
@@ -68,10 +68,9 @@ internal sealed class ClassCleanupManager
         using var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture, "context");
         TestContext testContext = new TestContextImplementation(null, writer, sourceLevelParameters, logger, testRunCancellationToken: null);
         IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;
-        LogMessageListener? listener = null;
         foreach (TestClassInfo classInfo in classInfoCache)
         {
-            TestFailedException? ex = classInfo.ExecuteClassCleanup(testContext, out listener);
+            TestFailedException? ex = classInfo.ExecuteClassCleanup(testContext);
             if (ex is not null)
             {
                 throw ex;
@@ -81,7 +80,7 @@ internal sealed class ClassCleanupManager
         IEnumerable<TestAssemblyInfo> assemblyInfoCache = typeCache.AssemblyInfoListWithExecutableCleanupMethods;
         foreach (TestAssemblyInfo assemblyInfo in assemblyInfoCache)
         {
-            TestFailedException? ex = assemblyInfo.ExecuteAssemblyCleanup(testContext, ref listener);
+            TestFailedException? ex = assemblyInfo.ExecuteAssemblyCleanup(testContext);
             if (ex is not null)
             {
                 throw ex;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleErrorCapturer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleErrorCapturer.cs
@@ -37,4 +37,16 @@ internal sealed class ConsoleErrorCapturer : TextWriter
             _originalConsoleErr.Write(value);
         }
     }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleErr(buffer, index, count);
+        }
+        else
+        {
+            _originalConsoleErr.Write(buffer, index, count);
+        }
+    }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleErrorCapturer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleErrorCapturer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+
+internal sealed class ConsoleErrorCapturer : TextWriter
+{
+    private readonly TextWriter _originalConsoleErr;
+
+    public ConsoleErrorCapturer(TextWriter originalConsoleErr)
+        => _originalConsoleErr = originalConsoleErr;
+
+    public override Encoding Encoding => Encoding.UTF8;
+
+    public override void Write(char value)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleErr(value);
+        }
+        else
+        {
+            _originalConsoleErr.Write(value);
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleErr(value);
+        }
+        else
+        {
+            _originalConsoleErr.Write(value);
+        }
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleOutCapturer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleOutCapturer.cs
@@ -37,4 +37,16 @@ internal sealed class ConsoleOutCapturer : TextWriter
             _originalConsoleOut.Write(value);
         }
     }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleOut(buffer, index, count);
+        }
+        else
+        {
+            _originalConsoleOut.Write(buffer, index, count);
+        }
+    }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleOutCapturer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleOutCapturer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+
+internal sealed class ConsoleOutCapturer : TextWriter
+{
+    private readonly TextWriter _originalConsoleOut;
+
+    public ConsoleOutCapturer(TextWriter originalConsoleOut)
+        => _originalConsoleOut = originalConsoleOut;
+
+    public override Encoding Encoding => Encoding.UTF8;
+
+    public override void Write(char value)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleOut(value);
+        }
+        else
+        {
+            _originalConsoleOut.Write(value);
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleOut(value);
+        }
+        else
+        {
+            _originalConsoleOut.Write(value);
+        }
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
@@ -473,7 +473,7 @@ public class TestClassInfo
                 var testContextImpl = testContext as TestContextImplementation;
                 result.LogOutput = initializationLogs + testContextImpl?.GetOut();
                 result.LogError = initializationErrorLogs + testContextImpl?.GetErr();
-                result.DebugTrace = initializationTrace; // TODO: DebugTrace
+                result.DebugTrace = initializationTrace + testContextImpl?.GetTrace();
                 result.TestContextMessages = initializationTestContextMessages + testContext.GetAndClearDiagnosticMessages();
             }
 
@@ -780,7 +780,7 @@ public class TestClassInfo
                     var testContextImpl = testContext as TestContextImplementation;
                     lastResult.LogOutput += testContextImpl?.GetOut();
                     lastResult.LogError += testContextImpl?.GetErr();
-                    // TODO: DebugTrace
+                    lastResult.DebugTrace += testContextImpl?.GetTrace();
                     lastResult.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
                 }
             }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -152,14 +152,10 @@ public class TestMethodInfo : ITestMethod
         // check if arguments are set for data driven tests
         arguments ??= Arguments;
 
-        LogMessageListener? listener = null;
         watch.Start();
 
         try
         {
-            ThreadSafeStringWriter.CleanState();
-            listener = new LogMessageListener(MSTestSettings.CurrentSettings.CaptureDebugTraces);
-
             result = IsTimeoutSet
                 ? await ExecuteInternalWithTimeoutAsync(arguments).ConfigureAwait(false)
                 : await ExecuteInternalAsync(arguments, null).ConfigureAwait(false);
@@ -172,15 +168,6 @@ public class TestMethodInfo : ITestMethod
             if (result != null)
             {
                 result.Duration = watch.Elapsed;
-                if (listener is not null)
-                {
-                    result.DebugTrace = listener.GetAndClearDebugTrace();
-                    result.LogOutput = listener.GetAndClearStandardOutput();
-                    result.LogError = listener.GetAndClearStandardError();
-                    result.TestContextMessages = TestContext?.GetAndClearDiagnosticMessages();
-                    result.ResultFiles = TestContext?.GetResultFiles();
-                    listener.Dispose();
-                }
             }
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -167,6 +167,12 @@ public class TestMethodInfo : ITestMethod
 
             if (result != null)
             {
+                // TODO: DebugTrace
+                var testContextImpl = TestContext as TestContextImplementation;
+                result.LogOutput = testContextImpl?.GetOut();
+                result.LogError = testContextImpl?.GetErr();
+                result.TestContextMessages = TestContext?.GetAndClearDiagnosticMessages();
+                result.ResultFiles = TestContext?.GetResultFiles();
                 result.Duration = watch.Elapsed;
             }
         }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -167,10 +167,10 @@ public class TestMethodInfo : ITestMethod
 
             if (result != null)
             {
-                // TODO: DebugTrace
                 var testContextImpl = TestContext as TestContextImplementation;
                 result.LogOutput = testContextImpl?.GetOut();
                 result.LogError = testContextImpl?.GetErr();
+                result.DebugTrace = testContextImpl?.GetTrace();
                 result.TestContextMessages = TestContext?.GetAndClearDiagnosticMessages();
                 result.ResultFiles = TestContext?.GetResultFiles();
                 result.Duration = watch.Elapsed;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -63,7 +63,7 @@ internal sealed class TestMethodRunner
     /// Executes a test.
     /// </summary>
     /// <returns>The test results.</returns>
-    internal async Task<TestResult[]> ExecuteAsync()
+    internal async Task<TestResult[]> ExecuteAsync(string? initializationLogs, string? initializationErrorLogs, string? initializationTrace, string? initializationTestContextMessages)
     {
         _testContext.Context.TestRunCount++;
         bool isSTATestClass = _testMethodInfo.Parent.ClassAttribute is STATestClassAttribute;
@@ -73,7 +73,7 @@ internal sealed class TestMethodRunner
         if (isSTARequested && isWindowsOS && Thread.CurrentThread.GetApartmentState() != ApartmentState.STA)
         {
             TestResult[]? results = null;
-            Thread entryPointThread = new(() => results = SafeRunTestMethodAsync().GetAwaiter().GetResult())
+            Thread entryPointThread = new(() => results = SafeRunTestMethodAsync(initializationLogs, initializationErrorLogs, initializationTrace, initializationTestContextMessages).GetAwaiter().GetResult())
             {
                 Name = (isSTATestClass, isSTATestMethod) switch
                 {
@@ -105,11 +105,11 @@ internal sealed class TestMethodRunner
                 PlatformServiceProvider.Instance.AdapterTraceLogger.LogWarning(Resource.STAIsOnlySupportedOnWindowsWarning);
             }
 
-            return await SafeRunTestMethodAsync().ConfigureAwait(false);
+            return await SafeRunTestMethodAsync(initializationLogs, initializationErrorLogs, initializationTrace, initializationTestContextMessages).ConfigureAwait(false);
         }
 
         // Local functions
-        async Task<TestResult[]> SafeRunTestMethodAsync()
+        async Task<TestResult[]> SafeRunTestMethodAsync(string? initializationLogs, string? initializationErrorLogs, string? initializationTrace, string? initializationTestContextMessages)
         {
             TestResult[]? result = null;
 
@@ -139,6 +139,15 @@ internal sealed class TestMethodRunner
                     Duration = result[result.Length - 1].Duration,
                 };
 #pragma warning restore IDE0056 // Use index operator
+            }
+            finally
+            {
+                // Assembly initialize and class initialize logs are pre-pended to the first result.
+                TestResult firstResult = result![0];
+                firstResult.LogOutput = initializationLogs + firstResult.LogOutput;
+                firstResult.LogError = initializationErrorLogs + firstResult.LogError;
+                firstResult.DebugTrace = initializationTrace + firstResult.DebugTrace;
+                firstResult.TestContextMessages = initializationTestContextMessages + firstResult.TestContextMessages;
             }
 
             return result;
@@ -460,7 +469,10 @@ internal sealed class TestMethodRunner
                 {
                     try
                     {
-                        tcs.SetResult(await _testMethodInfo.Executor.ExecuteAsync(testMethodInfo).ConfigureAwait(false));
+                        using (TestContextImplementation.SetCurrentTestContext(_testMethodInfo.TestContext as TestContextImplementation))
+                        {
+                            tcs.SetResult(await _testMethodInfo.Executor.ExecuteAsync(testMethodInfo).ConfigureAwait(false));
+                        }
                     }
                     catch (Exception e)
                     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+
+internal sealed class TraceTextWriter : TextWriter
+{
+    public override Encoding Encoding => Encoding.UTF8;
+
+    public override void Write(char value)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleErr(value);
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        if (TestContextImplementation.CurrentTestContext is { } testContext)
+        {
+            testContext.WriteConsoleErr(value);
+        }
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
@@ -13,7 +13,7 @@ internal sealed class TraceTextWriter : TextWriter
     {
         if (TestContextImplementation.CurrentTestContext is { } testContext)
         {
-            testContext.WriteConsoleErr(value);
+            testContext.WriteTrace(value);
         }
     }
 
@@ -21,7 +21,7 @@ internal sealed class TraceTextWriter : TextWriter
     {
         if (TestContextImplementation.CurrentTestContext is { } testContext)
         {
-            testContext.WriteConsoleErr(value);
+            testContext.WriteTrace(value);
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -156,9 +156,8 @@ internal sealed class UnitTestRunner : MarshalByRefObject
 
         try
         {
-            using var writer = new ThreadSafeStringWriter(CultureInfo.InvariantCulture, "context");
             var properties = new Dictionary<string, object?>(testContextProperties);
-            testContextForTestExecution = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, UTF.UnitTestOutcome.InProgress);
+            testContextForTestExecution = PlatformServiceProvider.Instance.GetTestContext(testMethod, properties, messageLogger, UTF.UnitTestOutcome.InProgress);
 
             // Get the testMethod
             TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
@@ -178,7 +177,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 _assemblyFixtureTests.TryAdd(testMethod.AssemblyName, testMethodInfo.Parent.Parent);
                 _classFixtureTests.TryAdd(testMethod.AssemblyName + testMethod.FullClassName, testMethodInfo.Parent);
 
-                testContextForAssemblyInit = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
+                testContextForAssemblyInit = PlatformServiceProvider.Instance.GetTestContext(testMethod, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
 
                 TestResult assemblyInitializeResult = RunAssemblyInitializeIfNeeded(testMethodInfo, testContextForAssemblyInit);
 
@@ -188,7 +187,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 }
                 else
                 {
-                    testContextForClassInit = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForAssemblyInit.Context.CurrentTestOutcome);
+                    testContextForClassInit = PlatformServiceProvider.Instance.GetTestContext(testMethod, properties, messageLogger, testContextForAssemblyInit.Context.CurrentTestOutcome);
 
                     TestResult classInitializeResult = testMethodInfo.Parent.GetResultOrRunClassInitialize(testContextForClassInit, assemblyInitializeResult.LogOutput, assemblyInitializeResult.LogError, assemblyInitializeResult.DebugTrace, assemblyInitializeResult.TestContextMessages);
                     DebugEx.Assert(testMethodInfo.Parent.IsClassInitializeExecuted, "IsClassInitializeExecuted should be true after attempting to run it.");
@@ -216,12 +215,12 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 }
             }
 
-            testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
+            testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
             testMethodInfo?.Parent.RunClassCleanup(testContextForClassCleanup, _classCleanupManager, testMethodInfo, testMethod, result);
 
             if (testMethodInfo?.Parent.Parent.IsAssemblyInitializeExecuted == true)
             {
-                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, writer, properties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
+                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod, properties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
                 RunAssemblyCleanupIfNeeded(testContextForAssemblyCleanup, _classCleanupManager, _typeCache, result);
             }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -286,7 +286,6 @@ internal sealed class UnitTestRunner : MarshalByRefObject
 
         try
         {
-
             // TODO: We are using the same TestContext here for ClassCleanup and AssemblyCleanup.
             // They should be different.
             IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -57,6 +57,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
         {
             Console.SetOut(new ConsoleOutCapturer(Console.Out));
             Console.SetError(new ConsoleErrorCapturer(Console.Error));
+            Trace.Listeners.Add(new TextWriterTraceListener(new TraceTextWriter()));
         }
 
         PlatformServiceProvider.Instance.TestRunCancellationToken ??= new TestRunCancellationToken();
@@ -270,7 +271,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
             var testContextImpl = testContext.Context as TestContextImplementation;
             result.LogOutput = testContextImpl?.GetOut();
             result.LogError = testContextImpl?.GetErr();
-            // TODO: DebugTrace
+            result.DebugTrace = testContextImpl?.GetTrace();
             result.TestContextMessages = testContext.GetAndClearDiagnosticMessages();
         }
 
@@ -330,7 +331,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 var testContextImpl = testContext as TestContextImplementation;
                 lastResult.LogOutput += testContextImpl?.GetOut();
                 lastResult.LogError += testContextImpl?.GetErr();
-                // TODO: DebugTrace
+                lastResult.DebugTrace += testContextImpl?.GetTrace();
                 lastResult.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
             }
         }

--- a/src/Adapter/MSTestAdapter.PlatformServices/IPlatformServiceProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/IPlatformServiceProvider.cs
@@ -117,9 +117,6 @@ internal interface IPlatformServiceProvider
     /// <param name="testMethod">
     /// The test method.
     /// </param>
-    /// <param name="writer">
-    /// The writer instance for logging.
-    /// </param>
     /// <param name="properties">
     /// The default set of properties the test context needs to be filled with.
     /// </param>
@@ -131,5 +128,5 @@ internal interface IPlatformServiceProvider
     /// <remarks>
     /// This was required for compatibility reasons since the TestContext object that the V1 adapter had for desktop is not .Net Core compliant.
     /// </remarks>
-    ITestContext GetTestContext(ITestMethod testMethod, StringWriter writer, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome);
+    ITestContext GetTestContext(ITestMethod testMethod, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PlatformServiceProvider.cs
@@ -192,9 +192,6 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     /// <param name="testMethod">
     /// The test method.
     /// </param>
-    /// <param name="writer">
-    /// The writer instance for logging.
-    /// </param>
     /// <param name="properties">
     /// The default set of properties the test context needs to be filled with.
     /// </param>
@@ -206,9 +203,9 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     /// <remarks>
     /// This was required for compatibility reasons since the TestContext object that the V1 adapter had for desktop is not .Net Core compliant.
     /// </remarks>
-    public ITestContext GetTestContext(ITestMethod testMethod, StringWriter writer, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome)
+    public ITestContext GetTestContext(ITestMethod testMethod, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome)
     {
-        var testContextImplementation = new TestContextImplementation(testMethod, writer, properties, messageLogger, TestRunCancellationToken);
+        var testContextImplementation = new TestContextImplementation(testMethod, properties, messageLogger, TestRunCancellationToken);
         testContextImplementation.SetOutcome(outcome);
         return testContextImplementation;
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -408,8 +408,14 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
 
     private StringBuilder GetTestContextMessagesStringBuilder()
     {
-        _ = _testContextMessageStringBuilder ?? Interlocked.CompareExchange(ref _testContextMessageStringBuilder, new StringBuilder(), null)!;
-        return _testContextMessageStringBuilder;
+        // Prefer writing to the current test context instead of 'this'.
+        // This is just a hack to preserve backward compatibility.
+        // It's relevant for cases where users store 'TestContext' in a static field.
+        // Then, they write to the "wrong" test context.
+        // Here, we are correcting user's fault by finding out the correct TestContext that should receive the message.
+        TestContextImplementation @this = CurrentTestContext ?? this;
+        _ = @this._testContextMessageStringBuilder ?? Interlocked.CompareExchange(ref @this._testContextMessageStringBuilder, new StringBuilder(), null)!;
+        return @this._testContextMessageStringBuilder;
     }
 
     internal string? GetOut()

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -47,6 +47,7 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
 
     private StringBuilder? _stdOutStringBuilder;
     private StringBuilder? _stdErrStringBuilder;
+    private StringBuilder? _traceStringBuilder;
     private StringBuilder? _testContextMessageStringBuilder;
 
     private bool _isDisposed;
@@ -381,6 +382,12 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
     internal void WriteConsoleErr(string? value)
         => GetErrStringBuilder().Append(value);
 
+    internal void WriteTrace(char value)
+        => GetTraceStringBuilder().Append(value);
+
+    internal void WriteTrace(string? value)
+        => GetTraceStringBuilder().Append(value);
+
     private StringBuilder GetOutStringBuilder()
     {
         _ = _stdOutStringBuilder ?? Interlocked.CompareExchange(ref _stdOutStringBuilder, new StringBuilder(), null)!;
@@ -391,6 +398,12 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
     {
         _ = _stdErrStringBuilder ?? Interlocked.CompareExchange(ref _stdErrStringBuilder, new StringBuilder(), null)!;
         return _stdErrStringBuilder;
+    }
+
+    private StringBuilder GetTraceStringBuilder()
+    {
+        _ = _traceStringBuilder ?? Interlocked.CompareExchange(ref _traceStringBuilder, new StringBuilder(), null)!;
+        return _traceStringBuilder;
     }
 
     private StringBuilder GetTestContextMessagesStringBuilder()
@@ -404,4 +417,7 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
 
     internal string? GetErr()
         => _stdErrStringBuilder?.ToString();
+
+    internal string? GetTrace()
+        => _traceStringBuilder?.ToString();
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -376,11 +376,17 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
     internal void WriteConsoleOut(string? value)
         => GetOutStringBuilder().Append(value);
 
+    internal void WriteConsoleOut(char[] buffer, int index, int count)
+        => GetOutStringBuilder().Append(buffer, index, count);
+
     internal void WriteConsoleErr(char value)
         => GetErrStringBuilder().Append(value);
 
     internal void WriteConsoleErr(string? value)
         => GetErrStringBuilder().Append(value);
+
+    internal void WriteConsoleErr(char[] buffer, int index, int count)
+        => GetErrStringBuilder().Append(buffer, index, count);
 
     internal void WriteTrace(char value)
         => GetTraceStringBuilder().Append(value);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
@@ -131,7 +131,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod")!;
         _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod")!;
 
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _); // call cleanup without calling init
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>())); // call cleanup without calling init
         Verify(ex is null);
         Verify(classCleanupCallCount == 0);
     }
@@ -145,7 +145,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod")!;
 
         GetResultOrRunClassInitialize();
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _); // call cleanup without calling init
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>())); // call cleanup without calling init
 
         Verify(ex is null);
         Verify(classCleanupCallCount == 1);
@@ -160,7 +160,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.BaseClassCleanupMethods.Add(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod")!);
 
         GetResultOrRunClassInitialize();
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         Verify(ex is null);
         Verify(classCleanupCallCount == 1);
@@ -464,7 +464,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(ex is null);
@@ -479,7 +479,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = null;
 
         // Act
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(ex is null);
@@ -494,7 +494,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -516,7 +516,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -537,7 +537,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -556,7 +556,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -575,7 +575,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.BaseClassCleanupMethods.Add(baseClassCleanupMethod);
 
         // Act
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert
         Verify(ex is null);
@@ -584,7 +584,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act 2
         GetResultOrRunClassInitialize(null);
-        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert 2
         Verify(ex is null);
@@ -593,7 +593,7 @@ public class TestClassInfoTests : TestContainer
         Verify(classCleanupCallCount == 1, "DummyBaseTestClass.CleanupClassMethod call count");
 
         // Act 3
-        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         // Assert 3
         Verify(ex is null);
@@ -610,7 +610,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod")!;
 
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()), out _);
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new StringWriter(), new Dictionary<string, object?>()));
 
         Verify(classCleanupException is not null);
         Verify(classCleanupException.Message.StartsWith("Class Cleanup method DummyTestClass.ClassCleanupMethod failed. Error Message: System.InvalidOperationException: I fail..", StringComparison.Ordinal));

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/PlatformServiceProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/PlatformServiceProviderTests.cs
@@ -58,13 +58,12 @@ public class PlatformServiceProviderTests : TestContainer
     {
         // Arrange.
         var testMethod = new Mock<Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel.ITestMethod>();
-        var writer = new ThreadSafeStringWriter(null!, "test");
         var properties = new Dictionary<string, object?> { { "prop", "value" } };
         testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
         testMethod.Setup(tm => tm.Name).Returns("M");
 
         // Act.
-        PlatformServices.Interface.ITestContext testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod.Object, writer, properties, null!, default);
+        PlatformServices.Interface.ITestContext testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod.Object, properties, null!, default);
 
         // Assert.
         Verify(testContext.Context.FullyQualifiedTestClassName == "A.C.M");

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -398,7 +398,7 @@ public class TestContextImplementationTests : TestContainer
         messageLoggerMock
             .Setup(l => l.SendMessage(It.IsAny<TestMessageLevel>(), It.IsAny<string>()));
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, new ThreadSafeStringWriter(null!, "test"), _properties, messageLoggerMock.Object, testRunCancellationToken: null);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties, messageLoggerMock.Object, testRunCancellationToken: null);
         _testContextImplementation.DisplayMessage(MessageLevel.Informational, "InfoMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Warning, "WarningMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Error, "ErrorMessage");

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
@@ -69,9 +69,9 @@ internal class TestablePlatformServiceProvider : IPlatformServiceProvider
 
     public bool IsGracefulStopRequested { get; set; }
 
-    public ITestContext GetTestContext(ITestMethod testMethod, StringWriter writer, IDictionary<string, object?> properties, IMessageLogger messageLogger, UnitTestOutcome outcome)
+    public ITestContext GetTestContext(ITestMethod testMethod, IDictionary<string, object?> properties, IMessageLogger messageLogger, UnitTestOutcome outcome)
     {
-        var testContextImpl = new TestContextImplementation(testMethod, writer, properties, messageLogger, testRunCancellationToken: null);
+        var testContextImpl = new TestContextImplementation(testMethod, properties, messageLogger, testRunCancellationToken: null);
         testContextImpl.SetOutcome(outcome);
         return testContextImpl;
     }


### PR DESCRIPTION
Fixes #2616

Instead of repeatedly setting Console.Out/Console.Error and resetting to original in a thread-unsafe way, we now set Conosle.Out/Console.Error once in the UnitTestRunner constructor.

Additionally, the logic of capturing is way simplified now.

Each step of the test lifecycle (asm init, asm cleanup, class init, test, class cleanup, and asm cleanup) will set its current TestContext. The current TestContext is async local, so it's isolated properly when running in parallel. Then when each step creates its test result, it just needs to get the data from the current test context.

The redirected out/error will simply write to the current test context if there is one, or write to the original if there isn't one. This simplifies the logic a lot and makes it much easier to follow.

Note that there is a lot of code that can be deleted with this change, but we cannot do so now as it affects public API. I kept the public API the same. We simply just are not using it in the implementation.