### PR TITLE
Remove args from AddSelfRegisteredExtensions

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestingPlatformBuilderHook.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestingPlatformBuilderHook.cs
@@ -16,9 +16,8 @@ public static class TestingPlatformBuilderHook
     /// Adds MSTest support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder on which registering MSTest.</param>
-    /// <param name="arguments">The test application cli arguments.</param>
 #pragma warning disable IDE0060 // Remove unused parameter
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] arguments)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 }
 #endif

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/PublicAPI/PublicAPI.Shipped.txt
@@ -2,4 +2,4 @@
 Microsoft.Testing.Extensions.AzureDevOpsExtensions
 Microsoft.Testing.Extensions.AzureDevOpsReport.TestingPlatformBuilderHook
 static Microsoft.Testing.Extensions.AzureDevOpsExtensions.AddAzureDevOpsProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void
-static Microsoft.Testing.Extensions.AzureDevOpsReport.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.AzureDevOpsReport.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds Azure DevOps reporting support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddAzureDevOpsProvider();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/PublicAPI/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
 Microsoft.Testing.Extensions.CrashDump.TestingPlatformBuilderHook
 Microsoft.Testing.Extensions.CrashDumpExtensions
-static Microsoft.Testing.Extensions.CrashDump.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.CrashDump.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void
 static Microsoft.Testing.Extensions.CrashDumpExtensions.AddCrashDumpProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder, bool ignoreIfNotSupported = false) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds crash dump support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/PublicAPI/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
 Microsoft.Testing.Extensions.HangDump.TestingPlatformBuilderHook
 Microsoft.Testing.Extensions.HangDumpExtensions
-static Microsoft.Testing.Extensions.HangDump.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.HangDump.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void
 static Microsoft.Testing.Extensions.HangDumpExtensions.AddHangDumpProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds HangDump support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddHangDumpProvider();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/PublicAPI/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
 Microsoft.Testing.Extensions.HotReload.TestingPlatformBuilderHook
 Microsoft.Testing.Extensions.HotReloadExtensions
-static Microsoft.Testing.Extensions.HotReload.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.HotReload.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void
 static Microsoft.Testing.Extensions.HotReloadExtensions.AddHotReloadProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds Hot Reload support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddHotReloadProvider();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/PublicAPI.Shipped.txt
@@ -2,4 +2,4 @@
 Microsoft.Testing.Platform.MSBuild.MSBuildExtensions
 Microsoft.Testing.Platform.MSBuild.TestingPlatformBuilderHook
 static Microsoft.Testing.Platform.MSBuild.MSBuildExtensions.AddMSBuild(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void
-static Microsoft.Testing.Platform.MSBuild.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Platform.MSBuild.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds MSBuild support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddMSBuild();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/PublicAPI/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
 Microsoft.Testing.Extensions.Retry.TestingPlatformBuilderHook
 Microsoft.Testing.Extensions.RetryExtensions
-static Microsoft.Testing.Extensions.Retry.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.Retry.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void
 static Microsoft.Testing.Extensions.RetryExtensions.AddRetryProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds Retry support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddRetryProvider();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/PublicAPI/PublicAPI.Shipped.txt
@@ -2,4 +2,4 @@
 Microsoft.Testing.Extensions.AppInsightsTelemetryProviderExtensions
 Microsoft.Testing.Extensions.Telemetry.TestingPlatformBuilderHook
 static Microsoft.Testing.Extensions.AppInsightsTelemetryProviderExtensions.AddAppInsightsTelemetryProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void
-static Microsoft.Testing.Extensions.Telemetry.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.Telemetry.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds AppInsights support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddAppInsightsTelemetryProvider();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/PublicAPI/PublicAPI.Shipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
 Microsoft.Testing.Extensions.TrxReport.TestingPlatformBuilderHook
 Microsoft.Testing.Extensions.TrxReportExtensions
-static Microsoft.Testing.Extensions.TrxReport.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, string![]! _) -> void
+static Microsoft.Testing.Extensions.TrxReport.TestingPlatformBuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder) -> void
 static Microsoft.Testing.Extensions.TrxReportExtensions.AddTrxReportProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TestingPlatformBuilderHook.cs
