### PR TITLE
Store the actual data to instead of deserializing

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -464,6 +464,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             try
             {
                 discoveredTest.TestMethod.SerializedData = DataSerializationHelper.Serialize(d);
+                discoveredTest.TestMethod.ActualData = d;
                 discoveredTest.TestMethod.TestDataSourceIgnoreMessage = testDataSourceIgnoreMessage;
                 discoveredTest.TestMethod.DataType = DynamicDataType.ITestDataSource;
             }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -85,7 +85,7 @@ internal class UnitTestDiscoverer
         SendTestCases(source, testElements, discoverySink, discoveryContext, logger);
     }
 
-    private static readonly ConditionalWeakTable<TestCase, object[]> TestCaseToDataDictionary = new();
+    private static readonly ConditionalWeakTable<TestCase, object?[]> TestCaseToDataDictionary = new();
 
     internal static bool TryGetActualData(TestCase testCase, [NotNullWhen(true)] out object?[]? actualData)
         => TestCaseToDataDictionary.TryGetValue(testCase, out actualData);
@@ -128,7 +128,10 @@ internal class UnitTestDiscoverer
                     continue;
                 }
 
-                TestCaseToDataDictionary.Add(testCase, testElement.TestMethod.ActualData);
+                if (testElement.TestMethod.ActualData is { } actualData)
+                {
+                    TestCaseToDataDictionary.Add(testCase, actualData);
+                }
 
                 if (!hasAnyRunnableTests)
                 {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -85,6 +85,11 @@ internal class UnitTestDiscoverer
         SendTestCases(source, testElements, discoverySink, discoveryContext, logger);
     }
 
+    private static readonly ConditionalWeakTable<TestCase, object[]> TestCaseToDataDictionary = new();
+
+    internal static bool TryGetActualData(TestCase testCase, [NotNullWhen(true)] out object?[]? actualData)
+        => TestCaseToDataDictionary.TryGetValue(testCase, out actualData);
+
     internal void SendTestCases(string source, IEnumerable<UnitTestElement> testElements, ITestCaseDiscoverySink discoverySink, IDiscoveryContext? discoveryContext, IMessageLogger logger)
     {
         bool shouldCollectSourceInformation = MSTestSettings.RunConfigurationSettings.CollectSourceInformation;
@@ -122,6 +127,8 @@ internal class UnitTestDiscoverer
 
                     continue;
                 }
+
+                TestCaseToDataDictionary.Add(testCase, testElement.TestMethod.ActualData);
 
                 if (!hasAnyRunnableTests)
                 {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -85,7 +85,9 @@ internal class UnitTestDiscoverer
         SendTestCases(source, testElements, discoverySink, discoveryContext, logger);
     }
 
+#pragma warning disable IDE0028 // Collection initialization can be simplified - cannot be done for all TFMs. So suppressing.
     private static readonly ConditionalWeakTable<TestCase, object?[]> TestCaseToDataDictionary = new();
+#pragma warning restore IDE0028 // Collection initialization can be simplified
 
     internal static bool TryGetActualData(TestCase testCase, [NotNullWhen(true)] out object?[]? actualData)
         => TestCaseToDataDictionary.TryGetValue(testCase, out actualData);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -179,7 +179,7 @@ internal sealed class TestMethodRunner
                 return [TestResult.CreateIgnoredResult(_test.TestDataSourceIgnoreMessage)];
             }
 
-            object?[]? data = DataSerializationHelper.Deserialize(_test.SerializedData);
+            object?[]? data = _test.ActualData ?? DataSerializationHelper.Deserialize(_test.SerializedData);
             TestResult[] testResults = await ExecuteTestWithDataSourceAsync(null, data).ConfigureAwait(false);
             results.AddRange(testResults);
         }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
@@ -86,6 +86,11 @@ internal static class TestCaseExtensions
 
             testMethod.DataType = dataType;
             testMethod.SerializedData = data;
