### PR TITLE
TestContext cleanup

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
@@ -50,10 +50,10 @@ internal sealed class ClassCleanupManager
 
     internal static void ForceCleanup(TypeCache typeCache, IDictionary<string, object?> sourceLevelParameters, IMessageLogger logger)
     {
-        TestContext testContext = new TestContextImplementation(null, sourceLevelParameters, logger, testRunCancellationToken: null);
         IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;
         foreach (TestClassInfo classInfo in classInfoCache)
         {
+            TestContext testContext = new TestContextImplementation(null, classInfo, sourceLevelParameters, logger, testRunCancellationToken: null);
             TestFailedException? ex = classInfo.ExecuteClassCleanup(testContext);
             if (ex is not null)
             {
@@ -64,6 +64,7 @@ internal sealed class ClassCleanupManager
         IEnumerable<TestAssemblyInfo> assemblyInfoCache = typeCache.AssemblyInfoListWithExecutableCleanupMethods;
         foreach (TestAssemblyInfo assemblyInfo in assemblyInfoCache)
         {
+            TestContext testContext = new TestContextImplementation(null, null, sourceLevelParameters, logger, testRunCancellationToken: null);
             TestFailedException? ex = assemblyInfo.ExecuteAssemblyCleanup(testContext);
             if (ex is not null)
             {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
@@ -53,7 +53,7 @@ internal sealed class ClassCleanupManager
         IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;
         foreach (TestClassInfo classInfo in classInfoCache)
         {
-            TestContext testContext = new TestContextImplementation(null, classInfo, sourceLevelParameters, logger, testRunCancellationToken: null);
+            TestContext testContext = new TestContextImplementation(null, classInfo.ClassType.FullName, sourceLevelParameters, logger, testRunCancellationToken: null);
             TestFailedException? ex = classInfo.ExecuteClassCleanup(testContext);
             if (ex is not null)
             {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -141,7 +141,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
         try
         {
             var properties = new Dictionary<string, object?>(testContextProperties);
-            testContextForTestExecution = PlatformServiceProvider.Instance.GetTestContext(testMethod, properties, messageLogger, UTF.UnitTestOutcome.InProgress);
+            testContextForTestExecution = PlatformServiceProvider.Instance.GetTestContext(testMethod, null, properties, messageLogger, UTF.UnitTestOutcome.InProgress);
 
             // Get the testMethod
             TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
@@ -161,7 +161,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 _assemblyFixtureTests.TryAdd(testMethod.AssemblyName, testMethodInfo.Parent.Parent);
                 _classFixtureTests.TryAdd(testMethod.AssemblyName + testMethod.FullClassName, testMethodInfo.Parent);
 
-                testContextForAssemblyInit = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
+                testContextForAssemblyInit = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
 
                 TestResult assemblyInitializeResult = RunAssemblyInitializeIfNeeded(testMethodInfo, testContextForAssemblyInit);
 
@@ -171,7 +171,7 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 }
                 else
                 {
-                    testContextForClassInit = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, properties, messageLogger, testContextForAssemblyInit.Context.CurrentTestOutcome);
+                    testContextForClassInit = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, testMethod.FullClassName, properties, messageLogger, testContextForAssemblyInit.Context.CurrentTestOutcome);
 
                     TestResult classInitializeResult = testMethodInfo.Parent.GetResultOrRunClassInitialize(testContextForClassInit, assemblyInitializeResult.LogOutput, assemblyInitializeResult.LogError, assemblyInitializeResult.DebugTrace, assemblyInitializeResult.TestContextMessages);
                     DebugEx.Assert(testMethodInfo.Parent.IsClassInitializeExecuted, "IsClassInitializeExecuted should be true after attempting to run it.");
@@ -199,12 +199,12 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 }
             }
 
-            testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
+            testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, testMethod.FullClassName, properties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
             testMethodInfo?.Parent.RunClassCleanup(testContextForClassCleanup, _classCleanupManager, testMethodInfo, result);
 
             if (testMethodInfo?.Parent.Parent.IsAssemblyInitializeExecuted == true)
             {
-                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, properties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
+                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, properties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
                 RunAssemblyCleanupIfNeeded(testContextForAssemblyCleanup, _classCleanupManager, _typeCache, result);
             }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/IPlatformServiceProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/IPlatformServiceProvider.cs
@@ -90,6 +90,9 @@ internal interface IPlatformServiceProvider
     /// <param name="testMethod">
     /// The test method.
     /// </param>
+    /// <param name="testClassFullName">
+    /// The test class full name.
+    /// </param>
     /// <param name="properties">
     /// The default set of properties the test context needs to be filled with.
     /// </param>
@@ -101,5 +104,5 @@ internal interface IPlatformServiceProvider
     /// <remarks>
     /// This was required for compatibility reasons since the TestContext object that the V1 adapter had for desktop is not .Net Core compliant.
     /// </remarks>
-    ITestContext GetTestContext(ITestMethod? testMethod, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome);
+    ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PlatformServiceProvider.cs
@@ -165,6 +165,9 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     /// <param name="testMethod">
     /// The test method.
     /// </param>
+    /// <param name="testClassFullName">
+    /// The test class full name.
+    /// </param>
     /// <param name="properties">
     /// The default set of properties the test context needs to be filled with.
     /// </param>
@@ -176,9 +179,9 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     /// <remarks>
     /// This was required for compatibility reasons since the TestContext object that the V1 adapter had for desktop is not .Net Core compliant.
     /// </remarks>
-    public ITestContext GetTestContext(ITestMethod? testMethod, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome)
+    public ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome)
     {
-        var testContextImplementation = new TestContextImplementation(testMethod, properties, messageLogger, TestRunCancellationToken);
+        var testContextImplementation = new TestContextImplementation(testMethod, testClassFullName, properties, messageLogger, TestRunCancellationToken);
         testContextImplementation.SetOutcome(outcome);
         return testContextImplementation;
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -88,7 +88,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
         // testMethod can be null when running ForceCleanup (done when reaching --maximum-failed-tests.
         DebugEx.Assert(properties != null, "properties is not null");
 
-        _properties = [];
+        _properties = new Dictionary<string, object?>(properties);
         testClassFullName ??= testMethod?.FullClassName;
         if (testClassFullName is not null)
         {

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -14,8 +14,6 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 public abstract class TestContext
 {
     internal static readonly string FullyQualifiedTestClassNameLabel = nameof(FullyQualifiedTestClassName);
-    internal static readonly string ManagedTypeLabel = nameof(ManagedType);
-    internal static readonly string ManagedMethodLabel = nameof(ManagedMethod);
     internal static readonly string TestNameLabel = nameof(TestName);
 #if WINDOWS_UWP || WIN_UI
     internal static readonly string TestRunDirectoryLabel = "TestRunDirectory";
@@ -105,18 +103,6 @@ public abstract class TestContext
     /// </summary>
     public virtual string FullyQualifiedTestClassName => GetProperty<string>(FullyQualifiedTestClassNameLabel)
         ?? throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, FrameworkMessages.InvalidAccessToTestContextProperty, nameof(FullyQualifiedTestClassName)));
-
-    /// <summary>
-    /// Gets the fully specified type name metadata format.
-    /// </summary>
-    public virtual string ManagedType => GetProperty<string>(ManagedTypeLabel)
-        ?? throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, FrameworkMessages.InvalidAccessToTestContextProperty, nameof(ManagedType)));
-
-    /// <summary>
-    /// Gets the fully specified method name metadata format.
-    /// </summary>
-    public virtual string ManagedMethod => GetProperty<string>(ManagedMethodLabel)
-        ?? throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, FrameworkMessages.InvalidAccessToTestContextProperty, nameof(ManagedMethod)));
 
     /// <summary>
     /// Gets the name of the test method currently being executed.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