@@ -14,7 +14,6 @@ public static class TestingPlatformBuilderHook
     /// Adds TrxReport support to the Testing Platform Builder.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
-    /// <param name="_">The command line arguments.</param>
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddTrxReportProvider();
 }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformAutoRegisteredExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformAutoRegisteredExtensions.cs
@@ -80,7 +80,7 @@ Expected item spec:
     </TestingPlatformBuilderHook>
 </ItemGroup>
 Expected method signature
-static Contoso.BuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.TestApplicationBuilder builder, string[] args)
+static Contoso.BuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.TestApplicationBuilder builder)
 """;
 
     private readonly IFileSystem _fileSystem;
@@ -179,7 +179,7 @@ static Contoso.BuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.Test
                 _ => throw ApplicationStateGuard.Unreachable(),
             };
 
-            builder.Append(CultureInfo.InvariantCulture, $"{global}{taskItems[i].GetMetadata(TypeFullNameMetadataName)}.AddExtensions(builder, args){(language == CSharpLanguageSymbol ? ";" : string.Empty)}");
+            builder.Append(CultureInfo.InvariantCulture, $"{global}{taskItems[i].GetMetadata(TypeFullNameMetadataName)}.AddExtensions(builder){(language == CSharpLanguageSymbol ? ";" : string.Empty)}");
             if (i < taskItems.Length - 1)
             {
                 builder.AppendLine();
@@ -211,7 +211,7 @@ static Contoso.BuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.Test
 [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 internal static class SelfRegisteredExtensions
 {
-    public static void AddSelfRegisteredExtensions(this global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder, string[] args)
+    public static void AddSelfRegisteredExtensions(this global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder)
     {
         {{extensionsFragments}}
     }
@@ -229,7 +229,7 @@ namespace {{rootNamespace}}
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     internal static class SelfRegisteredExtensions
     {
-        public static void AddSelfRegisteredExtensions(this global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder, string[] args)
+        public static void AddSelfRegisteredExtensions(this global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder)
         {
             {{extensionsFragments}}
         }
@@ -252,7 +252,7 @@ namespace {{rootNamespace}}
 <System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage>
 Friend Module SelfRegisteredExtensions
     <System.Runtime.CompilerServices.Extension>
-    Public Sub AddSelfRegisteredExtensions(ByVal builder As Global.Microsoft.Testing.Platform.Builder.ITestApplicationBuilder, ByVal args As Global.System.String())
+    Public Sub AddSelfRegisteredExtensions(ByVal builder As Global.Microsoft.Testing.Platform.Builder.ITestApplicationBuilder)
         {{extensionsFragments}}
     End Sub
 End Module
@@ -277,7 +277,7 @@ open System.Runtime.CompilerServices
 type SelfRegisteredExtensions() =
 
     [<Extension>]
-    static member AddSelfRegisteredExtensions (builder: Microsoft.Testing.Platform.Builder.ITestApplicationBuilder, args: string[]) =
+    static member AddSelfRegisteredExtensions (builder: Microsoft.Testing.Platform.Builder.ITestApplicationBuilder) =
         {{(extensionsFragments.Length > 0 ? extensionsFragments : "()")}}
 """
                 : $$"""
@@ -296,7 +296,7 @@ open System.Runtime.CompilerServices
 type SelfRegisteredExtensions() =
 
     [<Extension>]
-    static member AddSelfRegisteredExtensions (builder: Microsoft.Testing.Platform.Builder.ITestApplicationBuilder, args: string[]) =
+    static member AddSelfRegisteredExtensions (builder: Microsoft.Testing.Platform.Builder.ITestApplicationBuilder) =
         {{(extensionsFragments.Length > 0 ? extensionsFragments : "()")}}
 """;
         }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformEntryPointTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformEntryPointTask.cs
@@ -112,7 +112,7 @@ internal sealed class MicrosoftTestingPlatformEntryPoint
     public static async global::System.Threading.Tasks.Task<int> Main(string[] args)
     {
         global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder = await global::Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args);
