### PR TITLE
Cleanup assertions

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -382,7 +382,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual<T>(T? expected, T? actual)
-        => AreEqual(expected, actual, null, string.Empty, null);
+        => AreEqual(expected, actual, null, string.Empty);
 
     /// <summary>
     /// Tests whether the specified values are equal and throws an exception
@@ -406,7 +406,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual<T>(T? expected, T? actual, IEqualityComparer<T>? comparer)
-        => AreEqual(expected, actual, comparer, string.Empty, null);
+        => AreEqual(expected, actual, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether the specified values are equal and throws an exception
@@ -432,11 +432,17 @@ public sealed partial class Assert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual<T>(T? expected, T? actual, string? message)
-        => AreEqual(expected, actual, null, message, null);
+        => AreEqual(expected, actual, null, message);
 
     /// <inheritdoc cref="AreEqual{T}(IEquatable{T}?, IEquatable{T}?, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void AreEqual<T>(T? expected, T? actual, [InterpolatedStringHandlerArgument(nameof(expected), nameof(actual))] ref AssertAreEqualInterpolatedStringHandler<T> message)
+#pragma warning restore IDE0060 // Remove unused parameter
+        => message.ComputeAssertion();
+
+    /// <inheritdoc cref="AreEqual{T}(T, T, IEqualityComparer{T}?, string?)" />
+#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
+    public static void AreEqual<T>(T? expected, T? actual, IEqualityComparer<T>? comparer, [InterpolatedStringHandlerArgument(nameof(expected), nameof(actual), nameof(comparer))] ref AssertAreEqualInterpolatedStringHandler<T> message)
 #pragma warning restore IDE0060 // Remove unused parameter
         => message.ComputeAssertion();
 
@@ -468,82 +474,13 @@ public sealed partial class Assert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual<T>(T? expected, T? actual, IEqualityComparer<T>? comparer, string? message)
-        => AreEqual(expected, actual, comparer, message, null);
-
-    /// <inheritdoc cref="AreEqual{T}(T, T, IEqualityComparer{T}?, string?)" />
-#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
-    public static void AreEqual<T>(T? expected, T? actual, IEqualityComparer<T>? comparer, [InterpolatedStringHandlerArgument(nameof(expected), nameof(actual), nameof(comparer))] ref AssertAreEqualInterpolatedStringHandler<T> message)
-#pragma warning restore IDE0060 // Remove unused parameter
-        => message.ComputeAssertion();
-
-    /// <summary>
-    /// Tests whether the specified values are equal and throws an exception
-    /// if the two values are not equal.
-    /// The equality is computed using the default <see cref="EqualityComparer{T}"/>.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="expected">
-    /// The first value to compare. This is the value the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual<T>(T? expected, T? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => AreEqual(expected, actual, null, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified values are equal and throws an exception
-    /// if the two values are not equal.
-    /// The equality is computed using the provided <paramref name="comparer"/> parameter.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="expected">
-    /// The first value to compare. This is the value the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="comparer">
-    /// The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys,
-    /// or null to use the default <see cref="EqualityComparer{T}"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual<T>(T? expected, T? actual, IEqualityComparer<T>? comparer,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         if (!AreEqualFailing(expected, actual, comparer))
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertAreEqualFailed(expected, actual, userMessage);
     }
 
