### PR TITLE
remove redundant environment instance in TestHostBuilder

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -134,7 +134,6 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         // Current test platform is picky on unhandled exception, we will tear down the process in that case.
         // This mode can be too aggressive especially compared to the old framework, so we allow the user to disable it if their suite
         // relies on unhandled exception.
-        IEnvironment environment = serviceProvider.GetEnvironment();
 
         // Check the config file, by default is not specified the policy is false.
         _ = bool.TryParse(configuration[PlatformConfigurationConstants.PlatformExitProcessOnUnhandledException]!, out bool isFileConfiguredToFailFast);


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->