@@ -642,7 +642,7 @@ public class BaseClassWithTestInitCleanup
     [TestCleanup]
     public void BaseTestCleanup()
     {
-        switch (TestContext.ManagedMethod)
+        switch (TestContext.TestName)
         {
             case "DerivedClassIntermediateClassWithTestInitCleanupBaseClassWithTestInitCleanupTestMethod":
             case "DerivedClassIntermediateClassWithTestInitCleanupBaseClassWithTestInitCleanupTestMethod2":
@@ -655,7 +655,7 @@ public class BaseClassWithTestInitCleanup
                 break;
 
             default:
-                throw new NotSupportedException($"Unsupported method name '{TestContext.ManagedMethod}'");
+                throw new NotSupportedException($"Unsupported method name '{TestContext.TestName}'");
         }
     }
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
@@ -430,7 +430,7 @@ public class ExpectedCultures
 
 public class BaseClassWithInheritance
 {
-    private protected static string _managedMethod;
+    private protected static string _testName;
 
     public TestContext TestContext
     {
@@ -438,16 +438,16 @@ public class BaseClassWithInheritance
         set
         {
             field = value;
-            _managedMethod ??= value.ManagedMethod;
+            _testName ??= value.TestName;
         }
     }
 
     [ClassInitialize(InheritanceBehavior.BeforeEachDerivedClass)]
     public static void BaseClassInitialize(TestContext testContext)
     {
-        if (_managedMethod is not null)
+        if (_testName is not null)
         {
-            throw new InvalidOperationException($"Was expected to be running tests sequentially but '{_managedMethod}' is still running.");
+            throw new InvalidOperationException($"Was expected to be running tests sequentially but '{_testName}' is still running.");
         }
 
         CultureInfo.CurrentCulture = new CultureInfo(ExpectedCultures.BaseClassInitCulture);
@@ -456,7 +456,7 @@ public class BaseClassWithInheritance
     [ClassCleanup(InheritanceBehavior.BeforeEachDerivedClass)]
     public static void BaseClassCleanup()
     {
-        switch (_managedMethod)
+        switch (_testName)
         {
             case "DerivedClassIntermediateClassWithoutInheritanceBaseClassWithInheritanceTestMethod":
             case "DerivedClassIntermediateClassWithoutInheritanceBaseClassWithInheritanceTestMethod2":
@@ -469,7 +469,7 @@ public class BaseClassWithInheritance
                 break;
 
             default:
-                throw new NotSupportedException($"Unsupported method name '{_managedMethod}'");
+                throw new NotSupportedException($"Unsupported method name '{_testName}'");
         }
 
         _managedMethod = null;

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadContextTests.cs
@@ -472,7 +472,7 @@ public class BaseClassWithInheritance
                 throw new NotSupportedException($"Unsupported method name '{_testName}'");
         }
 
-        _managedMethod = null;
+        _testName = null;
     }
 }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
