### PR TITLE
Ensure MSTest.GlobalConfigsGenerator is built before MSTest.Analyzers.Package

### DIFF
--- a/TestFx.sln
+++ b/TestFx.sln
@@ -163,6 +163,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSTest.Analyzers.CodeFixes", "src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj", "{462B0201-1C26-4951-97C9-722C2A58EF8C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSTest.Analyzers.Package", "src\Analyzers\MSTest.Analyzers.Package\MSTest.Analyzers.Package.csproj", "{DC068986-7549-4B75-8EFC-A9958FD5CF88}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A85AA656-6DB6-4A0B-AA80-CBB4058B3DDB} = {A85AA656-6DB6-4A0B-AA80-CBB4058B3DDB}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSTest.Analyzers.UnitTests", "test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj", "{1FF35C23-C128-4C95-B3F8-67B1B4C51E4D}"
 EndProject

--- a/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
+++ b/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
@@ -40,7 +40,7 @@
       <DotNetExecutable Condition="'$(OS)' == 'Windows_NT'">$(DotNetRoot)dotnet.exe</DotNetExecutable>
       <DotNetExecutable Condition="'$(DotNetExecutable)' == ''">$(DotNetRoot)dotnet</DotNetExecutable>
     </PropertyGroup>
-    <Exec Command="$(DotNetExecutable) run" WorkingDirectory="$(RepoRoot)src\Analyzers\MSTest.GlobalConfigsGenerator" EnvironmentVariables="OUTPUT_PATH=$(OutputPath)" />
+    <Exec Command="$(DotNetExecutable) run --no-build -c $(Configuration)" WorkingDirectory="$(RepoRoot)src\Analyzers\MSTest.GlobalConfigsGenerator" EnvironmentVariables="OUTPUT_PATH=$(OutputPath)" />
   </Target>
 
   <Target Name="_AddAnalyzersToOutput" DependsOnTargets="_GenerateGlobalConfigs">


### PR DESCRIPTION
I think `dotnet run` could be invoking a build which is racing with the main build of GlobalConfigsGenerator. Adding a `ProjectReference` to force GlobalConfigsGenerator to be built before MSTest.Analyzers.Package. Then invoking `dotnet run` with `--no-build`.