-        SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args);
+        SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder);
         using (global::Microsoft.Testing.Platform.Builder.ITestApplication app = await builder.BuildAsync())
         {
             return await app.RunAsync();
@@ -135,7 +135,7 @@ namespace {{rootNamespace}}
         public static async global::System.Threading.Tasks.Task<int> Main(string[] args)
         {
             global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder = await global::Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args);
-            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args);
+            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder);
             using (global::Microsoft.Testing.Platform.Builder.ITestApplication app = await builder.BuildAsync())
             {
                 return await app.RunAsync();
@@ -166,7 +166,7 @@ Module MicrosoftTestingPlatformEntryPoint
 
     Public Async Function MainAsync(args As String()) As Global.System.Threading.Tasks.Task(Of Integer)
         Dim builder = Await Global.Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args)
-        SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args)
+        SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder)
         Using testApplication = Await builder.BuildAsync()
             Return Await testApplication.RunAsync()
         End Using
@@ -192,7 +192,7 @@ module MicrosoftTestingPlatformEntryPoint =
     let main args =
         task {
             let! builder = Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync args
-            Microsoft.TestingPlatform.Extensions.SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args)
+            Microsoft.TestingPlatform.Extensions.SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder)
             use! app = builder.BuildAsync()
             return! app.RunAsync()
         }
@@ -215,7 +215,7 @@ module MicrosoftTestingPlatformEntryPoint =
     let main args =
         task {
             let! builder = Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync args
-            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args)
+            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder)
             use! app = builder.BuildAsync()
             return! app.RunAsync()
         }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -668,7 +668,7 @@ public class Program
         builder.RegisterTestFramework(
             sp => new TestFrameworkCapabilities(),
             (_,__) => new DummyTestFramework());
-        builder.AddSelfRegisteredExtensions(args);
+        builder.AddSelfRegisteredExtensions();
         using ITestApplication app = await builder.BuildAsync();
         return await app.RunAsync();
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuild.KnownExtensionRegistration.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuild.KnownExtensionRegistration.cs
@@ -90,7 +90,7 @@ namespace MyNamespaceRoot.Level1.Level2;
 
 public static class DummyTestFrameworkRegistration
 {
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] args)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
     {
         testApplicationBuilder.RegisterTestFramework(_ => new Capabilities(), (_, __) => new DummyTestFramework());
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
@@ -48,7 +48,7 @@ namespace MSBuildTests
         public static async global::System.Threading.Tasks.Task<int> Main(string[] args)
         {
             global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder = await global::Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args);
-            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args);
+            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder);
             using (global::Microsoft.Testing.Platform.Builder.ITestApplication app = await builder.BuildAsync())
             {
                 return await app.RunAsync();
@@ -77,7 +77,7 @@ Module MicrosoftTestingPlatformEntryPoint
 
     Public Async Function MainAsync(args As String()) As Global.System.Threading.Tasks.Task(Of Integer)
         Dim builder = Await Global.Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args)
-        SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args)
+        SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder)
         Using testApplication = Await builder.BuildAsync()
             Return Await testApplication.RunAsync()
         End Using
@@ -105,7 +105,7 @@ module MicrosoftTestingPlatformEntryPoint =
     let main args =
         task {
             let! builder = Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync args
-            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args)
+            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder)
             use! app = builder.BuildAsync()
             return! app.RunAsync()
         }
@@ -194,7 +194,7 @@ namespace MyNamespaceRoot.Level1.Level2;
 
 public static class DummyTestFrameworkRegistration
 {
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] args)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
     {
         testApplicationBuilder.RegisterTestFramework(_ => new Capabilities(), (_, __) => new DummyTestFramework());
     }
@@ -202,7 +202,7 @@ public static class DummyTestFrameworkRegistration
 
 public static class DummyTestFrameworkRegistration2
 {
-    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] args)
+    public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder)
     {
 
     }

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/MSBuildTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/MSBuildTests.cs
@@ -45,7 +45,7 @@ namespace SomeNamespace
         public static async global::System.Threading.Tasks.Task<int> Main(string[] args)
         {
             global::Microsoft.Testing.Platform.Builder.ITestApplicationBuilder builder = await global::Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args);
