### PR TITLE
Fix AppDomain base directory regression in v4

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/AppDomainEngineInvoker.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/AppDomainEngineInvoker.cs
@@ -22,7 +22,6 @@ internal sealed class AppDomainEngineInvoker : IDisposable
     public AppDomainEngineInvoker(string testSourcePath)
         => _appDomain = CreateNewAppDomain(testSourcePath);
 
-
     /// <summary>
     /// Invokes the Engine.
     /// </summary>

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/AppDomainEngineInvoker.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/AppDomainEngineInvoker.cs
@@ -67,7 +67,7 @@ internal sealed class AppDomainEngineInvoker : IDisposable
     /// <summary>
     /// Create the Engine Invoker in new AppDomain based on test source path.
     /// </summary>
-    /// <typeparam name="T">The type to create in the app domain</typeparam>
+    /// <typeparam name="T">The type to create in the app domain.</typeparam>
     /// <returns>The engine invoker in AppDomain.</returns>
     internal T CreateInvokerInAppDomain<T>()
         where T : new()

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/AppDomainEngineInvoker.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/AppDomainEngineInvoker.cs
@@ -1,0 +1,300 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+
+/// <summary>
+/// Implementation for the Invoker which invokes engine in a new AppDomain
+/// Type of the engine must be a marshalable object for app domain calls and also must have a parameterless constructor.
+/// </summary>
+internal sealed class AppDomainEngineInvoker
+{
+    private sealed class ActionWrapper : MarshalByRefObject
+    {
+        public ActionWrapper(Action action)
+            => Action = action;
+
+        public Action Action { get; }
+    }
+
+    private const string XmlNamespace = "urn:schemas-microsoft-com:asm.v1";
+
+    private readonly AppDomain _appDomain;
+    private readonly ActionWrapper _actualInvoker;
+
+    private string? _mergedTempConfigFile;
+
+    public AppDomainEngineInvoker(string testSourcePath, Action action)
+    {
+        _appDomain = CreateNewAppDomain(testSourcePath);
+        _actualInvoker = CreateInvokerInAppDomain(_appDomain, action);
+    }
+
+    /// <summary>
+    /// Invokes the Engine.
+    /// </summary>
+    public void Invoke()
+    {
+        try
+        {
+            _actualInvoker.Action.Invoke();
+        }
+        finally
+        {
+            try
+            {
+                // if(appDomain != null)
+                // {
+                //     // Do not unload appdomain as there are lot is issues reported against appdomain unload
+                //     // any ways the process is going to die off.
+                //     AppDomain.Unload(appDomain);
+                // }
+                if (!string.IsNullOrWhiteSpace(_mergedTempConfigFile) && File.Exists(_mergedTempConfigFile))
+                {
+                    File.Delete(_mergedTempConfigFile);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    private AppDomain CreateNewAppDomain(string testSourcePath)
+    {
+        var appDomainSetup = new AppDomainSetup();
+        string testSourceFolder = Path.GetDirectoryName(testSourcePath);
+
+        // Set AppBase to TestAssembly location
+        appDomainSetup.ApplicationBase = testSourceFolder;
+        appDomainSetup.LoaderOptimization = LoaderOptimization.MultiDomainHost;
+
+        // Set User Config file as app domain config
+        SetConfigurationFile(appDomainSetup, testSourcePath, testSourceFolder);
+
+        // Create new AppDomain
+        var appDomain = AppDomain.CreateDomain("TestHostAppDomainByMSTest", null, appDomainSetup);
+
+        return appDomain;
+    }
+
+    /// <summary>
+    /// Create the Engine Invoker in new AppDomain based on test source path.
+    /// </summary>
+    /// <param name="appDomain">The appdomain in which the invoker should be created.</param>
+    /// <param name="action">The action to invoke in app domain.</param>
+    /// <returns>The engine invoker in AppDomain.</returns>
+    private static ActionWrapper CreateInvokerInAppDomain(AppDomain appDomain, Action action)
+    {
+        // Create CustomAssembly setup that sets a custom assembly resolver to be able to resolve TestPlatform assemblies
+        // and also sets the correct UI culture to propagate the dotnet or VS culture to the adapters running in the app domain
+        appDomain.CreateInstanceFromAndUnwrap(
+            typeof(CustomAssemblySetup).Assembly.Location,
+            typeof(CustomAssemblySetup).FullName,
+            false,
+            BindingFlags.Default,
+            null,
+            [CultureInfo.DefaultThreadCurrentUICulture?.Name, Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)],
+            null,
+            null);
+
+        // Create Invoker object in new appdomain
+        Type invokerType = typeof(ActionWrapper);
+        return (ActionWrapper)appDomain.CreateInstanceFromAndUnwrap(
+            invokerType.Assembly.Location,
+            invokerType.FullName,
+            false,
+            BindingFlags.Default,
+            null,
+            args: [action],
+            null,
+            null);
+    }
+
+    private void SetConfigurationFile(AppDomainSetup appDomainSetup, string testSource, string testSourceFolder)
+    {
+        string? userConfigFile = GetConfigFile(testSource, testSourceFolder);
+        string testHostAppConfigFile = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+
+        if (!string.IsNullOrEmpty(userConfigFile))
+        {
+            var userConfigDoc = XDocument.Load(userConfigFile);
+            var testHostConfigDoc = XDocument.Load(testHostAppConfigFile);
+
+            // Merge user's config file and testHost config file and use merged one
+            XDocument mergedConfigDocument = MergeApplicationConfigFiles(userConfigDoc, testHostConfigDoc);
+
+            // Create a temp file with config
+            _mergedTempConfigFile = Path.GetTempFileName();
+            mergedConfigDocument.Save(_mergedTempConfigFile);
+
+            // Set config file to merged one
+            appDomainSetup.ConfigurationFile = _mergedTempConfigFile;
+        }
+        else
+        {
+            // Use the current domains configuration setting.
+            appDomainSetup.ConfigurationFile = testHostAppConfigFile;
+        }
+    }
+
+    private static string? GetConfigFile(string testSource, string testSourceFolder)
+    {
+        string? configFile = null;
+
+        if (File.Exists(testSource + ".config"))
+        {
+            // Path to config file cannot be bad: storage is already checked, and extension is valid.
+            configFile = testSource + ".config";
+        }
+        else
+        {
+            string netAppConfigFile = Path.Combine(testSourceFolder, "App.Config");
+            if (File.Exists(netAppConfigFile))
+            {
+                configFile = netAppConfigFile;
+            }
+        }
+
+        return configFile;
+    }
+
+    private static XDocument MergeApplicationConfigFiles(XDocument userConfigDoc, XDocument testHostConfigDoc)
+    {
+        // Start with User's config file as the base
+        var mergedDoc = new XDocument(userConfigDoc);
+
+        // Take testhost.exe Startup node
+        XElement? startupNode = testHostConfigDoc.Descendants("startup")?.FirstOrDefault();
+        if (startupNode != null)
+        {
+            // Remove user's startup and add ours which supports NET35
+            mergedDoc.Descendants("startup")?.Remove();
+            mergedDoc.Root.Add(startupNode);
+        }
+
+        // Runtime node must be merged which contains assembly redirections
+        XElement? runtimeTestHostNode = testHostConfigDoc.Descendants("runtime")?.FirstOrDefault();
+        if (runtimeTestHostNode != null)
+        {
+            XElement? runTimeNode = mergedDoc.Descendants("runtime")?.FirstOrDefault();
+            if (runTimeNode == null)
+            {
+                // remove test host relative probing paths' element
+                // TestHost Probing Paths do not make sense since we are setting "AppBase" to user's test assembly location
+                runtimeTestHostNode.Descendants().Where((element) => string.Equals(element.Name.LocalName, "probing", StringComparison.Ordinal)).Remove();
+
+                // no runtime node exists in user's config - just add ours entirely
+                mergedDoc.Root.Add(runtimeTestHostNode);
+            }
+            else
+            {
+                var assemblyBindingXName = XName.Get("assemblyBinding", XmlNamespace);
+                XElement? mergedDocAssemblyBindingNode = mergedDoc.Descendants(assemblyBindingXName)?.FirstOrDefault();
+                XElement? testHostAssemblyBindingNode = runtimeTestHostNode.Descendants(assemblyBindingXName)?.FirstOrDefault();
+
+                if (testHostAssemblyBindingNode != null)
+                {
+                    if (mergedDocAssemblyBindingNode == null)
+                    {
+                        // add another assemblyBinding element as none exists in user's config
+                        runTimeNode.Add(testHostAssemblyBindingNode);
+                    }
+                    else
+                    {
+                        var dependentAssemblyXName = XName.Get("dependentAssembly", XmlNamespace);
+                        IEnumerable<XElement> redirections = testHostAssemblyBindingNode.Descendants(dependentAssemblyXName);
+
+                        if (redirections != null)
+                        {
+                            mergedDocAssemblyBindingNode.Add(redirections);
+                        }
+                    }
+                }
+            }
+        }
+
+        return mergedDoc;
+    }
+}
+
+/// <summary>
+/// Custom domain setup that sets UICulture and an Assembly resolver for child app domain to resolve testplatform assemblies.
+/// </summary>
+// The normal AppDomainInitializer api was not used to do this because it cannot load the assemblies for testhost. --JJR
+internal sealed class CustomAssemblySetup : MarshalByRefObject
+{
+    private readonly Dictionary<string, Assembly?> _resolvedAssemblies;
+
+    private readonly string[] _resolverPaths;
+
+    public CustomAssemblySetup(string uiCulture, string testPlatformPath)
+    {
+        if (uiCulture != null)
+        {
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture(uiCulture);
+        }
+
+        _resolverPaths = [testPlatformPath, Path.Combine(testPlatformPath, "Extensions")];
+        _resolvedAssemblies = [];
+        AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+    }
+
+    private Assembly? CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+    {
+        var assemblyName = new AssemblyName(args.Name);
+
+        Assembly? assembly = null;
+        lock (_resolvedAssemblies)
+        {
+            try
+            {
+                EqtTrace.Verbose("CurrentDomain_AssemblyResolve: Resolving assembly '{0}'.", args.Name);
+
+                if (_resolvedAssemblies.TryGetValue(args.Name, out assembly))
+                {
+                    return assembly;
+                }
+
+                // Put it in the resolved assembly so that if below Assembly.Load call
+                // triggers another assembly resolution, then we don't end up in stack overflow
+                _resolvedAssemblies[args.Name] = null;
+
+                foreach (string path in _resolverPaths)
+                {
+                    string testPlatformFilePath = Path.Combine(path, assemblyName.Name) + ".dll";
+                    if (File.Exists(testPlatformFilePath))
+                    {
+                        try
+                        {
+                            assembly = Assembly.LoadFrom(testPlatformFilePath);
+                            break;
+                        }
+                        catch (Exception)
+                        {
+                            // ignore
+                        }
+                    }
+                }
+
+                // Replace the value with the loaded assembly
+                _resolvedAssemblies[args.Name] = assembly;
+
+                return assembly;
+            }
+            finally
+            {
+                if (assembly == null)
+                {
+                    EqtTrace.Verbose("CurrentDomainAssemblyResolve: Failed to resolve assembly '{0}'.", args.Name);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -35,7 +35,8 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
             AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
             sources.FirstOrDefault() is { } source)
         {
-            new AppDomainEngineInvoker(source, () => DiscoverTests(sources, discoveryContext, logger, discoverySink, null)).Invoke();
+            using var invoker = new AppDomainEngineInvoker(source);
+            invoker.CreateInvokerInAppDomain<MSTestDiscoverer>().DiscoverTests(sources, discoveryContext, logger, discoverySink);
         }
         else
 #endif

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -27,7 +27,22 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
     /// <param name="discoverySink">Used to send testcases and discovery related events back to Discoverer manager.</param>
     [System.Security.SecurityCritical]
     [SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0", Justification = "Discovery context can be null.")]
-    public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink) => DiscoverTests(sources, discoveryContext, logger, discoverySink, null);
+    public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
+    {
+#if NETFRAMEWORK
+        if (AppDomain.CurrentDomain.Id == 1 &&
+            AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.net", StringComparison.Ordinal) &&
+            AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
+            sources.FirstOrDefault() is { } source)
+        {
+            new AppDomainEngineInvoker(source, () => DiscoverTests(sources, discoveryContext, logger, discoverySink, null)).Invoke();
+        }
+        else
+#endif
+        {
+            DiscoverTests(sources, discoveryContext, logger, discoverySink, null);
+        }
+    }
 
     internal static void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, IConfiguration? configuration)
     {

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -75,7 +75,8 @@ internal sealed class MSTestExecutor : ITestExecutor
             AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
             tests?.FirstOrDefault()?.Source is { } source)
         {
-            new AppDomainEngineInvoker(source, () => RunTestsAsync(tests, runContext, frameworkHandle, null).GetAwaiter().GetResult()).Invoke();
+            using var invoker = new AppDomainEngineInvoker(source);
+            invoker.CreateInvokerInAppDomain<MSTestExecutor>().RunTests(tests, runContext, frameworkHandle);
         }
         else
 #endif
@@ -101,7 +102,8 @@ internal sealed class MSTestExecutor : ITestExecutor
             AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
             sources.FirstOrDefault() is { } source)
         {
-            new AppDomainEngineInvoker(source, () => RunTestsAsync(sources, runContext, frameworkHandle, null).GetAwaiter().GetResult()).Invoke();
+            using var invoker = new AppDomainEngineInvoker(source);
+            invoker.CreateInvokerInAppDomain<MSTestExecutor>().RunTests(sources, runContext, frameworkHandle);
         }
         else
 #endif

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -98,7 +98,7 @@ internal sealed class MSTestExecutor : ITestExecutor
     {
 #if NETFRAMEWORK
         if (AppDomain.CurrentDomain.Id == 1 &&
-            AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.net", StringComparison.Ordinal) &&
+            AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.", StringComparison.Ordinal) &&
             AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
             sources.FirstOrDefault() is { } source)
         {

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -68,7 +68,21 @@ internal sealed class MSTestExecutor : ITestExecutor
     [Obsolete("Use RunTestsAsync instead.")]
 #endif
     public void RunTests(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
-        => RunTestsAsync(tests, runContext, frameworkHandle, null).GetAwaiter().GetResult();
+    {
+#if NETFRAMEWORK
+        if (AppDomain.CurrentDomain.Id == 1 &&
+            AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.net", StringComparison.Ordinal) &&
+            AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
+            tests?.FirstOrDefault()?.Source is { } source)
+        {
+            new AppDomainEngineInvoker(source, () => RunTestsAsync(tests, runContext, frameworkHandle, null).GetAwaiter().GetResult()).Invoke();
+        }
+        else
+#endif
+        {
+            RunTestsAsync(tests, runContext, frameworkHandle, null).GetAwaiter().GetResult();
+        }
+    }
 
     /// <summary>
     /// Runs the tests.
@@ -80,7 +94,21 @@ internal sealed class MSTestExecutor : ITestExecutor
     [Obsolete("Use RunTestsAsync instead.")]
 #endif
     public void RunTests(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle)
-        => RunTestsAsync(sources, runContext, frameworkHandle, null).GetAwaiter().GetResult();
+    {
+#if NETFRAMEWORK
+        if (AppDomain.CurrentDomain.Id == 1 &&
+            AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.net", StringComparison.Ordinal) &&
+            AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal) &&
+            sources.FirstOrDefault() is { } source)
+        {
+            new AppDomainEngineInvoker(source, () => RunTestsAsync(sources, runContext, frameworkHandle, null).GetAwaiter().GetResult()).Invoke();
+        }
+        else
+#endif
+        {
+            RunTestsAsync(sources, runContext, frameworkHandle, null).GetAwaiter().GetResult();
+        }
+    }
 
     internal async Task RunTestsAsync(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration)
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -186,6 +186,15 @@ internal class TestExecutionManager
         foreach (var group in testsBySource)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
+
+#if NETFRAMEWORK
+            if (AppDomain.CurrentDomain.Id == 1 &&
+                AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.net", StringComparison.Ordinal) &&
+                AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal))
+            {
+                AppDomain.CurrentDomain.SetupInformation.ApplicationBase = Path.GetDirectoryName(group.Source);
+            }
+#endif
             await ExecuteTestsInSourceAsync(group.Tests, runContext, frameworkHandle, group.Source, isDeploymentDone).ConfigureAwait(false);
         }
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -186,15 +186,6 @@ internal class TestExecutionManager
         foreach (var group in testsBySource)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
-
-#if NETFRAMEWORK
-            if (AppDomain.CurrentDomain.Id == 1 &&
-                AppDomain.CurrentDomain.FriendlyName.StartsWith("testhost.net", StringComparison.Ordinal) &&
-                AppDomain.CurrentDomain.FriendlyName.EndsWith(".exe", StringComparison.Ordinal))
-            {
-                AppDomain.CurrentDomain.SetupInformation.ApplicationBase = Path.GetDirectoryName(group.Source);
-            }
-#endif
             await ExecuteTestsInSourceAsync(group.Tests, runContext, frameworkHandle, group.Source, isDeploymentDone).ConfigureAwait(false);
         }
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AppDomainTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AppDomainTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+[TestClass]
+[OSCondition(OperatingSystems.Windows)]
+public sealed class AppDomainTests : AcceptanceTestBase<NopAssetFixture>
+{
+    private const string AssetName = "AppDomainTests";
+
+    private const string SingleTestSourceCode = """
+#file AppDomainTests.csproj
+<Project Sdk="MSTest.Sdk/$MSTestVersion$" >
+
+  <PropertyGroup>
+    <!--
+        This property is not required by users and is only set to simplify our testing infrastructure. When testing out in local or ci,
+        we end up with a -dev or -ci version which will lose resolution over -preview dependency of code coverage. Because we want to
+        ensure we are testing with locally built version, we force adding the platform dependency.
+    -->
+    <EnableMicrosoftTestingPlatform>true</EnableMicrosoftTestingPlatform>
+    <TargetFramework>$TargetFramework$</TargetFramework>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+    <UseVSTest>true</UseVSTest>
+  </PropertyGroup>
+
+</Project>
+
+#file dotnet.config
+[dotnet.test.runner]
+name= "VSTest"
+
+#file UnitTest1.cs
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AppDomainTests
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+            Assert.AreEqual(Path.GetDirectoryName(typeof(UnitTest1).Assembly.Location), AppDomain.CurrentDomain.BaseDirectory);
+        }
+    }
+}
+""";
+
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    [DataRow(null)]
+    public async Task RunTests_With_VSTest(bool? disableAppDomain)
+    {
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            AssetName,
+            SingleTestSourceCode
+            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+            .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetFramework[0]));
+
+        string disableAppDomainCommand = disableAppDomain switch
+        {
+            true => " -- RunConfiguration.DisableAppDomain=true",
+            false => " -- RunConfiguration.EnableAppDomain=false",
+            null => string.Empty,
+        };
+
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"test {testAsset.TargetAssetPath}{disableAppDomainCommand}", AcceptanceFixture.NuGetGlobalPackagesFolder.Path, workingDirectory: testAsset.TargetAssetPath);
+        Assert.AreEqual(0, compilationResult.ExitCode);
+
+        compilationResult.AssertOutputContains(@"Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1");
+    }
+}


### PR DESCRIPTION
Both MSTest and VSTest use DisableAppDomain under RunConfiguration.

- VSTest behavior:
    - DisableAppDomain default is false.
    - The behavior of "false" actually does **not** create app domain, then the "default" app domain will have its directory set to the same directory as `testhost.netXX.exe` which is from VS installation or SDK installation (depends on where you are running).
    - The behavior of "true" **does** create a `TestHostAppDomain` app domain with the expected directory.
    - Relevant parts of VSTest implementation:
        - https://github.com/microsoft/vstest/blob/b9c33d9d01f64a4c63b6dcc28c5fd6835fb99ef0/src/Microsoft.TestPlatform.TestHostProvider/Hosting/DefaultTestHostManager.cs#L203-L208
        - https://github.com/microsoft/vstest/blob/b9c33d9d01f64a4c63b6dcc28c5fd6835fb99ef0/src/testhost.x86/Program.cs#L71-L86
- MSTest behavior:
    - DisableAppDomain default was false in v3, but is now true.
    - The behavior of "false" is that we create our own app domain, with the right base directory.
    - The behavior of "true" is that we do nothing, following what VSTest hands to us.

The bug manifests when VSTest treats DisableAppDomain as "false" (thus, we get unexpected base directory), and MSTest treats DisableAppDomain as "true" (thus, we use what we get from VSTest).

I confirmed the test without the fix fails:

>    Assert.AreEqual failed. Expected:<D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\gwlME\AppDomainTests\bin\Debug\net462>. Actual:<D:\a\_work\1\s\.dotnet\sdk\10.0.100-preview.7.25359.101\TestHostNetFramework\>. 