@@ -310,7 +310,7 @@ public class TestAssemblyInfoTests : TestContainer
     }
 
     private static TestContextImplementation GetTestContext()
-        => new(null, new Dictionary<string, object?>());
+        => new(null, null, new Dictionary<string, object?>());
 
     #endregion
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
@@ -131,7 +131,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod")!;
         _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod")!;
 
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>())); // call cleanup without calling init
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>())); // call cleanup without calling init
         Verify(ex is null);
         Verify(classCleanupCallCount == 0);
     }
@@ -145,7 +145,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod")!;
 
         GetResultOrRunClassInitialize();
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>())); // call cleanup without calling init
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>())); // call cleanup without calling init
 
         Verify(ex is null);
         Verify(classCleanupCallCount == 1);
@@ -160,7 +160,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.BaseClassCleanupMethods.Add(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod")!);
 
         GetResultOrRunClassInitialize();
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         Verify(ex is null);
         Verify(classCleanupCallCount == 1);
@@ -464,7 +464,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(ex is null);
@@ -479,7 +479,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = null;
 
         // Act
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(ex is null);
@@ -494,7 +494,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -516,7 +516,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -537,7 +537,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -556,7 +556,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(classCleanupException is not null);
@@ -575,7 +575,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.BaseClassCleanupMethods.Add(baseClassCleanupMethod);
 
         // Act
-        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert
         Verify(ex is null);
@@ -584,7 +584,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act 2
         GetResultOrRunClassInitialize(null);
-        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert 2
         Verify(ex is null);
@@ -593,7 +593,7 @@ public class TestClassInfoTests : TestContainer
         Verify(classCleanupCallCount == 1, "DummyBaseTestClass.CleanupClassMethod call count");
 
         // Act 3
-        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        ex = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         // Assert 3
         Verify(ex is null);
@@ -610,7 +610,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod")!;
 
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = _testClassInfo.ExecuteClassCleanup(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
 
         Verify(classCleanupException is not null);
         Verify(classCleanupException.Message.StartsWith("Class Cleanup method DummyTestClass.ClassCleanupMethod failed. Error Message: System.InvalidOperationException: I fail..", StringComparison.Ordinal));

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -46,7 +46,7 @@ public class TestMethodInfoTests : TestContainer
 
         _testAssemblyInfo = new TestAssemblyInfo(typeof(DummyTestClass).Assembly);
         var testMethod = new TestMethod("dummyTestName", "dummyClassName", "dummyAssemblyName", false);
-        _testContextImplementation = new TestContextImplementation(testMethod, new Dictionary<string, object?>());
+        _testContextImplementation = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
         _testClassInfo = new TestClassInfo(typeof(DummyTestClass), _constructorInfo, true, _classAttribute, _testAssemblyInfo);
 
         _testMethodInfo = new TestMethodInfo(

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
@@ -39,7 +39,7 @@ public class TestMethodRunnerTests : TestContainer
         _testMethodAttribute = new TestMethodAttribute();
 
         _testMethod = new TestMethod("dummyTestName", "dummyClassName", "dummyAssemblyName", false);
-        _testContextImplementation = new TestContextImplementation(_testMethod, new Dictionary<string, object?>());
+        _testContextImplementation = new TestContextImplementation(_testMethod, null, new Dictionary<string, object?>());
         _testClassInfo = GetTestClassInfo<DummyTestClass>();
 
         _testMethodOptions = new TestMethodOptions(TimeoutInfo.FromTimeout(200), _testContextImplementation, _testMethodAttribute);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestPropertyAttributeTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestPropertyAttributeTests.cs
@@ -45,7 +45,7 @@ public class TestPropertyAttributeTests : TestContainer
         string className = typeof(DummyTestClassBase).FullName!;
         var testMethod = new TestMethod(nameof(DummyTestClassBase.VirtualTestMethodInBaseAndDerived), className, typeof(DummyTestClassBase).Assembly.GetName().Name!, isAsync: false);
 
-        var testContext = new TestContextImplementation(testMethod, new Dictionary<string, object?>());
+        var testContext = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
 
         _ = _typeCache.GetTestMethodInfo(
             testMethod,
@@ -75,7 +75,7 @@ public class TestPropertyAttributeTests : TestContainer
         string className = typeof(DummyTestClassDerived).FullName!;
         var testMethod = new TestMethod(nameof(DummyTestClassDerived.VirtualTestMethodInBaseAndDerived), className, typeof(DummyTestClassBase).Assembly.GetName().Name!, isAsync: false);
 
-        var testContext = new TestContextImplementation(testMethod, new Dictionary<string, object?>());
+        var testContext = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
 
         _ = _typeCache.GetTestMethodInfo(
             testMethod,
@@ -120,7 +120,7 @@ public class TestPropertyAttributeTests : TestContainer
         string className = typeof(DummyTestClassDerived).FullName!;
         var testMethod = new TestMethod(nameof(DummyTestClassDerived.VirtualTestMethodInDerivedButNotTestMethodInBase), className, typeof(DummyTestClassBase).Assembly.GetName().Name!, isAsync: false);
 
-        var testContext = new TestContextImplementation(testMethod, new Dictionary<string, object?>());
+        var testContext = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
 
         _ = _typeCache.GetTestMethodInfo(
             testMethod,

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
@@ -56,7 +56,7 @@ public class TypeCacheTests : TestContainer
     {
         var testMethod = new TestMethod("M", "C", "A", isAsync: false);
 
-        var context = new TestContextImplementation(testMethod, new Dictionary<string, object?>());
+        var context = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
         VerifyThrows<ArgumentNullException>(() => _typeCache.GetTestMethodInfo(null!, context));
     }
 
@@ -73,7 +73,7 @@ public class TypeCacheTests : TestContainer
         Verify(
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>())) is null);
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>())) is null);
     }
 
     public void GetTestMethodInfoShouldReturnNullIfLoadingTypeThrowsTypeLoadException()