-            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args);
+            SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder);
             using (global::Microsoft.Testing.Platform.Builder.ITestApplication app = await builder.BuildAsync())
             {
                 return await app.RunAsync();


### PR DESCRIPTION
This pull request introduces several updates to the project configuration, dependencies, and test framework support. The changes primarily focus on modernizing the supported platforms, streamlining configurations, and updating packages to align with newer versions. Additionally, some temporary adjustments and cleanup tasks are noted for future action.

### Updates to platform and framework support:
* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR17-R30): Updated `WinUiMinimum` to `net8.0-windows10.0.18362.0` and removed support for older frameworks (`net6.0` and `net7.0`) in `MicrosoftTestingTargetFrameworks` and `SupportedNetFrameworks`.
* [`src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj`](diffhunk://#diff-17b431dbe7bf1c3ee0a13cbf4014b326c50f4a43bd6d652598cebc4abe8b9b17L8-R9): Removed support for `netstandard2.0`, `netcoreapp3.1`, and `net6.0` in non-Windows target frameworks, retaining support for `net8.0` and newer. Updated supported platforms description in package metadata. [[1]](diffhunk://#diff-17b431dbe7bf1c3ee0a13cbf4014b326c50f4a43bd6d652598cebc4abe8b9b17L8-R9) [[2]](diffhunk://#diff-17b431dbe7bf1c3ee0a13cbf4014b326c50f4a43bd6d652598cebc4abe8b9b17L32-R32)

### Dependency and version updates:
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L56-R56): Updated `Microsoft.WindowsAppSDK` package version from `1.0.0` to `1.6.240923002`.
* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L4-R6): Incremented `VersionPrefix` for MSTest to `4.0.0` and `TestingPlatformVersionPrefix` to `2.0.0`.

### Configuration cleanup and temporary adjustments:
* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eR17-R30): Temporarily disabled public API warnings (`RS0016`, `RS0017`, `RS2003`, `RS2002`) with a note to re-enable before merging to the main branch.
* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R7): Added temporary inclusion of `dev/v4` branch for pipeline operations, with a note to clean up later.

### Test framework adjustments:
* [`eng/verify-nupkgs.ps1`](diffhunk://#diff-c2cf82accd054db84a0799d3c4e0ae629294d0b2bf9c728a6f7a918402b834b7L23-R25): Reduced the expected number of files for several packages (`MSTest.TestFramework`, `MSTest.TestAdapter`, and `MSTest`), reflecting streamlined configurations.
* [`src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.NonWindows.nuspec`](diffhunk://#diff-e94bb44fd64a95f2e2b7955e010d73e9a626bb5b418b778029c69d18b2f917f7L6-L21): Removed dependency and file entries for unsupported frameworks (`netstandard2.0`, `netcoreapp3.1`, `net6.0`, and `net7.0`). Updated file paths for `net8.0` and `net9.0`. [[1]](diffhunk://#diff-e94bb44fd64a95f2e2b7955e010d73e9a626bb5b418b778029c69d18b2f917f7L6-L21) [[2]](diffhunk://#diff-e94bb44fd64a95f2e2b7955e010d73e9a626bb5b418b778029c69d18b2f917f7L36-R40)

### Miscellaneous changes:
* [`TestFx.slnx`](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL15-R15): Added unique IDs to solution folder definitions for better organization. [[1]](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL15-R15) [[2]](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL26-R34) [[3]](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL49-R58) [[4]](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL68-R68) [[5]](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL77-R84) [[6]](diffhunk://#diff-797ede5e78c405de5968cec4cd09ed0f0e74f96c994abec1db101db3e6684dcbL110-R121)
* [`src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj`](diffhunk://#diff-17b431dbe7bf1c3ee0a13cbf4014b326c50f4a43bd6d652598cebc4abe8b9b17R120-R123): Added `InternalsVisibleTo` for `MSTest.Analyzers.UnitTests` to allow conditional inclusion of adapters in tests.