### PR TITLE
Comment out AttachCurrentProcessToParentVSProcess

### DIFF
--- a/samples/Playground/Program.cs
+++ b/samples/Playground/Program.cs
@@ -26,7 +26,7 @@ public class Program
         {
 #if NETCOREAPP
             // To attach to the children
-            Microsoft.Testing.TestInfrastructure.DebuggerUtility.AttachCurrentProcessToParentVSProcess();
+            // Microsoft.Testing.TestInfrastructure.DebuggerUtility.AttachCurrentProcessToParentVSProcess();
 #endif
 
             ITestApplicationBuilder testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);


### PR DESCRIPTION
This is so annoying when working with testfx locally.