### PR TITLE
Add analyzer to flow TestContext.CTS.Token

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -70,15 +70,6 @@ namespace MSTest.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Change to &apos;class&apos; and add &apos;[TestClass]&apos;.
-        /// </summary>
-        internal static string ChangeStructToClassAndAddTestClassFix {
-            get {
-                return ResourceManager.GetString("ChangeStructToClassAndAddTestClassFix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Add &apos;[TestMethod]&apos;.
         /// </summary>
         internal static string AddTestMethodAttributeFix {
@@ -124,6 +115,15 @@ namespace MSTest.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Change to &apos;class&apos; and add &apos;[TestClass]&apos;.
+        /// </summary>
+        internal static string ChangeStructToClassAndAddTestClassFix {
+            get {
+                return ResourceManager.GetString("ChangeStructToClassAndAddTestClassFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix actual/expected arguments order.
         /// </summary>
         internal static string FixAssertionArgsOrder {
@@ -138,6 +138,15 @@ namespace MSTest.Analyzers {
         internal static string FixSignatureCodeFix {
             get {
                 return ResourceManager.GetString("FixSignatureCodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pass &apos;TestContext.CancellationTokenSource.Token&apos; argument to method call.
+        /// </summary>
+        internal static string PassCancellationTokenFix {
+            get {
+                return ResourceManager.GetString("PassCancellationTokenFix", resourceCulture);
             }
         }
         
@@ -196,6 +205,15 @@ namespace MSTest.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;Assert.{0}&apos; instead of &apos;StringAssert&apos;.
+        /// </summary>
+        internal static string StringAssertToAssertTitle {
+            get {
+                return ResourceManager.GetString("StringAssertToAssertTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fix test class signature.
         /// </summary>
         internal static string TestClassShouldBeValidFix {
@@ -241,6 +259,15 @@ namespace MSTest.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &apos;CooperativeCancellation = true&apos;.
+        /// </summary>
+        internal static string UseCooperativeCancellationForTimeoutFix {
+            get {
+                return ResourceManager.GetString("UseCooperativeCancellationForTimeoutFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use &apos;{0}&apos;.
         /// </summary>
         internal static string UseNewerAssertThrows {
@@ -255,24 +282,6 @@ namespace MSTest.Analyzers {
         internal static string UseProperAssertMethodsFix {
             get {
                 return ResourceManager.GetString("UseProperAssertMethodsFix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use &apos;CooperativeCancellation = true&apos;.
-        /// </summary>
-        internal static string UseCooperativeCancellationForTimeoutFix {
-            get {
-                return ResourceManager.GetString("UseCooperativeCancellationForTimeoutFix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use &apos;Assert.{0}&apos; instead of &apos;StringAssert&apos;.
-        /// </summary>
-        internal static string StringAssertToAssertTitle {
-            get {
-                return ResourceManager.GetString("StringAssertToAssertTitle", resourceCulture);
             }
         }
     }

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -189,4 +189,7 @@
   <data name="StringAssertToAssertTitle" xml:space="preserve">
     <value>Use 'Assert.{0}' instead of 'StringAssert'</value>
   </data>
+  <data name="PassCancellationTokenFix" xml:space="preserve">
+    <value>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</value>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/FlowTestContextCancellationTokenFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/FlowTestContextCancellationTokenFixer.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+
+using Analyzer.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// Code fixer for <see cref="FlowTestContextCancellationTokenAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FlowTestContextCancellationTokenFixer))]
+[Shared]
+public sealed class FlowTestContextCancellationTokenFixer : CodeFixProvider
+{
+    /// <inheritdoc />
+    public sealed override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(DiagnosticIds.FlowTestContextCancellationTokenRuleId);
+
+    /// <inheritdoc />
+    public override FixAllProvider GetFixAllProvider()
+        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        Diagnostic diagnostic = context.Diagnostics[0];
+        TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the invocation expression identified by the diagnostic
+        SyntaxNode node = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true);
+        if (node is not InvocationExpressionSyntax invocationExpression)
+        {
+            return;
+        }
+
+        diagnostic.Properties.TryGetValue(FlowTestContextCancellationTokenAnalyzer.TestContextMemberNamePropertyKey, out string? testContextMemberName);
+
+        // Register a code action that will invoke the fix
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: CodeFixResources.PassCancellationTokenFix,
+                createChangedDocument: c => AddCancellationTokenParameterAsync(context.Document, invocationExpression, testContextMemberName, c),
+                equivalenceKey: "AddTestContextCancellationToken"),
+            diagnostic);
+    }
+
+    private static async Task<Document> AddCancellationTokenParameterAsync(
+        Document document,
+        InvocationExpressionSyntax invocationExpression,
+        string? testContextMemberName,
+        CancellationToken cancellationToken)
+    {
+        DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        // Create the TestContext.CancellationTokenSource.Token expression
+        MemberAccessExpressionSyntax testContextExpression = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName(testContextMemberName ?? "testContext"),
+                SyntaxFactory.IdentifierName("CancellationTokenSource")),
+            SyntaxFactory.IdentifierName("Token"));
+
+        ArgumentListSyntax currentArguments = invocationExpression.ArgumentList;
+        SeparatedSyntaxList<ArgumentSyntax> newArguments = currentArguments.Arguments.Add(SyntaxFactory.Argument(testContextExpression));
+        InvocationExpressionSyntax newInvocation = invocationExpression.WithArgumentList(currentArguments.WithArguments(newArguments));
+        editor.ReplaceNode(invocationExpression, newInvocation);
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
 #nullable enable
+MSTest.Analyzers.FlowTestContextCancellationTokenFixer
+MSTest.Analyzers.FlowTestContextCancellationTokenFixer.FlowTestContextCancellationTokenFixer() -> void
+override MSTest.Analyzers.FlowTestContextCancellationTokenFixer.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override sealed MSTest.Analyzers.FlowTestContextCancellationTokenFixer.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override sealed MSTest.Analyzers.FlowTestContextCancellationTokenFixer.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!
 MSTest.Analyzers.CodeFixes.StringAssertToAssertFixer
 MSTest.Analyzers.CodeFixes.StringAssertToAssertFixer.StringAssertToAssertFixer() -> void
 MSTest.Analyzers.PreferTestMethodOverDataTestMethodFixer

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Opravit podpis</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Nahradit DataTestMethod hodnotou TestMethod</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Signatur korrigieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">„DataTestMethod“ durch „TestMethod“ ersetzen</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Corregir firma</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Reemplazar "DataTestMethod" por "TestMethod"</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Corriger la signature numérique</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Remplacer « DataTestMethod » par « TestMethod »</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Correggi firma</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Sostituisci 'DataTestMethod' con 'TestMethod'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">署名の修正</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">'DataTestMethod' を 'TestMethod' に置き換えます</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">서명 수정</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">'DataTestMethod'를 'TestMethod'로 바꾸기</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Popraw podpis</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Zastąp element „DataTestMethod” elementem „TestMethod”</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Corrigir assinatura</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Substitua 'DataTestMethod' por 'TestMethod'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Исправить подпись</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">Заменить "DataTestMethod" на "TestMethod"</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">İmzayı düzelt</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">'DataTestMethod' yöntemini 'TestMethod' ile değiştirin</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">修复签名</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">将 'DataTestMethod' 替换为 'TestMethod'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">修正簽章</target>
         <note />
       </trans-unit>
+      <trans-unit id="PassCancellationTokenFix">
+        <source>Pass 'TestContext.CancellationTokenSource.Token' argument to method call</source>
+        <target state="new">Pass 'TestContext.CancellationTokenSource.Token' argument to method call</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ReplaceDataTestMethodWithTestMethodTitle">
         <source>Replace 'DataTestMethod' with 'TestMethod'</source>
         <target state="translated">將 'DataTestMethod' 取代為 'TestMethod'</target>

--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,6 +9,7 @@ MSTEST0044 | Design | Warning | PreferTestMethodOverDataTestMethodAnalyzer, [Doc
 MSTEST0045 | Usage | Info | UseCooperativeCancellationForTimeoutAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0045)
 MSTEST0046 | Usage | Info | StringAssertToAssertAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0046)
 MSTEST0048 | Usage | Warning | TestContextPropertyUsageAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0047)
+MSTEST0049 | Usage | Info | FlowTestContextCancellationTokenAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0049)
 
 ### Changed Rules
 

--- a/src/Analyzers/MSTest.Analyzers/FlowTestContextCancellationTokenAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/FlowTestContextCancellationTokenAnalyzer.cs
@@ -172,7 +172,12 @@ public sealed class FlowTestContextCancellationTokenAnalyzer : DiagnosticAnalyze
             method.ContainingType.GetMembers().FirstOrDefault(
                 m => !m.IsStatic && m.Kind is SymbolKind.Field or SymbolKind.Property && testContextSymbol.Equals(m.GetMemberType(), SymbolEqualityComparer.Default)) is { } testContextMember)
         {
-            testContextMemberNameInScope = ((testContextMember as IFieldSymbol)?.AssociatedSymbol ?? testContextMember).Name;
+            testContextMember = (testContextMember as IFieldSymbol)?.AssociatedSymbol ?? testContextMember;
+            // Workaround https://github.com/dotnet/roslyn/issues/70208
+            // https://github.com/dotnet/roslyn/blob/f25ae8e02a91169f45060951a168b233ad588ed3/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L47
+            testContextMemberNameInScope = testContextMember.Name.StartsWith('<') && testContextMember.Name.EndsWith(">P", StringComparison.Ordinal)
+                ? testContextMember.Name.Substring(1, testContextMember.Name.Length - 3)
+                : testContextMember.Name;
             return true;
         }
 

--- a/src/Analyzers/MSTest.Analyzers/FlowTestContextCancellationTokenAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/FlowTestContextCancellationTokenAnalyzer.cs
@@ -1,0 +1,226 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// MSTEST0049: <inheritdoc cref="Resources.FlowTestContextCancellationTokenTitle"/>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class FlowTestContextCancellationTokenAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly LocalizableResourceString Title = new(nameof(Resources.FlowTestContextCancellationTokenTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString Description = new(nameof(Resources.FlowTestContextCancellationTokenDescription), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.FlowTestContextCancellationTokenMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+    internal const string TestContextMemberNamePropertyKey = nameof(TestContextMemberNamePropertyKey);
+
+    internal static readonly DiagnosticDescriptor FlowTestContextCancellationTokenRule = DiagnosticDescriptorHelper.Create(
+        DiagnosticIds.FlowTestContextCancellationTokenRuleId,
+        Title,
+        MessageFormat,
+        Description,
+        Category.Usage,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+        = ImmutableArray.Create(FlowTestContextCancellationTokenRule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            // Get the required symbols
+            if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingCancellationToken, out INamedTypeSymbol? cancellationTokenSymbol) ||
+                !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext, out INamedTypeSymbol? testContextSymbol) ||
+                !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassCleanupAttribute, out INamedTypeSymbol? classCleanupAttributeSymbol) ||
+                !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyCleanupAttribute, out INamedTypeSymbol? assemblyCleanupAttributeSymbol) ||
+                !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute, out INamedTypeSymbol? testMethodAttributeSymbol))
+            {
+                return;
+            }
+
+            context.RegisterOperationAction(
+                context => AnalyzeInvocation(context, cancellationTokenSymbol, testContextSymbol, classCleanupAttributeSymbol, assemblyCleanupAttributeSymbol, testMethodAttributeSymbol),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        INamedTypeSymbol cancellationTokenSymbol,
+        INamedTypeSymbol testContextSymbol,
+        INamedTypeSymbol classCleanupAttributeSymbol,
+        INamedTypeSymbol assemblyCleanupAttributeSymbol,
+        INamedTypeSymbol testMethodAttributeSymbol)
+    {
+        var invocationOperation = (IInvocationOperation)context.Operation;
+        IMethodSymbol method = invocationOperation.TargetMethod;
+
+        // Check if we're in a context where a TestContext is already available or could be made available.
+        if (!HasOrCouldHaveTestContextInScope(context.ContainingSymbol, testContextSymbol, classCleanupAttributeSymbol, assemblyCleanupAttributeSymbol, testMethodAttributeSymbol, out string? testContextMemberNameInScope))
+        {
+            return;
+        }
+
+        IParameterSymbol? cancellationTokenParameter = method.Parameters.LastOrDefault(p => SymbolEqualityComparer.Default.Equals(p.Type, cancellationTokenSymbol));
+        bool parameterHasDefaultValue = cancellationTokenParameter is not null && cancellationTokenParameter.HasExplicitDefaultValue;
+        if (cancellationTokenParameter is not null && !parameterHasDefaultValue)
+        {
+            // The called method has a required CancellationToken parameter.
+            // No need to report diagnostic, even if user is explicitly passing CancellationToken.None or default(CancellationToken).
+            // We consider it "intentional" if the user is passing it explicitly.
+            return;
+        }
+
+        if (parameterHasDefaultValue &&
+            invocationOperation.Arguments.FirstOrDefault(arg => SymbolEqualityComparer.Default.Equals(arg.Parameter, cancellationTokenParameter))?.ArgumentKind != ArgumentKind.Explicit)
+        {
+            // The called method has an optional CancellationToken parameter, but it was not explicitly provided.
+            ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty;
+            if (testContextMemberNameInScope is not null)
+            {
+                properties = properties.Add(TestContextMemberNamePropertyKey, testContextMemberNameInScope);
+            }
+
+            context.ReportDiagnostic(invocationOperation.Syntax.CreateDiagnostic(FlowTestContextCancellationTokenRule, properties: GetPropertiesBag(testContextMemberNameInScope)));
+            return;
+        }
+
+        // At this point, we want to only continue analysis if and only if the called method didn't have a CancellationToken parameter.
+        // In this case, we look for other overloads that might accept a CancellationToken.
+        if (cancellationTokenParameter is null &&
+            HasOverloadWithCancellationToken(method, cancellationTokenSymbol))
+        {
+            context.ReportDiagnostic(invocationOperation.Syntax.CreateDiagnostic(FlowTestContextCancellationTokenRule, properties: GetPropertiesBag(testContextMemberNameInScope)));
+        }
+
+        static ImmutableDictionary<string, string?> GetPropertiesBag(string? testContextMemberNameInScope)
+        {
+            ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty;
+            if (testContextMemberNameInScope is not null)
+            {
+                properties = properties.Add(TestContextMemberNamePropertyKey, testContextMemberNameInScope);
+            }
+
+            return properties;
+        }
+    }
+
+    private static bool HasOverloadWithCancellationToken(IMethodSymbol method, INamedTypeSymbol cancellationTokenSymbol)
+    {
+        // Look for overloads of the same method that accept CancellationToken
+        INamedTypeSymbol containingType = method.ContainingType;
+
+        foreach (ISymbol member in containingType.GetMembers(method.Name))
+        {
+            if (member is IMethodSymbol candidateMethod &&
+                candidateMethod.MethodKind == method.MethodKind &&
+                candidateMethod.IsStatic == method.IsStatic)
+            {
+                // Check if this method has the same parameters plus a CancellationToken
+                if (IsCompatibleOverloadWithCancellationToken(method, candidateMethod, cancellationTokenSymbol))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasOrCouldHaveTestContextInScope(
+        ISymbol containingSymbol,
+        INamedTypeSymbol testContextSymbol,
+        INamedTypeSymbol classCleanupAttributeSymbol,
+        INamedTypeSymbol assemblyCleanupAttributeSymbol,
+        INamedTypeSymbol testMethodAttributeSymbol,
+        out string? testContextMemberNameInScope)
+    {
+        testContextMemberNameInScope = null;
+
+        if (containingSymbol is not IMethodSymbol method)
+        {
+            return false;
+        }
+
+        // We have a TestContext in scope (as a parameter)
+        if (method.Parameters.FirstOrDefault(p => testContextSymbol.Equals(p.Type, SymbolEqualityComparer.Default)) is { } testContextParameter)
+        {
+            testContextMemberNameInScope = testContextParameter.Name;
+            return true;
+        }
+
+        // We have a TestContext in scope (as a field or property)
+        if (!method.IsStatic &&
+            method.ContainingType.GetMembers().FirstOrDefault(
+                m => !m.IsStatic && m.Kind is SymbolKind.Field or SymbolKind.Property && testContextSymbol.Equals(m.GetMemberType(), SymbolEqualityComparer.Default)) is { } testContextMember)
+        {
+            testContextMemberNameInScope = ((testContextMember as IFieldSymbol)?.AssociatedSymbol ?? testContextMember).Name;
+            return true;
+        }
+
+        // If we have AssemblyCleanup or ClassCleanup with no parameters, then we *could* have a TestContext in scope.
+        // Note that assembly/class cleanup method can optionally have a TestContext parameter, but it is not required.
+        // Also, for test methods (parameterized or not), we *could* have a TestContext in scope by adding a property to the test class (or injecting it via constructor).
+        ImmutableArray<AttributeData> attributes = method.GetAttributes();
+        foreach (AttributeData attribute in attributes)
+        {
+            if (method.Parameters.IsEmpty &&
+                (classCleanupAttributeSymbol.Equals(attribute.AttributeClass, SymbolEqualityComparer.Default) ||
+                assemblyCleanupAttributeSymbol.Equals(attribute.AttributeClass, SymbolEqualityComparer.Default)))
+            {
+                return true;
+            }
+
+            if (attribute.AttributeClass?.Inherits(testMethodAttributeSymbol) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCompatibleOverloadWithCancellationToken(IMethodSymbol originalMethod, IMethodSymbol candidateMethod, INamedTypeSymbol cancellationTokenSymbol)
+    {
+        // Check if the candidate method has all the same parameters as the original method plus a CancellationToken
+        ImmutableArray<IParameterSymbol> originalParams = originalMethod.Parameters;
+        ImmutableArray<IParameterSymbol> candidateParams = candidateMethod.Parameters;
+
+        // The candidate should have one more parameter (the CancellationToken)
+        if (candidateParams.Length != originalParams.Length + 1)
+        {
+            return false;
+        }
+
+        // Check if all original parameters match the first N parameters of the candidate
+        for (int i = 0; i < originalParams.Length; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(originalParams[i].Type, candidateParams[i].Type))
+            {
+                return false;
+            }
+        }
+
+        // Check if the last parameter is CancellationToken
+        IParameterSymbol lastParam = candidateParams[candidateParams.Length - 1];
+        return SymbolEqualityComparer.Default.Equals(lastParam.Type, cancellationTokenSymbol);
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -53,4 +53,5 @@ internal static class DiagnosticIds
     public const string StringAssertToAssertRuleId = "MSTEST0046";
     public const string UnusedParameterSuppressorRuleId = "MSTEST0047";
     public const string TestContextPropertyUsageRuleId = "MSTEST0048";
+    public const string FlowTestContextCancellationTokenRuleId = "MSTEST0049";
 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -50,6 +50,7 @@ internal static class WellKnownTypeNames
     public const string SystemIAsyncDisposable = "System.IAsyncDisposable";
     public const string SystemIDisposable = "System.IDisposable";
     public const string SystemReflectionMethodInfo = "System.Reflection.MethodInfo";
+    public const string SystemThreadingCancellationToken = "System.Threading.CancellationToken";
     public const string SystemThreadingTasksTask = "System.Threading.Tasks.Task";
     public const string SystemThreadingTasksTask1 = "System.Threading.Tasks.Task`1";
     public const string SystemThreadingTasksValueTask = "System.Threading.Tasks.ValueTask";

--- a/src/Analyzers/MSTest.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Analyzers/MSTest.Analyzers/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+MSTest.Analyzers.FlowTestContextCancellationTokenAnalyzer
+MSTest.Analyzers.FlowTestContextCancellationTokenAnalyzer.FlowTestContextCancellationTokenAnalyzer() -> void
+override MSTest.Analyzers.FlowTestContextCancellationTokenAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
+override MSTest.Analyzers.FlowTestContextCancellationTokenAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 MSTest.Analyzers.PreferTestMethodOverDataTestMethodAnalyzer
 MSTest.Analyzers.PreferTestMethodOverDataTestMethodAnalyzer.PreferTestMethodOverDataTestMethodAnalyzer() -> void
 override MSTest.Analyzers.PreferTestMethodOverDataTestMethodAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void

--- a/src/Analyzers/MSTest.Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/MSTest.Analyzers/Resources.Designer.cs
@@ -1329,5 +1329,32 @@ namespace MSTest.Analyzers {
                 return ResourceManager.GetString("TestContextPropertyUsageDescription", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.
+        /// </summary>
+        internal static string FlowTestContextCancellationTokenDescription {
+            get {
+                return ResourceManager.GetString("FlowTestContextCancellationTokenDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'.
+        /// </summary>
+        internal static string FlowTestContextCancellationTokenMessageFormat {
+            get {
+                return ResourceManager.GetString("FlowTestContextCancellationTokenMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flow TestContext.CancellationToken to async operations.
+        /// </summary>
+        internal static string FlowTestContextCancellationTokenTitle {
+            get {
+                return ResourceManager.GetString("FlowTestContextCancellationTokenTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -624,4 +624,13 @@ The type declaring these methods should also respect the following rules:
   <data name="TestContextPropertyUsageDescription" xml:space="preserve">
     <value>Some TestContext properties are only available during test execution and cannot be accessed in assembly initialize, class initialize, class cleanup, or assembly cleanup methods.</value>
   </data>
+  <data name="FlowTestContextCancellationTokenTitle" xml:space="preserve">
+    <value>Flow TestContext.CancellationToken to async operations</value>
+  </data>
+  <data name="FlowTestContextCancellationTokenMessageFormat" xml:space="preserve">
+    <value>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</value>
+  </data>
+  <data name="FlowTestContextCancellationTokenDescription" xml:space="preserve">
+    <value>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</value>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -432,6 +432,21 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="translated">Položka DynamicData by měla být platná.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Místo trvalého neúspěšného vyhodnocovacího výrazu „Assert.{0}“ použijte „Assert.Fail“.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -433,6 +433,21 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="translated">DynamicData muss gültig sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Verwenden Sie „Assert.Fail“ anstelle einer Assert-Anweisung „Assert.{0}“, bei der immer ein Fehler auftritt.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -432,6 +432,21 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="translated">DynamicData debe ser válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Usar "Assert.Fail" en lugar de una aserción 'Assert.{0}' que siempre tiene errores</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -432,6 +432,21 @@ Le type doit être une classe
         <target state="translated">DynamicData doit être valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Utilisez « Assert.Fail » à la place d’une assertion « Assert.{0} » toujours en échec</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -432,6 +432,21 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="translated">DynamicData deve essere valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Usare 'Assert.Fail' invece di un'asserzione 'Assert.{0}' che ha sempre esito negativo.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -432,6 +432,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">DynamicData は有効である必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">常に失敗している 'Assert.{0}' アサートの代わりに 'Assert.Fail' を使用する。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -432,6 +432,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">DynamicData는 유효해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">항상 실패하는 'Assert.{0}' 어설션 대신 'Assert.Fail'을 사용합니다.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -432,6 +432,21 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="translated">Wartość DynamicData powinna być prawidłowa</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Użyj trybu „Assert.Fail” zamiast kończącej się zawsze niepowodzeniem instrukcji „Assert.{0}”</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -432,6 +432,21 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <target state="translated">DynamicData deve ser válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Use "Assert.Fail" em vez de uma asserção "Assert.{0}" sempre com falha</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -438,6 +438,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">Значение DynamicData должно быть допустимым</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Используйте "Assert.Fail" вместо утверждения с постоянным сбоем "Assert.{0}"</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -432,6 +432,21 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="translated">DynamicData geçerli olmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">Her zaman başarısız olan 'Assert.{0}' onaylaması yerine 'Assert.Fail' seçeneğini kullanın</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -432,6 +432,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">DynamicData 应有效</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">使用 “Assert.Fail” 而不是始终失败的 “Assert.{0}” 断言</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -432,6 +432,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">DynamicData 應該有效</target>
         <note />
       </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenDescription">
+        <source>When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</source>
+        <target state="new">When calling async methods that have overloads accepting a CancellationToken parameter, prefer using the overload with TestContext.CancellationTokenSource.Token to enable cooperative cancellation and respect test timeouts.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenMessageFormat">
+        <source>Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</source>
+        <target state="new">Consider using the overload that accepts a CancellationToken and pass 'TestContext.CancellationTokenSource.Token'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FlowTestContextCancellationTokenTitle">
+        <source>Flow TestContext.CancellationToken to async operations</source>
+        <target state="new">Flow TestContext.CancellationToken to async operations</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
         <target state="translated">使用 'Assert.Fail'，而不是一直失敗的　'Assert.{0}' 聲明</target>

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/FlowTestContextCancellationTokenAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/FlowTestContextCancellationTokenAnalyzerTests.cs
@@ -1,0 +1,315 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
+    MSTest.Analyzers.FlowTestContextCancellationTokenAnalyzer,
+    MSTest.Analyzers.FlowTestContextCancellationTokenFixer>;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public sealed class FlowTestContextCancellationTokenAnalyzerTests
+{
+    [TestMethod]
+    public async Task WhenTaskDelayWithoutCancellationToken_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public async Task MyTestMethod()
+                {
+                    await [|Task.Delay(1000)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public async Task MyTestMethod()
+                {
+                    await Task.Delay(1000, TestContext.CancellationTokenSource.Token);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodCallAlreadyHasCancellationToken_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public async Task MyTestMethod()
+                {
+                    await Task.Delay(1000, TestContext.CancellationTokenSource.Token);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenNotInTestMethod_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            public class MyClass
+            {
+                public async Task MyMethod()
+                {
+                    await Task.Delay(1000);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodHasNoOverloadWithCancellationToken_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Console.WriteLine("Hello World");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenInTestInitialize_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestInitialize]
+                public async Task TestInit()
+                {
+                    await [|Task.Delay(1000)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestInitialize]
+                public async Task TestInit()
+                {
+                    await Task.Delay(1000, TestContext.CancellationTokenSource.Token);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenInTestCleanup_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestCleanup]
+                public async Task TestCleanup()
+                {
+                    await [|Task.Delay(1000)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestCleanup]
+                public async Task TestCleanup()
+                {
+                    await Task.Delay(1000, TestContext.CancellationTokenSource.Token);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenInClassInitialize_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [ClassInitialize]
+                public static async Task ClassInit(TestContext testContext)
+                {
+                    await [|Task.Delay(1000)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [ClassInitialize]
+                public static async Task ClassInit(TestContext testContext)
+                {
+                    await Task.Delay(1000, testContext.CancellationTokenSource.Token);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenWithCancellationTokenNone_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public async Task MyTestMethod()
+                {
+                    await Task.Delay(1000, CancellationToken.None);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenHttpClientMethodWithoutCancellationToken_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Net.Http;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public async Task MyTestMethod()
+                {
+                    using var client = new HttpClient();
+                    var response = await [|client.GetAsync("https://example.com")|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Net.Http;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public async Task MyTestMethod()
+                {
+                    using var client = new HttpClient();
+                    var response = await client.GetAsync("https://example.com", TestContext.CancellationTokenSource.Token);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+}


### PR DESCRIPTION
Fixes #5878
Replaces #5941

- Codefix doesn't handle correctly if a TestContext property or parameter needs to be added. This will require a custom fix all provider.