### PR TITLE
Fix STA regression when async method completes asynchronously between sync methods

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
@@ -342,12 +342,17 @@ public class UnitTest1
     public async Task TestMethod2()
     {
         AssertCorrectThreadApartmentState();
+        // Ensure that we continue on a thread pool thread after this await.
         await Task.Yield();
+        Assert.IsTrue(Thread.CurrentThread.IsThreadPoolThread);
     }
 
     [TestMethod]
     public Task TestMethod3()
     {
+        // TestMethod2 finished on a thread pool thread.
+        // However, here in this method we should still start on STA thread.
+        Assert.IsFalse(Thread.CurrentThread.IsThreadPoolThread);
         AssertCorrectThreadApartmentState();
         return Task.CompletedTask;
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
@@ -349,7 +349,7 @@ public class UnitTest1
     public Task TestMethod3()
     {
         AssertCorrectThreadApartmentState();
-        return Task.Yield();
+        return Task.CompletedTask;
     }
 
 #if NET

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
@@ -342,14 +342,14 @@ public class UnitTest1
     public async Task TestMethod2()
     {
         AssertCorrectThreadApartmentState();
-        await Task.CompletedTask;
+        await Task.Yield();
     }
 
     [TestMethod]
     public Task TestMethod3()
     {
         AssertCorrectThreadApartmentState();
-        return Task.CompletedTask;
+        return Task.Yield();
     }
 
 #if NET

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ThreadingTests.cs
@@ -350,9 +350,13 @@ public class UnitTest1
     [TestMethod]
     public Task TestMethod3()
     {
-        // TestMethod2 finished on a thread pool thread.
-        // However, here in this method we should still start on STA thread.
-        Assert.IsFalse(Thread.CurrentThread.IsThreadPoolThread);
+        if (Environment.GetEnvironmentVariable("MSTEST_THREAD_STATE_IS_STA") == "1")
+        {
+            // TestMethod2 finished on a thread pool thread.
+            // However, here in this method we should still start on STA thread.
+            Assert.IsFalse(Thread.CurrentThread.IsThreadPoolThread);
+        }
+
         AssertCorrectThreadApartmentState();
         return Task.CompletedTask;
     }


### PR DESCRIPTION
This is one possible fix for #5920, and it's the "easy" fix.

We could go with adding our own synchronization context, which actually will ensure that async sta test methods will also continue on STA, which isn't (and was never) the case.

Maybe we can fix it better in v4 and add our custom synchronization context for both STATestMethodAttribute and the global setting as well?