### PR TITLE
MSTest configuration improvement

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
@@ -260,9 +260,6 @@ public class MSTestSettings
 
 #if !WINDOWS_UWP
     private static bool IsRunSettingsFileHasMSTestSettings(string? runSettingsXml)
-    => IsRunSettingsFileHasSettingName(runSettingsXml, SettingsName) || IsRunSettingsFileHasSettingName(runSettingsXml, SettingsNameAlias);
-
-    private static bool IsRunSettingsFileHasSettingName(string? runSettingsXml, string SettingName)
     {
         if (StringEx.IsNullOrWhiteSpace(runSettingsXml))
         {
@@ -277,7 +274,8 @@ public class MSTestSettings
         reader.ReadToNextElement();
 
         // Read till we reach nodeName element or reach EOF
-        while (!string.Equals(reader.Name, SettingName, StringComparison.OrdinalIgnoreCase)
+        while (!string.Equals(reader.Name, SettingsName, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(reader.Name, SettingsNameAlias, StringComparison.OrdinalIgnoreCase)
                 && !reader.EOF)
         {
             reader.SkipToNextElement();
@@ -308,6 +306,8 @@ public class MSTestSettings
         var settings = new MSTestSettings();
         var runConfigurationSettings = RunConfigurationSettings.PopulateSettings(context);
 
+        // We have runsettings, but we don't have testconfig.
+        // Just use runsettings.
 #if !WINDOWS_UWP
         if (!StringEx.IsNullOrEmpty(context?.RunSettings?.SettingsXml)
             && configuration?["mstest"] is null)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
@@ -161,7 +161,7 @@ public class MSTestAdapterSettings
         //  },
         //  ... remaining settings
         // }
-        var settings = new MSTestAdapterSettings();
+        MSTestAdapterSettings settings = MSTestSettingsProvider.Settings;
         Configuration = configuration;
         ParseBooleanSetting(configuration, "deployment:enabled", value => settings.DeploymentEnabled = value);
         ParseBooleanSetting(configuration, "deployment:deployTestSourceDependencies", value => settings.DeployTestSourceDependencies = value);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
@@ -37,9 +37,16 @@ public class MSTestSettingsProvider : ISettingsProvider
     internal static void Load(IConfiguration configuration)
     {
 #if !WINDOWS_UWP
-#pragma warning disable IDE0022 // Use expression body for method
         var settings = MSTestAdapterSettings.ToSettings(configuration);
-#pragma warning restore IDE0022 // Use expression body for method
+        if (!ReferenceEquals(settings, Settings))
+        {
+            // NOTE: ToSettings mutates the Settings property and just returns it.
+            // This invariant is important to preserve, because we load from from runsettings through the XmlReader overload below.
+            // Then we read via IConfiguration.
+            // So this path should be unreachable.
+            // In v4 when we will make this class internal, we can start changing the API to clean this up.
+            throw ApplicationStateGuard.Unreachable();
+        }
 #endif
     }
 
@@ -51,7 +58,16 @@ public class MSTestSettingsProvider : ISettingsProvider
     {
 #if !WINDOWS_UWP
         Guard.NotNull(reader);
-        Settings = MSTestAdapterSettings.ToSettings(reader);
+        var settings = MSTestAdapterSettings.ToSettings(reader);
+        if (!ReferenceEquals(settings, Settings))
+        {
+            // NOTE: ToSettings mutates the Settings property and just returns it.
+            // This invariant is important to preserve, because we load from from runsettings through the XmlReader overload below.
+            // Then we read via IConfiguration.
+            // So this path should be unreachable.
+            // In v4 when we will make this class internal, we can start changing the API to clean this up.
+            throw ApplicationStateGuard.Unreachable();
+        }
 #endif
     }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestSettingsProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestSettingsProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using TestFramework.ForTestingMSTest;
@@ -69,5 +70,33 @@ public class DesktopSettingsProviderTests : TestContainer
         reader.Read();
         _settingsProvider.Load(reader);
         Verify(!MSTestSettingsProvider.Settings.DeploymentEnabled);
+    }
+
+    public void LoadShouldReadAndFillInSettingsFromIConfiguration()
+    {
+        Verify(MSTestSettingsProvider.Settings.DeploymentEnabled);
+
+        MSTestSettingsProvider.Load(new MockConfiguration(
+            new Dictionary<string, string?>()
+            {
+                ["mstest:deployment:enabled"] = "false",
+            }, null));
+
+        Verify(!MSTestSettingsProvider.Settings.DeploymentEnabled);
+    }
+
+    private sealed class MockConfiguration : IConfiguration
+    {
+        private readonly Dictionary<string, string?> _values;
+        private readonly string? _defaultValue;
+
+        public MockConfiguration(Dictionary<string, string?> values, string? defaultValue)
+        {
+            _values = values;
+            _defaultValue = defaultValue;
+        }
+
+        public string? this[string key]
+            => _values.TryGetValue(key, out string? value) ? value : _defaultValue;
     }
 }


### PR DESCRIPTION
- IsRunSettingsFileHasMSTestSettings was unnecessarily parsing the XML twice.
- `MSTestAdapterSettings.Load(IConfiguration)` didn't have any side effect previously. We now correctly reflect that in the current settings.

Note that for MSTest-specific settings, we have a guard in place that prevents having settings both in runsettings and testconfig.json.

https://github.com/microsoft/testfx/blob/62ff112616e444cb5cf735724e1f030c2db3b428/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs#L299-L304

So, `MSTestSettingsProvider.Load(XmlReader)` and `MSTestSettingsProvider.Load(IConfiguration)` are never both called. It's one of them at max will be called.

Fixes #6077