### PR TITLE
projects should inherit defined constants

### DIFF
--- a/samples/FxExtensibility/FxExtensibility.csproj
+++ b/samples/FxExtensibility/FxExtensibility.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <RootNamespace>MSTest.Extensibility.Samples</RootNamespace>
     <AssemblyName>MSTest.Extensibility.Samples</AssemblyName>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -42,7 +42,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter</AssemblyName>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <!-- Force NuGet package dependencies to be copied to the output directory so we can embed AdapterUtilities in our NuGet. -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</AssemblyName>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
   <!-- Properties specific to UWP -->

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(MicrosoftTestingTargetFrameworks);netstandard2.0</TargetFrameworks>
-    <DefineConstants>PLATFORM_MSBUILD</DefineConstants>
+    <DefineConstants>$(DefineConstants);PLATFORM_MSBUILD</DefineConstants>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
   </PropertyGroup>
 

--- a/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
+++ b/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
@@ -36,7 +36,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio.TestTools.UnitTesting</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions</AssemblyName>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
   <!-- WinUI specific properties -->

--- a/src/TestFramework/TestFramework/TestFramework.csproj
+++ b/src/TestFramework/TestFramework/TestFramework.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio.TestTools.UnitTesting</RootNamespace>
     <AssemblyName>Microsoft.VisualStudio.TestPlatform.TestFramework</AssemblyName>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/TestProject/TestProjectForDiscovery.csproj
+++ b/test/IntegrationTests/TestAssets/TestProject/TestProjectForDiscovery.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <IsCodedUITest>False</IsCodedUITest>


### PR DESCRIPTION
this was one of the blockers when i was working on https://github.com/microsoft/testfx/pull/4368

since those csproj ignored solution level constants