### PR TITLE
Revert "[rel/3.10] Use stable CC"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,9 +13,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e2fed65f9c524d12c64876194ae4ce177b935bb3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2">
+    <Dependency Name="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.0-preview.25378.1">
       <Uri>https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage</Uri>
-      <Sha>005149fac82d93baa64fa87c3bae1004c9cd11e1</Sha>
+      <Sha>4fa8f0c467e38db87fae04266d98e4288dad4697</Sha>
     </Dependency>
     <Dependency Name="MSTest" Version="3.10.0-preview.25378.9">
       <Uri>https://github.com/microsoft/testfx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>10.0.0-beta.25374.4</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftTestingExtensionsCodeCoverageVersion>17.14.2</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.0.0-preview.25378.1</MicrosoftTestingExtensionsCodeCoverageVersion>
     <!-- empty line to avoid merge conflicts for darc PRs to update CC and MSTest+MTP -->
     <MSTestVersion>3.10.0-preview.25378.9</MSTestVersion>
     <MicrosoftTestingPlatformVersion>1.8.0-preview.25378.9</MicrosoftTestingPlatformVersion>


### PR DESCRIPTION
Reverts microsoft/testfx#6211

The PR was incorrectly merged to main instead of rel/3.10.

So reverting in main and opened https://github.com/microsoft/testfx/pull/6216 for 3.10