@@ -83,7 +83,7 @@ public class TypeCacheTests : TestContainer
         Verify(
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>())) is null);
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>())) is null);
     }
 
     public void GetTestMethodInfoShouldThrowIfLoadingTypeThrowsException()
@@ -96,7 +96,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
 
@@ -111,7 +111,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
         Verify(exception.Message.StartsWith("Cannot find a valid constructor for test class 'Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TypeCacheTests+DummyTestClassWithNoDefaultConstructor'. Valid constructors are 'public' and either parameterless or with one parameter of type 'TestContext'.", StringComparison.Ordinal));
@@ -125,7 +125,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
         Verify(exception.Message.StartsWith($"The {className}.TestContext has incorrect type.", StringComparison.Ordinal));
@@ -139,7 +139,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
         Verify(exception.Message.StartsWith(string.Format(CultureInfo.InvariantCulture, "Unable to find property {0}.TestContext. Error:{1}.", className, "Ambiguous match found."), StringComparison.Ordinal));
@@ -156,7 +156,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                                     testMethod,
-                                    new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                                    new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(testMethodInfo is not null);
         Verify(testMethodInfo.Parent.TestContextProperty is not null);
@@ -173,7 +173,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                                 testMethod,
-                                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(testMethodInfo is not null);
         Verify(testMethodInfo.Parent.TestContextProperty is null);
