### PR TITLE
use XElement.LoadAsync in TrxCompareTool

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
-    <PackageVersion Include="Polyfill" Version="9.0.0-beta.10" />
+    <PackageVersion Include="Polyfill" Version="9.0.0-beta.12" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup Label="Test dependencies">

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
@@ -177,8 +177,8 @@ internal sealed class TrxCompareTool : ITool, IOutputDeviceDataProducer
 
     private static async Task CollectEntriesAndErrorsAsync(string trxFile, XNamespace ns, List<(string TestName, string Outcome, string Storage)> results, List<string> issues)
     {
-        using var stream = File.OpenRead(trxFile);
-        var trxTestRun = await XElement.LoadAsync(stream, LoadOptions.None, CancellationToken.None).ConfigureAwait(false);
+        using FileStream stream = File.OpenRead(trxFile);
+        XElement trxTestRun = await XElement.LoadAsync(stream, LoadOptions.None, CancellationToken.None).ConfigureAwait(false);
         int testResultIndex = 0;
         foreach (XElement testResult in trxTestRun.Elements(ns + "Results").Elements(ns + "UnitTestResult"))
         {

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
@@ -60,8 +60,9 @@ internal sealed class TrxCompareTool : ITool, IOutputDeviceDataProducer
         List<(string TestName, string Outcome, string Storage)> comparedResults = [];
         List<string> comparedIssues = [];
         await _task.WhenAll(
-            _task.Run(() => CollectEntriesAndErrors(baselineFilePaths[0], trxNamespace, baseLineResults, baseLineIssues)),
-            _task.Run(() => CollectEntriesAndErrors(comparedFilePaths[0], trxNamespace, comparedResults, comparedIssues))).ConfigureAwait(false);
+            CollectEntriesAndErrorsAsync(baselineFilePaths[0], trxNamespace, baseLineResults, baseLineIssues),
+            CollectEntriesAndErrorsAsync(comparedFilePaths[0], trxNamespace, comparedResults, comparedIssues))
+            .ConfigureAwait(false);
 
         StringBuilder outputBuilder = new();
         AppendResultsAndIssues("Baseline", baselineFilePaths[0], baseLineResults, baseLineIssues, outputBuilder);
@@ -174,9 +175,10 @@ internal sealed class TrxCompareTool : ITool, IOutputDeviceDataProducer
         outputBuilder.AppendLine();
     }
 
-    private static void CollectEntriesAndErrors(string trxFile, XNamespace ns, List<(string TestName, string Outcome, string Storage)> results, List<string> issues)
+    private static async Task CollectEntriesAndErrorsAsync(string trxFile, XNamespace ns, List<(string TestName, string Outcome, string Storage)> results, List<string> issues)
     {
-        var trxTestRun = XElement.Parse(File.ReadAllText(trxFile));
+        using var stream = File.OpenRead(trxFile);
+        var trxTestRun = await XElement.LoadAsync(stream, LoadOptions.None, CancellationToken.None).ConfigureAwait(false);
         int testResultIndex = 0;
         foreach (XElement testResult in trxTestRun.Elements(ns + "Results").Elements(ns + "UnitTestResult"))
         {


### PR DESCRIPTION
and avoid task.Run calls

<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->