### PR TITLE
Avoid generate package on build

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
+++ b/src/Analyzers/MSTest.Analyzers.Package/MSTest.Analyzers.Package.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <GeneratePackageOnBuild Condition=" '$(OS)' == 'Windows_NT' ">true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <!-- C# Source generators have to target netstandard -->
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <!-- Generates a package at build -->
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Do not include the generator as a lib dependency -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoWarn>NU5128</NoWarn>


### PR DESCRIPTION
Brings consistency with the rest of the repo. Building is building only. It's unnecessary to produce packages when only build is requested.