@@ -192,7 +192,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
     }
@@ -211,7 +211,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
     }
@@ -229,7 +229,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyInit")! == _typeCache.AssemblyInfoCache.First().AssemblyInitializeMethod);
@@ -248,7 +248,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyCleanup")! == _typeCache.AssemblyInfoCache.First().AssemblyCleanupMethod);
@@ -269,7 +269,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyCleanup")! == _typeCache.AssemblyInfoCache.First().AssemblyCleanupMethod);
@@ -290,7 +290,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -319,7 +319,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -345,11 +345,11 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         _mockReflectHelper.Verify(rh => rh.IsAttributeDefined<TestClassAttribute>(type), Times.Once);
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
@@ -370,7 +370,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.TestInitializeMethod is null);
@@ -390,7 +390,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.BaseClassInitMethods.Count == 0);
@@ -418,7 +418,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
             testMethod,
-            new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+            new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.BaseClassCleanupMethods.Count == 0, "No base class cleanup");
@@ -438,7 +438,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyCleanup")! == _typeCache.ClassInfoCache.First()!.ClassCleanupMethod);
@@ -461,7 +461,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
             testMethod,
-            new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+            new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.BaseClassInitMethods.Count == 0, "No base class init");
@@ -482,7 +482,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyInit")! == _typeCache.ClassInfoCache.First()!.ClassInitializeMethod);
@@ -519,7 +519,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyInit")! == _typeCache.ClassInfoCache.First()!.ClassInitializeMethod);
@@ -575,7 +575,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod("TestMethod", type.FullName!, "A", isAsync: false);
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TestClassInfo? classInfo = _typeCache.ClassInfoCache.FirstOrDefault();
         Verify(_typeCache.ClassInfoCache.Count == 1);
@@ -605,7 +605,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -634,7 +634,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -662,7 +662,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("TestInit")! == _typeCache.ClassInfoCache.First()!.TestInitializeMethod);
@@ -681,7 +681,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("TestCleanup")! == _typeCache.ClassInfoCache.First()!.TestCleanupMethod);
@@ -701,7 +701,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -730,7 +730,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(baseType.GetMethod("TestInit")! == _typeCache.ClassInfoCache.First()!.BaseTestInitializeMethodsQueue.Peek());
@@ -750,7 +750,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(baseType.GetMethod("TestCleanup")! == _typeCache.ClassInfoCache.First()!.BaseTestCleanupMethodsQueue.Peek());
@@ -767,11 +767,11 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         _testablePlatformServiceProvider.MockFileOperations.Verify(fo => fo.LoadAssembly(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
         Verify(_typeCache.ClassInfoCache.Count == 1);
@@ -790,7 +790,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -812,7 +812,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -832,7 +832,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TimeoutAttribute>(methodInfo)).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 10);
@@ -853,7 +853,7 @@ public class TypeCacheTests : TestContainer
 
         void A() => _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -880,7 +880,7 @@ public class TypeCacheTests : TestContainer
 
         void A() => _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -913,7 +913,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(testMethodInfo!.TimeoutInfo.Timeout == 4000);
     }
@@ -942,7 +942,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(testMethodInfo!.TimeoutInfo.Timeout == 10);
     }
@@ -966,7 +966,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(testMethodInfo!.TimeoutInfo.Timeout == 0);
     }
@@ -980,7 +980,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -1196,7 +1196,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -1213,7 +1213,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -1234,7 +1234,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         // The two MethodInfo instances will have different ReflectedType properties,
         // so cannot be compared directly. Use MethodHandle to verify it's the same.
