### PR TITLE
Mark TestHostControllersTestHost.InternalRunAsync as Unsupported browser

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -60,6 +60,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
 
     public Task<bool> IsEnabledAsync() => Task.FromResult(false);
 
+    [UnsupportedOSPlatform("browser")]
     protected override async Task<int> InternalRunAsync()
     {
         int exitCode;
@@ -107,7 +108,6 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
             string arguments = string.Join(' ', partialCommandLine);
 #endif
 
-#pragma warning disable CA1416 // Validate platform compatibility
             ProcessStartInfo processStartInfo = new(
                 executableInfo.FilePath,
                 arguments)
@@ -123,7 +123,6 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
                 UseShellExecute = false,
 #endif
             };
-#pragma warning restore CA1416
 
             List<IDataConsumer> dataConsumersBuilder = [.. _testHostsInformation.DataConsumer];
 
@@ -211,9 +210,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
 
                 foreach (EnvironmentVariable envVar in environmentVariables.GetAll())
                 {
-#pragma warning disable CA1416 // Validate platform compatibility
                     processStartInfo.EnvironmentVariables[envVar.Variable] = envVar.Value;
-#pragma warning restore CA1416
                 }
             }
 
@@ -228,13 +225,9 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
 
             // Launch the test host process
             string testHostProcessStartupTime = _clock.UtcNow.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);
-#pragma warning disable CA1416 // Validate platform compatibility
             processStartInfo.EnvironmentVariables.Add($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_TESTHOSTPROCESSSTARTTIME}_{currentPid}", testHostProcessStartupTime);
-#pragma warning restore CA1416
             await _logger.LogDebugAsync($"{EnvironmentVariableConstants.TESTINGPLATFORM_TESTHOSTCONTROLLER_TESTHOSTPROCESSSTARTTIME}_{currentPid} '{testHostProcessStartupTime}'").ConfigureAwait(false);
-#pragma warning disable CA1416 // Validate platform compatibility
             await _logger.LogDebugAsync($"Starting test host process '{processStartInfo.FileName}' with args '{processStartInfo.Arguments}'").ConfigureAwait(false);
-#pragma warning restore CA1416
             using IProcess testHostProcess = process.Start(processStartInfo);
 
             int? testHostProcessId = null;
@@ -274,9 +267,7 @@ internal sealed class TestHostControllersTestHost : CommonTestHost, ITestHost, I
                 // Wait for the test host controller to send the PID of the test host process
                 using (CancellationTokenSource timeout = new(TimeoutHelper.DefaultHangTimeSpanTimeout))
                 {
-#pragma warning disable CA1416 // Validate platform compatibility
                     _waitForPid.Wait(timeout.Token);
-#pragma warning restore CA1416
                 }
 
                 await _logger.LogDebugAsync("Fire OnTestHostProcessStartedAsync").ConfigureAwait(false);


### PR DESCRIPTION
so we can remove the repetitive `pragma warning disable CA1416`

<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->