### PR TITLE
Disable ThreadSafeStringWriterWritesLinesFromDifferentTasksSeparately

### DIFF
--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/ThreadSafeStringWriterTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/ThreadSafeStringWriterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if false
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
 using TestFramework.ForTestingMSTest;
@@ -84,9 +85,7 @@ public class ThreadSafeStringWriterTests : TestContainer
         while (exception != null && currentAttempt++ < 3);
     }
 
-#pragma warning disable IDE0051 // Remove unused private members - Test is flaky.
-    private void ThreadSafeStringWriterWritesLinesIntoDifferentWritesSeparately()
-#pragma warning restore IDE0051 // Remove unused private members
+    public void ThreadSafeStringWriterWritesLinesIntoDifferentWritesSeparately()
     {
         // Suppress the flow of parent context here because this test method will run in
         // a task already and we don't want the existing async context to interfere with this.
@@ -129,3 +128,4 @@ public class ThreadSafeStringWriterTests : TestContainer
         }
     }
 }
+#endif


### PR DESCRIPTION
Similar to https://github.com/microsoft/testfx/pull/6095, but disabling the full class now.