### PR TITLE
Make ConditionBaseAttribute.IgnoreMessage settable

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/TestMethod/CIConditionAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/CIConditionAttribute.cs
@@ -35,9 +35,6 @@ public sealed class CIConditionAttribute : ConditionBaseAttribute
     /// <inheritdoc />
     public override bool IsConditionMet => IsCIEnvironment();
 
-    /// <inheritdoc />
-    public override string? IgnoreMessage { get; set; }
-
     /// <summary>
     /// Gets the group name for this attribute.
     /// </summary>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/ConditionBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/ConditionBaseAttribute.cs
@@ -27,7 +27,7 @@ public abstract class ConditionBaseAttribute : Attribute
     /// <summary>
     /// Gets or sets the ignore message indicating the reason for ignoring the test method or test class.
     /// </summary>
-    public abstract string? IgnoreMessage { get; set; }
+    public string? IgnoreMessage { get; set; }
 
     /// <summary>
     /// Gets the group name for this attribute. This is relevant when multiple

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/IgnoreAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/IgnoreAttribute.cs
@@ -31,9 +31,6 @@ public sealed class IgnoreAttribute : ConditionBaseAttribute
         => IgnoreMessage = message;
 
     /// <inheritdoc />
-    public override string? IgnoreMessage { get; set; }
-
-    /// <inheritdoc />
     public override bool IsConditionMet => false;
 
     /// <inheritdoc />

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/OSConditionAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/OSConditionAttribute.cs
@@ -79,9 +79,6 @@ public sealed class OSConditionAttribute : ConditionBaseAttribute
     }
 #endif
 
-    /// <inheritdoc />
-    public override string? IgnoreMessage { get; set; }
-
     /// <summary>
     /// Gets the group name for this attribute.
     /// </summary>


### PR DESCRIPTION
Drop property from children.

Relates to #6150