### PR TITLE
use escapedClassFullName in AppendAssemblyTestNodeBuilderContent

### DIFF
--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestNodesGenerator.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestNodesGenerator.cs
@@ -159,7 +159,7 @@ internal sealed class TestNodesGenerator : IIncrementalGenerator
             foreach (TestTypeInfo testClassInfo in namespaceClasses)
             {
                 string escapedClassFullName = TestNodeHelpers.GenerateEscapedName(testClassInfo.FullyQualifiedName);
-                sourceStringBuilder.AppendLine($"{namespaceTestsVariableName}.Add({testClassInfo.GeneratedTypeName}.TestNode);");
+                sourceStringBuilder.AppendLine($"{namespaceTestsVariableName}.Add({escapedClassFullName}.TestNode);");
             }
 
             variableIndex++;


### PR DESCRIPTION
should escapedClassFullName be used in AppendAssemblyTestNodeBuilderContent?

or should the variable just be deleted?