### PR TITLE
Attempt to fix race condition building MSTest.GlobalConfigsGenerator

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
+++ b/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\MSTest.Analyzers\MSTest.Analyzers.csproj" />
+    <ProjectReference Include="..\MSTest.GlobalConfigsGenerator\MSTest.GlobalConfigsGenerator.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,7 +41,7 @@
       <DotNetExecutable Condition="'$(OS)' == 'Windows_NT'">$(DotNetRoot)dotnet.exe</DotNetExecutable>
       <DotNetExecutable Condition="'$(DotNetExecutable)' == ''">$(DotNetRoot)dotnet</DotNetExecutable>
     </PropertyGroup>
-    <Exec Command="$(DotNetExecutable) run" WorkingDirectory="$(RepoRoot)src\Analyzers\MSTest.GlobalConfigsGenerator" EnvironmentVariables="OUTPUT_PATH=$(OutputPath)" />
+    <Exec Command="$(DotNetExecutable) run --no-build -c $(Configuration)" WorkingDirectory="$(RepoRoot)src\Analyzers\MSTest.GlobalConfigsGenerator" EnvironmentVariables="OUTPUT_PATH=$(OutputPath)" />
   </Target>
 
   <Target Name="_AddAnalyzersToOutput" DependsOnTargets="_GenerateGlobalConfigs">


### PR DESCRIPTION
I think `dotnet run` could be invoking a build which is racing with the main build of GlobalConfigsGenerator. Adding a `ProjectReference` to force GlobalConfigsGenerator to be built before MSTest.Analyzers.Package. Then invoking `dotnet run` with `--no-build`.