### PR TITLE
Cleanup PipeNameDescription

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/PipeNameDescription.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/PipeNameDescription.cs
@@ -10,18 +10,11 @@ internal sealed class PipeNameDescription(string name, bool isDirectory) : IDisp
 
     public string Name { get; } = name;
 
-    public void Dispose() => Dispose(true);
-
-    public void Dispose(bool disposing)
+    public void Dispose()
     {
         if (_disposed)
         {
             return;
-        }
-
-        if (disposing)
-        {
-            // TODO: dispose managed state (managed objects).
         }
 
         if (_isDirectory)


### PR DESCRIPTION
This class is sealed and the current dispose implementation is unnecessarily complicated. The `Dispose(bool)` method is only relevant in non-sealed classes.