### PR TITLE
Attempt to stabilize MTP AbortionTests

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Services/StopPoliciesService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/StopPoliciesService.cs
@@ -53,18 +53,23 @@ internal sealed class StopPoliciesService : IStopPoliciesService
 
     public async Task ExecuteAbortCallbacksAsync()
     {
-        IsAbortTriggered = true;
-
-        if (_abortCallbacks is null)
+        try
         {
-            return;
+            if (_abortCallbacks is null)
+            {
+                return;
+            }
+
+            foreach (Func<Task> callback in _abortCallbacks)
+            {
+                // For now, we are fine if the callback crashed us. It shouldn't happen for our
+                // current usage anyway and the APIs around this are all internal for now.
+                await callback.Invoke().ConfigureAwait(false);
+            }
         }
-
-        foreach (Func<Task> callback in _abortCallbacks)
+        finally
         {
-            // For now, we are fine if the callback crashed us. It shouldn't happen for our
-            // current usage anyway and the APIs around this are all internal for now.
-            await callback.Invoke().ConfigureAwait(false);
+            IsAbortTriggered = true;
         }
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/AbortionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/AbortionTests.cs
@@ -25,12 +25,7 @@ public class AbortionTests : AcceptanceTestBase<AbortionTests.TestAssetFixture>
 
         testHostResult.AssertExitCodeIs(ExitCodes.TestSessionAborted);
 
-        // We check only in netcore for netfx is now showing in CI every time, the same behavior in local something works sometime nope.
-        // Manual test works pretty always as expected, looks like the implementation is different, we care more on .NET Core.
-        if (TargetFrameworks.Net.Contains(tfm))
-        {
-            testHostResult.AssertOutputMatchesRegex("Canceling the test session.*");
-        }
+        testHostResult.AssertOutputMatchesRegex("Canceling the test session.*");
 
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 0, skipped: 0, aborted: true);
     }


### PR DESCRIPTION
Fixes #5785

Today's situation:

1. StopPoliciesService listens to cancellation [here](https://github.com/microsoft/testfx/blob/860abb97944315891d960bcf58c5909bc46c47a2/src/Platform/Microsoft.Testing.Platform/Services/StopPoliciesService.cs#L22). This registration happens first. It happens during `BuildAsync` (we are still building the test host). As part of this abort, we call TerminalTestReporter.StartCancelling.
2. `ExecuteRequestAsync` uses cancellation token (in the case of this specific test, it's passed to Task.Delay, which will internally also register for cancellation notification)
3. In .NET, cancellation callbacks are run in the reverse order of registration (likely an undocumented implementation detail that no one should rely on). But that means `Task.Delay` is first notified about the cancellation.
4. Now, Ctrl+C signal is received (we receive it on a background thread). `Task.Delay` receives cancellation (on main thread in most cases), then `StartCancelling` is called (on background thread).
5. These two threads are now racing. The `await Task.Delay` will throw OperationCanceledException that we catch and causes us to start writing the test summary. If we started writing the test summary before the background thread calls `StartCancelling`, the test fails.