### PR TITLE
Always publish TestResults folder

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -171,14 +171,11 @@ extends:
                   Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp -Recurse -Force
                 displayName: Remove artifacts/tmp
 
-              # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-              # through the console or trx
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish Test Results folders'
                 inputs:
                   PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
                   ArtifactName: TestResults_Windows
-                condition: failed()
 
             - task: NuGetAuthenticate@1
               displayName: 'NuGet Authenticate to test-tools feed'
@@ -221,14 +218,11 @@ extends:
                 name: Test
                 displayName: Tests
 
-              # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-              # through the console or trx
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish Test Results folders'
                 inputs:
                   PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
                   ArtifactName: TestResults_Linux
-                condition: failed()
 
       - ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,14 +200,11 @@ stages:
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
               DOTNET_CLI_CONTEXT_VERBOSE: 1
 
-          # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-          # through the console or trx
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Test Results folders'
             inputs:
               PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
               ArtifactName: TestResults_Linux_$(_BuildConfig)
-            condition: failed()
 
           - task: CopyFiles@2
             displayName: 'Copy binlogs'
@@ -266,14 +263,11 @@ stages:
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
               DOTNET_CLI_CONTEXT_VERBOSE: 1
 
-          # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-          # through the console or trx
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Test Results folders'
             inputs:
               PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
               ArtifactName: TestResults_MacOs_$(_BuildConfig)
-            condition: failed()
 
           - task: CopyFiles@2
             displayName: 'Copy binlogs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,14 +123,11 @@ stages:
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
               DOTNET_CLI_CONTEXT_VERBOSE: 1
 
-          # This step is only helpful for diagnosing some issues with vstest/test host that would not appear
-          # through the console or trx
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Test Results folders'
             inputs:
               PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
               ArtifactName: TestResults_Windows_$(_BuildConfig)
-            condition: failed()
 
           - task: CopyFiles@2
             displayName: 'Copy binlogs'


### PR DESCRIPTION
It's still useful to have the test results in successful pipelines, to use them for comparison with failed ones for example.