### PR TITLE
Allow to opt-out of Microsoft.NET.Test.Sdk

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
@@ -48,6 +48,7 @@
   <!-- Core (for test applications - not for test libraries) -->
   <ItemGroup Condition=" '$(IsTestApplication)' == 'true' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Sdk="MSTest"
+                      Condition=" '$(ExcludeMicrosoftNetTestSdk)' != 'true' "
                       Version="$(MicrosoftNETTestSdkVersion)" VersionOverride="$(MicrosoftNETTestSdkVersion)" />
     <!--
       Most of the times this dependency is not required but we leave the opportunity to align the version of the platform being used.


### PR DESCRIPTION
When a repo is fully onboarded to MTP and dotnet test, we should give the opportunity for developers to stop relying on VSTEst package. This should not be done by default, but as an opt-in, as some extra tools might be broken.