### PR TITLE
Add TryGetOptionArgument

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -87,10 +87,9 @@ internal sealed class AzureDevOpsReporter :
             return Task.FromResult(false);
         }
 
-        bool found = _commandLine.TryGetOptionArgumentList(AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity, out string[]? arguments);
-        if (found && arguments?.Length > 0)
+        if (_commandLine.TryGetOptionArgument(AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity, out string? argument))
         {
-            _severity = arguments[0].ToLowerInvariant();
+            _severity = argument.ToLowerInvariant();
             if (_logger.IsEnabled(LogLevel.Trace))
             {
                 _logger.LogTrace($"Severity is set to '{_severity}', by --report-azdo-severity parameter.");

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs
@@ -71,9 +71,9 @@ internal sealed class CrashDumpEnvironmentVariableProvider : ITestHostEnvironmen
 
         string miniDumpTypeValue = "4";
 
-        if (_commandLineOptions.TryGetOptionArgumentList(CrashDumpCommandLineOptions.CrashDumpTypeOptionName, out string[]? dumpTypeString))
+        if (_commandLineOptions.TryGetOptionArgument(CrashDumpCommandLineOptions.CrashDumpTypeOptionName, out string? dumpTypeString))
         {
-            switch (dumpTypeString[0].ToLowerInvariant().Trim())
+            switch (dumpTypeString.ToLowerInvariant().Trim())
             {
                 case "mini":
                     {
@@ -112,8 +112,8 @@ internal sealed class CrashDumpEnvironmentVariableProvider : ITestHostEnvironmen
             environmentVariables.SetVariable(new($"{prefix}{MiniDumpTypeVariable}", miniDumpTypeValue, false, true));
         }
 
-        _miniDumpNameValue = _commandLineOptions.TryGetOptionArgumentList(CrashDumpCommandLineOptions.CrashDumpFileNameOptionName, out string[]? dumpFileName)
-            ? Path.Combine(_configuration.GetTestResultDirectory(), dumpFileName[0])
+        _miniDumpNameValue = _commandLineOptions.TryGetOptionArgument(CrashDumpCommandLineOptions.CrashDumpFileNameOptionName, out string? dumpFileName)
+            ? Path.Combine(_configuration.GetTestResultDirectory(), dumpFileName)
             : Path.Combine(_configuration.GetTestResultDirectory(), $"{Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath())}_%p_crash.dmp");
         _crashDumpGeneratorConfiguration.DumpFileNamePattern = _miniDumpNameValue;
         foreach (string prefix in Prefixes)

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -103,19 +103,19 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
 
     public async Task BeforeTestHostProcessStartAsync(CancellationToken cancellationToken)
     {
-        if (_commandLineOptions.TryGetOptionArgumentList(HangDumpCommandLineProvider.HangDumpTimeoutOptionName, out string[]? timeout))
+        if (_commandLineOptions.TryGetOptionArgument(HangDumpCommandLineProvider.HangDumpTimeoutOptionName, out string? timeout))
         {
-            _activityTimerValue = TimeSpanParser.Parse(timeout[0]);
+            _activityTimerValue = TimeSpanParser.Parse(timeout);
         }
 
-        if (_commandLineOptions.TryGetOptionArgumentList(HangDumpCommandLineProvider.HangDumpTypeOptionName, out string[]? dumpType))
+        if (_commandLineOptions.TryGetOptionArgument(HangDumpCommandLineProvider.HangDumpTypeOptionName, out string? dumpType))
         {
-            _dumpType = dumpType[0];
+            _dumpType = dumpType;
         }
 
-        if (_commandLineOptions.TryGetOptionArgumentList(HangDumpCommandLineProvider.HangDumpFileNameOptionName, out string[]? fileName))
+        if (_commandLineOptions.TryGetOptionArgument(HangDumpCommandLineProvider.HangDumpFileNameOptionName, out string? fileName))
         {
-            _dumpFileNamePattern = fileName[0];
+            _dumpFileNamePattern = fileName;
         }
 
         await _logger.LogInformationAsync($"Hang dump timeout setup {_activityTimerValue}.").ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildOrchestratorLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildOrchestratorLifecycleCallbacks.cs
@@ -42,17 +42,17 @@ internal sealed class MSBuildOrchestratorLifetime : ITestHostOrchestratorApplica
 
     public async Task BeforeRunAsync(CancellationToken cancellationToken)
     {
-        if (!_commandLineOptions.TryGetOptionArgumentList(MSBuildConstants.MSBuildNodeOptionKey, out string[]? msbuildInfo))
+        if (!_commandLineOptions.TryGetOptionArgument(MSBuildConstants.MSBuildNodeOptionKey, out string? msbuildInfo))
         {
             throw new InvalidOperationException($"MSBuild pipe name not found in the command line, missing {MSBuildConstants.MSBuildNodeOptionKey}");
         }
 
-        if (msbuildInfo is null || msbuildInfo.Length != 1 || string.IsNullOrEmpty(msbuildInfo[0]))
+        if (msbuildInfo is null || string.IsNullOrEmpty(msbuildInfo))
         {
             throw new InvalidOperationException($"MSBuild pipe name not found in the command line, missing argument for {MSBuildConstants.MSBuildNodeOptionKey}");
         }
 
-        using var pipeClient = new NamedPipeClient(msbuildInfo[0]);
+        using var pipeClient = new NamedPipeClient(msbuildInfo);
         pipeClient.RegisterSerializer(new ModuleInfoRequestSerializer(), typeof(ModuleInfoRequest));
         pipeClient.RegisterSerializer(new VoidResponseSerializer(), typeof(VoidResponse));
         using var cancellationTokenSource = new CancellationTokenSource(TimeoutHelper.DefaultHangTimeSpanTimeout);

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildTestApplicationLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildTestApplicationLifecycleCallbacks.cs
@@ -44,17 +44,17 @@ internal sealed class MSBuildTestApplicationLifecycleCallbacks : ITestHostApplic
 
     public async Task BeforeRunAsync(CancellationToken cancellationToken)
     {
-        if (!_commandLineOptions.TryGetOptionArgumentList(MSBuildConstants.MSBuildNodeOptionKey, out string[]? msbuildInfo))
+        if (!_commandLineOptions.TryGetOptionArgument(MSBuildConstants.MSBuildNodeOptionKey, out string? msbuildInfo))
         {
             throw new InvalidOperationException($"MSBuild pipe name not found in the command line, missing {MSBuildConstants.MSBuildNodeOptionKey}");
         }
 
-        if (msbuildInfo is null || msbuildInfo.Length != 1 || string.IsNullOrEmpty(msbuildInfo[0]))
+        if (msbuildInfo is null || string.IsNullOrEmpty(msbuildInfo))
         {
             throw new InvalidOperationException($"MSBuild pipe name not found in the command line, missing argument for {MSBuildConstants.MSBuildNodeOptionKey}");
         }
 
-        PipeClient = new(msbuildInfo[0]);
+        PipeClient = new(msbuildInfo);
         PipeClient.RegisterSerializer(new ModuleInfoRequestSerializer(), typeof(ModuleInfoRequest));
         PipeClient.RegisterSerializer(new VoidResponseSerializer(), typeof(VoidResponse));
         PipeClient.RegisterSerializer(new FailedTestInfoRequestSerializer(), typeof(FailedTestInfoRequest));

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryLifecycleCallbacks.cs
@@ -46,7 +46,7 @@ internal sealed class RetryLifecycleCallbacks : ITestHostApplicationLifetime,
 
     public async Task BeforeRunAsync(CancellationToken cancellationToken)
     {
-        if (!_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName, out string[]? pipeName))
+        if (!_commandLineOptions.TryGetOptionArgument(RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName, out string? pipeName))
         {
             throw ApplicationStateGuard.Unreachable();
         }
@@ -55,9 +55,9 @@ internal sealed class RetryLifecycleCallbacks : ITestHostApplicationLifetime,
 
         Guard.NotNull(pipeName);
         ArgumentGuard.Ensure(pipeName.Length == 1, nameof(pipeName), "Pipe name expected");
-        logger.LogDebug($"Connecting to pipe '{pipeName[0]}'");
+        logger.LogDebug($"Connecting to pipe '{pipeName}'");
 
-        Client = new(pipeName[0]);
+        Client = new(pipeName);
         Client.RegisterSerializer(new VoidResponseSerializer(), typeof(VoidResponse));
         Client.RegisterSerializer(new FailedTestRequestSerializer(), typeof(FailedTestRequest));
         Client.RegisterSerializer(new GetListOfFailedTestsRequestSerializer(), typeof(GetListOfFailedTestsRequest));

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -87,13 +87,13 @@ internal sealed class RetryOrchestrator : ITestHostOrchestrator, IOutputDeviceDa
         ITestApplicationModuleInfo currentTestApplicationModuleInfo = _serviceProvider.GetTestApplicationModuleInfo();
         ExecutableInfo executableInfo = currentTestApplicationModuleInfo.GetCurrentExecutableInfo();
 
-        if (!_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsOptionName, out string[]? cmdRetries))
+        if (!_commandLineOptions.TryGetOptionArgument(RetryCommandLineOptionsProvider.RetryFailedTestsOptionName, out string? cmdRetries))
         {
             throw ApplicationStateGuard.Unreachable();
         }
 
         ApplicationStateGuard.Ensure(cmdRetries is not null);
-        int userMaxRetryCount = int.Parse(cmdRetries[0], CultureInfo.InvariantCulture);
+        int userMaxRetryCount = int.Parse(cmdRetries, CultureInfo.InvariantCulture);
 
         // Find out the retry args index inside the arguments to after cleanup the command line when we restart
         List<int> indexToCleanup = [];
@@ -241,15 +241,15 @@ internal sealed class RetryOrchestrator : ITestHostOrchestrator, IOutputDeviceDa
                     double? maxFailedTests = null;
                     double? maxPercentage = null;
                     double? maxCount = null;
-                    if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, out string[]? retryFailedTestsMaxPercentage))
+                    if (_commandLineOptions.TryGetOptionArgument(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, out string? retryFailedTestsMaxPercentage))
                     {
-                        maxPercentage = double.Parse(retryFailedTestsMaxPercentage[0], CultureInfo.InvariantCulture);
+                        maxPercentage = double.Parse(retryFailedTestsMaxPercentage, CultureInfo.InvariantCulture);
                         maxFailedTests = maxPercentage / 100 * retryFailedTestsPipeServer.TotalTestRan;
                     }
 
-                    if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, out string[]? retryFailedTestsMaxCount))
+                    if (_commandLineOptions.TryGetOptionArgument(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, out string? retryFailedTestsMaxCount))
                     {
-                        maxCount = double.Parse(retryFailedTestsMaxCount[0], CultureInfo.InvariantCulture);
+                        maxCount = double.Parse(retryFailedTestsMaxCount, CultureInfo.InvariantCulture);
                         maxFailedTests = maxCount.Value;
                     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
@@ -163,9 +163,9 @@ internal sealed partial class TrxReportEngine
             string runDeploymentRoot = AddTestSettings(testRun, testRunName);
             bool isFileNameExplicitlyProvided;
             string trxFileName;
-            if (_commandLineOptionsService.TryGetOptionArgumentList(TrxReportGeneratorCommandLine.TrxReportFileNameOptionName, out string[]? fileName))
+            if (_commandLineOptionsService.TryGetOptionArgument(TrxReportGeneratorCommandLine.TrxReportFileNameOptionName, out string? fileName))
             {
-                trxFileName = ReplaceInvalidFileNameChars(fileName[0]);
+                trxFileName = ReplaceInvalidFileNameChars(fileName);
                 isFileNameExplicitlyProvided = true;
             }
             else

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Configurations/RunSettingsConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Configurations/RunSettingsConfigurationProvider.cs
@@ -60,9 +60,9 @@ internal sealed class RunSettingsConfigurationProvider(IFileSystem fileSystem) :
     /// <inheritdoc />
     public async Task<IConfigurationProvider> BuildAsync(CommandLineParseResult commandLineParseResult)
     {
-        if (commandLineParseResult.TryGetOptionArgumentList(RunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string[]? runSettingsFilePath))
+        if (commandLineParseResult.TryGetOptionArgument(RunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string? runSettingsFilePath))
         {
-            if (_fileSystem.Exists(runSettingsFilePath[0]))
+            if (_fileSystem.Exists(runSettingsFilePath))
             {
                 _runSettingsFileContent = await _fileSystem.ReadAllTextAsync(runSettingsFilePath[0]).ConfigureAwait(false);
             }

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ContextAdapterBase.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ContextAdapterBase.cs
@@ -23,11 +23,9 @@ internal abstract class ContextAdapterBase
         string? filterFromCommandLineOption = null;
         if (commandLineOptions.TryGetOptionArgumentList(
             TestCaseFilterCommandLineOptionsProvider.TestCaseFilterOptionName,
-            out string[]? filterExpressions)
-            && filterExpressions is not null
-            && filterExpressions.Length == 1)
+            out string? filterExpression))
         {
-            filterFromCommandLineOption = filterExpressions[0];
+            filterFromCommandLineOption = filterExpression;
         }
 
         HandleFilter(filter, filterFromRunsettings, filterFromCommandLineOption);

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsAdapter.cs
@@ -42,12 +42,10 @@ internal sealed class RunSettingsAdapter : IRunSettings
     {
         string? runSettingsXml = string.Empty;
 
-        if (commandLineOptions.TryGetOptionArgumentList(RunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string[]? fileNames)
-             && fileNames is not null
-            && fileNames.Length == 1
-            && fileSystem.Exists(fileNames[0]))
+        if (commandLineOptions.TryGetOptionArgument(RunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string? fileName)
+            && fileSystem.Exists(fileName))
         {
-            runSettingsXml = fileSystem.ReadAllText(fileNames[0]);
+            runSettingsXml = fileSystem.ReadAllText(fileName);
         }
         else
         {

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/TestHostControllers/RunSettingsEnvironmentVariableProvider .cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/TestHostControllers/RunSettingsEnvironmentVariableProvider .cs
@@ -33,17 +33,17 @@ internal sealed class RunSettingsEnvironmentVariableProvider : ITestHostEnvironm
 
     public async Task<bool> IsEnabledAsync()
     {
-        if (!_commandLineOptions.TryGetOptionArgumentList(RunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string[]? runsettings))
+        if (!_commandLineOptions.TryGetOptionArgument(RunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string? runsettings))
         {
             return false;
         }
 
-        if (!_fileSystem.Exists(runsettings[0]))
+        if (!_fileSystem.Exists(runsettings))
         {
             return false;
         }
 
-        using IFileStream fileStream = _fileSystem.NewFileStream(runsettings[0], FileMode.Open, FileAccess.Read);
+        using IFileStream fileStream = _fileSystem.NewFileStream(runsettings, FileMode.Open, FileAccess.Read);
 #if NETCOREAPP
         _runSettings = await XDocument.LoadAsync(fileStream.Stream, LoadOptions.None, CancellationToken.None).ConfigureAwait(false);
 #else

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineOptions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineOptions.cs
@@ -28,7 +28,7 @@ internal static class CommandLineOptionsExtensions
 {
     public static bool TryGetOptionArgument(this ICommandLineOptions options, string optionName, [NotNullWhen(true)] out string? argument)
     {
-        if (!options.TryGetOptionArgumentList(optionName, out var arguments) ||
+        if (!options.TryGetOptionArgumentList(optionName, out string[]? arguments) ||
             arguments.Length == 0)
         {
             argument = null;

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineOptions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineOptions.cs
@@ -23,3 +23,24 @@ public interface ICommandLineOptions
     /// <returns>True if the argument list is found; otherwise, false.</returns>
     bool TryGetOptionArgumentList(string optionName, [NotNullWhen(true)] out string[]? arguments);
 }
+
+internal static class CommandLineOptionsExtensions
+{
+    public static bool TryGetOptionArgument(this ICommandLineOptions options, string optionName, [NotNullWhen(true)] out string? argument)
+    {
+        if (!options.TryGetOptionArgumentList(optionName, out var arguments) ||
+            arguments.Length == 0)
+        {
+            argument = null;
+            return false;
+        }
+
+        if (arguments.Length > 1)
+        {
+            throw new($"Multiple options named '{optionName}' are not supported.");
+        }
+
+        argument = arguments[0];
+        return true;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
@@ -148,8 +148,8 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
             return 0;
         }
 
-        ApplicationStateGuard.Ensure(commandLineOptions.TryGetOptionArgumentList(MinimumExpectedTestsOptionKey, out string[]? arguments));
-        return int.Parse(arguments[0], CultureInfo.InvariantCulture);
+        ApplicationStateGuard.Ensure(commandLineOptions.TryGetOptionArgument(MinimumExpectedTestsOptionKey, out string? argument));
+        return int.Parse(argument, CultureInfo.InvariantCulture);
     }
 
     private static Task<ValidationResult> IsMinimumExpectedTestsOptionValidAsync(CommandLineOption option, string[] arguments)
@@ -181,10 +181,9 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
 
         if (commandLineOptions.IsOptionSet(ExitOnProcessExitOptionKey))
         {
-            _ = commandLineOptions.TryGetOptionArgumentList(ExitOnProcessExitOptionKey, out string[]? pid);
+            _ = commandLineOptions.TryGetOptionArgument(ExitOnProcessExitOptionKey, out string? pid);
             ApplicationStateGuard.Ensure(pid is not null);
-            RoslynDebug.Assert(pid.Length == 1);
-            int parentProcessPid = int.Parse(pid[0], CultureInfo.InvariantCulture);
+            int parentProcessPid = int.Parse(pid, CultureInfo.InvariantCulture);
             try
             {
                 // We let the api to do the validity check before to go down the subscription path.

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/AbortForMaxFailedTestsExtension.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/AbortForMaxFailedTestsExtension.cs
@@ -26,8 +26,8 @@ internal sealed class AbortForMaxFailedTestsExtension : IDataConsumer
         IStopPoliciesService policiesService,
         ITestApplicationCancellationTokenSource testApplicationCancellationTokenSource)
     {
-        if (commandLineOptions.TryGetOptionArgumentList(MaxFailedTestsCommandLineOptionsProvider.MaxFailedTestsOptionKey, out string[]? args) &&
-            int.TryParse(args[0], out int maxFailedTests) &&
+        if (commandLineOptions.TryGetOptionArgument(MaxFailedTestsCommandLineOptionsProvider.MaxFailedTestsOptionKey, out string? args) &&
+            int.TryParse(args, out int maxFailedTests) &&
             maxFailedTests > 0)
         {
             _maxFailedTests = maxFailedTests;

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/NonCooperativeParentProcessListener.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/NonCooperativeParentProcessListener.cs
@@ -20,14 +20,13 @@ internal sealed class NonCooperativeParentProcessListener : IDisposable
 
     private void SubscribeToParentProcess()
     {
-        _commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.ExitOnProcessExitOptionKey, out string[]? pid);
+        _commandLineOptions.TryGetOptionArgument(PlatformCommandLineProvider.ExitOnProcessExitOptionKey, out string? pid);
         ApplicationStateGuard.Ensure(pid is not null);
-        RoslynDebug.Assert(pid.Length == 1);
 
         try
         {
 #pragma warning disable CA1416 // Validate platform compatibility
-            _parentProcess = Process.GetProcessById(int.Parse(pid[0], CultureInfo.InvariantCulture));
+            _parentProcess = Process.GetProcessById(int.Parse(pid, CultureInfo.InvariantCulture));
             _parentProcess.EnableRaisingEvents = true;
             _parentProcess.Exited += ParentProcess_Exited;
 #pragma warning restore CA1416

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -191,8 +191,8 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         var policiesService = new StopPoliciesService(testApplicationCancellationTokenSource);
         serviceProvider.AddService(policiesService);
 
-        bool hasServerFlag = commandLineHandler.TryGetOptionArgumentList(PlatformCommandLineProvider.ServerOptionKey, out string[]? protocolName);
-        bool isJsonRpcProtocol = protocolName is null || protocolName.Length == 0 || protocolName[0].Equals(PlatformCommandLineProvider.JsonRpcProtocolName, StringComparison.OrdinalIgnoreCase);
+        bool hasServerFlag = commandLineHandler.TryGetOptionArgument(PlatformCommandLineProvider.ServerOptionKey, out string? protocolName);
+        bool isJsonRpcProtocol = protocolName is null || protocolName.Equals(PlatformCommandLineProvider.JsonRpcProtocolName, StringComparison.OrdinalIgnoreCase);
 
         ProxyOutputDevice proxyOutputDevice = await _outputDisplay.BuildAsync(serviceProvider, hasServerFlag && isJsonRpcProtocol).ConfigureAwait(false);
 
@@ -250,9 +250,8 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         serviceProvider.TryAddService(commandLineHandler);
 
         // setting the timeout
-        if (commandLineOptions.IsOptionSet(PlatformCommandLineProvider.TimeoutOptionKey) && commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.TimeoutOptionKey, out string[]? args))
+        if (commandLineOptions.IsOptionSet(PlatformCommandLineProvider.TimeoutOptionKey) && commandLineOptions.TryGetOptionArgument(PlatformCommandLineProvider.TimeoutOptionKey, out string? arg))
         {
-            string arg = args[0];
             int size = arg.Length;
             if (!float.TryParse(arg[..(size - 1)], NumberStyles.Float, CultureInfo.InvariantCulture, out float value))
             {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -130,8 +130,8 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
         // This works but is NOT USED, we prefer to have the same experience of not showing passed tests in hotReload mode as in normal mode.
         // Func<bool> showPassed = () => _runtimeFeature.IsHotReloadEnabled;
         Func<bool> showPassed = () => false;
-        bool outputOption = _commandLineOptions.TryGetOptionArgumentList(TerminalTestReporterCommandLineOptionsProvider.OutputOption, out string[]? arguments);
-        if (outputOption && arguments?.Length > 0 && TerminalTestReporterCommandLineOptionsProvider.OutputOptionDetailedArgument.Equals(arguments[0], StringComparison.OrdinalIgnoreCase))
+        bool outputOption = _commandLineOptions.TryGetOptionArgument(TerminalTestReporterCommandLineOptionsProvider.OutputOption, out string? argument);
+        if (outputOption && TerminalTestReporterCommandLineOptionsProvider.OutputOptionDetailedArgument.Equals(argument, StringComparison.OrdinalIgnoreCase))
         {
             showPassed = () => true;
         }

--- a/src/Platform/Microsoft.Testing.Platform/Requests/ConsoleTestExecutionFilterFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/ConsoleTestExecutionFilterFactory.cs
@@ -22,7 +22,7 @@ internal sealed class ConsoleTestExecutionFilterFactory(ICommandLineOptions comm
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
     public Task<(bool Success, ITestExecutionFilter? TestExecutionFilter)> TryCreateAsync() =>
-        _commandLineService.TryGetOptionArgumentList(TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter, out string[]? filter)
-            ? Task.FromResult((true, (ITestExecutionFilter?)new TreeNodeFilter(filter[0])))
+        _commandLineService.TryGetOptionArgument(TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter, out string? filter)
+            ? Task.FromResult((true, (ITestExecutionFilter?)new TreeNodeFilter(filter)))
             : Task.FromResult((true, (ITestExecutionFilter?)new NopFilter()));
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -46,7 +46,7 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol,
         // If we are in server mode and the pipe name is provided
         // then, we need to connect to the pipe server.
         if (_commandLineHandler.HasDotnetTestServerOption() &&
-            _commandLineHandler.TryGetOptionArgumentList(PlatformCommandLineProvider.DotNetTestPipeOptionKey, out string[]? arguments))
+            _commandLineHandler.TryGetOptionArgument(PlatformCommandLineProvider.DotNetTestPipeOptionKey, out string? argument))
         {
             // The execution id is used to identify the test execution
             // We are storing it as an env var so that it can be read by the test host, test host controller and the test host orchestrator
@@ -56,7 +56,7 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol,
                 _environment.SetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID, Guid.NewGuid().ToString("N"));
             }
 
-            _dotnetTestPipeClient = new(arguments[0]);
+            _dotnetTestPipeClient = new(argument);
             _dotnetTestPipeClient.RegisterAllSerializers();
 
             await _dotnetTestPipeClient.ConnectAsync(_cancellationTokenSource.CancellationToken).ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestHelper.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Testing.Platform;
 internal static class DotnetTestHelper
 {
     public static bool HasDotnetTestServerOption(this CommandLineHandler commandLineHandler) =>
-        commandLineHandler.TryGetOptionArgumentList(PlatformCommandLineProvider.ServerOptionKey, out string[]? serverArgs) &&
-        serverArgs.Length == 1 &&
-        serverArgs[0].Equals(PlatformCommandLineProvider.DotnetTestCliProtocolName, StringComparison.Ordinal);
+        commandLineHandler.TryGetOptionArgument(PlatformCommandLineProvider.ServerOptionKey, out string? serverArg) &&
+        serverArg.Equals(PlatformCommandLineProvider.DotnetTestCliProtocolName, StringComparison.Ordinal);
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/ServerModeManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/ServerModeManager.cs
@@ -14,12 +14,12 @@ internal sealed partial class ServerModeManager
         ICommandLineOptions commandLineService = serviceProvider.GetCommandLineOptions();
 
         int? clientPort;
-        clientPort = commandLineService.TryGetOptionArgumentList(PlatformCommandLineProvider.ClientPortOptionKey, out string[]? clientPortArgs)
-            ? int.Parse(clientPortArgs[0], CultureInfo.InvariantCulture)
+        clientPort = commandLineService.TryGetOptionArgument(PlatformCommandLineProvider.ClientPortOptionKey, out string? clientPortArg)
+            ? int.Parse(clientPortArg, CultureInfo.InvariantCulture)
             : throw new InvalidOperationException(PlatformResources.MissingClientPortFoJsonRpc);
 
-        string clientHostName = commandLineService.TryGetOptionArgumentList(PlatformCommandLineProvider.ClientHostOptionKey, out string[]? clientHostArgs)
-            ? clientHostArgs[0]
+        string clientHostName = commandLineService.TryGetOptionArgument(PlatformCommandLineProvider.ClientHostOptionKey, out string? clientHostArg)
+            ? clientHostArg
             : "localhost";
 
         return new MessageHandlerFactory(clientHostName, clientPort.Value, serviceProvider.GetOutputDevice());

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -95,18 +95,18 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
         exitCode = exitCode == ExitCodes.Success && _policiesService.IsAbortTriggered ? ExitCodes.TestSessionAborted : exitCode;
         exitCode = exitCode == ExitCodes.Success && _totalRanTests == 0 ? ExitCodes.ZeroTests : exitCode;
 
-        if (_commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.MinimumExpectedTestsOptionKey, out string[]? argumentList))
+        if (_commandLineOptions.TryGetOptionArgument(PlatformCommandLineProvider.MinimumExpectedTestsOptionKey, out string? argument))
         {
-            exitCode = exitCode == ExitCodes.Success && _totalRanTests < int.Parse(argumentList[0], CultureInfo.InvariantCulture) ? ExitCodes.MinimumExpectedTestsPolicyViolation : exitCode;
+            exitCode = exitCode == ExitCodes.Success && _totalRanTests < int.Parse(argument, CultureInfo.InvariantCulture) ? ExitCodes.MinimumExpectedTestsPolicyViolation : exitCode;
         }
 
         // If the user has specified the IgnoreExitCode, then we don't want to return a non-zero exit code if the exit code matches the one specified.
         string? exitCodeToIgnore = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_EXITCODE_IGNORE);
         if (RoslynString.IsNullOrEmpty(exitCodeToIgnore))
         {
-            if (_commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.IgnoreExitCodeOptionKey, out string[]? commandLineExitCodes) && commandLineExitCodes.Length > 0)
+            if (_commandLineOptions.TryGetOptionArgument(PlatformCommandLineProvider.IgnoreExitCodeOptionKey, out string? commandLineExitCode) && commandLineExitCodes.Length > 0)
             {
-                exitCodeToIgnore = commandLineExitCodes[0];
+                exitCodeToIgnore = commandLineExitCode;
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -104,7 +104,7 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
         string? exitCodeToIgnore = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_EXITCODE_IGNORE);
         if (RoslynString.IsNullOrEmpty(exitCodeToIgnore))
         {
-            if (_commandLineOptions.TryGetOptionArgument(PlatformCommandLineProvider.IgnoreExitCodeOptionKey, out string? commandLineExitCode) && commandLineExitCodes.Length > 0)
+            if (_commandLineOptions.TryGetOptionArgument(PlatformCommandLineProvider.IgnoreExitCodeOptionKey, out string? commandLineExitCode))
             {
                 exitCodeToIgnore = commandLineExitCode;
             }


### PR DESCRIPTION
So usages of TryGetOptionArgumentList are problematic

 * some usages use the first arg and ignore the rest
 * some usages check if there is only one and dont use the first if there is more than one
 * some usages assume there is 1 and will throw if that is not correct

so this PR adds TryGetOptionArgument. which will formalize the usages. it will:

 * return false if there is no arg
 * return false if there is no items in the arg
 * throw if there is more than 1