+            if (UnitTestDiscoverer.TryGetActualData(testCase, out object?[]? actualData))
+            {
+                testMethod.ActualData = actualData;
+            }
+
             testMethod.TestDataSourceIgnoreMessage = testCase.GetPropertyValue(EngineConstants.TestDataSourceIgnoreMessageProperty) as string;
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -147,6 +147,10 @@ public sealed class TestMethod : ITestMethod
     /// </summary>
     internal string?[]? SerializedData { get; set; }
 
+    // This holds user types that may not be serializable.
+    // If app domains are enabled, we have no choice other than losing the original data.
+    // In that case, we fallback to deserializing the SerializedData.
+    [field: NonSerialized]
     internal object?[]? ActualData { get; set; }
 
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -147,6 +147,8 @@ public sealed class TestMethod : ITestMethod
     /// </summary>
     internal string?[]? SerializedData { get; set; }
 
+    internal object?[]? ActualData { get; set; }
+
     /// <summary>
     /// Gets or sets the test data source ignore message.
     /// </summary>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedTestTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedTestTests.cs
@@ -12,6 +12,7 @@ public class ParameterizedTestTests : AcceptanceTestBase<ParameterizedTestTests.
 {
     private const string DynamicDataAssetName = "DynamicData";
     private const string DataSourceAssetName = "DataSource";
+    private const string DataRowAssetName = "DataRowTests";
 
     [TestMethod]
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -115,6 +116,26 @@ public class ParameterizedTestTests : AcceptanceTestBase<ParameterizedTestTests.
             """);
     }
 
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task UsingDataRowThatDoesNotRoundTripUsingDataContractJsonSerializerWithAppDomains(string currentTfm)
+        => await UsingDataRowThatDoesNotRoundTripUsingDataContractJsonSerializerCore(currentTfm, "AppDomainEnabled");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task UsingDataRowThatDoesNotRoundTripUsingDataContractJsonSerializerWithoutAppDomains(string currentTfm)
+        => await UsingDataRowThatDoesNotRoundTripUsingDataContractJsonSerializerCore(currentTfm, "AppDomainDisabled");
+
+    private static async Task UsingDataRowThatDoesNotRoundTripUsingDataContractJsonSerializerCore(string currentTfm, string runSettings)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.GetAssetPath(DataRowAssetName), DataRowAssetName, currentTfm);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettings}.runsettings --filter ClassName=ParameterizedTestSerializationIssue2390");
+
+        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 3, skipped: 0);
+    }
+
     private static async Task RunTestsAsync(string currentTfm, string assetName, bool? isEmptyDataInconclusive)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.GetAssetPath(assetName), assetName, currentTfm);
@@ -163,7 +184,97 @@ public class ParameterizedTestTests : AcceptanceTestBase<ParameterizedTestTests.
                 SourceCodeDataSource
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+            yield return (DataRowAssetName, DataRowAssetName,
+                SourceCodeDataRow
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
+
+        private const string SourceCodeDataRow = """
+#file DataRowTests.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="AppDomainEnabled.runsettings">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="AppDomainDisabled.runsettings">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    </ItemGroup>
+
+</Project>
+  
+#file AppDomainEnabled.runsettings
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <RunConfiguration>
+        <!-- Currently, the default is already false, but we want to ensure the
+             test runs with AppDomain enabled even if we changed the default -->
+        <DisableAppDomain>false</DisableAppDomain>
+    </RunConfiguration>
+</RunSettings>
+
+#file AppDomainDisabled.runsettings
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <RunConfiguration>
+        <DisableAppDomain>true</DisableAppDomain>
+    </RunConfiguration>
+</RunSettings>
+
+#file UnitTest1.cs
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+// Test for https://github.com/microsoft/testfx/issues/2390
+[TestClass]
+public class ParameterizedTestSerializationIssue2390
+{
+    [TestMethod]
+    [DataRow((byte)0, new object[] { (byte)0 })]
+    [DataRow((short)0, new object[] { (short)0 })]
+    [DataRow(0L, new object[] { 0L })]
+    public void CheckNestedInputTypes(object expected, object nested)
+    {
+        object[] array = (object[])nested;
+        object actual = Assert.ContainsSingle(array);
+
+#if NETFRAMEWORK
+        var appDomainEnabled = Environment.GetCommandLineArgs().Contains("AppDomainEnabled.runsettings");
+        if (appDomainEnabled)
+        {
+            // Buggy behavior, because of app domains.
+            Assert.AreEqual(typeof(int), actual.GetType(), AppDomain.CurrentDomain.FriendlyName);
+        }
+        else
+#endif
+        {
+            Assert.AreEqual(expected.GetType(), actual.GetType(), AppDomain.CurrentDomain.FriendlyName);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}
+
+""";
 
         private const string SourceCodeDynamicData = """
 #file DynamicData.csproj
@@ -181,7 +292,7 @@ public class ParameterizedTestTests : AcceptanceTestBase<ParameterizedTestTests.
     <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
   </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
     <None Update="AppDomainEnabled.runsettings">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/ParameterizedTestSerializationIssue2390.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/ParameterizedTestSerializationIssue2390.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !NETFRAMEWORK // fails because of app domains.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MSTest.SelfRealExamples.UnitTests;
@@ -18,8 +17,12 @@ public class ParameterizedTestSerializationIssue2390
     {
         object[] array = (object[])nested;
         object actual = Assert.ContainsSingle(array);
-        Assert.AreEqual(expected.GetType(), ((object[])nested)[0].GetType());
+#if NETFRAMEWORK
+        // Buggy behavior, because of app domains.
+        Assert.AreEqual(typeof(int), actual.GetType());
+#else
+        Assert.AreEqual(expected.GetType(), actual.GetType());
         Assert.AreEqual(expected, actual);
+#endif
     }
 }
-#endif

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/ParameterizedTestSerializationIssue2390.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/ParameterizedTestSerializationIssue2390.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MSTest.SelfRealExamples.UnitTests;
+
+// Test for https://github.com/microsoft/testfx/issues/2390
+[TestClass]
+public class ParameterizedTestSerializationIssue2390
+{
+    [TestMethod]
+    [DataRow((byte)0, new object[] { (byte)0 })]
+    [DataRow((short)0, new object[] { (short)0 })]
+    [DataRow(0L, new object[] { 0L })]
+    public void CheckNestedInputTypes(object expected, object nested)
+    {
+        object[] array = (object[])nested;
+        object actual = Assert.ContainsSingle(array);
+        Assert.AreEqual(expected.GetType(), ((object[])nested)[0].GetType());
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/ParameterizedTestSerializationIssue2390.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/ParameterizedTestSerializationIssue2390.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if !NETFRAMEWORK // fails because of app domains.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MSTest.SelfRealExamples.UnitTests;
@@ -21,3 +22,4 @@ public class ParameterizedTestSerializationIssue2390
         Assert.AreEqual(expected, actual);
     }
 }
+#endif


### PR DESCRIPTION
When we get a run request with a given filter, we do:

1. Discovery
    - We call `UnitTestDiscoverer.DiscoverTestsInSource` which creates `UnitTestElement`s
    - It then converts `UnitTestElement`s to `TestCase`s (VSTest object model), and sends the test cases to discovery sink.
2. Execution
    - We call `ExecuteTestsAsync` with the `TestCase`s.
    - We then convert back `TestCase`s to `UnitTestElement`s that we pass to `UnitTestRunner`.

During discovery, we already have the "real data". We are only starting to lose them when moving from `UnitTestElement`s to `TestCase`s.

This PR makes the following changes:

1. Updates `AssemblyEnumerator` to store the real/original data along with the serialized data.
2. `UnitTestDiscoverer.SendTestCases` can read the data set in the previous step, and store that in CWT that maps `TestCase` to the actual data. Note that the `SendTestCases` step is exactly when we are starting to go from `UnitTestElement`s world to `TestCase`s world.
3. When converting the `TestCase`s back to `UnitTestElement`s, we set the actual data again from the CWT.
4. `TestMethodRunner` can then read the actual data instead of deserializing (which may not round trip correctly).
5. Note: I'm still keeping the `Deserialize` call if `ActualData` is null. That's probably still reachable when app domains are enabled (execution happens on different app domain). Propagating the info across app domain is probably not possible, because the `object[]` can carry user-defined types that cannot cross app domains.