### PR TITLE
Adjust TestCase.Id to account for randomized tests (include test case index instead of serialized data)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -417,7 +417,6 @@ internal class AssemblyEnumerator : MarshalByRefObject
             return true;
         }
 
-        var testDisplayNameFirstSeen = new Dictionary<string, int>();
         var discoveredTests = new List<UnitTestElement>();
         int index = 0;
 
@@ -436,6 +435,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             {
                 discoveredTest.TestMethod.SerializedData = DataSerializationHelper.Serialize(d);
                 discoveredTest.TestMethod.ActualData = d;
+                discoveredTest.TestMethod.TestCaseIndex = index;
                 discoveredTest.TestMethod.TestDataSourceIgnoreMessage = testDataSourceIgnoreMessage;
                 discoveredTest.TestMethod.DataType = DynamicDataType.ITestDataSource;
             }
@@ -452,7 +452,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             }
 
             discoveredTests.Add(discoveredTest);
-            testDisplayNameFirstSeen[discoveredTest.DisplayName!] = index++;
+            index++;
         }
 
         tests.AddRange(discoveredTests);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -341,10 +341,11 @@ internal class AssemblyEnumerator : MarshalByRefObject
         try
         {
             bool isDataDriven = false;
+            int globalTestCaseIndex = 0;
             foreach (ITestDataSource dataSource in testDataSources)
             {
                 isDataDriven = true;
-                if (!TryUnfoldITestDataSource(dataSource, dataSourcesUnfoldingStrategy, test, new(testMethodInfo.MethodInfo, test.DisplayName), tempListOfTests))
+                if (!TryUnfoldITestDataSource(dataSource, dataSourcesUnfoldingStrategy, test, new(testMethodInfo.MethodInfo, test.DisplayName), tempListOfTests, ref globalTestCaseIndex))
                 {
                     // TODO: Improve multi-source design!
                     // Ideally we would want to consider each data source separately but when one source cannot be expanded,
@@ -374,7 +375,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
         }
     }
 
-    private static bool TryUnfoldITestDataSource(ITestDataSource dataSource, TestDataSourceUnfoldingStrategy dataSourcesUnfoldingStrategy, UnitTestElement test, ReflectionTestMethodInfo methodInfo, List<UnitTestElement> tests)
+    private static bool TryUnfoldITestDataSource(ITestDataSource dataSource, TestDataSourceUnfoldingStrategy dataSourcesUnfoldingStrategy, UnitTestElement test, ReflectionTestMethodInfo methodInfo, List<UnitTestElement> tests, ref int globalTestCaseIndex)
     {
         var unfoldingCapability = dataSource as ITestDataSourceUnfoldingCapability;
 
@@ -418,7 +419,6 @@ internal class AssemblyEnumerator : MarshalByRefObject
         }
 
         var discoveredTests = new List<UnitTestElement>();
-        int index = 0;
 
         foreach (object?[] dataOrTestDataRow in data)
         {
@@ -435,7 +435,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             {
                 discoveredTest.TestMethod.SerializedData = DataSerializationHelper.Serialize(d);
                 discoveredTest.TestMethod.ActualData = d;
-                discoveredTest.TestMethod.TestCaseIndex = index;
+                discoveredTest.TestMethod.TestCaseIndex = globalTestCaseIndex;
                 discoveredTest.TestMethod.TestDataSourceIgnoreMessage = testDataSourceIgnoreMessage;
                 discoveredTest.TestMethod.DataType = DynamicDataType.ITestDataSource;
             }
@@ -452,7 +452,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             }
 
             discoveredTests.Add(discoveredTest);
-            index++;
+            globalTestCaseIndex++;
         }
 
         tests.AddRange(discoveredTests);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -441,7 +441,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             }
             catch (SerializationException ex)
             {
-                string warning = string.Format(CultureInfo.CurrentCulture, Resource.CannotExpandIDataSourceAttribute_CannotSerialize, index, discoveredTest.DisplayName);
+                string warning = string.Format(CultureInfo.CurrentCulture, Resource.CannotExpandIDataSourceAttribute_CannotSerialize, globalTestCaseIndex, discoveredTest.DisplayName);
                 warning += Environment.NewLine;
                 warning += ex.ToString();
                 warning = string.Format(CultureInfo.CurrentCulture, Resource.CannotExpandIDataSourceAttribute, test.TestMethod.ManagedTypeName, test.TestMethod.ManagedMethodName, warning);

--- a/src/Adapter/MSTestAdapter.PlatformServices/EngineConstants.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/EngineConstants.cs
@@ -126,6 +126,8 @@ internal static class EngineConstants
 
     internal static readonly TestProperty TestDynamicDataTypeProperty = TestProperty.Register("MSTest.DynamicDataType", "DynamicDataType", typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
 
+    internal static readonly TestProperty TestCaseIndexProperty = TestProperty.Register("MSTest.TestCaseIndex", "TestCaseIndex", typeof(int), TestPropertyAttributes.Hidden, typeof(TestCase));
+
     internal static readonly TestProperty TestDynamicDataProperty = TestProperty.Register("MSTest.DynamicData", "DynamicData", typeof(string[]), TestPropertyAttributes.Hidden, typeof(TestCase));
 
     internal static readonly TestProperty TestDataSourceIgnoreMessageProperty = TestProperty.Register("MSTest.TestDataSourceIgnoreMessageProperty", "TestDataSourceIgnoreMessageProperty", typeof(string), TestPropertyAttributes.Hidden, typeof(TestCase));

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
@@ -83,6 +83,7 @@ internal static class TestCaseExtensions
 
             testMethod.DataType = dataType;
             testMethod.SerializedData = data;
+            testMethod.TestCaseIndex = testCase.GetPropertyValue<int>(EngineConstants.TestCaseIndexProperty, 0);
             if (UnitTestDiscoverer.TryGetActualData(testCase, out object?[]? actualData))
             {
                 testMethod.ActualData = actualData;

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -132,6 +132,8 @@ internal sealed class TestMethod : ITestMethod
     /// </summary>
     internal string?[]? SerializedData { get; set; }
 
+    internal int TestCaseIndex { get; set; }
+
     // This holds user types that may not be serializable.
     // If app domains are enabled, we have no choice other than losing the original data.
     // In that case, we fallback to deserializing the SerializedData.

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -213,7 +213,7 @@ internal sealed class UnitTestElement
         idProvider.AppendString(testFullName);
         if (TestMethod.SerializedData != null)
         {
-            idProvider.AppendString($"#{TestMethod.TestCaseIndex.ToString(CultureInfo.InvariantCulture)}#");
+            idProvider.AppendString($"[{TestMethod.TestCaseIndex.ToString(CultureInfo.InvariantCulture)}]");
         }
 
         return idProvider.GetId();

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -166,6 +166,7 @@ internal sealed class UnitTestElement
 
             testCase.SetPropertyValue(EngineConstants.TestDynamicDataTypeProperty, (int)TestMethod.DataType);
             testCase.SetPropertyValue(EngineConstants.TestDynamicDataProperty, data);
+            testCase.SetPropertyValue(EngineConstants.TestCaseIndexProperty, TestMethod.TestCaseIndex);
             // VSTest serialization doesn't handle null so instead don't set the property so that it's deserialized as null
             if (TestMethod.TestDataSourceIgnoreMessage is not null)
             {
@@ -176,7 +177,7 @@ internal sealed class UnitTestElement
         testCase.LineNumber = DeclaringLineNumber ?? -1;
         testCase.CodeFilePath = DeclaringFilePath;
 
-        SetTestCaseId(testCase, testFullName);
+        SetTestCaseId(testCase, $"{TestMethod.ManagedTypeName}.{TestMethod.ManagedMethodName}");
 
         return testCase;
     }
@@ -210,13 +211,9 @@ internal sealed class UnitTestElement
 
         idProvider.AppendString(fileNameOrFilePath);
         idProvider.AppendString(testFullName);
-
         if (TestMethod.SerializedData != null)
         {
-            foreach (string? item in TestMethod.SerializedData)
-            {
-                idProvider.AppendString(item ?? "null");
-            }
+            idProvider.AppendString($"#{TestMethod.TestCaseIndex.ToString(CultureInfo.InvariantCulture)}#");
         }
 
         return idProvider.GetId();

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -177,7 +177,7 @@ internal sealed class UnitTestElement
         testCase.LineNumber = DeclaringLineNumber ?? -1;
         testCase.CodeFilePath = DeclaringFilePath;
 
-        SetTestCaseId(testCase, $"{TestMethod.ManagedTypeName}.{TestMethod.ManagedMethodName}");
+        SetTestCaseId(testCase, testFullName);
 
         return testCase;
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
@@ -195,18 +195,21 @@ public class UnitTestElementTests : TestContainer
                 new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", null)
                 {
                     SerializedData = ["System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "[]"],
+                    TestCaseIndex = 0,
                 })
             .ToTestCase(),
             new UnitTestElement(
                 new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", null)
                 {
                     SerializedData = ["System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "[1]"],
+                    TestCaseIndex = 1,
                 })
             .ToTestCase(),
             new UnitTestElement(
                 new("MyMethod", "MyProduct.MyNamespace.MyClass", "MyAssembly", null)
                 {
                     SerializedData = ["System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "[1,1]"],
+                    TestCaseIndex = 2,
                 })
             .ToTestCase()
         ];


### PR DESCRIPTION
Related to #1285 and #1462