@@ -1271,7 +1271,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         IEnumerable<TestClassInfo> cleanupMethods = _typeCache.ClassInfoListWithExecutableCleanupMethods;
 
@@ -1292,7 +1292,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         IEnumerable<TestClassInfo> cleanupMethods = _typeCache.ClassInfoListWithExecutableCleanupMethods;
 
@@ -1325,7 +1325,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         IEnumerable<TestAssemblyInfo> cleanupMethods = _typeCache.AssemblyInfoListWithExecutableCleanupMethods;
 
@@ -1346,7 +1346,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, new Dictionary<string, object?>()));
+                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
 
         IEnumerable<TestAssemblyInfo> cleanupMethods = _typeCache.AssemblyInfoListWithExecutableCleanupMethods;
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
@@ -999,6 +999,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1018,6 +1019,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1041,6 +1043,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1064,6 +1067,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1087,6 +1091,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1108,6 +1113,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1130,6 +1136,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1153,6 +1160,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
@@ -1176,6 +1184,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
         var testContext = new TestContextImplementation(
             testMethod,
+            null,
             new Dictionary<string, object?>());
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/PlatformServiceProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/PlatformServiceProviderTests.cs
@@ -63,7 +63,7 @@ public class PlatformServiceProviderTests : TestContainer
         testMethod.Setup(tm => tm.Name).Returns("M");
 
         // Act.
-        PlatformServices.Interface.ITestContext testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod.Object, properties, null!, default);
+        PlatformServices.Interface.ITestContext testContext = PlatformServiceProvider.Instance.GetTestContext(testMethod.Object, null, properties, null!, default);
 
         // Assert.
         Verify(testContext.Context.FullyQualifiedTestClassName == "A.C.M");

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -34,7 +34,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void TestContextConstructorShouldInitializeProperties()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.Properties is not null);
     }
@@ -44,7 +44,7 @@ public class TestContextImplementationTests : TestContainer
         _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.Properties is not null);
 
@@ -54,14 +54,14 @@ public class TestContextImplementationTests : TestContainer
 
     public void CurrentTestOutcomeShouldReturnDefaultOutcome()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.CurrentTestOutcome == UnitTestOutcome.Failed);
     }
 
     public void CurrentTestOutcomeShouldReturnOutcomeSet()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.SetOutcome(UnitTestOutcome.InProgress);
 
@@ -72,7 +72,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.FullyQualifiedTestClassName == "A.C.M");
     }
@@ -81,7 +81,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.TestName == "M");
     }
@@ -94,7 +94,7 @@ public class TestContextImplementationTests : TestContainer
         _properties.Add(property1);
         _properties.Add(property2);
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.Properties[property1.Key] == property1.Value);
         Verify(_testContextImplementation.Properties[property2.Key] == property2.Value);
@@ -104,7 +104,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.Context is not null);
         Verify(_testContextImplementation.Context.TestName == "M");
@@ -114,7 +114,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(_testContextImplementation.TryGetPropertyValue("TestName", out object? propValue));
         Verify("M".Equals(propValue));
@@ -122,7 +122,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void TryGetPropertyValueShouldReturnFalseIfPropertyIsNotPresent()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         Verify(!_testContextImplementation.TryGetPropertyValue("Random", out object? propValue));
         Verify(propValue is null);
@@ -130,7 +130,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddPropertyShouldAddPropertiesToThePropertyBag()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
         var property = new KeyValuePair<string, string>("SomeNewProperty", "SomeValue");
         _testContextImplementation.AddProperty(property.Key, property.Value);
 
@@ -139,7 +139,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldThrowIfFileNameIsNull()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         ArgumentException exception = VerifyThrows<ArgumentException>(() => _testContextImplementation.AddResultFile(null!));
         Verify(exception.Message.Contains(Resource.Common_CannotBeNullOrEmpty));
@@ -147,7 +147,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldThrowIfFileNameIsEmpty()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         ArgumentException exception = VerifyThrows<ArgumentException>(() => _testContextImplementation.AddResultFile(string.Empty));
         Verify(exception.Message.Contains(Resource.Common_CannotBeNullOrEmpty));
@@ -155,7 +155,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldAddFileToResultsFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.AddResultFile("C:\\temp.txt");
 
