### PR TITLE
Show whole error with stack trace

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,6 +225,7 @@ stages:
             env:
               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+              DOTNET_CLI_CONTEXT_VERBOSE: 1
 
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,6 +104,7 @@ stages:
             env:
               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+              DOTNET_CLI_CONTEXT_VERBOSE: 1
 
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx
@@ -168,6 +169,7 @@ stages:
             env:
               DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
+              DOTNET_CLI_CONTEXT_VERBOSE: 1
 
           # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
           # through the console or trx


### PR DESCRIPTION
Shows whole stack trace for unhandled and other exceptions so we can investigate that "handle not initialized" error.

https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/Parser.cs#L262-L265