### PR TITLE
Update azure-pipeline.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,6 @@ pr:
     include:
     - main
     - rel/*
-    - dev/v4
   paths:
     exclude:
       - .github/*
@@ -23,6 +22,7 @@ pr:
       - README.md
       - SECURITY.md
       - src/**/*.xlf
+      - azure-pipelines-official.yml
 
 parameters:
 # This option should be used with caution. This is useful for unblocking circular deps issue with testanywhere


### PR DESCRIPTION
If a change is made only to azure-pipeline-official.yml, that shouldn't need a build in PRs. Also cleaned up the `dev/v4` which is renamed now to rel/4.0