@@ -166,7 +166,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldAddMultipleFilesToResultsFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.AddResultFile("C:\\files\\file1.txt");
         _testContextImplementation.AddResultFile("C:\\files\\files2.html");
@@ -179,35 +179,35 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
         _testContextImplementation.Write("{0} Testing write", 1);
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing write"));
     }
 
     public void WriteShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
         _testContextImplementation.Write("{0} Testing \0 write \0", 1);
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing \\0 write \\0"));
     }
 
     public void WriteWithMessageShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
         _testContextImplementation.Write("1 Testing write");
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing write"));
     }
 
     public void WriteWithMessageShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
         _testContextImplementation.Write("1 Testing \0 write \0");
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing \\0 write \\0"));
     }
 
     public void WriteWithMessageShouldWriteToStringWriterForReturnCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
         _testContextImplementation.Write("2 Testing write \n\r");
         _testContextImplementation.Write("3 Testing write\n\r");
         Verify(_testContextImplementation.GetDiagnosticMessages() == "2 Testing write \n\r3 Testing write\n\r");
@@ -215,7 +215,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.WriteLine("{0} Testing write", 1);
 
@@ -224,7 +224,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.WriteLine("{0} Testing \0 write \0", 1);
 
@@ -233,7 +233,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineWithMessageShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.WriteLine("1 Testing write");
 
@@ -242,7 +242,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineWithMessageShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.WriteLine("1 Testing \0 write \0");
 
@@ -251,7 +251,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void GetDiagnosticMessagesShouldReturnMessagesFromWriteLine()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.WriteLine("1 Testing write");
         _testContextImplementation.WriteLine("2 Its a happy day");
@@ -262,7 +262,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void ClearDiagnosticMessagesShouldClearMessagesFromWriteLine()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.WriteLine("1 Testing write");
         _testContextImplementation.WriteLine("2 Its a happy day");
@@ -275,7 +275,7 @@ public class TestContextImplementationTests : TestContainer
 #if NET462
     public void SetDataRowShouldSetDataRowObjectForCurrentRun()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         DataTable dataTable = new();
 
@@ -293,7 +293,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void SetDataConnectionShouldSetDbConnectionForFetchingData()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         DbProviderFactory factory = DbProviderFactories.GetFactory("System.Data.Odbc");
         DbConnection connection = factory.CreateConnection();
@@ -309,7 +309,7 @@ public class TestContextImplementationTests : TestContainer
 #if NETCOREAPP
     public void GetResultFilesShouldReturnNullIfNoAddedResultFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         IList<string>? resultFiles = _testContextImplementation.GetResultFiles();
 
@@ -318,7 +318,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void GetResultFilesShouldReturnListOfAddedResultFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
 
         _testContextImplementation.AddResultFile("C:\\files\\myfile.txt");
         _testContextImplementation.AddResultFile("C:\\files\\myfile2.txt");
@@ -338,7 +338,7 @@ public class TestContextImplementationTests : TestContainer
         messageLoggerMock
             .Setup(l => l.SendMessage(It.IsAny<TestMessageLevel>(), It.IsAny<string>()));
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, _properties, messageLoggerMock.Object, testRunCancellationToken: null);
+        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties, messageLoggerMock.Object, testRunCancellationToken: null);
         _testContextImplementation.DisplayMessage(MessageLevel.Informational, "InfoMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Warning, "WarningMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Error, "ErrorMessage");

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
@@ -65,9 +65,9 @@ internal class TestablePlatformServiceProvider : IPlatformServiceProvider
 
     public bool IsGracefulStopRequested { get; set; }
 
-    public ITestContext GetTestContext(ITestMethod? testMethod, IDictionary<string, object?> properties, IMessageLogger messageLogger, UnitTestOutcome outcome)
+    public ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, UnitTestOutcome outcome)
     {
-        var testContextImpl = new TestContextImplementation(testMethod, properties, messageLogger, testRunCancellationToken: null);
+        var testContextImpl = new TestContextImplementation(testMethod, testClassFullName, properties, messageLogger, testRunCancellationToken: null);
         testContextImpl.SetOutcome(outcome);
         return testContextImpl;
     }


### PR DESCRIPTION
Code cleanup, and also ensures that class name is available when running class init/cleanup.

Related to #1285