@@ -565,33 +502,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual<T>(IEquatable<T>? expected, IEquatable<T>? actual)
-        => AreEqual(expected, actual, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified values are equal and throws an exception
-    /// if the two values are not equal.
-    /// The equality is computed using the default <see cref="EqualityComparer{T}"/>.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="expected">
-    /// The first value to compare. This is the value the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual<T>(IEquatable<T>? expected, IEquatable<T>? actual, string? message)
-        => AreEqual(expected, actual, message, null);
+        => AreEqual(expected, actual, string.Empty);
 
     /// <inheritdoc cref="AreEqual{T}(IEquatable{T}?, IEquatable{T}?, string?)"/>
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -618,21 +529,18 @@ public sealed partial class Assert
     /// is not equal to <paramref name="expected"/>. The message is shown in
     /// test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> is not equal to
     /// <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual<T>(IEquatable<T>? expected, IEquatable<T>? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreEqual<T>(IEquatable<T>? expected, IEquatable<T>? actual, string? message)
     {
         if (!AreEqualFailing(expected, actual))
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertAreEqualFailed(expected, actual, userMessage);
     }
 
@@ -769,7 +677,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual<T>(T? notExpected, T? actual)
-        => AreNotEqual(notExpected, actual, null, string.Empty, null);
+        => AreNotEqual(notExpected, actual, null, string.Empty);
 
     /// <summary>
     /// Tests whether the specified values are unequal and throws an exception
@@ -794,7 +702,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual<T>(T? notExpected, T? actual, IEqualityComparer<T>? comparer)
-        => AreNotEqual(notExpected, actual, comparer, string.Empty, null);
+        => AreNotEqual(notExpected, actual, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether the specified values are unequal and throws an exception
@@ -820,11 +728,17 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual<T>(T? notExpected, T? actual, string? message)
-        => AreNotEqual(notExpected, actual, null, message, null);
+        => AreNotEqual(notExpected, actual, null, message);
 
     /// <inheritdoc cref="AreNotEqual{T}(T, T, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void AreNotEqual<T>(T? notExpected, T? actual, [InterpolatedStringHandlerArgument(nameof(notExpected), nameof(actual))] ref AssertAreNotEqualInterpolatedStringHandler<T> message)
+#pragma warning restore IDE0060 // Remove unused parameter
+        => message.ComputeAssertion();
+
+    /// <inheritdoc cref="AreNotEqual{T}(T, T, string?)" />
+#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
+    public static void AreNotEqual<T>(T? notExpected, T? actual, IEqualityComparer<T>? comparer, [InterpolatedStringHandlerArgument(nameof(notExpected), nameof(actual), nameof(comparer))] ref AssertAreNotEqualInterpolatedStringHandler<T> message)
 #pragma warning restore IDE0060 // Remove unused parameter
         => message.ComputeAssertion();
 
@@ -856,82 +770,13 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual<T>(T? notExpected, T? actual, IEqualityComparer<T>? comparer, string? message)
-        => AreNotEqual(notExpected, actual, comparer, message, null);
-
-    /// <inheritdoc cref="AreNotEqual{T}(T, T, string?)" />
-#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
-    public static void AreNotEqual<T>(T? notExpected, T? actual, IEqualityComparer<T>? comparer, [InterpolatedStringHandlerArgument(nameof(notExpected), nameof(actual), nameof(comparer))] ref AssertAreNotEqualInterpolatedStringHandler<T> message)
-#pragma warning restore IDE0060 // Remove unused parameter
-        => message.ComputeAssertion();
-
-    /// <summary>
-    /// Tests whether the specified values are unequal and throws an exception
-    /// if the two values are equal.
-    /// The equality is computed using the default <see cref="EqualityComparer{T}"/>.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="notExpected">
-    /// The first value to compare. This is the value the test expects not
-    /// to match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual<T>(T? notExpected, T? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => AreNotEqual(notExpected, actual, null, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified values are unequal and throws an exception
-    /// if the two values are equal.
-    /// The equality is computed using the provided <paramref name="comparer"/> parameter.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="notExpected">
-    /// The first value to compare. This is the value the test expects not
-    /// to match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="comparer">
-    /// The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys,
-    /// or null to use the default <see cref="EqualityComparer{T}"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual<T>(T? notExpected, T? actual, IEqualityComparer<T>? comparer,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         if (!AreNotEqualFailing(notExpected, actual, comparer))
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertAreNotEqualFailed(notExpected, actual, userMessage);
     }
 
@@ -955,34 +800,7 @@ public sealed partial class Assert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(float expected, float actual, float delta)
-        => AreEqual(expected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified floats are equal and throws an exception
-    /// if they are not equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first float to compare. This is the float the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second float to compare. This is the float produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="expected"/>
-    /// by more than <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is different than <paramref name="expected"/> by more than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(float expected, float actual, float delta, string? message)
-        => AreEqual(expected, actual, delta, message, null);
+        => AreEqual(expected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreEqual(float, float, float, string?)"/>
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1010,19 +828,15 @@ public sealed partial class Assert
     /// is different than <paramref name="expected"/> by more than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> is not equal to
     /// <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual(float expected, float actual, float delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreEqual(float expected, float actual, float delta, string? message)
     {
         if (AreEqualFailing(expected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreEqualFailed(expected, actual, delta, userMessage);
         }
     }
@@ -1047,34 +861,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(float notExpected, float actual, float delta)
-        => AreNotEqual(notExpected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified floats are unequal and throws an exception
-    /// if they are equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first float to compare. This is the float the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second float to compare. This is the float produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="notExpected"/>
-    /// by at most <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/> or different by less than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(float notExpected, float actual, float delta, string? message)
-        => AreNotEqual(notExpected, actual, delta, message, null);
+        => AreNotEqual(notExpected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreNotEqual(float, float, float, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1103,18 +890,14 @@ public sealed partial class Assert
     /// is equal to <paramref name="notExpected"/> or different by less than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotEqual(float notExpected, float actual, float delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreNotEqual(float notExpected, float actual, float delta, string? message)
     {
         if (AreNotEqualFailing(notExpected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreNotEqualFailed(notExpected, actual, delta, userMessage);
         }
     }
@@ -1160,34 +943,7 @@ public sealed partial class Assert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(decimal expected, decimal actual, decimal delta)
-        => AreEqual(expected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified decimals are equal and throws an exception
-    /// if they are not equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first decimal to compare. This is the decimal the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second decimal to compare. This is the decimal produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="expected"/>
-    /// by more than <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is different than <paramref name="expected"/> by more than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(decimal expected, decimal actual, decimal delta, string? message)
-        => AreEqual(expected, actual, delta, message, null);
+        => AreEqual(expected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreEqual(decimal, decimal, decimal, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1215,19 +971,15 @@ public sealed partial class Assert
     /// is different than <paramref name="expected"/> by more than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> is not equal to
     /// <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual(decimal expected, decimal actual, decimal delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreEqual(decimal expected, decimal actual, decimal delta, string? message)
     {
         if (AreEqualFailing(expected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreEqualFailed(expected, actual, delta, userMessage);
         }
     }
@@ -1252,34 +1004,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(decimal notExpected, decimal actual, decimal delta)
-        => AreNotEqual(notExpected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified decimals are unequal and throws an exception
-    /// if they are equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first decimal to compare. This is the decimal the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second decimal to compare. This is the decimal produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="notExpected"/>
-    /// by at most <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/> or different by less than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(decimal notExpected, decimal actual, decimal delta, string? message)
-        => AreNotEqual(notExpected, actual, delta, message, null);
+        => AreNotEqual(notExpected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreNotEqual(decimal, decimal, decimal, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1308,18 +1033,14 @@ public sealed partial class Assert
     /// is equal to <paramref name="notExpected"/> or different by less than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotEqual(decimal notExpected, decimal actual, decimal delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreNotEqual(decimal notExpected, decimal actual, decimal delta, string? message)
     {
         if (AreNotEqualFailing(notExpected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreNotEqualFailed(notExpected, actual, delta, userMessage);
         }
     }
@@ -1347,34 +1068,7 @@ public sealed partial class Assert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(long expected, long actual, long delta)
-        => AreEqual(expected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified longs are equal and throws an exception
-    /// if they are not equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first long to compare. This is the long the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second long to compare. This is the long produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="expected"/>
-    /// by more than <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is different than <paramref name="expected"/> by more than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(long expected, long actual, long delta, string? message)
-        => AreEqual(expected, actual, delta, message, null);
+        => AreEqual(expected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreEqual(long, long, long, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1402,19 +1096,15 @@ public sealed partial class Assert
     /// is different than <paramref name="expected"/> by more than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> is not equal to
     /// <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual(long expected, long actual, long delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreEqual(long expected, long actual, long delta, string? message)
     {
         if (AreEqualFailing(expected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreEqualFailed(expected, actual, delta, userMessage);
         }
     }
@@ -1439,34 +1129,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(long notExpected, long actual, long delta)
-        => AreNotEqual(notExpected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified longs are unequal and throws an exception
-    /// if they are equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first long to compare. This is the long the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second long to compare. This is the long produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="notExpected"/>
-    /// by at most <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/> or different by less than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(long notExpected, long actual, long delta, string? message)
-        => AreNotEqual(notExpected, actual, delta, message, null);
+        => AreNotEqual(notExpected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreNotEqual(long, long, long, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1495,18 +1158,14 @@ public sealed partial class Assert
     /// is equal to <paramref name="notExpected"/> or different by less than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotEqual(long notExpected, long actual, long delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreNotEqual(long notExpected, long actual, long delta, string? message)
     {
         if (AreNotEqualFailing(notExpected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreNotEqualFailed(notExpected, actual, delta, userMessage);
         }
     }
@@ -1534,33 +1193,7 @@ public sealed partial class Assert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(double expected, double actual, double delta)
-        => AreEqual(expected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified doubles are equal and throws an exception
-    /// if they are not equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first double to compare. This is the double the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second double to compare. This is the double produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="expected"/>
-    /// by more than <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is different than <paramref name="expected"/> by more than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(double expected, double actual, double delta, string? message)
-        => AreEqual(expected, actual, delta, message, null);
+        => AreEqual(expected, actual, delta, string.Empty);
 
     /// <inheritdoc cref="AreEqual(double, double, double, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1588,70 +1221,17 @@ public sealed partial class Assert
     /// is different than <paramref name="expected"/> by more than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual(double expected, double actual, double delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreEqual(double expected, double actual, double delta, string? message)
     {
         if (AreEqualFailing(expected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreEqualFailed(expected, actual, delta, userMessage);
         }
     }
-
-    /// <summary>
-    /// Tests whether the specified doubles are unequal and throws an exception
-    /// if they are equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first double to compare. This is the double the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second double to compare. This is the double produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="notExpected"/>
-    /// by at most <paramref name="delta"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(double notExpected, double actual, double delta)
-        => AreNotEqual(notExpected, actual, delta, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified doubles are unequal and throws an exception
-    /// if they are equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first double to compare. This is the double the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second double to compare. This is the double produced by the code under test.
-    /// </param>
-    /// <param name="delta">
-    /// The required accuracy. An exception will be thrown only if
-    /// <paramref name="actual"/> is different than <paramref name="notExpected"/>
-    /// by at most <paramref name="delta"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/> or different by less than
-    /// <paramref name="delta"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(double notExpected, double actual, double delta, string? message)
-        => AreNotEqual(notExpected, actual, delta, message, null);
 
     /// <inheritdoc cref="AreNotEqual(double, double, double, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1680,18 +1260,14 @@ public sealed partial class Assert
     /// is equal to <paramref name="notExpected"/> or different by less than
     /// <paramref name="delta"/>. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotEqual(double notExpected, double actual, double delta, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void AreNotEqual(double notExpected, double actual, double delta, string? message)
     {
         if (AreNotEqualFailing(notExpected, actual, delta))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertAreNotEqualFailed(notExpected, actual, delta, userMessage);
         }
     }
@@ -1749,7 +1325,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(string? expected, string? actual, bool ignoreCase)
-        => AreEqual(expected, actual, ignoreCase, string.Empty, null);
+        => AreEqual(expected, actual, ignoreCase, CultureInfo.InvariantCulture, string.Empty);
 
     /// <summary>
     /// Tests whether the specified strings are equal and throws an exception
@@ -1774,42 +1350,13 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(string? expected, string? actual, bool ignoreCase, string? message)
-        => AreEqual(expected, actual, ignoreCase, message, null);
+        => AreEqual(expected, actual, ignoreCase, CultureInfo.InvariantCulture, message);
 
     /// <inheritdoc cref="AreEqual(string?, string?, bool, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void AreEqual(string? expected, string? actual, bool ignoreCase, [InterpolatedStringHandlerArgument(nameof(expected), nameof(actual), nameof(ignoreCase))] ref AssertNonGenericAreEqualInterpolatedStringHandler message)
 #pragma warning restore IDE0060 // Remove unused parameter
         => message.ComputeAssertion();
-
-    /// <summary>
-    /// Tests whether the specified strings are equal and throws an exception
-    /// if they are not equal. The invariant culture is used for the comparison.
-    /// </summary>
-    /// <param name="expected">
-    /// The first string to compare. This is the string the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second string to compare. This is the string produced by the code under test.
-    /// </param>
-    /// <param name="ignoreCase">
-    /// A Boolean indicating a case-sensitive or insensitive comparison. (true
-    /// indicates a case-insensitive comparison.)
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(string? expected, string? actual, bool ignoreCase, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
-        => AreEqual(expected, actual, ignoreCase, CultureInfo.InvariantCulture, message, parameters);
 
     /// <summary>
     /// Tests whether the specified strings are equal and throws an exception
@@ -1832,35 +1379,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(string? expected, string? actual, bool ignoreCase, CultureInfo culture)
-        => AreEqual(expected, actual, ignoreCase, culture, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified strings are equal and throws an exception
-    /// if they are not equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first string to compare. This is the string the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second string to compare. This is the string produced by the code under test.
-    /// </param>
-    /// <param name="ignoreCase">
-    /// A Boolean indicating a case-sensitive or insensitive comparison. (true
-    /// indicates a case-insensitive comparison.)
-    /// </param>
-    /// <param name="culture">
-    /// A CultureInfo object that supplies culture-specific comparison information. If culture is null, the current culture is used.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(string? expected, string? actual, bool ignoreCase, CultureInfo culture, string? message)
-        => AreEqual(expected, actual, ignoreCase, culture, message, null);
+        => AreEqual(expected, actual, ignoreCase, culture, string.Empty);
 
     /// <inheritdoc cref="AreEqual(string?, string?, bool, CultureInfo, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -1894,13 +1413,10 @@ public sealed partial class Assert
     /// is not equal to <paramref name="expected"/>. The message is shown in
     /// test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual(string? expected, string? actual, bool ignoreCase, CultureInfo culture, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreEqual(string? expected, string? actual, bool ignoreCase, CultureInfo culture, string? message)
     {
         CheckParameterNotNull(culture, "Assert.AreEqual", "culture", string.Empty);
         if (!AreEqualFailing(expected, actual, ignoreCase, culture))
@@ -1908,7 +1424,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertAreEqualFailed(expected, actual, ignoreCase, culture, userMessage);
     }
 
@@ -1931,7 +1447,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase)
-        => AreNotEqual(notExpected, actual, ignoreCase, string.Empty, null);
+        => AreNotEqual(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, string.Empty);
 
     /// <summary>
     /// Tests whether the specified strings are unequal and throws an exception
@@ -1957,43 +1473,13 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase, string? message)
-        => AreNotEqual(notExpected, actual, ignoreCase, message, null);
+        => AreNotEqual(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, message);
 
     /// <inheritdoc cref="AreNotEqual(string?, string?, bool, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase, [InterpolatedStringHandlerArgument(nameof(notExpected), nameof(actual), nameof(ignoreCase))] ref AssertNonGenericAreNotEqualInterpolatedStringHandler message)
 #pragma warning restore IDE0060 // Remove unused parameter
         => message.ComputeAssertion();
-
-    /// <summary>
-    /// Tests whether the specified strings are unequal and throws an exception
-    /// if they are equal. The invariant culture is used for the comparison.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first string to compare. This is the string the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second string to compare. This is the string produced by the code under test.
-    /// </param>
-    /// <param name="ignoreCase">
-    /// A Boolean indicating a case-sensitive or insensitive comparison. (true
-    /// indicates a case-insensitive comparison.)
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => AreNotEqual(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, message, parameters);
 
     /// <summary>
     /// Tests whether the specified strings are unequal and throws an exception
@@ -2017,36 +1503,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase, CultureInfo culture)
-        => AreNotEqual(notExpected, actual, ignoreCase, culture, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified strings are unequal and throws an exception
-    /// if they are equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first string to compare. This is the string the test expects not to
-    /// match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second string to compare. This is the string produced by the code under test.
-    /// </param>
-    /// <param name="ignoreCase">
-    /// A Boolean indicating a case-sensitive or insensitive comparison. (true
-    /// indicates a case-insensitive comparison.)
-    /// </param>
-    /// <param name="culture">
-    /// A CultureInfo object that supplies culture-specific comparison information. If culture is null, the current culture is used.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase, CultureInfo culture, string? message)
-        => AreNotEqual(notExpected, actual, ignoreCase, culture, message, null);
+        => AreNotEqual(notExpected, actual, ignoreCase, culture, string.Empty);
 
     /// <inheritdoc cref="AreNotEqual(string?, string?, bool, CultureInfo, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -2081,14 +1538,10 @@ public sealed partial class Assert
     /// is equal to <paramref name="notExpected"/>. The message is shown in
     /// test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase,
-        CultureInfo culture, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase, CultureInfo culture, string? message)
     {
         CheckParameterNotNull(culture, "Assert.AreNotEqual", "culture", string.Empty);
         if (!AreNotEqualFailing(notExpected, actual, ignoreCase, culture))
@@ -2096,7 +1549,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertAreNotEqualFailed(notExpected, actual, userMessage);
     }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -1233,6 +1233,28 @@ public sealed partial class Assert
         }
     }
 
+    /// <summary>
+    /// Tests whether the specified doubles are unequal and throws an exception
+    /// if they are equal.
+    /// </summary>
+    /// <param name="notExpected">
+    /// The first double to compare. This is the double the test expects not to
+    /// match <paramref name="actual"/>.
+    /// </param>
+    /// <param name="actual">
+    /// The second double to compare. This is the double produced by the code under test.
+    /// </param>
+    /// <param name="delta">
+    /// The required accuracy. An exception will be thrown only if
+    /// <paramref name="actual"/> is different than <paramref name="notExpected"/>
+    /// by at most <paramref name="delta"/>.
+    /// </param>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
+    /// </exception>
+    public static void AreNotEqual(double notExpected, double actual, double delta)
+        => AreNotEqual(notExpected, actual, delta, string.Empty);
+
     /// <inheritdoc cref="AreNotEqual(double, double, double, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void AreNotEqual(double notExpected, double actual, double delta, [InterpolatedStringHandlerArgument(nameof(notExpected), nameof(actual), nameof(delta))] ref AssertNonGenericAreNotEqualInterpolatedStringHandler message)

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreSame.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreSame.cs
@@ -150,32 +150,7 @@ public sealed partial class Assert
     /// as <paramref name="actual"/>.
     /// </exception>
     public static void AreSame<T>(T? expected, T? actual)
-        => AreSame(expected, actual, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified objects both refer to the same object and
-    /// throws an exception if the two inputs do not refer to the same object.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="expected">
-    /// The first object to compare. This is the value the test expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second object to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not the same as <paramref name="expected"/>. The message is shown
-    /// in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> does not refer to the same object
-    /// as <paramref name="actual"/>.
-    /// </exception>
-    public static void AreSame<T>(T? expected, T? actual, string? message)
-        => AreSame(expected, actual, message, null);
+        => AreSame(expected, actual, string.Empty);
 
     /// <inheritdoc cref="AreSame{T}(T, T, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -201,21 +176,18 @@ public sealed partial class Assert
     /// is not the same as <paramref name="expected"/>. The message is shown
     /// in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="expected"/> does not refer to the same object
     /// as <paramref name="actual"/>.
     /// </exception>
-    public static void AreSame<T>(T? expected, T? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreSame<T>(T? expected, T? actual, string? message)
     {
         if (!IsAreSameFailing(expected, actual))
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertAreSameFailed(expected, actual, userMessage);
     }
 
@@ -256,33 +228,7 @@ public sealed partial class Assert
     /// as <paramref name="actual"/>.
     /// </exception>
     public static void AreNotSame<T>(T? notExpected, T? actual)
-        => AreNotSame(notExpected, actual, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified objects refer to different objects and
-    /// throws an exception if the two inputs refer to the same object.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="notExpected">
-    /// The first object to compare. This is the value the test expects not
-    /// to match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second object to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is the same as <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> refers to the same object
-    /// as <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotSame<T>(T? notExpected, T? actual, string? message)
-        => AreNotSame(notExpected, actual, message, null);
+        => AreNotSame(notExpected, actual, string.Empty);
 
     /// <inheritdoc cref="AreNotSame{T}(T, T, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -309,18 +255,15 @@ public sealed partial class Assert
     /// is the same as <paramref name="notExpected"/>. The message is shown in
     /// test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> refers to the same object
     /// as <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotSame<T>(T? notExpected, T? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreNotSame<T>(T? notExpected, T? actual, string? message)
     {
         if (IsAreNotSameFailing(notExpected, actual))
         {
-            ThrowAssertAreNotSameFailed(BuildUserMessage(message, parameters));
+            ThrowAssertAreNotSameFailed(BuildUserMessage(message));
         }
     }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -97,17 +97,7 @@ public sealed partial class Assert
     /// <param name="collection">The collection.</param>
     /// <returns>The item.</returns>
     public static T ContainsSingle<T>(IEnumerable<T> collection)
-        => ContainsSingle(collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified collection contains exactly one element.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    /// <returns>The item.</returns>
-    public static T ContainsSingle<T>(IEnumerable<T> collection, string? message)
-        => ContainsSingle(collection, message, null);
+        => ContainsSingle(collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains exactly one element.
@@ -127,9 +117,8 @@ public sealed partial class Assert
     /// <typeparam name="T">The type of the collection items.</typeparam>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
     /// <returns>The item.</returns>
-    public static T ContainsSingle<T>(IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static T ContainsSingle<T>(IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message)
     {
         int actualCount = collection.Count();
         if (actualCount == 1)
@@ -137,7 +126,7 @@ public sealed partial class Assert
             return collection.First();
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertContainsSingleFailed(actualCount, userMessage);
 
         // Unreachable code but compiler cannot work it out
@@ -152,18 +141,7 @@ public sealed partial class Assert
     /// <param name="collection">The collection.</param>
     /// <returns>The item that matches the predicate.</returns>
     public static T ContainsSingle<T>(Func<T, bool> predicate, IEnumerable<T> collection)
-        => ContainsSingle(predicate, collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified collection contains exactly one element that matches the given predicate.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="predicate">A function to test each element for a condition.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    /// <returns>The item that matches the predicate.</returns>
-    public static T ContainsSingle<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message)
-        => ContainsSingle(predicate, collection, message, null);
+        => ContainsSingle(predicate, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains exactly one element that matches the given predicate.
@@ -172,9 +150,8 @@ public sealed partial class Assert
     /// <param name="predicate">A function to test each element for a condition.</param>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
     /// <returns>The item that matches the predicate.</returns>
-    public static T ContainsSingle<T>(Func<T, bool> predicate, IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static T ContainsSingle<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message)
     {
         var matchingElements = collection.Where(predicate).ToList();
         int actualCount = matchingElements.Count;
@@ -184,7 +161,7 @@ public sealed partial class Assert
             return matchingElements[0];
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertSingleMatchFailed(actualCount, userMessage);
 
         // Unreachable code but compiler cannot work it out
@@ -200,17 +177,7 @@ public sealed partial class Assert
     /// <param name="expected">The expected item.</param>
     /// <param name="collection">The collection.</param>
     public static void Contains<T>(T expected, IEnumerable<T> collection)
-        => Contains(expected, collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified collection contains the given element.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="expected">The expected item.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    public static void Contains<T>(T expected, IEnumerable<T> collection, string? message)
-        => Contains(expected, collection, message, null);
+        => Contains(expected, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -219,12 +186,11 @@ public sealed partial class Assert
     /// <param name="expected">The expected item.</param>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void Contains<T>(T expected, IEnumerable<T> collection, string? message, params object?[]? parameters)
+    public static void Contains<T>(T expected, IEnumerable<T> collection, string? message)
     {
         if (!collection.Contains(expected))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertContainsItemFailed(userMessage);
         }
     }
@@ -237,7 +203,7 @@ public sealed partial class Assert
     /// <param name="collection">The collection.</param>
     /// <param name="comparer">An equality comparer to compare values.</param>
     public static void Contains<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer)
-        => Contains(expected, collection, comparer, string.Empty, null);
+        => Contains(expected, collection, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -248,22 +214,10 @@ public sealed partial class Assert
     /// <param name="comparer">An equality comparer to compare values.</param>
     /// <param name="message">The message to display when the assertion fails.</param>
     public static void Contains<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer, string? message)
-        => Contains(expected, collection, comparer, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collection contains the given element.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="expected">The expected item.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="comparer">An equality comparer to compare values.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void Contains<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer, string? message, params object?[]? parameters)
     {
         if (!collection.Contains(expected, comparer))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertContainsItemFailed(userMessage);
         }
     }
@@ -275,17 +229,7 @@ public sealed partial class Assert
     /// <param name="predicate">A function to test each element for a condition.</param>
     /// <param name="collection">The collection.</param>
     public static void Contains<T>(Func<T, bool> predicate, IEnumerable<T> collection)
-        => Contains(predicate, collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified collection contains the given element.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="predicate">A function to test each element for a condition.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    public static void Contains<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message)
-        => Contains(predicate, collection, message, null);
+        => Contains(predicate, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -294,12 +238,11 @@ public sealed partial class Assert
     /// <param name="predicate">A function to test each element for a condition.</param>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void Contains<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message, params object?[]? parameters)
+    public static void Contains<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message)
     {
         if (!collection.Any(predicate))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertContainsPredicateFailed(userMessage);
         }
     }
@@ -320,7 +263,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains(string substring, string value)
-        => Contains(substring, value, StringComparison.Ordinal, string.Empty, null);
+        => Contains(substring, value, StringComparison.Ordinal, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string contains the specified substring
@@ -343,34 +286,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains(string substring, string value, string? message)
-        => Contains(substring, value, StringComparison.Ordinal, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string contains the specified substring
-    /// and throws an exception if the substring does not occur within the
-    /// test string.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to occur within <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to contain <paramref name="substring"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="substring"/>
-    /// is not in <paramref name="value"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
-    /// </exception>
-    public static void Contains(string substring, string value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
-        => Contains(substring, value, StringComparison.Ordinal, message, parameters);
+        => Contains(substring, value, StringComparison.Ordinal, message);
 
     /// <summary>
     /// Tests whether the specified string contains the specified substring
@@ -391,7 +307,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains(string substring, string value, StringComparison comparisonType)
-        => Contains(substring, value, comparisonType, string.Empty, null);
+        => Contains(substring, value, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string contains the specified substring
@@ -417,36 +333,6 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains(string substring, string value, StringComparison comparisonType, string? message)
-        => Contains(substring, value, comparisonType, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string contains the specified substring
-    /// and throws an exception if the substring does not occur within the
-    /// test string.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to occur within <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to contain <paramref name="substring"/>.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="substring"/>
-    /// is not in <paramref name="value"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
-    /// </exception>
-    public static void Contains(string substring, string value, StringComparison comparisonType,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
 #if NETFRAMEWORK || NETSTANDARD
         if (value.IndexOf(substring, comparisonType) < 0)
@@ -454,7 +340,7 @@ public sealed partial class Assert
         if (!value.Contains(substring, comparisonType))
 #endif
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.ContainsFail, value, substring, userMessage);
             ThrowAssertFailed("Assert.Contains", finalMessage);
         }
@@ -471,7 +357,7 @@ public sealed partial class Assert
     /// <param name="expected">The expected item.</param>
     /// <param name="collection">The collection.</param>
     public static void DoesNotContain<T>(T expected, IEnumerable<T> collection)
-        => DoesNotContain(expected, collection, string.Empty, null);
+        => DoesNotContain(expected, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -481,21 +367,10 @@ public sealed partial class Assert
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message to display when the assertion fails.</param>
     public static void DoesNotContain<T>(T expected, IEnumerable<T> collection, string? message)
-        => DoesNotContain(expected, collection, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collection does not contain the specified item.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="expected">The expected item.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void DoesNotContain<T>(T expected, IEnumerable<T> collection, string? message, params object?[]? parameters)
     {
         if (collection.Contains(expected))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertDoesNotContainItemFailed(userMessage);
         }
     }
@@ -508,7 +383,7 @@ public sealed partial class Assert
     /// <param name="collection">The collection.</param>
     /// <param name="comparer">An equality comparer to compare values.</param>
     public static void DoesNotContain<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer)
-        => DoesNotContain(expected, collection, comparer, string.Empty, null);
+        => DoesNotContain(expected, collection, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -519,22 +394,10 @@ public sealed partial class Assert
     /// <param name="comparer">An equality comparer to compare values.</param>
     /// <param name="message">The message to display when the assertion fails.</param>
     public static void DoesNotContain<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer, string? message)
-        => DoesNotContain(expected, collection, comparer, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collection does not contain the specified item.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="expected">The expected item.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="comparer">An equality comparer to compare values.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void DoesNotContain<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer, string? message, params object?[]? parameters)
     {
         if (collection.Contains(expected, comparer))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertDoesNotContainItemFailed(userMessage);
         }
     }
@@ -546,7 +409,7 @@ public sealed partial class Assert
     /// <param name="predicate">A function to test each element for a condition.</param>
     /// <param name="collection">The collection.</param>
     public static void DoesNotContain<T>(Func<T, bool> predicate, IEnumerable<T> collection)
-        => DoesNotContain(predicate, collection, string.Empty, null);
+        => DoesNotContain(predicate, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -556,21 +419,10 @@ public sealed partial class Assert
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message to display when the assertion fails.</param>
     public static void DoesNotContain<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message)
-        => DoesNotContain(predicate, collection, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collection does not contain the specified item.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="predicate">A function to test each element for a condition.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void DoesNotContain<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message, params object?[]? parameters)
     {
         if (collection.Any(predicate))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertDoesNotContainPredicateFailed(userMessage);
         }
     }
@@ -627,33 +479,6 @@ public sealed partial class Assert
     /// <param name="value">
     /// The string that is expected to not contain <paramref name="substring"/>.
     /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="substring"/>
-    /// is in <paramref name="value"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> contains <paramref name="substring"/>.
-    /// </exception>
-    public static void DoesNotContain(string substring, string value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
-        => DoesNotContain(substring, value, StringComparison.Ordinal, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string does not contain the specified substring
-    /// and throws an exception if the substring occurs within the
-    /// test string.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to not occur within <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to not contain <paramref name="substring"/>.
-    /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
@@ -688,36 +513,6 @@ public sealed partial class Assert
     /// or <paramref name="value"/> contains <paramref name="substring"/>.
     /// </exception>
     public static void DoesNotContain(string substring, string value, StringComparison comparisonType, string? message)
-        => DoesNotContain(substring, value, comparisonType, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string does not contain the specified substring
-    /// and throws an exception if the substring occurs within the
-    /// test string.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to not occur within <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to not contain <paramref name="substring"/>.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="substring"/>
-    /// is in <paramref name="value"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> contains <paramref name="substring"/>.
-    /// </exception>
-    public static void DoesNotContain(string substring, string value, StringComparison comparisonType,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
 #if NETFRAMEWORK || NETSTANDARD
         if (value.IndexOf(substring, comparisonType) >= 0)
@@ -725,7 +520,7 @@ public sealed partial class Assert
         if (value.Contains(substring, comparisonType))
 #endif
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DoesNotContainFail, value, substring, userMessage);
             ThrowAssertFailed("Assert.DoesNotContain", finalMessage);
         }
@@ -745,20 +540,7 @@ public sealed partial class Assert
     /// <param name="value">The value to test.</param>
     public static void IsInRange<T>(T minValue, T maxValue, T value)
         where T : struct, IComparable<T>
-        => IsInRange(minValue, maxValue, value, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified value is within the expected range (inclusive).
-    /// The range includes both the minimum and maximum values.
-    /// </summary>
-    /// <typeparam name="T">The type of the values to compare.</typeparam>
-    /// <param name="minValue">The minimum value of the expected range (inclusive).</param>
-    /// <param name="maxValue">The maximum value of the expected range (inclusive).</param>
-    /// <param name="value">The value to test.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    public static void IsInRange<T>(T minValue, T maxValue, T value, string? message)
-        where T : struct, IComparable<T>
-        => IsInRange(minValue, maxValue, value, message, null);
+        => IsInRange(minValue, maxValue, value, string.Empty);
 
     /// <summary>
     /// Tests whether the specified value is within the expected range (inclusive).
@@ -769,8 +551,7 @@ public sealed partial class Assert
     /// <param name="maxValue">The maximum value of the expected range (inclusive).</param>
     /// <param name="value">The value to test.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void IsInRange<T>(T minValue, T maxValue, T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void IsInRange<T>(T minValue, T maxValue, T value, string? message)
         where T : struct, IComparable<T>
     {
         if (maxValue.CompareTo(minValue) <= 0)
@@ -780,7 +561,7 @@ public sealed partial class Assert
 
         if (value.CompareTo(minValue) < 0 || value.CompareTo(maxValue) > 0)
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsInRangeFail, value, minValue, maxValue, userMessage);
             ThrowAssertFailed("IsInRange", finalMessage);
         }

--- a/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
@@ -169,16 +169,7 @@ public sealed partial class Assert
     /// <typeparam name="T">The type of the items of the collection.</typeparam>
     /// <param name="collection">The collection.</param>
     public static void IsNotEmpty<T>(IEnumerable<T> collection)
-        => IsNotEmpty(collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the collection is not empty.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    public static void IsNotEmpty<T>(IEnumerable<T> collection, string? message)
-        => IsNotEmpty(collection, message, null);
+        => IsNotEmpty(collection, string.Empty);
 
     /// <summary>
     /// Tests that the collection is not empty.
@@ -197,15 +188,14 @@ public sealed partial class Assert
     /// <typeparam name="T">The type of the collection items.</typeparam>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void IsNotEmpty<T>(IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void IsNotEmpty<T>(IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message)
     {
         if (collection.Any())
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertIsNotEmptyFailed(userMessage);
     }
 
@@ -216,17 +206,7 @@ public sealed partial class Assert
     /// <param name="expected">The expected count.</param>
     /// <param name="collection">The collection.</param>
     public static void HasCount<T>(int expected, IEnumerable<T> collection)
-        => HasCount(expected, collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the collection has the expected count/length.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="expected">The expected count.</param>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    public static void HasCount<T>(int expected, IEnumerable<T> collection, string? message)
-        => HasCount(expected, collection, message, null);
+        => HasCount(expected, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the collection has the expected count/length.
@@ -247,9 +227,8 @@ public sealed partial class Assert
     /// <param name="expected">The expected count.</param>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void HasCount<T>(int expected, IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => HasCount("HasCount", expected, collection, message, parameters);
+    public static void HasCount<T>(int expected, IEnumerable<T> collection, string? message)
+        => HasCount("HasCount", expected, collection, message);
 
     /// <summary>
     /// Tests that the collection is empty.
@@ -257,16 +236,7 @@ public sealed partial class Assert
     /// <typeparam name="T">The type of the collection items.</typeparam>
     /// <param name="collection">The collection.</param>
     public static void IsEmpty<T>(IEnumerable<T> collection)
-        => IsEmpty(collection, string.Empty, null);
-
-    /// <summary>
-    /// Tests that the collection is empty.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection items.</typeparam>
-    /// <param name="collection">The collection.</param>
-    /// <param name="message">The message to display when the assertion fails.</param>
-    public static void IsEmpty<T>(IEnumerable<T> collection, string? message)
-        => IsEmpty(collection, message, null);
+        => IsEmpty(collection, string.Empty);
 
     /// <summary>
     /// Tests that the collection is empty.
@@ -285,11 +255,10 @@ public sealed partial class Assert
     /// <typeparam name="T">The type of the collection items.</typeparam>
     /// <param name="collection">The collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
-    /// <param name="parameters">The parameters to format the message.</param>
-    public static void IsEmpty<T>(IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => HasCount("IsEmpty", 0, collection, message, parameters);
+    public static void IsEmpty<T>(IEnumerable<T> collection, string? message)
+        => HasCount("IsEmpty", 0, collection, message);
 
-    private static void HasCount<T>(string assertionName, int expected, IEnumerable<T> collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    private static void HasCount<T>(string assertionName, int expected, IEnumerable<T> collection, string? message)
     {
         int actualCount = collection.Count();
         if (actualCount == expected)
@@ -297,7 +266,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertCountFailed(assertionName, expected, actualCount, userMessage);
     }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
@@ -59,32 +59,6 @@ public sealed partial class Assert
     /// <param name="value">
     /// The string that is expected to end with <paramref name="substring"/>.
     /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not end with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
-    /// </exception>
-    public static void EndsWith([NotNull] string? substring, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => EndsWith(substring, value, StringComparison.Ordinal, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string ends with the specified substring
-    /// and throws an exception if the test string does not end with the
-    /// substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to be a suffix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to end with <paramref name="substring"/>.
-    /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
@@ -93,33 +67,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
     /// </exception>
     public static void EndsWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType)
-        => EndsWith(substring, value, comparisonType, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified string ends with the specified substring
-    /// and throws an exception if the test string does not end with the
-    /// substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to be a suffix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to end with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not end with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
-    /// </exception>
-    public static void EndsWith([NotNull] string? substring, [NotNull] string? value, string? message, StringComparison comparisonType)
-        => EndsWith(substring, value, comparisonType, message, null);
+        => EndsWith(substring, value, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string ends with the specified substring
@@ -139,21 +87,18 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="value"/>
     /// does not end with <paramref name="substring"/>. The message is
     /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
     /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
-    public static void EndsWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void EndsWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType, string? message)
     {
         CheckParameterNotNull(value, "Assert.EndsWith", "value", string.Empty);
         CheckParameterNotNull(substring, "Assert.EndsWith", "substring", string.Empty);
         if (!value.EndsWith(substring, comparisonType))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.EndsWithFail, value, substring, userMessage);
             ThrowAssertFailed("Assert.EndsWith", finalMessage);
         }
@@ -215,32 +160,6 @@ public sealed partial class Assert
     /// <param name="value">
     /// The string that is expected not to end with <paramref name="substring"/>.
     /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// ends with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> ends with <paramref name="substring"/>.
-    /// </exception>
-    public static void DoesNotEndWith([NotNull] string? substring, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => DoesNotEndWith(substring, value, StringComparison.Ordinal, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string does not end with the specified substring
-    /// and throws an exception if the test string does not end with the
-    /// substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected not to be a suffix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected not to end with <paramref name="substring"/>.
-    /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
@@ -249,33 +168,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> ends with <paramref name="substring"/>.
     /// </exception>
     public static void DoesNotEndWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType)
-        => DoesNotEndWith(substring, value, comparisonType, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified string does not end with the specified substring
-    /// and throws an exception if the test string does not end with the
-    /// substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected not to be a suffix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected not to end with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// ends with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> ends with <paramref name="substring"/>.
-    /// </exception>
-    public static void DoesNotEndWith([NotNull] string? substring, [NotNull] string? value, string? message, StringComparison comparisonType)
-        => DoesNotEndWith(substring, value, comparisonType, message, null);
+        => DoesNotEndWith(substring, value, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string does not end with the specified substring
@@ -296,21 +189,17 @@ public sealed partial class Assert
     /// ends with <paramref name="substring"/>. The message is
     /// shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> ends with <paramref name="substring"/>.
     /// </exception>
-    public static void DoesNotEndWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void DoesNotEndWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType, string? message)
     {
         CheckParameterNotNull(value, "Assert.DoesNotEndWith", "value", string.Empty);
         CheckParameterNotNull(substring, "Assert.DoesNotEndWith", "substring", string.Empty);
         if (value.EndsWith(substring, comparisonType))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DoesNotEndWithFail, value, substring, userMessage);
             ThrowAssertFailed("Assert.DoesNotEndWith", finalMessage);
         }

--- a/src/TestFramework/TestFramework/Assertions/Assert.Fail.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Fail.cs
@@ -18,7 +18,7 @@ public sealed partial class Assert
     /// </exception>
     [DoesNotReturn]
     public static void Fail()
-        => Fail(string.Empty, null);
+        => Fail(string.Empty);
 
     /// <summary>
     /// Throws an AssertFailedException.
@@ -32,22 +32,5 @@ public sealed partial class Assert
     /// </exception>
     [DoesNotReturn]
     public static void Fail(string? message)
-        => Fail(message, null);
-
-    /// <summary>
-    /// Throws an AssertFailedException.
-    /// </summary>
-    /// <param name="message">
-    /// The message to include in the exception. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Always thrown.
-    /// </exception>
-    [DoesNotReturn]
-    public static void Fail([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => ThrowAssertFailed("Assert.Fail", BuildUserMessage(message, parameters));
+        => ThrowAssertFailed("Assert.Fail", BuildUserMessage(message));
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs
@@ -30,7 +30,7 @@ public sealed partial class Assert
     /// </exception>
     public static void IsGreaterThan<T>(T lowerBound, T value)
         where T : IComparable<T>
-        => IsGreaterThan(lowerBound, value, string.Empty, null);
+        => IsGreaterThan(lowerBound, value, string.Empty);
 
     /// <summary>
     /// Tests whether the value is greater than the lower bound and throws an exception
@@ -55,41 +55,13 @@ public sealed partial class Assert
     /// </exception>
     public static void IsGreaterThan<T>(T lowerBound, T value, string? message)
         where T : IComparable<T>
-        => IsGreaterThan(lowerBound, value, message, null);
-
-    /// <summary>
-    /// Tests whether the value is greater than the lower bound and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="lowerBound">
-    /// The lower bound value that the value should exceed.
-    /// </param>
-    /// <param name="value">
-    /// The value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not greater than <paramref name="lowerBound"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not greater than <paramref name="lowerBound"/>.
-    /// </exception>
-    public static void IsGreaterThan<T>(T lowerBound, T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        where T : IComparable<T>
     {
         if (value.CompareTo(lowerBound) > 0)
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertIsGreaterThanFailed(lowerBound, value, userMessage);
     }
 
@@ -115,7 +87,7 @@ public sealed partial class Assert
     /// </exception>
     public static void IsGreaterThanOrEqualTo<T>(T lowerBound, T value)
         where T : IComparable<T>
-        => IsGreaterThanOrEqualTo(lowerBound, value, string.Empty, null);
+        => IsGreaterThanOrEqualTo(lowerBound, value, string.Empty);
 
     /// <summary>
     /// Tests whether the value is greater than or equal to the lower bound and throws an exception
@@ -140,41 +112,13 @@ public sealed partial class Assert
     /// </exception>
     public static void IsGreaterThanOrEqualTo<T>(T lowerBound, T value, string? message)
         where T : IComparable<T>
-        => IsGreaterThanOrEqualTo(lowerBound, value, message, null);
-
-    /// <summary>
-    /// Tests whether the value is greater than or equal to the lower bound and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="lowerBound">
-    /// The lower bound value that the value should meet or exceed.
-    /// </param>
-    /// <param name="value">
-    /// The value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not greater than or equal to <paramref name="lowerBound"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not greater than or equal to <paramref name="lowerBound"/>.
-    /// </exception>
-    public static void IsGreaterThanOrEqualTo<T>(T lowerBound, T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        where T : IComparable<T>
     {
         if (value.CompareTo(lowerBound) >= 0)
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertIsGreaterThanOrEqualToFailed(lowerBound, value, userMessage);
     }
 
@@ -200,7 +144,7 @@ public sealed partial class Assert
     /// </exception>
     public static void IsLessThan<T>(T upperBound, T value)
         where T : IComparable<T>
-        => IsLessThan(upperBound, value, string.Empty, null);
+        => IsLessThan(upperBound, value, string.Empty);
 
     /// <summary>
     /// Tests whether the value is less than the upper bound and throws an exception
@@ -225,41 +169,13 @@ public sealed partial class Assert
     /// </exception>
     public static void IsLessThan<T>(T upperBound, T value, string? message)
         where T : IComparable<T>
-        => IsLessThan(upperBound, value, message, null);
-
-    /// <summary>
-    /// Tests whether the value is less than the upper bound and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="upperBound">
-    /// The upper bound value that the value should be less than.
-    /// </param>
-    /// <param name="value">
-    /// The value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not less than <paramref name="upperBound"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not less than <paramref name="upperBound"/>.
-    /// </exception>
-    public static void IsLessThan<T>(T upperBound, T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        where T : IComparable<T>
     {
         if (value.CompareTo(upperBound) < 0)
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertIsLessThanFailed(upperBound, value, userMessage);
     }
 
@@ -285,7 +201,7 @@ public sealed partial class Assert
     /// </exception>
     public static void IsLessThanOrEqualTo<T>(T upperBound, T value)
         where T : IComparable<T>
-        => IsLessThanOrEqualTo(upperBound, value, string.Empty, null);
+        => IsLessThanOrEqualTo(upperBound, value, string.Empty);
 
     /// <summary>
     /// Tests whether the value is less than or equal to the upper bound and throws an exception
@@ -310,41 +226,13 @@ public sealed partial class Assert
     /// </exception>
     public static void IsLessThanOrEqualTo<T>(T upperBound, T value, string? message)
         where T : IComparable<T>
-        => IsLessThanOrEqualTo(upperBound, value, message, null);
-
-    /// <summary>
-    /// Tests whether the value is less than or equal to the upper bound and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="upperBound">
-    /// The upper bound value that the value should not exceed.
-    /// </param>
-    /// <param name="value">
-    /// The value to compare. This is the value produced by the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not less than or equal to <paramref name="upperBound"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not less than or equal to <paramref name="upperBound"/>.
-    /// </exception>
-    public static void IsLessThanOrEqualTo<T>(T upperBound, T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        where T : IComparable<T>
     {
         if (value.CompareTo(upperBound) <= 0)
         {
             return;
         }
 
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         ThrowAssertIsLessThanOrEqualToFailed(upperBound, value, userMessage);
     }
 
@@ -367,7 +255,7 @@ public sealed partial class Assert
     /// </exception>
     public static void IsPositive<T>(T value)
         where T : struct, IComparable<T>
-        => IsPositive(value, string.Empty, null);
+        => IsPositive(value, string.Empty);
 
     /// <summary>
     /// Tests whether the specified value is positive and throws an exception
@@ -388,44 +276,20 @@ public sealed partial class Assert
     /// </exception>
     public static void IsPositive<T>(T value, string? message)
         where T : struct, IComparable<T>
-        => IsPositive(value, message, null);
-
-    /// <summary>
-    /// Tests whether the specified value is positive and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of value to test.
-    /// </typeparam>
-    /// <param name="value">
-    /// The value to test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not positive. The message is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not positive.
-    /// </exception>
-    public static void IsPositive<T>(T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        where T : struct, IComparable<T>
     {
         var zero = default(T);
 
         // Handle special case for floating point NaN values
         if (value is float floatValue && float.IsNaN(floatValue))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertIsPositiveFailed(value, userMessage);
             return;
         }
 
         if (value is double doubleValue && double.IsNaN(doubleValue))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertIsPositiveFailed(value, userMessage);
             return;
         }
@@ -435,7 +299,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage2 = BuildUserMessage(message, parameters);
+        string userMessage2 = BuildUserMessage(message);
         ThrowAssertIsPositiveFailed(value, userMessage2);
     }
 
@@ -458,7 +322,7 @@ public sealed partial class Assert
     /// </exception>
     public static void IsNegative<T>(T value)
         where T : struct, IComparable<T>
-        => IsNegative(value, string.Empty, null);
+        => IsNegative(value, string.Empty);
 
     /// <summary>
     /// Tests whether the specified value is negative and throws an exception
@@ -479,44 +343,20 @@ public sealed partial class Assert
     /// </exception>
     public static void IsNegative<T>(T value, string? message)
         where T : struct, IComparable<T>
-        => IsNegative(value, message, null);
-
-    /// <summary>
-    /// Tests whether the specified value is negative and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of value to test.
-    /// </typeparam>
-    /// <param name="value">
-    /// The value to test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not negative. The message is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not negative.
-    /// </exception>
-    public static void IsNegative<T>(T value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        where T : struct, IComparable<T>
     {
         var zero = default(T);
 
         // Handle special case for floating point NaN values
         if (value is float floatValue && float.IsNaN(floatValue))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertIsNegativeFailed(value, userMessage);
             return;
         }
 
         if (value is double doubleValue && double.IsNaN(doubleValue))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             ThrowAssertIsNegativeFailed(value, userMessage);
             return;
         }
@@ -526,7 +366,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage2 = BuildUserMessage(message, parameters);
+        string userMessage2 = BuildUserMessage(message);
         ThrowAssertIsNegativeFailed(value, userMessage2);
     }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.Inconclusive.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Inconclusive.cs
@@ -18,7 +18,7 @@ public sealed partial class Assert
     /// </exception>
     [DoesNotReturn]
     public static void Inconclusive()
-        => Inconclusive(string.Empty, null);
+        => Inconclusive(string.Empty);
 
     /// <summary>
     /// Throws an AssertInconclusiveException.
@@ -32,25 +32,8 @@ public sealed partial class Assert
     /// </exception>
     [DoesNotReturn]
     public static void Inconclusive(string? message)
-        => Inconclusive(message, null);
-
-    /// <summary>
-    /// Throws an AssertInconclusiveException.
-    /// </summary>
-    /// <param name="message">
-    /// The message to include in the exception. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertInconclusiveException">
-    /// Always thrown.
-    /// </exception>
-    [DoesNotReturn]
-    public static void Inconclusive([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
-        string userMessage = BuildUserMessage(message, parameters);
+        string userMessage = BuildUserMessage(message);
         throw new AssertInconclusiveException(
             string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AssertionFailed, "Assert.Inconclusive", userMessage));
     }

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
@@ -5,6 +5,8 @@ using System.ComponentModel;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
+#pragma warning disable CA2263 // Prefer generic overload when type is known - false positives
+
 /// <summary>
 /// A collection of helper classes to test various conditions within
 /// unit tests. If the condition being tested is not met, an exception
@@ -271,7 +273,7 @@ public sealed partial class Assert
     /// of <paramref name="value"/>.
     /// </exception>
     public static void IsInstanceOfType([NotNull] object? value, [NotNull] Type? expectedType)
-        => IsInstanceOfType(value, expectedType, string.Empty, null);
+        => IsInstanceOfType(value, expectedType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified object is an instance of the generic
@@ -281,33 +283,9 @@ public sealed partial class Assert
     /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
     public static T IsInstanceOfType<T>([NotNull] object? value)
     {
-        IsInstanceOfType(value, typeof(T), string.Empty, null);
+        IsInstanceOfType(value, typeof(T), string.Empty);
         return (T)value!;
     }
-
-    /// <summary>
-    /// Tests whether the specified object is an instance of the expected
-    /// type and throws an exception if the expected type is not in the
-    /// inheritance hierarchy of the object.
-    /// </summary>
-    /// <param name="value">
-    /// The object the test expects to be of the specified type.
-    /// </param>
-    /// <param name="expectedType">
-    /// The expected type of <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not an instance of <paramref name="expectedType"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is null or
-    /// <paramref name="expectedType"/> is not in the inheritance hierarchy
-    /// of <paramref name="value"/>.
-    /// </exception>
-    public static void IsInstanceOfType([NotNull] object? value, [NotNull] Type? expectedType, string? message)
-        => IsInstanceOfType(value, expectedType, message, null);
 
     /// <inheritdoc cref="IsInstanceOfType(object?, Type?, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -325,7 +303,7 @@ public sealed partial class Assert
     /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
     public static T IsInstanceOfType<T>([NotNull] object? value, string? message)
     {
-        IsInstanceOfType(value, typeof(T), message, null);
+        IsInstanceOfType(value, typeof(T), message);
         return (T)value!;
     }
 
@@ -356,20 +334,16 @@ public sealed partial class Assert
     /// is not an instance of <paramref name="expectedType"/>. The message is
     /// shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="value"/> is null or
     /// <paramref name="expectedType"/> is not in the inheritance hierarchy
     /// of <paramref name="value"/>.
     /// </exception>
-    public static void IsInstanceOfType([NotNull] object? value, [NotNull] Type? expectedType, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void IsInstanceOfType([NotNull] object? value, [NotNull] Type? expectedType, string? message)
     {
         if (IsInstanceOfTypeFailing(value, expectedType))
         {
-            ThrowAssertIsInstanceOfTypeFailed(value, expectedType, BuildUserMessage(message, parameters));
+            ThrowAssertIsInstanceOfTypeFailed(value, expectedType, BuildUserMessage(message));
         }
     }
 
@@ -394,15 +368,6 @@ public sealed partial class Assert
     }
 
     /// <summary>
-    /// Tests whether the specified object is an instance of the generic
-    /// type and throws an exception if the generic type is not in the
-    /// inheritance hierarchy of the object.
-    /// </summary>
-    /// <typeparam name="T">The expected type of <paramref name="value"/>.</typeparam>
-    public static void IsInstanceOfType<T>([NotNull] object? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => IsInstanceOfType(value, typeof(T), message, parameters);
-
-    /// <summary>
     /// Tests whether the specified object is not an instance of the wrong
     /// type and throws an exception if the specified type is in the
     /// inheritance hierarchy of the object.
@@ -419,7 +384,7 @@ public sealed partial class Assert
     /// of <paramref name="value"/>.
     /// </exception>
     public static void IsNotInstanceOfType(object? value, [NotNull] Type? wrongType)
-        => IsNotInstanceOfType(value, wrongType, string.Empty, null);
+        => IsNotInstanceOfType(value, wrongType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified object is not an instance of the wrong generic
@@ -428,31 +393,7 @@ public sealed partial class Assert
     /// </summary>
     /// <typeparam name="T">The type that <paramref name="value"/> should not be.</typeparam>
     public static void IsNotInstanceOfType<T>(object? value)
-        => IsNotInstanceOfType(value, typeof(T), string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified object is not an instance of the wrong
-    /// type and throws an exception if the specified type is in the
-    /// inheritance hierarchy of the object.
-    /// </summary>
-    /// <param name="value">
-    /// The object the test expects not to be of the specified type.
-    /// </param>
-    /// <param name="wrongType">
-    /// The type that <paramref name="value"/> should not be.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is an instance of <paramref name="wrongType"/>. The message is shown
-    /// in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not null and
-    /// <paramref name="wrongType"/> is in the inheritance hierarchy
-    /// of <paramref name="value"/>.
-    /// </exception>
-    public static void IsNotInstanceOfType(object? value, [NotNull] Type? wrongType, string? message)
-        => IsNotInstanceOfType(value, wrongType, message, null);
+        => IsNotInstanceOfType(value, typeof(T), string.Empty);
 
     /// <inheritdoc cref="IsNotInstanceOfType(object?, Type?, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -469,7 +410,7 @@ public sealed partial class Assert
     /// </summary>
     /// <typeparam name="T">The type that <paramref name="value"/> should not be.</typeparam>
     public static void IsNotInstanceOfType<T>(object? value, string? message)
-        => IsNotInstanceOfType(value, typeof(T), message, null);
+        => IsNotInstanceOfType(value, typeof(T), message);
 
     /// <inheritdoc cref="IsNotInstanceOfType{T}(object?, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -493,20 +434,16 @@ public sealed partial class Assert
     /// is an instance of <paramref name="wrongType"/>. The message is shown
     /// in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="value"/> is not null and
     /// <paramref name="wrongType"/> is in the inheritance hierarchy
     /// of <paramref name="value"/>.
     /// </exception>
-    public static void IsNotInstanceOfType(object? value, [NotNull] Type? wrongType, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void IsNotInstanceOfType(object? value, [NotNull] Type? wrongType, string? message)
     {
         if (IsNotInstanceOfTypeFailing(value, wrongType))
         {
-            ThrowAssertIsNotInstanceOfTypeFailed(value, wrongType, BuildUserMessage(message, parameters));
+            ThrowAssertIsNotInstanceOfTypeFailed(value, wrongType, BuildUserMessage(message));
         }
     }
 
@@ -531,13 +468,4 @@ public sealed partial class Assert
 
         ThrowAssertFailed("Assert.IsNotInstanceOfType", finalMessage);
     }
-
-    /// <summary>
-    /// Tests whether the specified object is not an instance of the wrong generic
-    /// type and throws an exception if the specified type is in the
-    /// inheritance hierarchy of the object.
-    /// </summary>
-    /// <typeparam name="T">The type that <paramref name="value"/> should not be.</typeparam>
-    public static void IsNotInstanceOfType<T>(object? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => IsNotInstanceOfType(value, typeof(T), message, parameters);
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
@@ -141,24 +141,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="value"/> is not null.
     /// </exception>
     public static void IsNull(object? value)
-        => IsNull(value, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified object is null and throws an exception
-    /// if it is not.
-    /// </summary>
-    /// <param name="value">
-    /// The object the test expects to be null.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is not null. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is not null.
-    /// </exception>
-    public static void IsNull(object? value, string? message)
-        => IsNull(value, message, null);
+        => IsNull(value, string.Empty);
 
     /// <inheritdoc cref="IsNull(object?, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -177,17 +160,14 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="value"/>
     /// is not null. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="value"/> is not null.
     /// </exception>
-    public static void IsNull(object? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void IsNull(object? value, string? message)
     {
         if (IsNullFailing(value))
         {
-            ThrowAssertIsNullFailed(BuildUserMessage(message, parameters));
+            ThrowAssertIsNullFailed(BuildUserMessage(message));
         }
     }
 
@@ -207,24 +187,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="value"/> is null.
     /// </exception>
     public static void IsNotNull([NotNull] object? value)
-        => IsNotNull(value, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified object is non-null and throws an exception
-    /// if it is null.
-    /// </summary>
-    /// <param name="value">
-    /// The object the test expects not to be null.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// is null. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="value"/> is null.
-    /// </exception>
-    public static void IsNotNull([NotNull] object? value, string? message)
-        => IsNotNull(value, message, null);
+        => IsNotNull(value, string.Empty);
 
     /// <inheritdoc cref="IsNull(object?, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -245,17 +208,14 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="value"/>
     /// is null. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="value"/> is null.
     /// </exception>
-    public static void IsNotNull([NotNull] object? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void IsNotNull([NotNull] object? value, string? message)
     {
         if (IsNotNullFailing(value))
         {
-            ThrowAssertIsNotNullFailed(BuildUserMessage(message, parameters));
+            ThrowAssertIsNotNullFailed(BuildUserMessage(message));
         }
     }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
@@ -139,7 +139,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="condition"/> is false.
     /// </exception>
     public static void IsTrue([DoesNotReturnIf(false)] bool condition)
-        => IsTrue(condition, string.Empty, null);
+        => IsTrue(condition, string.Empty);
 
     /// <summary>
     /// Tests whether the specified condition is true and throws an exception
@@ -152,47 +152,13 @@ public sealed partial class Assert
     /// Thrown if <paramref name="condition"/> is false.
     /// </exception>
     public static void IsTrue([DoesNotReturnIf(false)] bool? condition)
-        => IsTrue(condition, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified condition is true and throws an exception
-    /// if the condition is false.
-    /// </summary>
-    /// <param name="condition">
-    /// The condition the test expects to be true.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="condition"/>
-    /// is false. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="condition"/> is false.
-    /// </exception>
-    public static void IsTrue([DoesNotReturnIf(false)] bool condition, string? message)
-        => IsTrue(condition, message, null);
+        => IsTrue(condition, string.Empty);
 
     /// <inheritdoc cref="IsTrue(bool, string?)"/>
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void IsTrue([DoesNotReturnIf(false)] bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref AssertIsTrueInterpolatedStringHandler message)
 #pragma warning restore IDE0060 // Remove unused parameter
         => message.ComputeAssertion();
-
-    /// <summary>
-    /// Tests whether the specified condition is true and throws an exception
-    /// if the condition is false.
-    /// </summary>
-    /// <param name="condition">
-    /// The condition the test expects to be true.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="condition"/>
-    /// is false. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="condition"/> is false.
-    /// </exception>
-    public static void IsTrue([DoesNotReturnIf(false)] bool? condition, string? message)
-        => IsTrue(condition, message, null);
 
     /// <inheritdoc cref="IsTrue(bool?, string?)"/>
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -211,18 +177,14 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="condition"/>
     /// is false. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="condition"/> is false.
     /// </exception>
-    public static void IsTrue([DoesNotReturnIf(false)] bool condition, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void IsTrue([DoesNotReturnIf(false)] bool condition, string? message)
     {
         if (IsTrueFailing(condition))
         {
-            ThrowAssertIsTrueFailed(BuildUserMessage(message, parameters));
+            ThrowAssertIsTrueFailed(BuildUserMessage(message));
         }
     }
 
@@ -237,18 +199,14 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="condition"/>
     /// is false. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="condition"/> is false.
     /// </exception>
-    public static void IsTrue([DoesNotReturnIf(false)] bool? condition, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void IsTrue([DoesNotReturnIf(false)] bool? condition, string? message)
     {
         if (IsTrueFailing(condition))
         {
-            ThrowAssertIsTrueFailed(BuildUserMessage(message, parameters));
+            ThrowAssertIsTrueFailed(BuildUserMessage(message));
         }
     }
 
@@ -272,7 +230,7 @@ public sealed partial class Assert
     /// Thrown if <paramref name="condition"/> is true.
     /// </exception>
     public static void IsFalse([DoesNotReturnIf(true)] bool condition)
-        => IsFalse(condition, string.Empty, null);
+        => IsFalse(condition, string.Empty);
 
     /// <summary>
     /// Tests whether the specified condition is false and throws an exception
@@ -285,47 +243,13 @@ public sealed partial class Assert
     /// Thrown if <paramref name="condition"/> is true.
     /// </exception>
     public static void IsFalse([DoesNotReturnIf(true)] bool? condition)
-        => IsFalse(condition, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified condition is false and throws an exception
-    /// if the condition is true.
-    /// </summary>
-    /// <param name="condition">
-    /// The condition the test expects to be false.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="condition"/>
-    /// is true. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="condition"/> is true.
-    /// </exception>
-    public static void IsFalse([DoesNotReturnIf(true)] bool condition, string? message)
-        => IsFalse(condition, message, null);
+        => IsFalse(condition, string.Empty);
 
     /// <inheritdoc cref="IsFalse(bool, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static void IsFalse([DoesNotReturnIf(true)] bool condition, [InterpolatedStringHandlerArgument(nameof(condition))] ref AssertIsFalseInterpolatedStringHandler message)
 #pragma warning restore IDE0060 // Remove unused parameter
         => message.ComputeAssertion();
-
-    /// <summary>
-    /// Tests whether the specified condition is false and throws an exception
-    /// if the condition is true.
-    /// </summary>
-    /// <param name="condition">
-    /// The condition the test expects to be false.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="condition"/>
-    /// is true. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="condition"/> is true.
-    /// </exception>
-    public static void IsFalse([DoesNotReturnIf(true)] bool? condition, string? message)
-        => IsFalse(condition, message, null);
 
     /// <inheritdoc cref="IsFalse(bool, string?)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -344,18 +268,14 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="condition"/>
     /// is true. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="condition"/> is true.
     /// </exception>
-    public static void IsFalse([DoesNotReturnIf(true)] bool condition, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void IsFalse([DoesNotReturnIf(true)] bool condition, string? message)
     {
         if (IsFalseFailing(condition))
         {
-            ThrowAssertIsFalseFailed(BuildUserMessage(message, parameters));
+            ThrowAssertIsFalseFailed(BuildUserMessage(message));
         }
     }
 
@@ -370,18 +290,14 @@ public sealed partial class Assert
     /// The message to include in the exception when <paramref name="condition"/>
     /// is true. The message is shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="condition"/> is true.
     /// </exception>
-    public static void IsFalse([DoesNotReturnIf(true)] bool? condition, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+    public static void IsFalse([DoesNotReturnIf(true)] bool? condition, string? message)
     {
         if (IsFalseFailing(condition))
         {
-            ThrowAssertIsFalseFailed(BuildUserMessage(message, parameters));
+            ThrowAssertIsFalseFailed(BuildUserMessage(message));
         }
     }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
@@ -23,7 +23,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
     /// </exception>
     public static void MatchesRegex([NotNull] Regex? pattern, [NotNull] string? value)
-        => MatchesRegex(pattern, value, string.Empty, null);
+        => MatchesRegex(pattern, value, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string MatchesRegex a regular expression and
@@ -46,39 +46,13 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
     /// </exception>
     public static void MatchesRegex([NotNull] Regex? pattern, [NotNull] string? value, string? message)
-        => MatchesRegex(pattern, value, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string MatchesRegex a regular expression and
-    /// throws an exception if the string does not match the expression.
-    /// </summary>
-    /// <param name="pattern">
-    /// The regular expression that <paramref name="value"/> is
-    /// expected to match.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to match <paramref name="pattern"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not match <paramref name="pattern"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="pattern"/> is null,
-    /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
-    /// </exception>
-    public static void MatchesRegex([NotNull] Regex? pattern, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         CheckParameterNotNull(value, "Assert.MatchesRegex", "value", string.Empty);
         CheckParameterNotNull(pattern, "Assert.MatchesRegex", "pattern", string.Empty);
 
         if (!pattern.IsMatch(value))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsMatchFail, value, pattern, userMessage);
             ThrowAssertFailed("Assert.MatchesRegex", finalMessage);
         }
@@ -100,7 +74,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
     /// </exception>
     public static void MatchesRegex([NotNull] string? pattern, [NotNull] string? value)
-        => MatchesRegex(ToRegex(pattern), value, string.Empty, null);
+        => MatchesRegex(ToRegex(pattern), value, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string MatchesRegex a regular expression and
@@ -123,33 +97,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
     /// </exception>
     public static void MatchesRegex([NotNull] string? pattern, [NotNull] string? value, string? message)
-        => MatchesRegex(ToRegex(pattern), value, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string MatchesRegex a regular expression and
-    /// throws an exception if the string does not match the expression.
-    /// </summary>
-    /// <param name="pattern">
-    /// The regular expression that <paramref name="value"/> is
-    /// expected to match.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to match <paramref name="pattern"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not match <paramref name="pattern"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="pattern"/> is null,
-    /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
-    /// </exception>
-    public static void MatchesRegex([NotNull] string? pattern, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => MatchesRegex(ToRegex(pattern), value, message, parameters);
+        => MatchesRegex(ToRegex(pattern), value, message);
 
     #endregion // MatchesRegex
 
@@ -194,39 +142,13 @@ public sealed partial class Assert
     /// or <paramref name="value"/> MatchesRegex <paramref name="pattern"/>.
     /// </exception>
     public static void DoesNotMatchRegex([NotNull] Regex? pattern, [NotNull] string? value, string? message)
-        => DoesNotMatchRegex(pattern, value, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string does not match a regular expression
-    /// and throws an exception if the string MatchesRegex the expression.
-    /// </summary>
-    /// <param name="pattern">
-    /// The regular expression that <paramref name="value"/> is
-    /// expected to not match.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected not to match <paramref name="pattern"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// MatchesRegex <paramref name="pattern"/>. The message is shown in test
-    /// results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="pattern"/> is null,
-    /// or <paramref name="value"/> MatchesRegex <paramref name="pattern"/>.
-    /// </exception>
-    public static void DoesNotMatchRegex([NotNull] Regex? pattern, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         CheckParameterNotNull(value, "Assert.DoesNotMatchRegex", "value", string.Empty);
         CheckParameterNotNull(pattern, "Assert.DoesNotMatchRegex", "pattern", string.Empty);
 
         if (pattern.IsMatch(value))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsNotMatchFail, value, pattern, userMessage);
             ThrowAssertFailed("Assert.DoesNotMatchRegex", finalMessage);
         }
@@ -248,7 +170,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> MatchesRegex <paramref name="pattern"/>.
     /// </exception>
     public static void DoesNotMatchRegex([NotNull] string? pattern, [NotNull] string? value)
-        => DoesNotMatchRegex(ToRegex(pattern), value, string.Empty, null);
+        => DoesNotMatchRegex(ToRegex(pattern), value, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string does not match a regular expression
@@ -271,33 +193,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> MatchesRegex <paramref name="pattern"/>.
     /// </exception>
     public static void DoesNotMatchRegex([NotNull] string? pattern, [NotNull] string? value, string? message)
-        => DoesNotMatchRegex(ToRegex(pattern), value, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string does not match a regular expression
-    /// and throws an exception if the string MatchesRegex the expression.
-    /// </summary>
-    /// <param name="pattern">
-    /// The regular expression that <paramref name="value"/> is
-    /// expected to not match.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected not to match <paramref name="pattern"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// MatchesRegex <paramref name="pattern"/>. The message is shown in test
-    /// results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="pattern"/> is null,
-    /// or <paramref name="value"/> MatchesRegex <paramref name="pattern"/>.
-    /// </exception>
-    public static void DoesNotMatchRegex([NotNull] string? pattern, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => DoesNotMatchRegex(ToRegex(pattern), value, message, parameters);
+        => DoesNotMatchRegex(ToRegex(pattern), value, message);
 
     #endregion // DoesNotMatchRegex
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
@@ -59,32 +59,6 @@ public sealed partial class Assert
     /// <param name="value">
     /// The string that is expected to begin with <paramref name="substring"/>.
     /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not begin with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
-    /// </exception>
-    public static void StartsWith([NotNull] string? substring, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => StartsWith(substring, value, StringComparison.Ordinal, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string begins with the specified substring
-    /// and throws an exception if the test string does not start with the
-    /// substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to begin with <paramref name="substring"/>.
-    /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
@@ -93,33 +67,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
     public static void StartsWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType)
-        => StartsWith(substring, value, comparisonType, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified string begins with the specified substring
-    /// and throws an exception if the test string does not start with the
-    /// substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to begin with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not begin with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
-    /// </exception>
-    public static void StartsWith([NotNull] string? substring, [NotNull] string? value, string? message, StringComparison comparisonType)
-        => StartsWith(substring, value, comparisonType, message, null);
+        => StartsWith(substring, value, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string begins with the specified substring
@@ -140,20 +88,17 @@ public sealed partial class Assert
     /// does not begin with <paramref name="substring"/>. The message is
     /// shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
-    public static void StartsWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void StartsWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType, string? message)
     {
         CheckParameterNotNull(value, "Assert.StartsWith", "value", string.Empty);
         CheckParameterNotNull(substring, "Assert.StartsWith", "substring", string.Empty);
         if (!value.StartsWith(substring, comparisonType))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.StartsWithFail, value, substring, userMessage);
             ThrowAssertFailed("Assert.StartsWith", finalMessage);
         }
@@ -212,31 +157,6 @@ public sealed partial class Assert
     /// <param name="value">
     /// The string that is expected to begin with <paramref name="substring"/>.
     /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not begin with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
-    /// </exception>
-    public static void DoesNotStartWith([NotNull] string? substring, [NotNull] string? value, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => DoesNotStartWith(substring, value, StringComparison.Ordinal, message, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string does not begin with the specified substring
-    /// and throws an exception if the test string does start with the substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to begin with <paramref name="substring"/>.
-    /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
@@ -245,32 +165,7 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
     public static void DoesNotStartWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType)
-        => DoesNotStartWith(substring, value, comparisonType, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the specified string does not begin with the specified substring
-    /// and throws an exception if the test string does start with the substring.
-    /// </summary>
-    /// <param name="substring">
-    /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="value">
-    /// The string that is expected to begin with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not begin with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
-    /// </exception>
-    public static void DoesNotStartWith([NotNull] string? substring, [NotNull] string? value, string? message, StringComparison comparisonType)
-        => DoesNotStartWith(substring, value, comparisonType, message, null);
+        => DoesNotStartWith(substring, value, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string does not begin with the specified substring
@@ -290,21 +185,17 @@ public sealed partial class Assert
     /// does not begin with <paramref name="substring"/>. The message is
     /// shown in test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
-    public static void DoesNotStartWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void DoesNotStartWith([NotNull] string? substring, [NotNull] string? value, StringComparison comparisonType, string? message)
     {
         CheckParameterNotNull(value, "Assert.DoesNotStartWith", "value", string.Empty);
         CheckParameterNotNull(substring, "Assert.DoesNotStartWith", "substring", string.Empty);
         if (value.StartsWith(substring, comparisonType))
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DoesNotStartWithFail, value, substring, userMessage);
             ThrowAssertFailed("Assert.DoesNotStartWith", finalMessage);
         }

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
@@ -164,9 +164,6 @@ public sealed partial class Assert
     /// <param name="message">
     /// The message to include in the exception when <paramref name="action"/> does not throws exception of type <typeparamref name="TException"/>.
     /// </param>
-    /// <param name="messageArgs">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <typeparam name="TException">
     /// The type of exception expected to be thrown.
     /// </typeparam>
@@ -176,16 +173,18 @@ public sealed partial class Assert
     /// <returns>
     /// The exception that was thrown.
     /// </returns>
-    public static TException Throws<TException>(Action action, string message = "", params object[] messageArgs)
-        where TException : Exception
-        => ThrowsException<TException>(action, isStrictType: false, message, parameters: messageArgs);
-
-    /// <inheritdoc cref="Throws{TException}(Action, string, object[])"/>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-    public static TException Throws<TException>(Func<object?> action, string message = "", params object[] messageArgs)
+    public static TException Throws<TException>(Action action, string message = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         where TException : Exception
-        => ThrowsException<TException>(() => _ = action(), isStrictType: false, message, parameters: messageArgs);
+        => ThrowsException<TException>(action, isStrictType: false, message);
+
+    /// <inheritdoc cref="Throws{TException}(Action, string)"/>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static TException Throws<TException>(Func<object?> action, string message = "")
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        where TException : Exception
+        => ThrowsException<TException>(() => _ = action(), isStrictType: false, message);
 
     /// <summary>
     /// Asserts that the delegate <paramref name="action"/> throws an exception of type <typeparamref name="TException"/>
@@ -216,14 +215,14 @@ public sealed partial class Assert
         where TException : Exception
         => ThrowsException<TException>(() => _ = action(), isStrictType: false, messageBuilder);
 
-    /// <inheritdoc cref="Throws{TException}(Action, string, object[])" />
+    /// <inheritdoc cref="Throws{TException}(Action, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static TException Throws<TException>(Action action, [InterpolatedStringHandlerArgument(nameof(action))] ref AssertNonStrictThrowsInterpolatedStringHandler<TException> message)
 #pragma warning restore IDE0060 // Remove unused parameter
         where TException : Exception
         => message.ComputeAssertion();
 
-    /// <inheritdoc cref="Throws{TException}(Action, string, object[])" />
+    /// <inheritdoc cref="Throws{TException}(Action, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static TException Throws<TException>(Func<object?> action, [InterpolatedStringHandlerArgument(nameof(action))] ref AssertNonStrictThrowsInterpolatedStringHandler<TException> message)
 #pragma warning restore IDE0060 // Remove unused parameter
@@ -241,9 +240,6 @@ public sealed partial class Assert
     /// <param name="message">
     /// The message to include in the exception when <paramref name="action"/> does not throws exception of type <typeparamref name="TException"/>.
     /// </param>
-    /// <param name="messageArgs">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <typeparam name="TException">
     /// The type of exception expected to be thrown.
     /// </typeparam>
@@ -253,16 +249,18 @@ public sealed partial class Assert
     /// <returns>
     /// The exception that was thrown.
     /// </returns>
-    public static TException ThrowsExactly<TException>(Action action, string message = "", params object[] messageArgs)
-        where TException : Exception
-        => ThrowsException<TException>(action, isStrictType: true, message, parameters: messageArgs);
-
-    /// <inheritdoc cref="ThrowsExactly{TException}(Action, string, object[])" />
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
-    public static TException ThrowsExactly<TException>(Func<object?> action, string message = "", params object[] messageArgs)
+    public static TException ThrowsExactly<TException>(Action action, string message = "")
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         where TException : Exception
-        => ThrowsException<TException>(() => _ = action(), isStrictType: true, message, parameters: messageArgs);
+        => ThrowsException<TException>(action, isStrictType: true, message);
+
+    /// <inheritdoc cref="ThrowsExactly{TException}(Action, string)" />
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public static TException ThrowsExactly<TException>(Func<object?> action, string message = "")
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        where TException : Exception
+        => ThrowsException<TException>(() => _ = action(), isStrictType: true, message);
 
     /// <summary>
     /// Asserts that the delegate <paramref name="action"/> throws an exception of type <typeparamref name="TException"/>
@@ -293,7 +291,7 @@ public sealed partial class Assert
     where TException : Exception
         => ThrowsException<TException>(() => _ = action(), isStrictType: true, messageBuilder);
 
-    /// <inheritdoc cref="ThrowsExactly{TException}(Action, string, object[])" />
+    /// <inheritdoc cref="ThrowsExactly{TException}(Action, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
     public static TException ThrowsExactly<TException>(Action action, [InterpolatedStringHandlerArgument(nameof(action))] ref AssertThrowsExactlyInterpolatedStringHandler<TException> message)
 #pragma warning restore IDE0060 // Remove unused parameter
@@ -320,7 +318,58 @@ public sealed partial class Assert
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static T ThrowsException<T>(Action action)
         where T : Exception
-        => ThrowsException<T>(action, string.Empty, null);
+        => ThrowsException<T>(action, string.Empty);
+
+    /// <summary>
+    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
+    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
+    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="action">
+    /// Delegate to code to be tested and which is expected to throw exception.
+    /// </param>
+    /// <typeparam name="T">
+    /// Type of exception expected to be thrown.
+    /// </typeparam>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/>.
+    /// </exception>
+    /// <returns>
+    /// The exception that was thrown.
+    /// </returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static T ThrowsException<T>(Func<object?> action)
+        where T : Exception
+        => ThrowsException<T>(action, string.Empty);
+
+    /// <summary>
+    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
+    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
+    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="action">
+    /// Delegate to code to be tested and which is expected to throw exception.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception when <paramref name="action"/>
+    /// does not throws exception of type <typeparamref name="T"/>.
+    /// </param>
+    /// <typeparam name="T">
+    /// Type of exception expected to be thrown.
+    /// </typeparam>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="action"/> does not throw exception of type <typeparamref name="T"/>.
+    /// </exception>
+    /// <returns>
+    /// The exception that was thrown.
+    /// </returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static T ThrowsException<T>(Func<object?> action, string message)
+        where T : Exception
+#pragma warning disable IDE0053 // Use expression body for lambda expression
+        // Despite the discard, using lambda makes the action considered as Func and so recursing on the same method
+        => ThrowsException<T>(() => { _ = action(); }, message);
+#pragma warning restore IDE0053 // Use expression body for lambda expression
 
     /// <summary>
     /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
@@ -346,118 +395,9 @@ public sealed partial class Assert
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static T ThrowsException<T>(Action action, string message)
         where T : Exception
-        => ThrowsException<T>(action, message, null);
+        => ThrowsException<T>(action, isStrictType: true, message);
 
-    /// <summary>
-    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
-    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
-    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="action">
-    /// Delegate to code to be tested and which is expected to throw exception.
-    /// </param>
-    /// <typeparam name="T">
-    /// Type of exception expected to be thrown.
-    /// </typeparam>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/>.
-    /// </exception>
-    /// <returns>
-    /// The exception that was thrown.
-    /// </returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static T ThrowsException<T>(Func<object?> action)
-        where T : Exception
-        => ThrowsException<T>(action, string.Empty, null);
-
-    /// <summary>
-    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
-    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
-    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="action">
-    /// Delegate to code to be tested and which is expected to throw exception.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="action"/>
-    /// does not throws exception of type <typeparamref name="T"/>.
-    /// </param>
-    /// <typeparam name="T">
-    /// Type of exception expected to be thrown.
-    /// </typeparam>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/>.
-    /// </exception>
-    /// <returns>
-    /// The exception that was thrown.
-    /// </returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static T ThrowsException<T>(Func<object?> action, string message)
-        where T : Exception
-        => ThrowsException<T>(action, message, null);
-
-    /// <summary>
-    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
-    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
-    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="action">
-    /// Delegate to code to be tested and which is expected to throw exception.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="action"/>
-    /// does not throws exception of type <typeparamref name="T"/>.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <typeparam name="T">
-    /// Type of exception expected to be thrown.
-    /// </typeparam>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="action"/> does not throw exception of type <typeparamref name="T"/>.
-    /// </exception>
-    /// <returns>
-    /// The exception that was thrown.
-    /// </returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static T ThrowsException<T>(Func<object?> action, string message, params object?[]? parameters)
-        where T : Exception
-#pragma warning disable IDE0053 // Use expression body for lambda expression
-        // Despite the discard, using lambda makes the action considered as Func and so recursing on the same method
-        => ThrowsException<T>(() => { _ = action(); }, message, parameters);
-#pragma warning restore IDE0053 // Use expression body for lambda expression
-
-    /// <summary>
-    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
-    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
-    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="action">
-    /// Delegate to code to be tested and which is expected to throw exception.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="action"/>
-    /// does not throws exception of type <typeparamref name="T"/>.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <typeparam name="T">
-    /// Type of exception expected to be thrown.
-    /// </typeparam>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/>.
-    /// </exception>
-    /// <returns>
-    /// The exception that was thrown.
-    /// </returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static T ThrowsException<T>(Action action, string message, params object?[]? parameters)
-        where T : Exception
-        => ThrowsException<T>(action, isStrictType: true, message, parameters: parameters);
-
-    private static TException ThrowsException<TException>(Action action, bool isStrictType, string message, [CallerMemberName] string assertMethodName = "", params object?[]? parameters)
+    private static TException ThrowsException<TException>(Action action, bool isStrictType, string message, [CallerMemberName] string assertMethodName = "")
         where TException : Exception
     {
         Guard.NotNull(action);
@@ -466,7 +406,7 @@ public sealed partial class Assert
         ThrowsExceptionState state = IsThrowsFailing<TException>(action, isStrictType, assertMethodName);
         if (state.FailAction is not null)
         {
-            state.FailAction(BuildUserMessage(message, parameters));
+            state.FailAction(BuildUserMessage(message));
         }
         else
         {
@@ -508,9 +448,6 @@ public sealed partial class Assert
     /// <param name="message">
     /// The message to include in the exception when <paramref name="action"/> does not throws exception of type <typeparamref name="TException"/>.
     /// </param>
-    /// <param name="messageArgs">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <typeparam name="TException">
     /// The type of exception expected to be thrown.
     /// </typeparam>
@@ -520,9 +457,11 @@ public sealed partial class Assert
     /// <returns>
     /// The exception that was thrown.
     /// </returns>
-    public static Task<TException> ThrowsAsync<TException>(Func<Task> action, string message = "", params object[] messageArgs)
+#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+    public static Task<TException> ThrowsAsync<TException>(Func<Task> action, string message = "")
+#pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
         where TException : Exception
-        => ThrowsExceptionAsync<TException>(action, isStrictType: false, message, parameters: messageArgs);
+        => ThrowsExceptionAsync<TException>(action, isStrictType: false, message);
 
     /// <summary>
     /// Asserts that the delegate <paramref name="action"/> throws an exception of type <typeparamref name="TException"/>
@@ -535,9 +474,6 @@ public sealed partial class Assert
     /// <param name="message">
     /// The message to include in the exception when <paramref name="action"/> does not throws exception of type <typeparamref name="TException"/>.
     /// </param>
-    /// <param name="messageArgs">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <typeparam name="TException">
     /// The type of exception expected to be thrown.
     /// </typeparam>
@@ -547,9 +483,11 @@ public sealed partial class Assert
     /// <returns>
     /// The exception that was thrown.
     /// </returns>
-    public static Task<TException> ThrowsExactlyAsync<TException>(Func<Task> action, string message = "", params object[] messageArgs)
+#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+    public static Task<TException> ThrowsExactlyAsync<TException>(Func<Task> action, string message = "")
+#pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
         where TException : Exception
-        => ThrowsExceptionAsync<TException>(action, isStrictType: true, message, parameters: messageArgs);
+        => ThrowsExceptionAsync<TException>(action, isStrictType: true, message);
 
     /// <summary>
     /// Asserts that the delegate <paramref name="action"/> throws an exception of type <typeparamref name="TException"/>
@@ -619,7 +557,7 @@ public sealed partial class Assert
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static async Task<T> ThrowsExceptionAsync<T>(Func<Task> action)
         where T : Exception
-        => await ThrowsExceptionAsync<T>(action, string.Empty, null)
+        => await ThrowsExceptionAsync<T>(action, string.Empty)
             .ConfigureAwait(false);
 
     /// <summary>
@@ -642,36 +580,10 @@ public sealed partial class Assert
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static async Task<T> ThrowsExceptionAsync<T>(Func<Task> action, string message)
         where T : Exception
-        => await ThrowsExceptionAsync<T>(action, message, null)
+        => await ThrowsExceptionAsync<T>(action, true, message)
             .ConfigureAwait(false);
 
-    /// <summary>
-    /// Tests whether the code specified by delegate <paramref name="action"/> throws exact given exception
-    /// of type <typeparamref name="T"/> (and not of derived type) and throws <c>AssertFailedException</c>
-    /// if code does not throws exception or throws exception of type other than <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="action">Delegate to code to be tested and which is expected to throw exception.</param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="action"/>
-    /// does not throws exception of type <typeparamref name="T"/>.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <typeparam name="T">Type of exception expected to be thrown.</typeparam>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="action"/> does not throws exception of type <typeparamref name="T"/>.
-    /// </exception>
-    /// <returns>
-    /// The <see cref="Task"/> executing the delegate.
-    /// </returns>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public static async Task<T> ThrowsExceptionAsync<T>(Func<Task> action, string message, params object?[]? parameters)
-        where T : Exception
-        => await ThrowsExceptionAsync<T>(action, true, message, parameters: parameters)
-            .ConfigureAwait(false);
-
-    private static async Task<TException> ThrowsExceptionAsync<TException>(Func<Task> action, bool isStrictType, string message, [CallerMemberName] string assertMethodName = "", params object?[]? parameters)
+    private static async Task<TException> ThrowsExceptionAsync<TException>(Func<Task> action, bool isStrictType, string message, [CallerMemberName] string assertMethodName = "")
         where TException : Exception
     {
         Guard.NotNull(action);
@@ -680,7 +592,7 @@ public sealed partial class Assert
         ThrowsExceptionState state = await IsThrowsAsyncFailingAsync<TException>(action, isStrictType, assertMethodName).ConfigureAwait(false);
         if (state.FailAction is not null)
         {
-            state.FailAction(BuildUserMessage(message, parameters));
+            state.FailAction(BuildUserMessage(message));
         }
         else
         {

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -79,20 +79,13 @@ public sealed partial class Assert
     /// <param name="format">
     /// A composite format string.
     /// </param>
-    /// <param name="parameters">
-    /// An object array that contains zero or more objects to format.
-    /// </param>
     /// <returns>
     /// The formatted string based on format and parameters.
     /// </returns>
-    internal static string BuildUserMessage(string? format, params object?[]? parameters)
+    internal static string BuildUserMessage(string? format)
         => format is null
-            ? ReplaceNulls(format)
-            : format.Length == 0
-                ? string.Empty
-                : parameters == null || parameters.Length == 0
-                    ? ReplaceNulls(format)
-                    : string.Format(CultureInfo.CurrentCulture, ReplaceNulls(format), parameters);
+            ? FrameworkMessages.Common_NullInMessages.ToString()
+            : ReplaceNullChars(format);
 
     /// <summary>
     /// Checks the parameter for valid conditions.
@@ -109,15 +102,11 @@ public sealed partial class Assert
     /// <param name="message">
     /// message for the invalid parameter exception.
     /// </param>
-    /// <param name="parameters">
-    /// The parameters.
-    /// </param>
-    internal static void CheckParameterNotNull([NotNull] object? param, string assertionName, string parameterName,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    internal static void CheckParameterNotNull([NotNull] object? param, string assertionName, string parameterName, string? message)
     {
         if (param == null)
         {
-            string userMessage = BuildUserMessage(message, parameters);
+            string userMessage = BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.NullParameterToAssert, parameterName, userMessage);
             ThrowAssertFailed(assertionName, finalMessage);
         }

--- a/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs
+++ b/src/TestFramework/TestFramework/Assertions/CollectionAssert.cs
@@ -62,7 +62,7 @@ public sealed class CollectionAssert
     /// element <paramref name="element"/>.
     /// </exception>
     public static void Contains([NotNull] ICollection? collection, object? element)
-        => Contains(collection, element, string.Empty, null);
+        => Contains(collection, element, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains the specified element
@@ -84,32 +84,6 @@ public sealed class CollectionAssert
     /// element <paramref name="element"/>.
     /// </exception>
     public static void Contains([NotNull] ICollection? collection, object? element, string? message)
-        => Contains(collection, element, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collection contains the specified element
-    /// and throws an exception if the element is not in the collection.
-    /// </summary>
-    /// <param name="collection">
-    /// The collection in which to search for the element.
-    /// </param>
-    /// <param name="element">
-    /// The element that is expected to be in the collection.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="element"/>
-    /// is not in <paramref name="collection"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="collection"/> is null, or <paramref name="collection"/> does not contain
-    /// element <paramref name="element"/>.
-    /// </exception>
-    public static void Contains([NotNull] ICollection? collection, object? element, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(collection, "CollectionAssert.Contains", "collection", string.Empty);
 
@@ -121,7 +95,7 @@ public sealed class CollectionAssert
             }
         }
 
-        Assert.ThrowAssertFailed("CollectionAssert.Contains", Assert.BuildUserMessage(message, parameters));
+        Assert.ThrowAssertFailed("CollectionAssert.Contains", Assert.BuildUserMessage(message));
     }
 
     /// <summary>
@@ -139,7 +113,7 @@ public sealed class CollectionAssert
     /// element <paramref name="element"/>.
     /// </exception>
     public static void DoesNotContain([NotNull] ICollection? collection, object? element)
-        => DoesNotContain(collection, element, string.Empty, null);
+        => DoesNotContain(collection, element, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified
@@ -161,32 +135,6 @@ public sealed class CollectionAssert
     /// element <paramref name="element"/>.
     /// </exception>
     public static void DoesNotContain([NotNull] ICollection? collection, object? element, string? message)
-        => DoesNotContain(collection, element, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collection does not contain the specified
-    /// element and throws an exception if the element is in the collection.
-    /// </summary>
-    /// <param name="collection">
-    /// The collection in which to search for the element.
-    /// </param>
-    /// <param name="element">
-    /// The element that is expected not to be in the collection.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="element"/>
-    /// is in <paramref name="collection"/>. The message is shown in test
-    /// results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="collection"/> is null, or <paramref name="collection"/> contains
-    /// element <paramref name="element"/>.
-    /// </exception>
-    public static void DoesNotContain([NotNull] ICollection? collection, object? element, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(collection, "CollectionAssert.DoesNotContain", "collection", string.Empty);
 
@@ -194,7 +142,7 @@ public sealed class CollectionAssert
         {
             if (object.Equals(current, element))
             {
-                Assert.ThrowAssertFailed("CollectionAssert.DoesNotContain", Assert.BuildUserMessage(message, parameters));
+                Assert.ThrowAssertFailed("CollectionAssert.DoesNotContain", Assert.BuildUserMessage(message));
             }
         }
     }
@@ -210,7 +158,7 @@ public sealed class CollectionAssert
     /// <paramref name="collection"/> is null, or <paramref name="collection"/> contains a null element.
     /// </exception>
     public static void AllItemsAreNotNull([NotNull] ICollection? collection)
-        => AllItemsAreNotNull(collection, string.Empty, null);
+        => AllItemsAreNotNull(collection, string.Empty);
 
     /// <summary>
     /// Tests whether all items in the specified collection are non-null and throws
@@ -227,34 +175,13 @@ public sealed class CollectionAssert
     /// <paramref name="collection"/> is null, or <paramref name="collection"/> contains a null element.
     /// </exception>
     public static void AllItemsAreNotNull([NotNull] ICollection? collection, string? message)
-        => AllItemsAreNotNull(collection, message, null);
-
-    /// <summary>
-    /// Tests whether all items in the specified collection are non-null and throws
-    /// an exception if any element is null.
-    /// </summary>
-    /// <param name="collection">
-    /// The collection in which to search for null elements.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="collection"/>
-    /// contains a null element. The message is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="collection"/> is null, or <paramref name="collection"/> contains a null element.
-    /// </exception>
-    public static void AllItemsAreNotNull([NotNull] ICollection? collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(collection, "CollectionAssert.AllItemsAreNotNull", "collection", string.Empty);
         foreach (object? current in collection)
         {
             if (current == null)
             {
-                Assert.ThrowAssertFailed("CollectionAssert.AllItemsAreNotNull", Assert.BuildUserMessage(message, parameters));
+                Assert.ThrowAssertFailed("CollectionAssert.AllItemsAreNotNull", Assert.BuildUserMessage(message));
             }
         }
     }
@@ -271,7 +198,7 @@ public sealed class CollectionAssert
     /// element.
     /// </exception>
     public static void AllItemsAreUnique([NotNull] ICollection? collection)
-        => AllItemsAreUnique(collection, string.Empty, null);
+        => AllItemsAreUnique(collection, string.Empty);
 
     /// <summary>
     /// Tests whether all items in the specified collection are unique or not and
@@ -290,29 +217,6 @@ public sealed class CollectionAssert
     /// element.
     /// </exception>
     public static void AllItemsAreUnique([NotNull] ICollection? collection, string? message)
-        => AllItemsAreUnique(collection, message, null);
-
-    /// <summary>
-    /// Tests whether all items in the specified collection are unique or not and
-    /// throws if any two elements in the collection are equal.
-    /// </summary>
-    /// <param name="collection">
-    /// The collection in which to search for duplicate elements.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="collection"/>
-    /// contains at least one duplicate element. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="collection"/> is null, or <paramref name="collection"/> contains at least one duplicate
-    /// element.
-    /// </exception>
-    public static void AllItemsAreUnique([NotNull] ICollection? collection, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(collection, "CollectionAssert.AllItemsAreUnique", "collection", string.Empty);
 
@@ -331,7 +235,7 @@ public sealed class CollectionAssert
                 else
                 {
                     // Found a second occurrence of null.
-                    string userMessage = Assert.BuildUserMessage(message, parameters);
+                    string userMessage = Assert.BuildUserMessage(message);
                     string finalMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         FrameworkMessages.AllItemsAreUniqueFailMsg,
@@ -346,7 +250,7 @@ public sealed class CollectionAssert
 #pragma warning disable CA1864 // Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
                 if (table.ContainsKey(current))
                 {
-                    string userMessage = Assert.BuildUserMessage(message, parameters);
+                    string userMessage = Assert.BuildUserMessage(message);
                     string finalMessage = string.Format(
                         CultureInfo.CurrentCulture,
                         FrameworkMessages.AllItemsAreUniqueFailMsg,
@@ -385,7 +289,7 @@ public sealed class CollectionAssert
     /// <paramref name="superset"/>.
     /// </exception>
     public static void IsSubsetOf([NotNull] ICollection? subset, [NotNull] ICollection? superset)
-        => IsSubsetOf(subset, superset, string.Empty, null);
+        => IsSubsetOf(subset, superset, string.Empty);
 
     /// <summary>
     /// Tests whether one collection is a subset of another collection and
@@ -409,40 +313,12 @@ public sealed class CollectionAssert
     /// <paramref name="superset"/>.
     /// </exception>
     public static void IsSubsetOf([NotNull] ICollection? subset, [NotNull] ICollection? superset, string? message)
-        => IsSubsetOf(subset, superset, message, null);
-
-    /// <summary>
-    /// Tests whether one collection is a subset of another collection and
-    /// throws an exception if any element in the subset is not also in the
-    /// superset.
-    /// </summary>
-    /// <param name="subset">
-    /// The collection expected to be a subset of <paramref name="superset"/>.
-    /// </param>
-    /// <param name="superset">
-    /// The collection expected to be a superset of <paramref name="subset"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when an element in
-    /// <paramref name="subset"/> is not found in <paramref name="superset"/>.
-    /// The message is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="subset"/> is null, or <paramref name="superset"/> is null,
-    /// or <paramref name="subset"/> contains at least one element not contained in
-    /// <paramref name="superset"/>.
-    /// </exception>
-    public static void IsSubsetOf([NotNull] ICollection? subset, [NotNull] ICollection? superset, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(subset, "CollectionAssert.IsSubsetOf", "subset", string.Empty);
         Assert.CheckParameterNotNull(superset, "CollectionAssert.IsSubsetOf", "superset", string.Empty);
         if (!IsSubsetOfHelper(subset, superset))
         {
-            Assert.ThrowAssertFailed("CollectionAssert.IsSubsetOf", Assert.BuildUserMessage(message, parameters));
+            Assert.ThrowAssertFailed("CollectionAssert.IsSubsetOf", Assert.BuildUserMessage(message));
         }
     }
 
@@ -462,7 +338,7 @@ public sealed class CollectionAssert
     /// or all elements of <paramref name="subset"/> are contained in <paramref name="superset"/>.
     /// </exception>
     public static void IsNotSubsetOf([NotNull] ICollection? subset, [NotNull] ICollection? superset)
-        => IsNotSubsetOf(subset, superset, string.Empty, null);
+        => IsNotSubsetOf(subset, superset, string.Empty);
 
     /// <summary>
     /// Tests whether one collection is not a subset of another collection and
@@ -485,39 +361,12 @@ public sealed class CollectionAssert
     /// or all elements of <paramref name="subset"/> are contained in <paramref name="superset"/>.
     /// </exception>
     public static void IsNotSubsetOf([NotNull] ICollection? subset, [NotNull] ICollection? superset, string? message)
-        => IsNotSubsetOf(subset, superset, message, null);
-
-    /// <summary>
-    /// Tests whether one collection is not a subset of another collection and
-    /// throws an exception if all elements in the subset are also in the
-    /// superset.
-    /// </summary>
-    /// <param name="subset">
-    /// The collection expected not to be a subset of <paramref name="superset"/>.
-    /// </param>
-    /// <param name="superset">
-    /// The collection expected not to be a superset of <paramref name="subset"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when every element in
-    /// <paramref name="subset"/> is also found in <paramref name="superset"/>.
-    /// The message is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="subset"/> is null, or <paramref name="superset"/> is null,
-    /// or all elements of <paramref name="subset"/> are contained in <paramref name="superset"/>.
-    /// </exception>
-    public static void IsNotSubsetOf([NotNull] ICollection? subset, [NotNull] ICollection? superset, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(subset, "CollectionAssert.IsNotSubsetOf", "subset", string.Empty);
         Assert.CheckParameterNotNull(superset, "CollectionAssert.IsNotSubsetOf", "superset", string.Empty);
         if (IsSubsetOfHelper(subset, superset))
         {
-            Assert.ThrowAssertFailed("CollectionAssert.IsNotSubsetOf", Assert.BuildUserMessage(message, parameters));
+            Assert.ThrowAssertFailed("CollectionAssert.IsNotSubsetOf", Assert.BuildUserMessage(message));
         }
     }
 
@@ -544,7 +393,7 @@ public sealed class CollectionAssert
     /// </exception>
     public static void AreEquivalent(
         [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual)
-        => AreEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, string.Empty, null);
+        => AreEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, string.Empty);
 
     /// <summary>
     /// Tests whether two collections contain the same elements and throws an
@@ -569,39 +418,8 @@ public sealed class CollectionAssert
     /// or if any element was found in one of the collections but not the other.
     /// </exception>
     public static void AreEquivalent(
-        [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual,
-        string? message)
-        => AreEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, message, null);
-
-    /// <summary>
-    /// Tests whether two collections contain the same elements and throws an
-    /// exception if either collection contains an element not in the other
-    /// collection.
-    /// </summary>
-    /// <param name="expected">
-    /// The first collection to compare. This contains the elements the test
-    /// expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by
-    /// the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when an element was found
-    /// in one of the collections but not the other. The message is shown
-    /// in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="expected"/> and <paramref name="actual"/> nullabilities don't match,
-    /// or if any element was found in one of the collections but not the other.
-    /// </exception>
-    public static void AreEquivalent(
-        [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => AreEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, message, parameters);
+        [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual, string? message)
+        => AreEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, message);
 
     /// <summary>
     /// Tests whether two collections contain the same elements and throws an
@@ -628,7 +446,7 @@ public sealed class CollectionAssert
     /// </exception>
     public static void AreEquivalent<T>(
         [NotNullIfNotNull(nameof(actual))] IEnumerable<T?>? expected, [NotNullIfNotNull(nameof(expected))] IEnumerable<T?>? actual, [NotNull] IEqualityComparer<T>? comparer)
-        => AreEquivalent(expected, actual, comparer, string.Empty, null);
+        => AreEquivalent(expected, actual, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether two collections contain the same elements and throws an
@@ -661,49 +479,13 @@ public sealed class CollectionAssert
     public static void AreEquivalent<T>(
         [NotNullIfNotNull(nameof(actual))] IEnumerable<T?>? expected, [NotNullIfNotNull(nameof(expected))] IEnumerable<T?>? actual, [NotNull] IEqualityComparer<T>? comparer,
         string? message)
-        => AreEquivalent(expected, actual, comparer, message, null);
-
-    /// <summary>
-    /// Tests whether two collections contain the same elements and throws an
-    /// exception if either collection contains an element not in the other
-    /// collection.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="expected">
-    /// The first collection to compare. This contains the elements the test
-    /// expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by
-    /// the code under test.
-    /// </param>
-    /// <param name="comparer">
-    /// The compare implementation to use when comparing elements of the collection.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when an element was found
-    /// in one of the collections but not the other. The message is shown
-    /// in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="expected"/> and <paramref name="actual"/> nullabilities don't match,
-    /// or if any element was found in one of the collections but not the other.
-    /// </exception>
-    public static void AreEquivalent<T>(
-        [NotNullIfNotNull(nameof(actual))] IEnumerable<T?>? expected, [NotNullIfNotNull(nameof(expected))] IEnumerable<T?>? actual, [NotNull] IEqualityComparer<T>? comparer,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(comparer, "Assert.AreCollectionsEqual", "comparer", string.Empty);
 
         // Check whether one is null while the other is not.
         if (expected == null != (actual == null))
         {
-            Assert.ThrowAssertFailed("CollectionAssert.AreEquivalent", Assert.BuildUserMessage(message, parameters));
+            Assert.ThrowAssertFailed("CollectionAssert.AreEquivalent", Assert.BuildUserMessage(message));
         }
 
         // If the references are the same or both collections are null, they are equivalent.
@@ -720,7 +502,7 @@ public sealed class CollectionAssert
         // Check whether the element counts are different.
         if (expectedCollectionCount != actualCollectionCount)
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(
                 CultureInfo.CurrentCulture,
                 FrameworkMessages.ElementNumbersDontMatch,
@@ -739,7 +521,7 @@ public sealed class CollectionAssert
         // Search for a mismatched element.
         if (FindMismatchedElement(expected, actual, comparer, out int expectedCount, out int actualCount, out object? mismatchedElement))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(
                 CultureInfo.CurrentCulture,
                 FrameworkMessages.ActualHasMismatchedElements,
@@ -773,7 +555,7 @@ public sealed class CollectionAssert
     /// </exception>
     public static void AreNotEquivalent(
         [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual)
-        => AreNotEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, string.Empty, null);
+        => AreNotEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, string.Empty);
 
     /// <summary>
     /// Tests whether two collections contain the different elements and throws an
@@ -801,38 +583,7 @@ public sealed class CollectionAssert
     public static void AreNotEquivalent(
         [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual,
         string? message)
-        => AreNotEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), EqualityComparer<object>.Default, message, null);
-
-    /// <summary>
-    /// Tests whether two collections contain the different elements and throws an
-    /// exception if the two collections contain identical elements without regard
-    /// to order.
-    /// </summary>
-    /// <param name="expected">
-    /// The first collection to compare. This contains the elements the test
-    /// expects to be different than the actual collection.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by
-    /// the code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// contains the same elements as <paramref name="expected"/>. The message
-    /// is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="expected"/> and <paramref name="actual"/> nullabilities don't match,
-    /// or if collections contain the same elements, including the same number of duplicate
-    /// occurrences of each element.
-    /// </exception>
-    public static void AreNotEquivalent(
-        [NotNullIfNotNull(nameof(actual))] ICollection? expected, [NotNullIfNotNull(nameof(expected))] ICollection? actual,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
-        => AreNotEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), comparer: EqualityComparer<object>.Default, message, parameters);
+        => AreNotEquivalent(expected?.Cast<object>(), actual?.Cast<object>(), comparer: EqualityComparer<object>.Default, message);
 
     /// <summary>
     /// Tests whether two collections contain the different elements and throws an
@@ -860,7 +611,7 @@ public sealed class CollectionAssert
     /// </exception>
     public static void AreNotEquivalent<T>(
         [NotNullIfNotNull(nameof(actual))] IEnumerable<T?>? expected, [NotNullIfNotNull(nameof(expected))] IEnumerable<T?>? actual, [NotNull] IEqualityComparer<T>? comparer)
-        => AreNotEquivalent(expected, actual, comparer, string.Empty, null);
+        => AreNotEquivalent(expected, actual, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether two collections contain the different elements and throws an
@@ -894,43 +645,6 @@ public sealed class CollectionAssert
     public static void AreNotEquivalent<T>(
         [NotNullIfNotNull(nameof(actual))] IEnumerable<T?>? expected, [NotNullIfNotNull(nameof(expected))] IEnumerable<T?>? actual, [NotNull] IEqualityComparer<T>? comparer,
         string? message)
-        => AreNotEquivalent(expected, actual, comparer, message, null);
-
-    /// <summary>
-    /// Tests whether two collections contain the different elements and throws an
-    /// exception if the two collections contain identical elements without regard
-    /// to order.
-    /// </summary>
-    /// <typeparam name="T">
-    /// The type of values to compare.
-    /// </typeparam>
-    /// <param name="expected">
-    /// The first collection to compare. This contains the elements the test
-    /// expects to be different than the actual collection.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by
-    /// the code under test.
-    /// </param>
-    /// <param name="comparer">
-    /// The compare implementation to use when comparing elements of the collection.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// contains the same elements as <paramref name="expected"/>. The message
-    /// is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="expected"/> and <paramref name="actual"/> nullabilities don't match,
-    /// or if collections contain the same elements, including the same number of duplicate
-    /// occurrences of each element.
-    /// </exception>
-    public static void AreNotEquivalent<T>(
-        [NotNullIfNotNull(nameof(actual))] IEnumerable<T?>? expected, [NotNullIfNotNull(nameof(expected))] IEnumerable<T?>? actual, [NotNull] IEqualityComparer<T>? comparer,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(comparer, "Assert.AreCollectionsEqual", "comparer", string.Empty);
 
@@ -944,7 +658,7 @@ public sealed class CollectionAssert
         // are equivalent. object.ReferenceEquals will handle case where both are null.
         if (object.ReferenceEquals(expected, actual))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(
                 CultureInfo.CurrentCulture,
                 FrameworkMessages.BothCollectionsSameReference,
@@ -964,7 +678,7 @@ public sealed class CollectionAssert
         // If both collections are empty, they are equivalent.
         if (!expected.Any())
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(
                 CultureInfo.CurrentCulture,
                 FrameworkMessages.BothCollectionsEmpty,
@@ -975,7 +689,7 @@ public sealed class CollectionAssert
         // Search for a mismatched element.
         if (!FindMismatchedElement(expected, actual, comparer, out _, out _, out _))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(
                 CultureInfo.CurrentCulture,
                 FrameworkMessages.BothSameElements,
@@ -1006,7 +720,7 @@ public sealed class CollectionAssert
     /// <paramref name="expectedType"/>.
     /// </exception>
     public static void AllItemsAreInstancesOfType([NotNull] ICollection? collection, [NotNull] Type? expectedType)
-        => AllItemsAreInstancesOfType(collection, expectedType, string.Empty, null);
+        => AllItemsAreInstancesOfType(collection, expectedType, string.Empty);
 
     /// <summary>
     /// Tests whether all elements in the specified collection are instances
@@ -1024,35 +738,6 @@ public sealed class CollectionAssert
     /// The message to include in the exception when an element in
     /// <paramref name="collection"/> is not an instance of
     /// <paramref name="expectedType"/>. The message is shown in test results.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="collection"/> is null or, <paramref name="expectedType"/> is null,
-    /// or some elements of <paramref name="collection"/> do not inherit/implement
-    /// <paramref name="expectedType"/>.
-    /// </exception>
-    public static void AllItemsAreInstancesOfType([NotNull] ICollection? collection, [NotNull] Type? expectedType,
-        string? message)
-        => AllItemsAreInstancesOfType(collection, expectedType, message, null);
-
-    /// <summary>
-    /// Tests whether all elements in the specified collection are instances
-    /// of the expected type and throws an exception if the expected type is
-    /// not in the inheritance hierarchy of one or more of the elements.
-    /// </summary>
-    /// <param name="collection">
-    /// The collection containing elements the test expects to be of the
-    /// specified type.
-    /// </param>
-    /// <param name="expectedType">
-    /// The expected type of each element of <paramref name="collection"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when an element in
-    /// <paramref name="collection"/> is not an instance of
-    /// <paramref name="expectedType"/>. The message is shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
     /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="collection"/> is null or, <paramref name="expectedType"/> is null,
@@ -1060,7 +745,7 @@ public sealed class CollectionAssert
     /// <paramref name="expectedType"/>.
     /// </exception>
     public static void AllItemsAreInstancesOfType(
-        [NotNull] ICollection? collection, [NotNull] Type? expectedType, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+        [NotNull] ICollection? collection, [NotNull] Type? expectedType, string? message)
     {
         Assert.CheckParameterNotNull(collection, "CollectionAssert.AllItemsAreInstancesOfType", "collection", string.Empty);
         Assert.CheckParameterNotNull(expectedType, "CollectionAssert.AllItemsAreInstancesOfType", "expectedType", string.Empty);
@@ -1071,7 +756,7 @@ public sealed class CollectionAssert
                 && element?.GetType().GetTypeInfo() is { } elementTypeInfo
                 && !expectedTypeInfo.IsAssignableFrom(elementTypeInfo))
             {
-                string userMessage = Assert.BuildUserMessage(message, parameters);
+                string userMessage = Assert.BuildUserMessage(message);
                 string finalMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     FrameworkMessages.ElementTypesAtIndexDontMatch,
@@ -1109,7 +794,7 @@ public sealed class CollectionAssert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(ICollection? expected, ICollection? actual)
-        => AreEqual(expected, actual, string.Empty, null);
+        => AreEqual(expected, actual, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collections are equal and throws an exception
@@ -1135,41 +820,11 @@ public sealed class CollectionAssert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(ICollection? expected, ICollection? actual, string? message)
-        => AreEqual(expected, actual, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collections are equal and throws an exception
-    /// if the two collections are not equal. Equality is defined as having the same
-    /// elements in the same order and quantity. Whether two elements are the same
-    /// is checked using <see cref="object.Equals(object, object)" /> method.
-    /// Different references to the same value are considered equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first collection to compare. This is the collection the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by the
-    /// code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(ICollection? expected, ICollection? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         string reason = string.Empty;
         if (!AreCollectionsEqual(expected, actual, new ObjectComparer(), ref reason))
         {
-            string finalMessage = ConstructFinalMessage(reason, message, parameters);
+            string finalMessage = ConstructFinalMessage(reason, message);
             Assert.ThrowAssertFailed("CollectionAssert.AreEqual", finalMessage);
         }
     }
@@ -1193,7 +848,7 @@ public sealed class CollectionAssert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(ICollection? notExpected, ICollection? actual)
-        => AreNotEqual(notExpected, actual, string.Empty, null);
+        => AreNotEqual(notExpected, actual, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collections are unequal and throws an exception
@@ -1219,41 +874,11 @@ public sealed class CollectionAssert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(ICollection? notExpected, ICollection? actual, string? message)
-        => AreNotEqual(notExpected, actual, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collections are unequal and throws an exception
-    /// if the two collections are equal. Equality is defined as having the same
-    /// elements in the same order and quantity. Whether two elements are the same
-    /// is checked using <see cref="object.Equals(object, object)" /> method.
-    /// Different references to the same value are considered equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first collection to compare. This is the collection the tests expects
-    /// not to match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by the
-    /// code under test.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(ICollection? notExpected, ICollection? actual, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
     {
         string reason = string.Empty;
         if (AreCollectionsEqual(notExpected, actual, new ObjectComparer(), ref reason))
         {
-            string finalMessage = ConstructFinalMessage(reason, message, parameters);
+            string finalMessage = ConstructFinalMessage(reason, message);
             Assert.ThrowAssertFailed("CollectionAssert.AreNotEqual", finalMessage);
         }
     }
@@ -1279,7 +904,7 @@ public sealed class CollectionAssert
     /// <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(ICollection? expected, ICollection? actual, [NotNull] IComparer? comparer)
-        => AreEqual(expected, actual, comparer, string.Empty, null);
+        => AreEqual(expected, actual, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collections are equal and throws an exception
@@ -1306,45 +931,12 @@ public sealed class CollectionAssert
     /// Thrown if <paramref name="expected"/> is not equal to
     /// <paramref name="actual"/>.
     /// </exception>
-    public static void AreEqual(ICollection? expected, ICollection? actual, [NotNull] IComparer? comparer,
-        string? message)
-        => AreEqual(expected, actual, comparer, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collections are equal and throws an exception
-    /// if the two collections are not equal. Equality is defined as having the same
-    /// elements in the same order and quantity. Different references to the same
-    /// value are considered equal.
-    /// </summary>
-    /// <param name="expected">
-    /// The first collection to compare. This is the collection the tests expects.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by the
-    /// code under test.
-    /// </param>
-    /// <param name="comparer">
-    /// The compare implementation to use when comparing elements of the collection.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is not equal to <paramref name="expected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="expected"/> is not equal to
-    /// <paramref name="actual"/>.
-    /// </exception>
-    public static void AreEqual(ICollection? expected, ICollection? actual, [NotNull] IComparer? comparer,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreEqual(ICollection? expected, ICollection? actual, [NotNull] IComparer? comparer, string? message)
     {
         string reason = string.Empty;
         if (!AreCollectionsEqual(expected, actual, comparer, ref reason))
         {
-            string finalMessage = ConstructFinalMessage(reason, message, parameters);
+            string finalMessage = ConstructFinalMessage(reason, message);
             Assert.ThrowAssertFailed("CollectionAssert.AreEqual", finalMessage);
         }
     }
@@ -1370,7 +962,7 @@ public sealed class CollectionAssert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(ICollection? notExpected, ICollection? actual, [NotNull] IComparer? comparer)
-        => AreNotEqual(notExpected, actual, comparer, string.Empty, null);
+        => AreNotEqual(notExpected, actual, comparer, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collections are unequal and throws an exception
@@ -1397,45 +989,12 @@ public sealed class CollectionAssert
     /// <exception cref="AssertFailedException">
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
-    public static void AreNotEqual(ICollection? notExpected, ICollection? actual, [NotNull] IComparer? comparer,
-        string? message)
-        => AreNotEqual(notExpected, actual, comparer, message, null);
-
-    /// <summary>
-    /// Tests whether the specified collections are unequal and throws an exception
-    /// if the two collections are equal. Equality is defined as having the same
-    /// elements in the same order and quantity. Different references to the same
-    /// value are considered equal.
-    /// </summary>
-    /// <param name="notExpected">
-    /// The first collection to compare. This is the collection the tests expects
-    /// not to match <paramref name="actual"/>.
-    /// </param>
-    /// <param name="actual">
-    /// The second collection to compare. This is the collection produced by the
-    /// code under test.
-    /// </param>
-    /// <param name="comparer">
-    /// The compare implementation to use when comparing elements of the collection.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="actual"/>
-    /// is equal to <paramref name="notExpected"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
-    /// </exception>
-    public static void AreNotEqual(ICollection? notExpected, ICollection? actual, [NotNull] IComparer? comparer,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
+    public static void AreNotEqual(ICollection? notExpected, ICollection? actual, [NotNull] IComparer? comparer, string? message)
     {
         string reason = string.Empty;
         if (AreCollectionsEqual(notExpected, actual, comparer, ref reason))
         {
-            string finalMessage = ConstructFinalMessage(reason, message, parameters);
+            string finalMessage = ConstructFinalMessage(reason, message);
             Assert.ThrowAssertFailed("CollectionAssert.AreNotEqual", finalMessage);
         }
     }
@@ -1684,10 +1243,9 @@ public sealed class CollectionAssert
 
     private static string ConstructFinalMessage(
         string reason,
-        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
+        string? message)
     {
-        string userMessage = Assert.BuildUserMessage(message, parameters);
+        string userMessage = Assert.BuildUserMessage(message);
         return userMessage.Length == 0
             ? reason
             : string.Format(CultureInfo.CurrentCulture, FrameworkMessages.CollectionEqualReason, userMessage, reason);

--- a/src/TestFramework/TestFramework/Assertions/StringAssert.cs
+++ b/src/TestFramework/TestFramework/Assertions/StringAssert.cs
@@ -8,8 +8,6 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed class StringAssert
 {
-    private static readonly object[] Empty = [];
-
     #region Singleton constructor
 
     private StringAssert()
@@ -63,7 +61,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains([NotNull] string? value, [NotNull] string? substring)
-        => Contains(value, substring, string.Empty, StringComparison.Ordinal);
+        => Contains(value, substring, StringComparison.Ordinal, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string contains the specified substring
@@ -84,7 +82,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains([NotNull] string? value, [NotNull] string? substring, StringComparison comparisonType)
-        => Contains(value, substring, string.Empty, comparisonType);
+        => Contains(value, substring, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string contains the specified substring
@@ -107,7 +105,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains([NotNull] string? value, [NotNull] string? substring, string? message)
-        => Contains(value, substring, message, StringComparison.Ordinal);
+        => Contains(value, substring, StringComparison.Ordinal, message);
 
     /// <summary>
     /// Tests whether the specified string contains the specified substring
@@ -119,84 +117,26 @@ public sealed class StringAssert
     /// </param>
     /// <param name="substring">
     /// The string expected to occur within <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="substring"/>
-    /// is not in <paramref name="value"/>. The message is shown in
-    /// test results.
     /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
-    /// </exception>
-    public static void Contains([NotNull] string? value, [NotNull] string? substring, string? message,
-        StringComparison comparisonType)
-        => Contains(value, substring, message, comparisonType, Empty);
-
-    /// <summary>
-    /// Tests whether the specified string contains the specified substring
-    /// and throws an exception if the substring does not occur within the
-    /// test string.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to contain <paramref name="substring"/>.
-    /// </param>
-    /// <param name="substring">
-    /// The string expected to occur within <paramref name="value"/>.
-    /// </param>
     /// <param name="message">
     /// The message to include in the exception when <paramref name="substring"/>
     /// is not in <paramref name="value"/>. The message is shown in
     /// test results.
     /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
-    public static void Contains([NotNull] string? value, [NotNull] string? substring, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
-        => Contains(value, substring, message, StringComparison.Ordinal, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string contains the specified substring
-    /// and throws an exception if the substring does not occur within the
-    /// test string.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to contain <paramref name="substring"/>.
-    /// </param>
-    /// <param name="substring">
-    /// The string expected to occur within <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="substring"/>
-    /// is not in <paramref name="value"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
-    /// </exception>
-    public static void Contains([NotNull] string? value, [NotNull] string? substring, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        StringComparison comparisonType, params object?[]? parameters)
+    public static void Contains([NotNull] string? value, [NotNull] string? substring, StringComparison comparisonType, string? message)
     {
         Assert.CheckParameterNotNull(value, "StringAssert.Contains", "value", string.Empty);
         Assert.CheckParameterNotNull(substring, "StringAssert.Contains", "substring", string.Empty);
         if (value.IndexOf(substring, comparisonType) < 0)
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.ContainsFail, value, substring, userMessage);
             Assert.ThrowAssertFailed("StringAssert.Contains", finalMessage);
         }
@@ -218,7 +158,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
     public static void StartsWith([NotNull] string? value, [NotNull] string? substring)
-        => StartsWith(value, substring, string.Empty, StringComparison.Ordinal);
+        => StartsWith(value, substring, StringComparison.Ordinal, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string begins with the specified substring
@@ -238,9 +178,8 @@ public sealed class StringAssert
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
-    public static void StartsWith([NotNull] string? value, [NotNull] string? substring,
-        StringComparison comparisonType)
-        => StartsWith(value, substring, string.Empty, comparisonType, Empty);
+    public static void StartsWith([NotNull] string? value, [NotNull] string? substring, StringComparison comparisonType)
+        => StartsWith(value, substring, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string begins with the specified substring
@@ -263,7 +202,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
     public static void StartsWith([NotNull] string? value, [NotNull] string? substring, string? message)
-        => StartsWith(value, substring, message, StringComparison.Ordinal);
+        => StartsWith(value, substring, StringComparison.Ordinal, message);
 
     /// <summary>
     /// Tests whether the specified string begins with the specified substring
@@ -275,84 +214,26 @@ public sealed class StringAssert
     /// </param>
     /// <param name="substring">
     /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not begin with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
-    /// </exception>
-    public static void StartsWith([NotNull] string? value, [NotNull] string? substring, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
-        => StartsWith(value, substring, message, StringComparison.Ordinal, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string begins with the specified substring
-    /// and throws an exception if the test string does not start with the
-    /// substring.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to begin with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="substring">
-    /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not begin with <paramref name="substring"/>. The message is
-    /// shown in test results.
     /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
-    /// </exception>
-    public static void StartsWith([NotNull] string? value, [NotNull] string? substring, string? message,
-        StringComparison comparisonType)
-        => StartsWith(value, substring, message, comparisonType, Empty);
-
-    /// <summary>
-    /// Tests whether the specified string begins with the specified substring
-    /// and throws an exception if the test string does not start with the
-    /// substring.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to begin with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="substring">
-    /// The string expected to be a prefix of <paramref name="value"/>.
-    /// </param>
     /// <param name="message">
     /// The message to include in the exception when <paramref name="value"/>
     /// does not begin with <paramref name="substring"/>. The message is
     /// shown in test results.
     /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not start with <paramref name="substring"/>.
     /// </exception>
-    public static void StartsWith([NotNull] string? value, [NotNull] string? substring, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        StringComparison comparisonType, params object?[]? parameters)
+    public static void StartsWith([NotNull] string? value, [NotNull] string? substring, StringComparison comparisonType, string? message)
     {
         Assert.CheckParameterNotNull(value, "StringAssert.StartsWith", "value", string.Empty);
         Assert.CheckParameterNotNull(substring, "StringAssert.StartsWith", "substring", string.Empty);
         if (!value.StartsWith(substring, comparisonType))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.StartsWithFail, value, substring, userMessage);
             Assert.ThrowAssertFailed("StringAssert.StartsWith", finalMessage);
         }
@@ -374,7 +255,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
     /// </exception>
     public static void EndsWith([NotNull] string? value, [NotNull] string? substring)
-        => EndsWith(value, substring, string.Empty, StringComparison.Ordinal);
+        => EndsWith(value, substring, StringComparison.Ordinal, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string ends with the specified substring
@@ -394,9 +275,8 @@ public sealed class StringAssert
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
     /// </exception>
-    public static void EndsWith([NotNull] string? value, [NotNull] string? substring,
-        StringComparison comparisonType)
-        => EndsWith(value, substring, string.Empty, comparisonType, Empty);
+    public static void EndsWith([NotNull] string? value, [NotNull] string? substring, StringComparison comparisonType)
+        => EndsWith(value, substring, comparisonType, string.Empty);
 
     /// <summary>
     /// Tests whether the specified string ends with the specified substring
@@ -419,7 +299,7 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
     /// </exception>
     public static void EndsWith([NotNull] string? value, [NotNull] string? substring, string? message)
-        => EndsWith(value, substring, message, StringComparison.Ordinal);
+        => EndsWith(value, substring, StringComparison.Ordinal, message);
 
     /// <summary>
     /// Tests whether the specified string ends with the specified substring
@@ -431,84 +311,26 @@ public sealed class StringAssert
     /// </param>
     /// <param name="substring">
     /// The string expected to be a suffix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not end with <paramref name="substring"/>. The message is
-    /// shown in test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
-    /// </exception>
-    public static void EndsWith([NotNull] string? value, [NotNull] string? substring, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        params object?[]? parameters)
-        => EndsWith(value, substring, message, StringComparison.Ordinal, parameters);
-
-    /// <summary>
-    /// Tests whether the specified string ends with the specified substring
-    /// and throws an exception if the test string does not end with the
-    /// substring.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to end with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="substring">
-    /// The string expected to be a suffix of <paramref name="value"/>.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not end with <paramref name="substring"/>. The message is
-    /// shown in test results.
     /// </param>
     /// <param name="comparisonType">
     /// The comparison method to compare strings <paramref name="comparisonType"/>.
     /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
-    /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
-    /// </exception>
-    public static void EndsWith([NotNull] string? value, [NotNull] string? substring, string? message,
-        StringComparison comparisonType)
-        => EndsWith(value, substring, message, comparisonType, Empty);
-
-    /// <summary>
-    /// Tests whether the specified string ends with the specified substring
-    /// and throws an exception if the test string does not end with the
-    /// substring.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to end with <paramref name="substring"/>.
-    /// </param>
-    /// <param name="substring">
-    /// The string expected to be a suffix of <paramref name="value"/>.
-    /// </param>
     /// <param name="message">
     /// The message to include in the exception when <paramref name="value"/>
     /// does not end with <paramref name="substring"/>. The message is
     /// shown in test results.
     /// </param>
-    /// <param name="comparisonType">
-    /// The comparison method to compare strings <paramref name="comparisonType"/>.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="substring"/> is null,
     /// or <paramref name="value"/> does not end with <paramref name="substring"/>.
     /// </exception>
-    public static void EndsWith([NotNull] string? value, [NotNull] string? substring, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message,
-        StringComparison comparisonType, params object?[]? parameters)
+    public static void EndsWith([NotNull] string? value, [NotNull] string? substring, StringComparison comparisonType, string? message)
     {
         Assert.CheckParameterNotNull(value, "StringAssert.EndsWith", "value", string.Empty);
         Assert.CheckParameterNotNull(substring, "StringAssert.EndsWith", "substring", string.Empty);
         if (!value.EndsWith(substring, comparisonType))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.EndsWithFail, value, substring, userMessage);
             Assert.ThrowAssertFailed("StringAssert.EndsWith", finalMessage);
         }
@@ -557,39 +379,13 @@ public sealed class StringAssert
     /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
     /// </exception>
     public static void Matches([NotNull] string? value, [NotNull] Regex? pattern, string? message)
-        => Matches(value, pattern, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string matches a regular expression and
-    /// throws an exception if the string does not match the expression.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected to match <paramref name="pattern"/>.
-    /// </param>
-    /// <param name="pattern">
-    /// The regular expression that <paramref name="value"/> is
-    /// expected to match.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// does not match <paramref name="pattern"/>. The message is shown in
-    /// test results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="pattern"/> is null,
-    /// or <paramref name="value"/> does not match <paramref name="pattern"/>.
-    /// </exception>
-    public static void Matches([NotNull] string? value, [NotNull] Regex? pattern, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(value, "StringAssert.Matches", "value", string.Empty);
         Assert.CheckParameterNotNull(pattern, "StringAssert.Matches", "pattern", string.Empty);
 
         if (!pattern.IsMatch(value))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsMatchFail, value, pattern, userMessage);
             Assert.ThrowAssertFailed("StringAssert.Matches", finalMessage);
         }
@@ -634,39 +430,13 @@ public sealed class StringAssert
     /// or <paramref name="value"/> matches <paramref name="pattern"/>.
     /// </exception>
     public static void DoesNotMatch([NotNull] string? value, [NotNull] Regex? pattern, string? message)
-        => DoesNotMatch(value, pattern, message, null);
-
-    /// <summary>
-    /// Tests whether the specified string does not match a regular expression
-    /// and throws an exception if the string matches the expression.
-    /// </summary>
-    /// <param name="value">
-    /// The string that is expected not to match <paramref name="pattern"/>.
-    /// </param>
-    /// <param name="pattern">
-    /// The regular expression that <paramref name="value"/> is
-    /// expected to not match.
-    /// </param>
-    /// <param name="message">
-    /// The message to include in the exception when <paramref name="value"/>
-    /// matches <paramref name="pattern"/>. The message is shown in test
-    /// results.
-    /// </param>
-    /// <param name="parameters">
-    /// An array of parameters to use when formatting <paramref name="message"/>.
-    /// </param>
-    /// <exception cref="AssertFailedException">
-    /// <paramref name="value"/> is null, or <paramref name="pattern"/> is null,
-    /// or <paramref name="value"/> matches <paramref name="pattern"/>.
-    /// </exception>
-    public static void DoesNotMatch([NotNull] string? value, [NotNull] Regex? pattern, [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string? message, params object?[]? parameters)
     {
         Assert.CheckParameterNotNull(value, "StringAssert.DoesNotMatch", "value", string.Empty);
         Assert.CheckParameterNotNull(pattern, "StringAssert.DoesNotMatch", "pattern", string.Empty);
 
         if (pattern.IsMatch(value))
         {
-            string userMessage = Assert.BuildUserMessage(message, parameters);
+            string userMessage = Assert.BuildUserMessage(message);
             string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsNotMatchFail, value, pattern, userMessage);
             Assert.ThrowAssertFailed("StringAssert.DoesNotMatch", finalMessage);
         }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests.cs
@@ -46,17 +46,12 @@ public sealed class AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests
                     [|Assert.AreEqual(s, "", EqualityComparer<string>.Default)|];
                     [|Assert.AreEqual(s, "", "some message")|];
                     [|Assert.AreEqual(s, "", EqualityComparer<string>.Default, "some message")|];
-                    [|Assert.AreEqual(s, "", "some message", 1, "input")|];
-                    [|Assert.AreEqual(s, "", EqualityComparer<string>.Default, "some message", 1, "input")|];
-
+                    
                     [|Assert.AreNotEqual(s, "", EqualityComparer<string>.Default)|];
                     [|Assert.AreNotEqual(s, "", "some message")|];
                     [|Assert.AreNotEqual(s, "", EqualityComparer<string>.Default, "some message")|];
-                    [|Assert.AreNotEqual(s, "", "some message", 1, "input")|];
-                    [|Assert.AreNotEqual(s, "", EqualityComparer<string>.Default, "some message", 1, "input")|];
 
                     [|Assert.AreSame(s, "", "some message")|];
-                    [|Assert.AreSame(s, "", "some message", 1, "input")|];
                 }
 
                 [TestMethod]
@@ -118,17 +113,12 @@ public sealed class AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests
                     Assert.AreEqual("", s, EqualityComparer<string>.Default);
                     Assert.AreEqual("", s, "some message");
                     Assert.AreEqual("", s, EqualityComparer<string>.Default, "some message");
-                    Assert.AreEqual("", s, "some message", 1, "input");
-                    Assert.AreEqual("", s, EqualityComparer<string>.Default, "some message", 1, "input");
 
                     Assert.AreNotEqual("", s, EqualityComparer<string>.Default);
                     Assert.AreNotEqual("", s, "some message");
                     Assert.AreNotEqual("", s, EqualityComparer<string>.Default, "some message");
-                    Assert.AreNotEqual("", s, "some message", 1, "input");
-                    Assert.AreNotEqual("", s, EqualityComparer<string>.Default, "some message", 1, "input");
 
                     Assert.AreSame("", s, "some message");
-                    Assert.AreSame("", s, "some message", 1, "input");
                 }
 
                 [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests.cs
@@ -46,7 +46,7 @@ public sealed class AssertionArgsShouldBePassedInCorrectOrderAnalyzerTests
                     [|Assert.AreEqual(s, "", EqualityComparer<string>.Default)|];
                     [|Assert.AreEqual(s, "", "some message")|];
                     [|Assert.AreEqual(s, "", EqualityComparer<string>.Default, "some message")|];
-                    
+
                     [|Assert.AreNotEqual(s, "", EqualityComparer<string>.Default)|];
                     [|Assert.AreNotEqual(s, "", "some message")|];
                     [|Assert.AreNotEqual(s, "", EqualityComparer<string>.Default, "some message")|];

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
@@ -26,30 +26,25 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
                     // Both are value types
                     [|Assert.AreSame(0, 0)|];
                     [|Assert.AreSame(0, 0, "Message")|];
-                    [|Assert.AreSame(0, 0, "Message {0}", "Arg")|];
                     [|Assert.AreSame(message: "Message", expected: 0, actual: 0)|];
 
                     [|Assert.AreSame<object>(0, 0)|];
                     [|Assert.AreSame<object>(0, 0, "Message")|];
-                    [|Assert.AreSame<object>(0, 0, "Message {0}", "Arg")|];
                     [|Assert.AreSame<object>(message: "Message", expected: 0, actual: 0)|];
 
                     // Expected is value type. This is always-failing assert.
                     [|Assert.AreSame<object>("0", 0)|];
                     [|Assert.AreSame<object>("0", 0, "Message")|];
-                    [|Assert.AreSame<object>("0", 0, "Message {0}", "Arg")|];
                     [|Assert.AreSame<object>(message: "Message", expected: "0", actual: 0)|];
 
                     // Actual is value type. This is always-failing assert.
                     [|Assert.AreSame<object>(0, "0")|];
                     [|Assert.AreSame<object>(0, "0", "Message")|];
-                    [|Assert.AreSame<object>(0, "0", "Message {0}", "Arg")|];
                     [|Assert.AreSame<object>(message: "Message", expected: 0, actual: "0")|];
 
                     // Both are reference types. No diagnostic.
                     Assert.AreSame("0", "0");
                     Assert.AreSame("0", "0", "Message");
-                    Assert.AreSame("0", "0", "Message {0}", "Arg");
                     Assert.AreSame(message: "Message", expected: "0", actual: "0");
                 }
             }
@@ -68,30 +63,25 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
                     // Both are value types
                     Assert.AreEqual(0, 0);
                     Assert.AreEqual(0, 0, "Message");
-                    Assert.AreEqual(0, 0, "Message {0}", "Arg");
                     Assert.AreEqual(message: "Message", expected: 0, actual: 0);
 
                     Assert.AreEqual<object>(0, 0);
                     Assert.AreEqual<object>(0, 0, "Message");
-                    Assert.AreEqual<object>(0, 0, "Message {0}", "Arg");
                     Assert.AreEqual<object>(message: "Message", expected: 0, actual: 0);
 
                     // Expected is value type. This is always-failing assert.
                     Assert.AreEqual<object>("0", 0);
                     Assert.AreEqual<object>("0", 0, "Message");
-                    Assert.AreEqual<object>("0", 0, "Message {0}", "Arg");
                     Assert.AreEqual<object>(message: "Message", expected: "0", actual: 0);
 
                     // Actual is value type. This is always-failing assert.
                     Assert.AreEqual<object>(0, "0");
                     Assert.AreEqual<object>(0, "0", "Message");
-                    Assert.AreEqual<object>(0, "0", "Message {0}", "Arg");
                     Assert.AreEqual<object>(message: "Message", expected: 0, actual: "0");
 
                     // Both are reference types. No diagnostic.
                     Assert.AreSame("0", "0");
                     Assert.AreSame("0", "0", "Message");
-                    Assert.AreSame("0", "0", "Message {0}", "Arg");
                     Assert.AreSame(message: "Message", expected: "0", actual: "0");
                 }
             }
@@ -116,30 +106,25 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
                     // Both are value types
                     [|Assert.AreNotSame(0, 1)|];
                     [|Assert.AreNotSame(0, 1, "Message")|];
-                    [|Assert.AreNotSame(0, 1, "Message {0}", "Arg")|];
                     [|Assert.AreNotSame(message: "Message", notExpected: 0, actual: 1)|];
 
                     [|Assert.AreNotSame<object>(0, 1)|];
                     [|Assert.AreNotSame<object>(0, 1, "Message")|];
-                    [|Assert.AreNotSame<object>(0, 1, "Message {0}", "Arg")|];
                     [|Assert.AreNotSame<object>(message: "Message", notExpected: 0, actual: 1)|];
 
                     // Expected is value type. This is always-failing assert.
                     [|Assert.AreNotSame<object>("0", 1)|];
                     [|Assert.AreNotSame<object>("0", 1, "Message")|];
-                    [|Assert.AreNotSame<object>("0", 1, "Message {0}", "Arg")|];
                     [|Assert.AreNotSame<object>(message: "Message", notExpected: "0", actual: 1)|];
 
                     // Actual is value type. This is always-failing assert.
                     [|Assert.AreNotSame<object>(0, "1")|];
                     [|Assert.AreNotSame<object>(0, "1", "Message")|];
-                    [|Assert.AreNotSame<object>(0, "1", "Message {0}", "Arg")|];
                     [|Assert.AreNotSame<object>(message: "Message", notExpected: 0, actual: "1")|];
 
                     // Both are reference types. No diagnostic.
                     Assert.AreNotSame("0", "1");
                     Assert.AreNotSame("0", "1", "Message");
-                    Assert.AreNotSame("0", "1", "Message {0}", "Arg");
                     Assert.AreNotSame(message: "Message", notExpected: "0", actual: "1");
                 }
             }
@@ -158,30 +143,25 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
                     // Both are value types
                     Assert.AreNotEqual(0, 1);
                     Assert.AreNotEqual(0, 1, "Message");
-                    Assert.AreNotEqual(0, 1, "Message {0}", "Arg");
                     Assert.AreNotEqual(message: "Message", notExpected: 0, actual: 1);
 
                     Assert.AreNotEqual<object>(0, 1);
                     Assert.AreNotEqual<object>(0, 1, "Message");
-                    Assert.AreNotEqual<object>(0, 1, "Message {0}", "Arg");
                     Assert.AreNotEqual<object>(message: "Message", notExpected: 0, actual: 1);
 
                     // Expected is value type. This is always-failing assert.
                     Assert.AreNotEqual<object>("0", 1);
                     Assert.AreNotEqual<object>("0", 1, "Message");
-                    Assert.AreNotEqual<object>("0", 1, "Message {0}", "Arg");
                     Assert.AreNotEqual<object>(message: "Message", notExpected: "0", actual: 1);
 
                     // Actual is value type. This is always-failing assert.
                     Assert.AreNotEqual<object>(0, "1");
                     Assert.AreNotEqual<object>(0, "1", "Message");
-                    Assert.AreNotEqual<object>(0, "1", "Message {0}", "Arg");
                     Assert.AreNotEqual<object>(message: "Message", notExpected: 0, actual: "1");
 
                     // Both are reference types. No diagnostic.
                     Assert.AreNotSame("0", "1");
                     Assert.AreNotSame("0", "1", "Message");
-                    Assert.AreNotSame("0", "1", "Message {0}", "Arg");
                     Assert.AreNotSame(message: "Message", notExpected: "0", actual: "1");
                 }
             }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -346,44 +346,6 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenAssertIsTrueIsPassedFalse_WithMessageAndArgsAsParams_Diagnostic()
-    {
-        string code = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod]
-                public void TestMethod()
-                {
-                    [|Assert.IsTrue(false, "message", "1")|];
-                    [|Assert.IsTrue(false, "message", "1", "2")|];
-                    [|Assert.IsTrue(false, "message", new object[] { "1", "2" })|];
-                    [|Assert.IsTrue(message: "message", parameters: new object[] { "1", "2" }, condition: false)|];
-                }
-            }
-            """;
-        string fixedCode = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod]
-                public void TestMethod()
-                {
-                    Assert.Fail("message", "1");
-                    Assert.Fail("message", "1", "2");
-                    Assert.Fail("message", new object[] { "1", "2" });
-                    Assert.Fail(message: "message", parameters: new object[] { "1", "2" });
-                }
-            }
-            """;
-        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
-    }
-
-    [TestMethod]
     public async Task WhenAssertIsTrueIsPassedFalse_WithMessageFirst_Diagnostic()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseNewerAssertThrowsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseNewerAssertThrowsAnalyzerTests.cs
@@ -41,12 +41,6 @@ public sealed class UseNewerAssertThrowsAnalyzerTests
                     [|Assert.ThrowsExceptionAsync<Exception>(message: "Message", action: () => Task.CompletedTask)|];
                     [|Assert.ThrowsExceptionAsync<Exception>(action: () => Task.CompletedTask, "Message")|];
                     [|Assert.ThrowsExceptionAsync<Exception>(() => Task.CompletedTask, message: "Message")|];
-
-                    // action, message, and parameters overload
-                    [|Assert.ThrowsException<Exception>(() => Console.WriteLine(), "Message", "A", "B", "C")|];
-                    [|Assert.ThrowsException<Exception>(() => Console.WriteLine(), "Message", parameters: new object[] { "A", "B", "C" })|];
-                    [|Assert.ThrowsExceptionAsync<Exception>(() => Task.CompletedTask, "Message", "A", "B", "C")|];
-                    [|Assert.ThrowsExceptionAsync<Exception>(() => Task.CompletedTask, "Message", parameters: new object[] { "A", "B", "C" })|];
                 }
             }
             """;
@@ -79,12 +73,6 @@ public sealed class UseNewerAssertThrowsAnalyzerTests
                     Assert.ThrowsExactlyAsync<Exception>(message: "Message", action: () => Task.CompletedTask);
                     Assert.ThrowsExactlyAsync<Exception>(action: () => Task.CompletedTask, "Message");
                     Assert.ThrowsExactlyAsync<Exception>(() => Task.CompletedTask, message: "Message");
-
-                    // action, message, and parameters overload
-                    Assert.ThrowsExactly<Exception>(() => Console.WriteLine(), "Message", "A", "B", "C");
-                    Assert.ThrowsExactly<Exception>(() => Console.WriteLine(), "Message", messageArgs: new object[] { "A", "B", "C" });
-                    Assert.ThrowsExactlyAsync<Exception>(() => Task.CompletedTask, "Message", "A", "B", "C");
-                    Assert.ThrowsExactlyAsync<Exception>(() => Task.CompletedTask, "Message", messageArgs: new object[] { "A", "B", "C" });
                 }
             }
             """;

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreSame.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreSame.cs
@@ -45,18 +45,6 @@ public partial class AssertTests
         Verify(o.WasToStringCalled);
     }
 
-    public void AreSame_MessageArgs_PassSameObject_ShouldPass()
-    {
-        object o = new();
-        Assert.AreSame(o, o, "User-provided message: {0}", new object().GetType());
-    }
-
-    public void AreSame_MessageArgs_PassDifferentObject_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.AreSame(new object(), new object(), "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.AreSame failed. User-provided message: System.Object type: System.Object");
-    }
-
     public void AreNotSame_PassDifferentObject_ShouldPass()
         => Assert.AreNotSame(new object(), new object());
 
@@ -75,12 +63,6 @@ public partial class AssertTests
     public void AreSame_InterpolatedString_BothAreValueTypes_ShouldFailWithSpecializedMessage()
     {
         Exception ex = VerifyThrows(() => Assert.AreSame(1, 1, $"User-provided message {new object().GetType()}"));
-        Verify(ex.Message == "Assert.AreSame failed. Do not pass value types to AreSame(). Values converted to Object will never be the same. Consider using AreEqual(). User-provided message System.Object");
-    }
-
-    public void AreSame_MessageArgs_BothAreValueTypes_ShouldFailWithSpecializedMessage()
-    {
-        Exception ex = VerifyThrows(() => Assert.AreSame(1, 1, "User-provided message {0}", new object().GetType()));
         Verify(ex.Message == "Assert.AreSame failed. Do not pass value types to AreSame(). Values converted to Object will never be the same. Consider using AreEqual(). User-provided message System.Object");
     }
 
@@ -115,15 +97,5 @@ public partial class AssertTests
         Exception ex = await VerifyThrowsAsync(async () => Assert.AreNotSame(o, o, $"User-provided message. {o}, {o,35}, {await GetHelloStringAsync()}, {new DummyIFormattable()}, {dateTime:tt}, {dateTime,5:tt}"));
         Verify(ex.Message == $"Assert.AreNotSame failed. User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}");
         Verify(o.WasToStringCalled);
-    }
-
-    public void AreNotSame_MessageArgs_PassDifferentObject_ShouldPass()
-        => Assert.AreNotSame(new object(), new object(), "User-provided message: {0}", new object().GetType());
-
-    public void AreNotSame_MessageArgs_PassSameObject_ShouldFail()
-    {
-        object o = new();
-        Exception ex = VerifyThrows(() => Assert.AreNotSame(o, o, "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.AreNotSame failed. User-provided message: System.Object type: System.Object");
     }
 }

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
@@ -311,22 +311,6 @@ public partial class AssertTests : TestContainer
         action.Should().Throw<AssertFailedException>().WithMessage("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). ");
     }
 
-    /// <summary>
-    /// Tests the ContainsSingle method with message and parameters when the collection does not have exactly one element.
-    /// Expects an exception.
-    /// </summary>
-    public void ContainsSingle_WithMessageAndParams_WithInvalidCollection_ThrowsException()
-    {
-        // Arrange
-        var collection = new List<string> { "a", "b" };
-
-        // Act
-        Action action = () => Assert.ContainsSingle(collection, "Expected: {0}", "SingleItem");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("*SingleItem*");
-    }
-
     #endregion
 
     #region Contains Tests
@@ -340,7 +324,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 5, 10, 15 };
 
         // Act
-        Action action = () => Assert.Contains(10, collection, "No failure expected", null);
+        Action action = () => Assert.Contains(10, collection, "No failure expected");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -356,7 +340,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 5, 10, 15 };
 
         // Act
-        Action action = () => Assert.Contains(20, collection, "Item {0} not found", 20);
+        Action action = () => Assert.Contains(20, collection, "Item 20 not found");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*20*");
@@ -372,7 +356,7 @@ public partial class AssertTests : TestContainer
         IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
 
         // Act
-        Action action = () => Assert.Contains("APPLE", collection, comparer, "Should find apple", null);
+        Action action = () => Assert.Contains("APPLE", collection, comparer, "Should find apple");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -389,7 +373,7 @@ public partial class AssertTests : TestContainer
         IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
 
         // Act
-        Action action = () => Assert.Contains("cherry", collection, comparer, "Missing {0}", "cherry");
+        Action action = () => Assert.Contains("cherry", collection, comparer, "Missing cherry");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*cherry*");
@@ -404,7 +388,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 2, 4, 6 };
 
         // Act
-        Action action = () => Assert.Contains(IsEven, collection, "Even number exists", null);
+        Action action = () => Assert.Contains(IsEven, collection, "Even number exists");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -420,7 +404,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 1, 3, 5 };
 
         // Act
-        Action action = () => Assert.Contains(IsEven, collection, "No even number found", null);
+        Action action = () => Assert.Contains(IsEven, collection, "No even number found");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*even*");
@@ -436,7 +420,7 @@ public partial class AssertTests : TestContainer
         string substring = "brown";
 
         // Act
-        Action action = () => Assert.Contains(substring, value, StringComparison.Ordinal, "Substring found", null);
+        Action action = () => Assert.Contains(substring, value, StringComparison.Ordinal, "Substring found");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -453,7 +437,7 @@ public partial class AssertTests : TestContainer
         string substring = "lazy";
 
         // Act
-        Action action = () => Assert.Contains(substring, value, StringComparison.Ordinal, "Missing substring", null);
+        Action action = () => Assert.Contains(substring, value, StringComparison.Ordinal, "Missing substring");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*lazy*");
@@ -472,7 +456,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 5, 10, 15 };
 
         // Act
-        Action action = () => Assert.DoesNotContain(20, collection, "No failure expected", null);
+        Action action = () => Assert.DoesNotContain(20, collection, "No failure expected");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -488,7 +472,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 5, 10, 15 };
 
         // Act
-        Action action = () => Assert.DoesNotContain(10, collection, "Item {0} should not be found", 10);
+        Action action = () => Assert.DoesNotContain(10, collection, "Item 10 should not be found");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*10*");
@@ -504,7 +488,7 @@ public partial class AssertTests : TestContainer
         IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
 
         // Act
-        Action action = () => Assert.DoesNotContain("cherry", collection, comparer, "No cherry found", null);
+        Action action = () => Assert.DoesNotContain("cherry", collection, comparer, "No cherry found");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -521,7 +505,7 @@ public partial class AssertTests : TestContainer
         IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
 
         // Act
-        Action action = () => Assert.DoesNotContain("APPLE", collection, comparer, "Unexpected {0}", "APPLE");
+        Action action = () => Assert.DoesNotContain("APPLE", collection, comparer, "Unexpected \"APPLE\"");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*APPLE*");
@@ -536,7 +520,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 1, 3, 5 };
 
         // Act
-        Action action = () => Assert.DoesNotContain(IsEven, collection, "All items are odd", null);
+        Action action = () => Assert.DoesNotContain(IsEven, collection, "All items are odd");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -552,7 +536,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 2, 3, 5 };
 
         // Act
-        Action action = () => Assert.DoesNotContain(IsEven, collection, "An even number exists", null);
+        Action action = () => Assert.DoesNotContain(IsEven, collection, "An even number exists");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*even*");
@@ -568,7 +552,7 @@ public partial class AssertTests : TestContainer
         string substring = "lazy";
 
         // Act
-        Action action = () => Assert.DoesNotContain(substring, value, StringComparison.Ordinal, "Should not contain", null);
+        Action action = () => Assert.DoesNotContain(substring, value, StringComparison.Ordinal, "Should not contain");
 
         // Assert
         action.Should().NotThrow<AssertFailedException>();
@@ -585,7 +569,7 @@ public partial class AssertTests : TestContainer
         string substring = "brown";
 
         // Act
-        Action action = () => Assert.DoesNotContain(substring, value, StringComparison.Ordinal, "Unexpected substring", null);
+        Action action = () => Assert.DoesNotContain(substring, value, StringComparison.Ordinal, "Unexpected substring");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*brown*");
@@ -671,7 +655,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 1, 3, 5 };
 
         // Act
-        Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection, "No even numbers found in collection with {0} items", collection.Count);
+        Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection, $"No even numbers found in collection with {collection.Count} items");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*No even numbers found in collection with 3 items*");
@@ -687,7 +671,7 @@ public partial class AssertTests : TestContainer
         var collection = new List<int> { 2, 4, 6 };
 
         // Act
-        Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection, "Too many even numbers found: {0}", collection.Count);
+        Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection, $"Too many even numbers found: {collection.Count}");
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage("*Too many even numbers found: 3*");

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IComparableTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IComparableTests.cs
@@ -45,16 +45,6 @@ public partial class AssertTests : TestContainer
             .WithMessage("Assert.IsGreaterThan failed. Actual value <5> is not greater than expected value <10>. A Message");
     }
 
-    public void IsGreaterThanShouldThrowWithMessageAndParameters()
-    {
-        // Act
-        Action action = () => Assert.IsGreaterThan(10, 5, "A Message {0}", "param");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsGreaterThan failed. Actual value <5> is not greater than expected value <10>. A Message param");
-    }
-
     public void IsGreaterThanShouldWorkWithDoubles() =>
         Assert.IsGreaterThan(5.0, 5.5);
 
@@ -97,16 +87,6 @@ public partial class AssertTests : TestContainer
         // Assert
         action.Should().Throw<AssertFailedException>()
             .WithMessage("Assert.IsGreaterThanOrEqualTo failed. Actual value <5> is not greater than or equal to expected value <10>. A Message");
-    }
-
-    public void IsGreaterThanOrEqualToShouldThrowWithMessageAndParameters()
-    {
-        // Act
-        Action action = () => Assert.IsGreaterThanOrEqualTo(10, 5, "A Message {0}", "param");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsGreaterThanOrEqualTo failed. Actual value <5> is not greater than or equal to expected value <10>. A Message param");
     }
 
     public void IsGreaterThanOrEqualToShouldWorkWithDoubles() =>
@@ -153,16 +133,6 @@ public partial class AssertTests : TestContainer
             .WithMessage("Assert.IsLessThan failed. Actual value <10> is not less than expected value <5>. A Message");
     }
 
-    public void IsLessThanShouldThrowWithMessageAndParameters()
-    {
-        // Act
-        Action action = () => Assert.IsLessThan(5, 10, "A Message {0}", "param");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsLessThan failed. Actual value <10> is not less than expected value <5>. A Message param");
-    }
-
     public void IsLessThanShouldWorkWithDoubles() =>
         Assert.IsLessThan(5.5, 5.0);
 
@@ -205,16 +175,6 @@ public partial class AssertTests : TestContainer
         // Assert
         action.Should().Throw<AssertFailedException>()
             .WithMessage("Assert.IsLessThanOrEqualTo failed. Actual value <10> is not less than or equal to expected value <5>. A Message");
-    }
-
-    public void IsLessThanOrEqualToShouldThrowWithMessageAndParameters()
-    {
-        // Act
-        Action action = () => Assert.IsLessThanOrEqualTo(5, 10, "A Message {0}", "param");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsLessThanOrEqualTo failed. Actual value <10> is not less than or equal to expected value <5>. A Message param");
     }
 
     public void IsLessThanOrEqualToShouldWorkWithDoubles() =>
@@ -274,16 +234,6 @@ public partial class AssertTests : TestContainer
         // Assert
         action.Should().Throw<AssertFailedException>()
             .WithMessage("Assert.IsPositive failed. Expected value <-5> to be positive. A Message");
-    }
-
-    public void IsPositiveShouldThrowWithMessageAndParameters()
-    {
-        // Act
-        Action action = () => Assert.IsPositive(-5, "A Message {0}", "param");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsPositive failed. Expected value <-5> to be positive. A Message param");
     }
 
     public void IsPositiveShouldWorkWithDoubles() =>
@@ -349,16 +299,6 @@ public partial class AssertTests : TestContainer
         // Assert
         action.Should().Throw<AssertFailedException>()
             .WithMessage("Assert.IsNegative failed. Expected value <5> to be negative. A Message");
-    }
-
-    public void IsNegativeShouldThrowWithMessageAndParameters()
-    {
-        // Act
-        Action action = () => Assert.IsNegative(5, "A Message {0}", "param");
-
-        // Assert
-        action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsNegative failed. Expected value <5> to be negative. A Message param");
     }
 
     public void IsNegativeShouldWorkWithDoubles() =>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.InconclusiveTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.InconclusiveTests.cs
@@ -11,9 +11,4 @@ public partial class AssertTests
         Exception ex = VerifyThrows<AssertInconclusiveException>(() => Assert.Inconclusive("{"));
         Verify(ex.Message.Contains("Assert.Inconclusive failed. {"));
     }
-
-    // See https://github.com/dotnet/sdk/issues/25373
-    [SuppressMessage("Usage", "CA2241:Provide correct arguments to formatting methods", Justification = "We want to test invalid format")]
-    public void InconclusiveThrowsWhenMessageContainsInvalidStringFormatComposite() =>
-        VerifyThrows<FormatException>(() => Assert.Inconclusive("{", "arg"));
 }

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInRange.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInRange.cs
@@ -88,24 +88,6 @@ public partial class AssertTests : TestContainer
             .And.Contain(customMessage);
     }
 
-    public void IsInRange_WithMessageAndParameters_FormatsMessage()
-    {
-        // Arrange
-        int minValue = 1;
-        int maxValue = 5;
-        int value = 10;
-        string messageFormat = "Test with parameter: {0}";
-        string parameter = "TestValue";
-
-        // Act
-        Action action = () => Assert.IsInRange(minValue, maxValue, value, messageFormat, parameter);
-
-        // Assert
-        action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '10' is not within the expected range [1, 5]")
-            .And.Contain("Test with parameter: TestValue");
-    }
-
     public void IsInRange_WithDoubleValues_WorksCorrectly()
     {
         // Arrange
@@ -174,17 +156,6 @@ public partial class AssertTests : TestContainer
 
         // Act & Assert
         Assert.IsInRange(minValue, maxValue, value, string.Empty);
-    }
-
-    public void IsInRange_WithNullParameters_DoesNotThrow()
-    {
-        // Arrange
-        int minValue = 1;
-        int maxValue = 5;
-        int value = 3;
-
-        // Act & Assert
-        Assert.IsInRange(minValue, maxValue, value, "Test message", null);
     }
 
     public void IsInRange_WithAllNegativeValuesInRange_DoesNotThrow()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInstanceOfTypeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInstanceOfTypeTests.cs
@@ -201,34 +201,6 @@ public partial class AssertTests
         _ = obj.ToString(); // no warning about possible null
     }
 
-    public void IsInstanceOfType_WhenNonNullNullableValueAndCompositeMessage_LearnNonNull()
-    {
-        object? obj = GetObj();
-        Assert.IsInstanceOfType(obj, typeof(object), "my message with {0}", "arg");
-        _ = obj.ToString(); // no warning about possible null
-    }
-
-    public void IsInstanceOfType_WhenNonNullNullableTypeAndCompositeMessage_LearnNonNull()
-    {
-        Type? objType = GetObjType();
-        Assert.IsInstanceOfType(new object(), objType, "my message with {0}", "arg");
-        _ = objType.ToString(); // no warning about possible null
-    }
-
-    public void IsInstanceOfTypeGeneric_WhenNonNullNullableValueAndCompositeMessage_LearnNonNull()
-    {
-        object? obj = GetObj();
-        Assert.IsInstanceOfType<object>(obj, "my message with {0}", "arg");
-        _ = obj.ToString(); // no warning about possible null
-    }
-
-    public void IsInstanceOfTypeGenericWithOutParameter_WhenNonNullNullableValueAndCompositeMessage_LearnNonNull()
-    {
-        object? obj = GetObj();
-        Assert.IsInstanceOfType<object>(obj, "my message with {0}", "arg");
-        _ = obj.ToString(); // no warning about possible null
-    }
-
     public void IsNotInstanceOfType_WhenNonNullNullableType_LearnNonNull()
     {
         Type? intType = GetIntType();
@@ -240,13 +212,6 @@ public partial class AssertTests
     {
         Type? intType = GetIntType();
         Assert.IsNotInstanceOfType(new object(), intType, "my message");
-        _ = intType.ToString(); // no warning about possible null
-    }
-
-    public void IsNotInstanceOfType_WhenNonNullNullableTypeAndCompositeMessage_LearnNonNull()
-    {
-        Type? intType = GetIntType();
-        Assert.IsNotInstanceOfType(new object(), intType, "my message with {0}", "arg");
         _ = intType.ToString(); // no warning about possible null
     }
 

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsNull.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsNull.cs
@@ -41,15 +41,6 @@ public partial class AssertTests : TestContainer
         Verify(o.WasToStringCalled);
     }
 
-    public void IsNull_MessageFormat_PassNull_ShouldPass()
-        => Assert.IsNull(null, "User-provided message {0}", new object().GetType());
-
-    public void IsNull_MessageFormat_PassNonNull_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.IsNull(new object(), "User-provided message {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.IsNull failed. User-provided message System.Object");
-    }
-
     public void IsNotNull_WhenNonNullNullableValue_DoesNotThrowAndLearnNotNull()
     {
         object? obj = GetObj();
@@ -73,13 +64,6 @@ public partial class AssertTests : TestContainer
         _ = obj.ToString(); // No potential NRE warning
     }
 
-    public void IsNotNull_WhenNonNullNullableValueAndCompositeMessage_DoesNotThrowAndLearnNotNull()
-    {
-        object? obj = GetObj();
-        Assert.IsNotNull(obj, "my message with {0}", "some arg");
-        _ = obj.ToString(); // No potential NRE warning
-    }
-
     public void IsNotNull_PassNull_ShouldFail()
     {
         Exception ex = VerifyThrows(() => Assert.IsNotNull(null));
@@ -99,11 +83,5 @@ public partial class AssertTests : TestContainer
         Exception ex = await VerifyThrowsAsync(async () => Assert.IsNotNull(null, $"User-provided message. {o}, {o,35}, {await GetHelloStringAsync()}, {new DummyIFormattable()}, {dateTime:tt}, {dateTime,5:tt}"));
         Verify(ex.Message == $"Assert.IsNotNull failed. User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}");
         Verify(o.WasToStringCalled);
-    }
-
-    public void IsNotNull_MessageFormat_PassNonNull_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.IsNotNull(null, "User-provided message {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.IsNotNull failed. User-provided message System.Object");
     }
 }

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsTrueTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsTrueTests.cs
@@ -98,35 +98,6 @@ public partial class AssertTests
     public void IsFalseBooleanInterpolatedStringMessageShouldNotFailWithFalse()
         => Assert.IsFalse(false, $"User-provided message. Input: {false}");
 
-    public void IsFalseNullableBooleanMessageArgsShouldFailWithNull()
-    {
-        bool? nullBool = null;
-        Exception ex = VerifyThrows(() => Assert.IsFalse(nullBool, "User-provided message. Input: {0}", nullBool));
-        Verify(ex.Message == "Assert.IsFalse failed. User-provided message. Input: ");
-    }
-
-    public void IsFalseNullableBooleanMessageArgsShouldFailWithTrue()
-    {
-        bool? nullBool = true;
-        Exception ex = VerifyThrows(() => Assert.IsFalse(nullBool, "User-provided message. Input: {0}", nullBool));
-        Verify(ex.Message == "Assert.IsFalse failed. User-provided message. Input: True");
-    }
-
-    public void IsFalseNullableBooleanMessageArgsShouldNotFailWithFalse()
-    {
-        bool? nullBool = false;
-        Assert.IsFalse(nullBool, "User-provided message. Input: {0}", nullBool);
-    }
-
-    public void IsFalseBooleanMessageArgsShouldFailWithTrue()
-    {
-        Exception ex = VerifyThrows(() => Assert.IsFalse(true, "User-provided message. Input: {0}", true));
-        Verify(ex.Message == "Assert.IsFalse failed. User-provided message. Input: True");
-    }
-
-    public void IsFalseBooleanMessageArgsShouldNotFailWithFalse()
-        => Assert.IsFalse(false, "User-provided message. Input: {0}", false);
-
     public void IsTrueNullableBooleanShouldFailWithNull()
     {
         bool? nullBool = null;
@@ -219,33 +190,4 @@ public partial class AssertTests
 
     public void IsTrueBooleanInterpolatedStringMessageShouldNotFailWithTrue()
         => Assert.IsTrue(true, $"User-provided message. Input: {true}");
-
-    public void IsTrueNullableBooleanMessageArgsShouldFailWithNull()
-    {
-        bool? nullBool = null;
-        Exception ex = VerifyThrows(() => Assert.IsTrue(nullBool, "User-provided message. Input: {0}", nullBool));
-        Verify(ex.Message == "Assert.IsTrue failed. User-provided message. Input: ");
-    }
-
-    public void IsTrueNullableBooleanMessageArgsShouldFailWithFalse()
-    {
-        bool? nullBool = false;
-        Exception ex = VerifyThrows(() => Assert.IsTrue(nullBool, "User-provided message. Input: {0}", nullBool));
-        Verify(ex.Message == "Assert.IsTrue failed. User-provided message. Input: False");
-    }
-
-    public void IsTrueNullableBooleanMessageArgsShouldNotFailWithTrue()
-    {
-        bool? nullBool = true;
-        Assert.IsTrue(nullBool, "User-provided message. Input: {0}", nullBool);
-    }
-
-    public void IsTrueBooleanMessageArgsShouldFailWithFalse()
-    {
-        Exception ex = VerifyThrows(() => Assert.IsTrue(false, "User-provided message. Input: {0}", false));
-        Verify(ex.Message == "Assert.IsTrue failed. User-provided message. Input: False");
-    }
-
-    public void IsTrueBooleanMessageArgsShouldNotFailWithTrue()
-        => Assert.IsTrue(true, "User-provided message. Input: {0}", true);
 }

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
@@ -25,12 +25,6 @@ public partial class AssertTests
         Verify(ex.Message == "Assert.HasCount failed. Expected collection of size 3. Actual: 1. ");
     }
 
-    public void Count_MessageArgs_WhenCountIsNotSame_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.HasCount(1, Array.Empty<float>(), "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.HasCount failed. Expected collection of size 1. Actual: 0. User-provided message: System.Object type: System.Object");
-    }
-
     public async Task Count_InterpolatedString_WhenCountIsNotSame_ShouldFail()
     {
         DummyClassTrackingToStringCalls o = new();
@@ -55,13 +49,6 @@ public partial class AssertTests
         var collection = new List<int> { 1 };
         Exception ex = VerifyThrows(() => Assert.IsEmpty(collection));
         Verify(ex.Message == "Assert.IsEmpty failed. Expected collection of size 0. Actual: 1. ");
-    }
-
-    public void NotAny_MessageArgs_WhenNotEmpty_ShouldFail()
-    {
-        var collection = new List<int> { 1 };
-        Exception ex = VerifyThrows(() => Assert.IsEmpty(collection, "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.IsEmpty failed. Expected collection of size 0. Actual: 1. User-provided message: System.Object type: System.Object");
     }
 
     public async Task NotAny_InterpolatedString_WhenNotEmpty_ShouldFail()
@@ -99,18 +86,6 @@ public partial class AssertTests
     {
         Exception ex = VerifyThrows(() => Assert.ContainsSingle([1, 2, 3]));
         Verify(ex.Message == "Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). ");
-    }
-
-    public void Single_MessageArgs_WhenNoItem_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.ContainsSingle(Array.Empty<float>(), "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 0 element(s). User-provided message: System.Object type: System.Object");
-    }
-
-    public void Single_MessageArgs_WhenMultipleItems_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.ContainsSingle([1, 2, 3], "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). User-provided message: System.Object type: System.Object");
     }
 
     public async Task Single_InterpolatedString_WhenNoItem_ShouldFail()
@@ -161,20 +136,6 @@ public partial class AssertTests
         Verify(ex.Message == "Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 3 item(s). ");
     }
 
-    public void SinglePredicate_MessageArgs_WhenNoItemMatches_ShouldFail()
-    {
-        var collection = new List<int> { 1, 3, 5 };
-        Exception ex = VerifyThrows(() => Assert.ContainsSingle(x => x % 2 == 0, collection, "No even numbers found: {0}", "test"));
-        Verify(ex.Message == "Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). No even numbers found: test");
-    }
-
-    public void SinglePredicate_MessageArgs_WhenMultipleItemsMatch_ShouldFail()
-    {
-        var collection = new List<int> { 2, 4, 6 };
-        Exception ex = VerifyThrows(() => Assert.ContainsSingle(x => x % 2 == 0, collection, "Too many even numbers: {0}", "test"));
-        Verify(ex.Message == "Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 3 item(s). Too many even numbers: test");
-    }
-
     public void Any_WhenOneItem_ShouldPass()
     {
         var collection = new List<int> { 1 };
@@ -205,12 +166,6 @@ public partial class AssertTests
     {
         Exception ex = VerifyThrows(() => Assert.IsNotEmpty(Array.Empty<int>()));
         Verify(ex.Message == "Assert.IsNotEmpty failed. Expected collection to contain any item but it is empty. ");
-    }
-
-    public void Any_MessageArgs_WhenNoItem_ShouldFail()
-    {
-        Exception ex = VerifyThrows(() => Assert.IsNotEmpty(Array.Empty<float>(), "User-provided message: System.Object type: {0}", new object().GetType()));
-        Verify(ex.Message == "Assert.IsNotEmpty failed. Expected collection to contain any item but it is empty. User-provided message: System.Object type: System.Object");
     }
 
     public async Task Any_InterpolatedString_WhenNoItem_ShouldFail()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
@@ -38,12 +38,6 @@ public partial class AssertTests
         Exception ex = VerifyThrows<AssertFailedException>(() => Assert.ThrowsException<ArgumentException>(() => null, "message"));
         Verify(ex.Message.Equals("Assert.ThrowsException failed. Expected exception type:<System.ArgumentException> but no exception was thrown. message", StringComparison.Ordinal));
     }
-
-    public void ThrowsException_FuncArgumentOverloadWithMessagesAndParameters_AllowsToReturnNull()
-    {
-        Exception ex = VerifyThrows<AssertFailedException>(() => Assert.ThrowsException<ArgumentException>(() => null, "message {0}", 1));
-        Verify(ex.Message.Equals("Assert.ThrowsException failed. Expected exception type:<System.ArgumentException> but no exception was thrown. message 1", StringComparison.Ordinal));
-    }
     #endregion
 
     #region ThrowsExceptionAsync tests.
@@ -122,74 +116,6 @@ public partial class AssertTests
         Verify(innerException.Message.Equals("Assert.ThrowsExceptionAsync failed. Expected exception type:<System.ArgumentException>. Actual exception type:<System.FormatException>. Happily ever after.", StringComparison.Ordinal));
     }
 
-    public void ThrowsExceptionAsyncWithMessageAndParamsShouldThrowOnNullAction()
-    {
-        static void A()
-        {
-            Task t = Assert.ThrowsExceptionAsync<ArgumentException>(null!, null!, null);
-            t.Wait();
-        }
-
-        Exception ex = VerifyThrows(A);
-
-        Exception? innerException = ex.InnerException;
-
-        Verify(innerException is not null);
-        Verify(typeof(ArgumentNullException) == innerException.GetType());
-    }
-
-    public void ThrowsExceptionAsyncWithMessageAndParamsShouldThrowOnNullMessage()
-    {
-        static void A()
-        {
-            Task t = Assert.ThrowsExceptionAsync<ArgumentException>(async () => await Task.FromResult(true).ConfigureAwait(false), null!, null);
-            t.Wait();
-        }
-
-        Exception ex = VerifyThrows(A);
-
-        Exception? innerException = ex.InnerException;
-
-        Verify(innerException is not null);
-        Verify(typeof(ArgumentNullException) == innerException.GetType());
-    }
-
-    public void ThrowsExceptionAsyncWithMessageAndParamsShouldThrowAssertionOnNoException()
-    {
-        Task t = Assert.ThrowsExceptionAsync<ArgumentException>(
-            async () => await Task.Delay(5).ConfigureAwait(false),
-            "The world is not on fire {0}.{1}-{2}.",
-            "ta",
-            "da",
-            123);
-        Exception ex = VerifyThrows(t.Wait);
-
-        Exception? innerException = ex.InnerException;
-
-        Verify(innerException is not null);
-        Assert.AreEqual(typeof(AssertFailedException), innerException.GetType());
-        Verify(innerException.Message.Equals("Assert.ThrowsExceptionAsync failed. Expected exception type:<System.ArgumentException> but no exception was thrown. The world is not on fire ta.da-123.", StringComparison.Ordinal));
-    }
-
-    public void ThrowsExceptionAsyncWithMessageAndParamsShouldThrowAssertionOnWrongException()
-    {
-        Task t = Assert.ThrowsExceptionAsync<ArgumentException>(
-            async () =>
-            {
-                await Task.Delay(5).ConfigureAwait(false);
-                throw new FormatException();
-            },
-            "Happily ever after. {0} {1}.",
-            "The",
-            "End");
-        Exception ex = VerifyThrows(t.Wait);
-
-        Exception? innerException = ex.InnerException;
-
-        Verify(innerException is not null);
-        Assert.AreEqual(typeof(AssertFailedException), innerException.GetType());
-        Verify(innerException.Message.Equals("Assert.ThrowsExceptionAsync failed. Expected exception type:<System.ArgumentException>. Actual exception type:<System.FormatException>. Happily ever after. The End.", StringComparison.Ordinal));
-    }
     #endregion
 
     public void Throws_WhenExceptionIsDerivedFromExpectedType_ShouldNotThrow()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.cs
@@ -24,13 +24,6 @@ public partial class AssertTests
     #region BuildUserMessage tests
 
     // See https://github.com/dotnet/sdk/issues/25373
-    public void BuildUserMessageThrowsWhenMessageContainsInvalidStringFormatComposite()
-    {
-        Exception ex = VerifyThrows(() => Assert.BuildUserMessage("{", "arg"));
-        Verify(ex is FormatException);
-    }
-
-    // See https://github.com/dotnet/sdk/issues/25373
     public void BuildUserMessageDoesNotThrowWhenMessageContainsInvalidStringFormatCompositeAndNoArgumentsPassed()
     {
         string message = Assert.BuildUserMessage("{");

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/CollectionAssertTests.cs
@@ -29,14 +29,6 @@ public class CollectionAssertTests : TestContainer
         _ = collection.Count; // no warning
     }
 
-    public void CollectionAssertContainsMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        object? element = GetMatchingElement();
-        CollectionAssert.Contains(collection, element, "message format {0} {1}", 1, 2);
-        _ = collection.Count; // no warning
-    }
-
     public void CollectionAssertDoesNotContainNullabilityPostConditions()
     {
         ICollection? collection = GetCollection();
@@ -50,14 +42,6 @@ public class CollectionAssertTests : TestContainer
         ICollection? collection = GetCollection();
         object? element = GetNotMatchingElement();
         CollectionAssert.DoesNotContain(collection, element, "message");
-        _ = collection.Count; // no warning
-    }
-
-    public void CollectionAssertDoesNotContainMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        object? element = GetNotMatchingElement();
-        CollectionAssert.DoesNotContain(collection, element, "message format {0} {1}", 1, 2);
         _ = collection.Count; // no warning
     }
 
@@ -75,13 +59,6 @@ public class CollectionAssertTests : TestContainer
         _ = collection.Count; // no warning
     }
 
-    public void CollectionAssertAllItemsAreNotNullMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        CollectionAssert.AllItemsAreNotNull(collection, "message format {0} {1}", 1, 2);
-        _ = collection.Count; // no warning
-    }
-
     public void CollectionAssertAllItemsAreUniqueNullabilityPostConditions()
     {
         ICollection? collection = GetCollection();
@@ -93,13 +70,6 @@ public class CollectionAssertTests : TestContainer
     {
         ICollection? collection = GetCollection();
         CollectionAssert.AllItemsAreUnique(collection, "message");
-        _ = collection.Count; // no warning
-    }
-
-    public void CollectionAssertAllItemsAreUniqueMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        CollectionAssert.AllItemsAreUnique(collection, "message format {0} {1}", 1, 2);
         _ = collection.Count; // no warning
     }
 
@@ -117,15 +87,6 @@ public class CollectionAssertTests : TestContainer
         ICollection? collection = GetCollection();
         ICollection? superset = GetMatchingSuperSet();
         CollectionAssert.IsSubsetOf(collection, superset, "message");
-        _ = collection.Count; // no warning
-        _ = superset.Count; // no warning
-    }
-
-    public void CollectionAssertIsSubsetOfMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        ICollection? superset = GetMatchingSuperSet();
-        CollectionAssert.IsSubsetOf(collection, superset, "message format {0} {1}", 1, 2);
         _ = collection.Count; // no warning
         _ = superset.Count; // no warning
     }
@@ -148,15 +109,6 @@ public class CollectionAssertTests : TestContainer
         _ = superset.Count; // no warning
     }
 
-    public void CollectionAssertIsNotSubsetOfMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        ICollection? superset = GetNotMatchingSuperSet();
-        CollectionAssert.IsNotSubsetOf(collection, superset, "message format {0} {1}", 1, 2);
-        _ = collection.Count; // no warning
-        _ = superset.Count; // no warning
-    }
-
     public void CollectionAssertAllItemsAreInstancesOfTypeNullabilityPostConditions()
     {
         ICollection? collection = GetCollection();
@@ -171,15 +123,6 @@ public class CollectionAssertTests : TestContainer
         ICollection? collection = GetCollection();
         Type? type = GetStringType();
         CollectionAssert.AllItemsAreInstancesOfType(collection, type, "message");
-        _ = collection.Count; // no warning
-        type.ToString(); // no warning
-    }
-
-    public void CollectionAssertAllItemsAreInstancesOfTypeMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection = GetCollection();
-        Type? type = GetStringType();
-        CollectionAssert.AllItemsAreInstancesOfType(collection, type, "message format {0} {1}", 1, 2);
         _ = collection.Count; // no warning
         type.ToString(); // no warning
     }
@@ -220,15 +163,6 @@ public class CollectionAssertTests : TestContainer
         ICollection? collection2 = GetCollection();
         IComparer? comparer = GetComparer();
         CollectionAssert.AreEqual(collection1, collection2, comparer, "message");
-        comparer.ToString(); // no warning
-    }
-
-    public void CollectionAssertAreEqualComparerMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection1 = GetCollection();
-        ICollection? collection2 = GetCollection();
-        IComparer? comparer = GetComparer();
-        CollectionAssert.AreEqual(collection1, collection2, comparer, "message format {0} {1}", 1, 2);
         comparer.ToString(); // no warning
     }
 
@@ -344,15 +278,6 @@ public class CollectionAssertTests : TestContainer
         comparer.ToString(); // no warning
     }
 
-    public void CollectionAssertAreNotEqualComparerMessageParametersNullabilityPostConditions()
-    {
-        ICollection? collection1 = GetCollection();
-        ICollection? collection2 = GetMatchingSuperSet();
-        IComparer? comparer = GetComparer();
-        CollectionAssert.AreNotEqual(collection1, collection2, comparer, "message format {0} {1}", 1, 2);
-        comparer.ToString(); // no warning
-    }
-
     public void CollectionAssertAreEquivalent_SameItemsWithDifferentOrder_DoesNotThrow()
     {
         ICollection? collection1 = GetMatchingSuperSet();
@@ -377,14 +302,6 @@ public class CollectionAssertTests : TestContainer
         Verify(ex.Message.Contains("message"));
     }
 
-    public void CollectionAssertAreEquivalent_FailWhenNotEquivalent_WithMessageAndParams()
-    {
-        ICollection? collection1 = GetCollection();
-        ICollection? collection2 = GetMatchingSuperSet();
-        Exception ex = VerifyThrows(() => CollectionAssert.AreEquivalent(collection1, collection2, "message format {0} {1}", 1, 2));
-        Verify(ex.Message.Contains("message"));
-    }
-
     public void CollectionAssertAreEquivalent_WithInsensitiveCaseComparer_DoesNotThrow()
     {
         ICollection? collection1 = GetMatchingSuperSet();
@@ -397,14 +314,6 @@ public class CollectionAssertTests : TestContainer
         ICollection? collection1 = GetCollection();
         ICollection? collection2 = GetLettersCaseMismatchingSuperSet();
         Exception ex = VerifyThrows(() => CollectionAssert.AreEquivalent(collection1?.Cast<string>(), collection2?.Cast<string>(), new CaseInsensitiveEqualityComparer(), "message"));
-        Verify(ex.Message.Contains("message"));
-    }
-
-    public void CollectionAssertAreEquivalent_FailsWithInsensitiveCaseComparer_WithMessageAndParams()
-    {
-        ICollection? collection1 = GetCollection();
-        ICollection? collection2 = GetLettersCaseMismatchingSuperSet();
-        Exception ex = VerifyThrows(() => CollectionAssert.AreEquivalent(collection1?.Cast<string>(), collection2?.Cast<string>(), new CaseInsensitiveEqualityComparer(), "message format {0} {1}", 1, 2));
         Verify(ex.Message.Contains("message"));
     }
 
@@ -423,14 +332,6 @@ public class CollectionAssertTests : TestContainer
         Verify(ex.Message.Contains("message"));
     }
 
-    public void CollectionAssertAreNotEquivalent_FailWhenNotEquivalent_WithMessageAndParams()
-    {
-        ICollection? collection1 = GetReversedMatchingSuperSet();
-        ICollection? collection2 = GetMatchingSuperSet();
-        Exception ex = VerifyThrows(() => CollectionAssert.AreNotEquivalent(collection1, collection2, "message format {0} {1}", 1, 2));
-        Verify(ex.Message.Contains("message"));
-    }
-
     public void CollectionAssertAreNotEquivalent_WithInsensitiveCaseComparer_DoesNotThrow()
     {
         ICollection? collection1 = GetCollection();
@@ -446,17 +347,9 @@ public class CollectionAssertTests : TestContainer
         Verify(ex.Message.Contains("message"));
     }
 
-    public void CollectionAssertAreNotEquivalent_FailsWithInsensitiveCaseComparer_WithMessageAndParams()
-    {
-        ICollection? collection1 = GetMatchingSuperSet();
-        ICollection? collection2 = GetLettersCaseMismatchingSuperSet();
-        Exception ex = VerifyThrows(() => CollectionAssert.AreNotEquivalent(collection1?.Cast<string>(), collection2?.Cast<string>(), new CaseInsensitiveNotEqualityComparer(), "message format {0} {1}", 1, 2));
-        Verify(ex.Message.Contains("message"));
-    }
-
     public void CollectionAssertAreNotEquivalent_FailsWithTwoNullsAndComparer_WithMessageAndParams()
     {
-        Exception ex = VerifyThrows(() => CollectionAssert.AreNotEquivalent(null, null, new CaseInsensitiveNotEqualityComparer(), "message format {0} {1}", 1, 2));
+        Exception ex = VerifyThrows(() => CollectionAssert.AreNotEquivalent(null, null, new CaseInsensitiveNotEqualityComparer(), "message format"));
         Verify(ex.Message.Contains("message"));
     }
 

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/StringAssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/StringAssertTests.cs
@@ -78,14 +78,6 @@ public class StringAssertTests : TestContainer
         Verify(ex.Message.Contains("StringAssert.Contains failed"));
     }
 
-    // See https://github.com/dotnet/sdk/issues/25373
-    [SuppressMessage("Usage", "CA2241:Provide correct arguments to formatting methods", Justification = "We want to test invalid format")]
-    public void StringAssertContainsFailsIfMessageIsInvalidStringFormatComposite()
-    {
-        Exception ex = VerifyThrows(() => StringAssert.Contains("a", "b", "message"));
-        Verify(ex is FormatException);
-    }
-
     public void StringAssertContainsNullabilitiesPostConditions()
     {
         string? value = GetValue();

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/StringAssertTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/StringAssertTests.cs
@@ -74,7 +74,7 @@ public class StringAssertTests : TestContainer
     // See https://github.com/dotnet/sdk/issues/25373
     public void StringAssertContainsDoesNotThrowFormatExceptionWithArguments()
     {
-        Exception ex = VerifyThrows(() => StringAssert.Contains("{", "x", "message {0}", "arg"));
+        Exception ex = VerifyThrows(() => StringAssert.Contains("{", "x", "message"));
         Verify(ex.Message.Contains("StringAssert.Contains failed"));
     }
 
@@ -82,7 +82,7 @@ public class StringAssertTests : TestContainer
     [SuppressMessage("Usage", "CA2241:Provide correct arguments to formatting methods", Justification = "We want to test invalid format")]
     public void StringAssertContainsFailsIfMessageIsInvalidStringFormatComposite()
     {
-        Exception ex = VerifyThrows(() => StringAssert.Contains("a", "b", "message {{0}", "arg"));
+        Exception ex = VerifyThrows(() => StringAssert.Contains("a", "b", "message"));
         Verify(ex is FormatException);
     }
 
@@ -117,25 +117,7 @@ public class StringAssertTests : TestContainer
     {
         string? value = GetValue();
         string? substring = GetMatchingStartsWithString();
-        StringAssert.Contains(value, substring, "message", StringComparison.OrdinalIgnoreCase);
-        value.ToString(); // no warning
-        substring.ToString(); // no warning
-    }
-
-    public void StringAssertContainsMessageParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        string? substring = GetMatchingStartsWithString();
-        StringAssert.Contains(value, substring, "message format {0} {1}", 1, 2);
-        value.ToString(); // no warning
-        substring.ToString(); // no warning
-    }
-
-    public void StringAssertContainsMessageStringComparisonParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        string? substring = GetMatchingStartsWithString();
-        StringAssert.Contains(value, substring, "message format {0} {1}", StringComparison.OrdinalIgnoreCase, 1, 2);
+        StringAssert.Contains(value, substring, StringComparison.OrdinalIgnoreCase, "message");
         value.ToString(); // no warning
         substring.ToString(); // no warning
     }
@@ -171,25 +153,7 @@ public class StringAssertTests : TestContainer
     {
         string? value = GetValue();
         string? substring = GetMatchingStartsWithString();
-        StringAssert.StartsWith(value, substring, "message", StringComparison.OrdinalIgnoreCase);
-        value.ToString(); // no warning
-        substring.ToString(); // no warning
-    }
-
-    public void StringAssertStartsWithMessageParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        string? substring = GetMatchingStartsWithString();
-        StringAssert.StartsWith(value, substring, "message format {0} {1}", 1, 2);
-        value.ToString(); // no warning
-        substring.ToString(); // no warning
-    }
-
-    public void StringAssertStartsWithMessageStringComparisonParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        string? substring = GetMatchingStartsWithString();
-        StringAssert.StartsWith(value, substring, "message format {0} {1}", StringComparison.OrdinalIgnoreCase, 1, 2);
+        StringAssert.StartsWith(value, substring, StringComparison.OrdinalIgnoreCase, "message");
         value.ToString(); // no warning
         substring.ToString(); // no warning
     }
@@ -225,25 +189,7 @@ public class StringAssertTests : TestContainer
     {
         string? value = GetValue();
         string? substring = GetMatchingEndsWithString();
-        StringAssert.EndsWith(value, substring, "message", StringComparison.OrdinalIgnoreCase);
-        value.ToString(); // no warning
-        substring.ToString(); // no warning
-    }
-
-    public void StringAssertEndsWithMessageParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        string? substring = GetMatchingEndsWithString();
-        StringAssert.EndsWith(value, substring, "message format {0} {1}", 1, 2);
-        value.ToString(); // no warning
-        substring.ToString(); // no warning
-    }
-
-    public void StringAssertEndsWithMessageStringComparisonParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        string? substring = GetMatchingEndsWithString();
-        StringAssert.EndsWith(value, substring, "message format {0} {1}", StringComparison.OrdinalIgnoreCase, 1, 2);
+        StringAssert.EndsWith(value, substring, StringComparison.OrdinalIgnoreCase, "message");
         value.ToString(); // no warning
         substring.ToString(); // no warning
     }
@@ -266,15 +212,6 @@ public class StringAssertTests : TestContainer
         pattern.ToString(); // no warning
     }
 
-    public void StringAssertMatchesMessageParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        Regex? pattern = GetMatchingPattern();
-        StringAssert.Matches(value, pattern, "message format {0} {1}", 1, 2);
-        value.ToString(); // no warning
-        pattern.ToString(); // no warning
-    }
-
     public void StringAssertDoesNotMatchNullabilitiesPostConditions()
     {
         string? value = GetValue();
@@ -289,15 +226,6 @@ public class StringAssertTests : TestContainer
         string? value = GetValue();
         Regex? pattern = GetNonMatchingPattern();
         StringAssert.DoesNotMatch(value, pattern, "message");
-        value.ToString(); // no warning
-        pattern.ToString(); // no warning
-    }
-
-    public void StringAssertDoesNotMatchMessageParametersNullabilitiesPostConditions()
-    {
-        string? value = GetValue();
-        Regex? pattern = GetNonMatchingPattern();
-        StringAssert.DoesNotMatch(value, pattern, "message format {0} {1}", 1, 2);
         value.ToString(); // no warning
         pattern.ToString(); // no warning
     }


### PR DESCRIPTION
Cleanup, in preparation for CallerArgumentExpression. This removes all overloads that take `params object[]`. These overloads are very rarely used IMO, and any users of it can switch to explicit `string.Format` call or better switch to interpolated string.

Related to #1285