### PR TITLE
Cleanup RunSettingsPatcher

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsPatcher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsPatcher.cs
@@ -49,12 +49,6 @@ internal static class RunSettingsPatcher
             runSettingsElement.AddFirst(runConfigurationElement);
         }
 
-        if (runConfigurationElement.Element("DisableAppDomain") is null)
-        {
-            AddPatchingCommentIfNeeded(runConfigurationElement, ref isPatchingCommentAdded);
-            runConfigurationElement.Add(new XElement("DisableAppDomain", false));
-        }
-
         if (runConfigurationElement.Element("DesignMode") is null)
         {
             AddPatchingCommentIfNeeded(runConfigurationElement, ref isPatchingCommentAdded);


### PR DESCRIPTION
`DisableAppDomain` is already `false` by default. In MSTest v4, if we decided to change the default, we want to make sure the bridge is following.