### PR TITLE
Integration tests are using MSTest

### DIFF
--- a/test/IntegrationTests/MSTest.IntegrationTests/ClsTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/ClsTests.cs
@@ -5,12 +5,14 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class ClsTests : CLITestBase
 {
     private const string TestAssetName = "ClsTestProject";
 
     // This test in itself is not so important. What matters is that the asset gets build. If we regress and start having
     // the [DataRow] attribute no longer CLS compliant, the build will raise a warning in VS (and the build will fail in CI).
+    [TestMethod]
     public async Task TestsAreRun()
     {
         // Arrange

--- a/test/IntegrationTests/MSTest.IntegrationTests/DiscoverInternalsTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/DiscoverInternalsTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class DiscoverInternalsTests : CLITestBase
 {
     private const string TestAsset = "DiscoverInternalsProject";
 
+    [TestMethod]
     public async Task InternalTestClassesAreDiscoveredWhenTheDiscoverInternalsAttributeIsPresent()
     {
         // Arrange
@@ -25,6 +27,7 @@ public class DiscoverInternalsTests : CLITestBase
             "NestedInternalClass_TestMethod1");
     }
 
+    [TestMethod]
     public void AnInternalTestClassDerivedFromAPublicAbstractGenericBaseClassForAnInternalTypeIsDiscovered()
     {
         // Arrange
@@ -39,6 +42,7 @@ public class DiscoverInternalsTests : CLITestBase
             "EqualityIsCaseInsensitive");
     }
 
+    [TestMethod]
     public async Task AnInternalTypeCanBeUsedInADynamicDataTestMethod()
     {
         string assemblyPath = Path.IsPathRooted(TestAsset) ? TestAsset : GetAssetFullPath(TestAsset);

--- a/test/IntegrationTests/MSTest.IntegrationTests/Extensions/VerifyE2E.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Extensions/VerifyE2E.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
@@ -58,16 +56,17 @@ public static class VerifyE2E
     {
         if (matchCount)
         {
-            discoveredTests.Should().HaveSameCount(expectedTests);
+            Assert.AreEqual(expectedTests.Count(), discoveredTests.Count());
         }
 
         foreach (string test in expectedTests)
         {
             // Test Discovery run was expecting to discover \"{test}\", but it has not discovered.
-            discoveredTests.Should().Contain(
+            Assert.Contains(
                 p => test.Equals(p.FullyQualifiedName, StringComparison.Ordinal)
                      || test.Equals(p.DisplayName, StringComparison.Ordinal)
-                     || test.Equals(p.DisplayName, StringComparison.Ordinal));
+                     || test.Equals(p.DisplayName, StringComparison.Ordinal),
+                discoveredTests);
         }
     }
 
@@ -82,10 +81,11 @@ public static class VerifyE2E
 
         foreach (string test in expectedTests)
         {
-            tests.Should().Contain(
+            Assert.Contains(
                 p => test.Equals(p.TestCase.FullyQualifiedName, StringComparison.Ordinal)
                      || test.Equals(p.DisplayName, StringComparison.Ordinal)
-                     || test.Equals(p.TestCase.DisplayName, StringComparison.Ordinal));
+                     || test.Equals(p.TestCase.DisplayName, StringComparison.Ordinal),
+                tests);
         }
     }
 
@@ -100,9 +100,10 @@ public static class VerifyE2E
 
         foreach (string test in expectedTests)
         {
-            tests.Should().Contain(p => p.DisplayName == test);
+            Assert.Contains(p => p.DisplayName == test, tests);
         }
     }
 
-    private static void AssertOutcomeCount(IEnumerable<TestResult> actual, TestOutcome expectedOutcome, int expectedCount) => actual.Where(i => i.Outcome == expectedOutcome).Should().HaveCount(expectedCount);
+    private static void AssertOutcomeCount(IEnumerable<TestResult> actual, TestOutcome expectedOutcome, int expectedCount)
+        => Assert.HasCount(expectedCount, actual.Where(i => i.Outcome == expectedOutcome));
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/FSharpTestProjectTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/FSharpTestProjectTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class FSharpTestProjectTests : CLITestBase
 {
     private const string TestAssetName = "FSharpTestProject";
 
+    [TestMethod]
     public async Task TestFSharpTestsWithSpaceAndDotInName()
     {
         // Arrange

--- a/test/IntegrationTests/MSTest.IntegrationTests/MSTest.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.IntegrationTests/MSTest.IntegrationTests.csproj
@@ -4,8 +4,9 @@
     <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn),1685</NoWarn>
-    <UseInternalTestFramework>true</UseInternalTestFramework>
     <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <UseMSTestFromSource>true</UseMSTestFromSource>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,14 +14,18 @@
     <Compile Include="$(RepoRoot)test\Utilities\Automation.CLI\RunConfiguration.cs" Link="Utilities\RunConfiguration.cs" />
     <Compile Include="$(RepoRoot)test\Utilities\Automation.CLI\XmlRunSettingsUtilities.cs" Link="Utilities\XmlRunSettingsUtilities.cs" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Internal.Analyzers\MSTest.Internal.Analyzers.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj">
       <OutputItemType>Analyzer</OutputItemType>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/test/IntegrationTests/MSTest.IntegrationTests/NoNamespaceTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/NoNamespaceTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
@@ -10,17 +8,19 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class NoNamespaceTests : CLITestBase
 {
     private const string TestAssetName = "HierarchyProject";
 
+    [TestMethod]
     public void TestsAreDiscoveredWithExpectedHierarchy()
     {
         // Arrange & Act
         System.Collections.Immutable.ImmutableArray<TestCase> testCases = DiscoverTests(GetAssetFullPath(TestAssetName));
 
         // Assert
-        testCases.Should().HaveCount(2);
+        Assert.HasCount(2, testCases, "Should discover exactly 2 tests with hierarchy information");
 
         VerifyHierarchy(testCases[0], null!, "ClassWithNoNamespace", "MyMethodUnderTest");
         VerifyHierarchy(testCases[1], "SomeNamespace.WithMultipleLevels", "ClassWithNamespace", "MyMethodUnderTest");
@@ -29,12 +29,13 @@ public class NoNamespaceTests : CLITestBase
     private static void VerifyHierarchy(TestCase testCase, string expectedNamespace, string expectedClassName, string expectedMethodName)
     {
         string[]? hierarchy = testCase.GetPropertyValue(TestCaseExtensions.HierarchyProperty) as string[];
-        hierarchy.Should().HaveCount(4);
+        Assert.IsNotNull(hierarchy);
+        Assert.HasCount(4, hierarchy);
 
         // This level is always null.
-        hierarchy![0].Should().BeNull();
-        hierarchy[1].Should().Be(expectedNamespace);
-        hierarchy[2].Should().Be(expectedClassName);
-        hierarchy[3].Should().Be(expectedMethodName);
+        Assert.IsNull(hierarchy[0]);
+        Assert.AreEqual(expectedNamespace, hierarchy[1]);
+        Assert.AreEqual(expectedClassName, hierarchy[2]);
+        Assert.AreEqual(expectedMethodName, hierarchy[3]);
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DataExtensibilityTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DataExtensibilityTests.cs
@@ -10,6 +10,7 @@ using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class DataExtensibilityTests : CLITestBase
 {
     private const string TestAssetName = "FxExtensibilityTestProject";
@@ -19,7 +20,7 @@ public class DataExtensibilityTests : CLITestBase
          - Ignored tests are discovered during discovery
          - Ignored tests are not expanded (DataRow, DataSource, etc)
      */
-
+    [TestMethod]
     public async Task CustomTestDataSourceTests()
     {
         // Arrange
@@ -33,6 +34,7 @@ public class DataExtensibilityTests : CLITestBase
         VerifyE2E.ContainsTestsPassed(testResults, "CustomTestDataSourceTestMethod1 (1,2,3)", "CustomTestDataSourceTestMethod1 (4,5,6)");
     }
 
+    [TestMethod]
     public async Task CustomEmptyTestDataSourceTests()
     {
         // Arrange
@@ -46,6 +48,7 @@ public class DataExtensibilityTests : CLITestBase
         VerifyE2E.ContainsTestsFailed(testResults, [null!]);
     }
 
+    [TestMethod]
     public async Task AssertExtensibilityTests()
     {
         // Arrange
@@ -59,6 +62,7 @@ public class DataExtensibilityTests : CLITestBase
         VerifyE2E.ContainsTestsFailed(testResults, "BasicFailingAssertExtensionTest", "ChainedFailingAssertExtensionTest");
     }
 
+    [TestMethod]
     public async Task ExecuteCustomTestExtensibilityTests()
     {
         // Arrange
@@ -86,6 +90,7 @@ public class DataExtensibilityTests : CLITestBase
             "CustomTestClass1 - Execution number 3");
     }
 
+    [TestMethod]
     public async Task ExecuteCustomTestExtensibilityWithTestDataTests()
     {
         // Arrange
@@ -112,6 +117,7 @@ public class DataExtensibilityTests : CLITestBase
             "CustomTestMethod2 (\"C\")");
     }
 
+    [TestMethod]
     public async Task WhenUsingCustomITestDataSourceWithExpansionDisabled_RespectSetting()
     {
         // Arrange
@@ -122,7 +128,7 @@ public class DataExtensibilityTests : CLITestBase
         ImmutableArray<TestResult> testResults = await RunTestsAsync(testCases);
 
         // Assert
-        Verify(testCases.Length == 1);
+        Assert.HasCount(1, testCases);
 
         VerifyE2E.TestsPassed(
             testResults,

--- a/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DataRowTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DataRowTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class DataRowTests : CLITestBase
 {
     private const string TestAssetName = "DataRowTestProject";
 
+    [TestMethod]
     public async Task ExecuteOnlyDerivedClassDataRowsWhenBothBaseAndDerivedClassHasDataRows_SimpleDataRows()
     {
         // Arrange
@@ -28,6 +30,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMethod (\"DerivedString2\")");
     }
 
+    [TestMethod]
     public async Task ExecuteOnlyDerivedClassDataRowsWhenItOverridesBaseClassDataRows_SimpleDataRows()
     {
         // Arrange
@@ -44,6 +47,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMethod (\"DerivedString2\")");
     }
 
+    [TestMethod]
     public async Task DataRowsExecuteWithRequiredAndOptionalParameters()
     {
         // Arrange
@@ -61,6 +65,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMethodWithSomeOptionalParameters (123,\"DerivedOptionalString2\",\"DerivedOptionalString3\")");
     }
 
+    [TestMethod]
     public async Task DataRowsExecuteWithParamsArrayParameter()
     {
         // Arrange
@@ -79,6 +84,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMethodWithParamsParameters (2,\"DerivedParamsArg1\",\"DerivedParamsArg2\",\"DerivedParamsArg3\")");
     }
 
+    [TestMethod]
     public async Task DataRowsFailWhenInvalidArgumentsProvided()
     {
         // Arrange
@@ -96,6 +102,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMethodFailsWithInvalidArguments (2,\"DerivedRequiredArgument\",\"DerivedOptionalArgument\",\"DerivedExtraArgument\")");
     }
 
+    [TestMethod]
     public async Task DataRowsShouldSerializeDoublesProperly()
     {
         // Arrange
@@ -112,6 +119,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestDouble (10.02,20.02)");
     }
 
+    [TestMethod]
     public async Task DataRowsShouldSerializeMixedTypesProperly()
     {
         // Arrange
@@ -127,6 +135,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMixed (10,10,10,10,10,10,10,\"10\")");
     }
 
+    [TestMethod]
     public async Task DataRowsShouldSerializeEnumsProperly()
     {
         // Arrange
@@ -145,6 +154,7 @@ public class DataRowTests : CLITestBase
             "DataRowEnums (Gamma)");
     }
 
+    [TestMethod]
     public async Task DataRowsShouldHandleNonSerializableValues()
     {
         // Arrange
@@ -166,6 +176,7 @@ public class DataRowTests : CLITestBase
             "DataRowNonSerializable (DataRowTestProject.DataRowTests_DerivedClass)");
     }
 
+    [TestMethod]
     public async Task ExecuteDataRowTests_Enums()
     {
         // Arrange
@@ -241,6 +252,7 @@ public class DataRowTests : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
     }
 
+    [TestMethod]
     public async Task ExecuteDataRowTests_NonSerializablePaths()
     {
         // Arrange
@@ -259,6 +271,7 @@ public class DataRowTests : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
     }
 
+    [TestMethod]
     public async Task ExecuteDataRowTests_Regular()
     {
         // Arrange
@@ -320,6 +333,7 @@ public class DataRowTests : CLITestBase
             "DataRowTestMethodFailsWithInvalidArguments (2,\"DerivedRequiredArgument\",\"DerivedOptionalArgument\",\"DerivedExtraArgument\")");
     }
 
+    [TestMethod]
     public async Task GetDisplayName_AfterOverriding_GetsTheNewDisplayName()
     {
         // Arrange
@@ -334,6 +348,7 @@ public class DataRowTests : CLITestBase
             "Overridden DisplayName");
     }
 
+    [TestMethod]
     public async Task ParameterizedTestsWithTestMethodSettingDisplayName_DataIsPrefixWithDisplayName()
     {
         // Arrange

--- a/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DataSourceTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DataSourceTests.cs
@@ -5,13 +5,15 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class DataSourceTests : CLITestBase
 {
     private const string TestAssetName = "DataSourceTestProject";
 
-    // TODO @haplois | @evangelink: This test fails under CI - will be fixed in a future PR (Marked as private to ignore the test)
 #pragma warning disable IDE0051 // Remove unused private members
-    private async Task ExecuteCsvTestDataSourceTests()
+    [TestMethod]
+    [Ignore("This test is ignored because it fails under CI. It will be fixed in a future PR.")]
+    public async Task ExecuteCsvTestDataSourceTests()
 #pragma warning restore IDE0051 // Remove unused private members
     {
         // Arrange

--- a/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DynamicDataTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Parameterized tests/DynamicDataTests.cs
@@ -10,10 +10,12 @@ using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class DynamicDataTests : CLITestBase
 {
     private const string TestAssetName = "DynamicDataTestProject";
 
+    [TestMethod]
     public async Task ExecuteDynamicDataTests()
     {
         // Arrange
@@ -84,6 +86,7 @@ public class DynamicDataTests : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
     }
 
+    [TestMethod]
     public async Task ExecuteDynamicDataTestsWithCategoryFilter()
     {
         // Arrange
@@ -102,6 +105,7 @@ public class DynamicDataTests : CLITestBase
         VerifyE2E.FailedTestCount(testResults, 0);
     }
 
+    [TestMethod]
     public async Task ExecuteNonExpandableDynamicDataTests()
     {
         // Arrange
@@ -112,7 +116,7 @@ public class DynamicDataTests : CLITestBase
         ImmutableArray<TestResult> testResults = await RunTestsAsync(testCases);
 
         // Assert
-        Verify(testCases.Length == 6);
+        Assert.HasCount(6, testCases);
 
         VerifyE2E.TestsPassed(
             testResults,

--- a/test/IntegrationTests/MSTest.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Program.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Testing.Extensions;
 
-using TestFramework.ForTestingMSTest;
+[assembly: Parallelize(Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel, Workers = 0)]
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
 
@@ -16,7 +16,7 @@ builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
 
-builder.AddInternalTestFramework();
+builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestCategoriesFromTestDataRowTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestCategoriesFromTestDataRowTests.cs
@@ -5,6 +5,7 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public class TestCategoriesFromTestDataRowTests : CLITestBase
 {
     private const string TestAssetName = "TestCategoriesFromTestDataRowProject";
@@ -19,10 +20,10 @@ public class TestCategoriesFromTestDataRowTests : CLITestBase
         System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> testCases = DiscoverTests(assemblyPath, "TestCategory~Integration");
 
         // Assert - Should discover the test that has Integration category from TestDataRow
-        Assert.AreEqual(1, testCases.Length, "Should discover exactly 1 test with Integration category");
+        Assert.HasCount(1, testCases, "Should discover exactly 1 test with Integration category");
 
         Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase integrationTest = testCases[0];
-        Assert.IsTrue(integrationTest.DisplayName.Contains("Integration and Slow"), "Should be the test with Integration and Slow categories");
+        Assert.Contains("Integration and Slow", integrationTest.DisplayName, "Should be the test with Integration and Slow categories");
     }
 
     [TestMethod]
@@ -35,10 +36,10 @@ public class TestCategoriesFromTestDataRowTests : CLITestBase
         System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> testCases = DiscoverTests(assemblyPath, "TestCategory~Unit");
 
         // Assert - Should discover the test that has Unit category from TestDataRow
-        Assert.AreEqual(1, testCases.Length, "Should discover exactly 1 test with Unit category");
+        Assert.HasCount(1, testCases, "Should discover exactly 1 test with Unit category");
 
         Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase unitTest = testCases[0];
-        Assert.IsTrue(unitTest.DisplayName.Contains("Unit and Fast"), "Should be the test with Unit and Fast categories");
+        Assert.Contains("Unit and Fast", unitTest.DisplayName, "Should be the test with Unit and Fast categories");
     }
 
     [TestMethod]
@@ -54,14 +55,14 @@ public class TestCategoriesFromTestDataRowTests : CLITestBase
         System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> dataLevelTests = DiscoverTests(assemblyPath, "TestCategory~DataLevel");
 
         // Assert - The same test should be found by both filters since categories are merged
-        Assert.AreEqual(1, methodLevelTests.Length, "Should discover exactly 1 test with MethodLevel category");
-        Assert.AreEqual(1, dataLevelTests.Length, "Should discover exactly 1 test with DataLevel category");
+        Assert.HasCount(1, methodLevelTests, "Should discover exactly 1 test with MethodLevel category");
+        Assert.HasCount(1, dataLevelTests, "Should discover exactly 1 test with DataLevel category");
 
         Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase methodTest = methodLevelTests[0];
         Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase dataTest = dataLevelTests[0];
 
         Assert.AreEqual(methodTest.FullyQualifiedName, dataTest.FullyQualifiedName, "Both filters should find the same test");
-        Assert.IsTrue(methodTest.DisplayName.Contains("method and data categories"), "Should be the test with combined categories");
+        Assert.Contains("method and data categories", methodTest.DisplayName, "Should be the test with combined categories");
     }
 
     [TestMethod]

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestId.DefaultStrategy.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestId.DefaultStrategy.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
@@ -11,6 +9,7 @@ public partial class TestId : CLITestBase
 {
     private const string DefaultStrategyDll = "TestIdProject.DefaultStrategy";
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowArray_DefaultStrategy()
     {
         // Arrange
@@ -29,9 +28,12 @@ public partial class TestId : CLITestBase
             "DataRowArraysTests (0,[0,0,0])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowString_DefaultStrategy()
     {
         // Arrange
@@ -51,9 +53,12 @@ public partial class TestId : CLITestBase
             "DataRowStringTests (\"  \")");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataArrays_DefaultStrategy()
     {
         // Arrange
@@ -72,9 +77,12 @@ public partial class TestId : CLITestBase
             "DynamicDataArraysTests (0,[0,0,0])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataTuple_DefaultStrategy()
     {
         // Arrange
@@ -92,9 +100,12 @@ public partial class TestId : CLITestBase
             "DynamicDataTuplesTests ((1, text, False))");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataGenericCollections_DefaultStrategy()
     {
         // Arrange
@@ -114,9 +125,12 @@ public partial class TestId : CLITestBase
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceArrays_DefaultStrategy()
     {
         // Arrange
@@ -135,9 +149,12 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceTuples_DefaultStrategy()
     {
         // Arrange
@@ -155,9 +172,12 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceGenericCollections_DefaultStrategy()
     {
         // Arrange
@@ -177,6 +197,8 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestId.DisplayNameStrategy.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestId.DisplayNameStrategy.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
@@ -11,6 +9,7 @@ public partial class TestId : CLITestBase
 {
     private const string DisplayNameStrategyDll = "TestIdProject.DisplayNameStrategy";
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowArray_DisplayNameStrategy()
     {
         // Arrange
@@ -29,9 +28,10 @@ public partial class TestId : CLITestBase
             "DataRowArraysTests (0,System.Int32[])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowString_DisplayNameStrategy()
     {
         // Arrange
@@ -52,9 +52,10 @@ public partial class TestId : CLITestBase
 
         // We cannot assert the expected ID as it is path dependent.
         // First two display names are equals so we have the same ID for them
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().HaveCount(3);
+        Assert.HasCount(3, testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataArrays_DisplayNameStrategy()
     {
         // Arrange
@@ -73,9 +74,10 @@ public partial class TestId : CLITestBase
             "DynamicDataArraysTests (0,System.Int32[])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataTuple_DisplayNameStrategy()
     {
         // Arrange
@@ -93,9 +95,12 @@ public partial class TestId : CLITestBase
             "DynamicDataTuplesTests ((1, text, False))");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataGenericCollections_DisplayNameStrategy()
     {
         // Arrange
@@ -115,9 +120,10 @@ public partial class TestId : CLITestBase
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceArrays_DisplayNameStrategy()
     {
         // Arrange
@@ -136,9 +142,10 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceTuples_DisplayNameStrategy()
     {
         // Arrange
@@ -156,9 +163,10 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceGenericCollections_DisplayNameStrategy()
     {
         // Arrange
@@ -178,6 +186,6 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestId.FullyQualifiedStrategy.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestId.FullyQualifiedStrategy.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Immutable;
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
@@ -13,6 +11,7 @@ public partial class TestId : CLITestBase
 {
     private const string FullyQualifiedStrategyDll = "TestIdProject.FullyQualifiedStrategy";
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowArray_FullyQualifiedStrategy()
     {
         // Arrange
@@ -31,9 +30,12 @@ public partial class TestId : CLITestBase
             "DataRowArraysTests (0,[0,0,0])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowString_FullyQualifiedStrategy()
     {
         // Arrange
@@ -53,9 +55,12 @@ public partial class TestId : CLITestBase
             "DataRowStringTests (\"  \")");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataArrays_FullyQualifiedStrategy()
     {
         // Arrange
@@ -74,9 +79,12 @@ public partial class TestId : CLITestBase
             "DynamicDataArraysTests (0,[0,0,0])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataTuple_FullyQualifiedStrategy()
     {
         // Arrange
@@ -94,9 +102,12 @@ public partial class TestId : CLITestBase
             "DynamicDataTuplesTests ((1, text, False))");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataGenericCollections_FullyQualifiedStrategy()
     {
         // Arrange
@@ -116,9 +127,12 @@ public partial class TestId : CLITestBase
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceArrays_FullyQualifiedStrategy()
     {
         // Arrange
@@ -137,9 +151,12 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceTuples_FullyQualifiedStrategy()
     {
         // Arrange
@@ -157,9 +174,12 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceGenericCollections_FullyQualifiedStrategy()
     {
         // Arrange
@@ -179,6 +199,8 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Should().OnlyHaveUniqueItems();
+        CollectionAssert.AllItemsAreUnique(
+            testResults.Select(x => x.TestCase.Id.ToString()).ToList(),
+            "Test IDs should be unique.");
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestId.LegacyStrategy.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestId.LegacyStrategy.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.IntegrationTests;
 
+[TestClass]
 public partial class TestId : CLITestBase
 {
     private const string LegacyStrategyDll = "TestIdProject.LegacyStrategy";
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowArray_LegacyStrategy()
     {
         // Arrange
@@ -30,9 +30,10 @@ public partial class TestId : CLITestBase
             "DataRowArraysTests (0,System.Int32[])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DataRowString_LegacyStrategy()
     {
         // Arrange
@@ -53,9 +54,10 @@ public partial class TestId : CLITestBase
             "DataRowStringTests (  )");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataArrays_LegacyStrategy()
     {
         // Arrange
@@ -75,9 +77,10 @@ public partial class TestId : CLITestBase
             "DynamicDataArraysTests (0,System.Int32[])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataTuple_LegacyStrategy()
     {
         // Arrange
@@ -96,9 +99,10 @@ public partial class TestId : CLITestBase
             "DynamicDataTuplesTests ((1, text, False))");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_DynamicDataGenericCollections_LegacyStrategy()
     {
         // Arrange
@@ -119,9 +123,10 @@ public partial class TestId : CLITestBase
             "DynamicDataGenericCollectionsTests (System.Collections.Generic.List`1[System.Int32],System.Collections.Generic.List`1[System.String],System.Collections.Generic.List`1[System.Boolean])");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceArrays_LegacyStrategy()
     {
         // Arrange
@@ -141,9 +146,10 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceTuples_LegacyStrategy()
     {
         // Arrange
@@ -162,9 +168,10 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 
+    [TestMethod]
     public async Task TestIdUniqueness_TestDataSourceGenericCollections_LegacyStrategy()
     {
         // Arrange
@@ -185,6 +192,6 @@ public partial class TestId : CLITestBase
             "Custom name");
 
         // We cannot assert the expected ID as it is path dependent
-        testResults.Select(x => x.TestCase.Id.ToString()).Distinct().Should().ContainSingle();
+        Assert.ContainsSingle(testResults.Select(x => x.TestCase.Id.ToString()).Distinct());
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -5,21 +5,17 @@ using System.Collections.Immutable;
 
 using DiscoveryAndExecutionTests.Utilities;
 
-using FluentAssertions;
-
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
-using TestFramework.ForTestingMSTest;
-
 using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace Microsoft.MSTestV2.CLIAutomation;
 
-public partial class CLITestBase : TestContainer
+public abstract partial class CLITestBase
 {
     internal static ImmutableArray<TestCase> DiscoverTests(string assemblyPath, string? testCaseFilter = null)
     {
@@ -102,14 +98,14 @@ public partial class CLITestBase : TestContainer
 
         public void RecordResult(TestResult testResult)
         {
-            testResult.Should().NotBeNull();
+            Assert.IsNotNull(testResult, "Test result should not be null.");
             _activeResults.Add(testResult);
         }
 
         public ImmutableArray<TestResult> GetFlattenedTestResults()
         {
             var allTestResults = _testResults.SelectMany(i => i.Value).ToImmutableArray();
-            allTestResults.Should().NotContainNulls();
+            CollectionAssert.AllItemsAreNotNull(allTestResults, "All test results should be non-null.");
 
             return allTestResults;
         }

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/AssertExtensibilityTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/AssertExtensibilityTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class AssertExtensibilityTests : CLITestBase
 {
     private const string TestAssetName = "FxExtensibilityTestProject";
 
+    [TestMethod]
     public void ExecuteAssertExtensibilityTests()
     {
         InvokeVsTestForExecution([TestAssetName]);

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/DeploymentTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/DeploymentTests.cs
@@ -5,6 +5,7 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class DeploymentTests : CLITestBase
 {
     private const string TestAssetNever = "DeploymentTestProject.Never";
@@ -18,26 +19,19 @@ public class DeploymentTests : CLITestBase
         </RunSettings>
         """;
 
-    public void ValidateTestSourceDependencyDeployment_net462()
-        => ValidateTestSourceDependencyDeployment("net462");
-
-    public void ValidateTestSourceDependencyDeployment_netcoreapp31()
-        => ValidateTestSourceDependencyDeployment("netcoreapp3.1");
-
-    private void ValidateTestSourceDependencyDeployment(string targetFramework)
+    [TestMethod]
+    [DataRow("net462")]
+    [DataRow("netcoreapp3.1")]
+    public void ValidateTestSourceDependencyDeployment(string targetFramework)
     {
         InvokeVsTestForExecution([TestAssetNever], targetFramework: targetFramework);
         ValidatePassedTestsContain("DeploymentTestProject.DeploymentTestProject.FailIfFilePresent", "DeploymentTestProject.DeploymentTestProject.PassIfDeclaredFilesPresent");
         ValidateFailedTestsContain(true, "DeploymentTestProject.DeploymentTestProject.PassIfFilePresent");
     }
 
-    public void ValidateTestSourceLocationDeployment_net462()
-        => ValidateTestSourceLocationDeployment("net462");
-
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "This is currently ignored and that's why we marked it as private")]
-    private void ValidateTestSourceLocationDeployment_netcoreapp31()
-        => ValidateTestSourceLocationDeployment("netcoreapp3.1");
-
+    [TestMethod]
+    [DataRow("net462")]
+    [DataRow("netcoreapp3.1", IgnoreMessage = "This is currently ignored and that's why we marked it as private")]
     public void ValidateTestSourceLocationDeployment(string targetFramework)
     {
         InvokeVsTestForExecution([TestAssetPreserveNewest], RunSetting, "DeploymentTestProject", targetFramework: targetFramework);
@@ -45,24 +39,18 @@ public class DeploymentTests : CLITestBase
         ValidateFailedTestsContain(true, "DeploymentTestProject.DeploymentTestProject.FailIfFilePresent");
     }
 
-    public void ValidateDirectoryDeployment_net462()
-        => ValidateDirectoryDeployment("net462");
-
-    public void ValidateDirectoryDeployment_netcoreapp31()
-        => ValidateDirectoryDeployment("netcoreapp3.1");
-
+    [TestMethod]
+    [DataRow("net462")]
+    [DataRow("netcoreapp3.1")]
     public void ValidateDirectoryDeployment(string targetFramework)
     {
         InvokeVsTestForExecution([TestAssetPreserveNewest], testCaseFilter: "DirectoryDeploymentTests", targetFramework: targetFramework);
         ValidatePassedTestsContain("DeploymentTestProject.PreserveNewest.DirectoryDeploymentTests.DirectoryWithForwardSlash", "DeploymentTestProject.PreserveNewest.DirectoryDeploymentTests.DirectoryWithBackSlash");
     }
 
-    public void ValidateFileDeployment_net462()
-        => ValidateFileDeployment("net462");
-
-    public void ValidateFileDeployment_netcoreapp31()
-        => ValidateFileDeployment("netcoreapp3.1");
-
+    [TestMethod]
+    [DataRow("net462")]
+    [DataRow("netcoreapp3.1")]
     public void ValidateFileDeployment(string targetFramework)
     {
         InvokeVsTestForExecution([TestAssetPreserveNewest], testCaseFilter: "FileDeploymentTests", targetFramework: targetFramework);

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/DesktopCSharpCLITests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/DesktopCSharpCLITests.cs
@@ -5,6 +5,7 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class DesktopCSharpCLITests : CLITestBase
 {
     private const string X86DebugTestProject = "DesktopTestProjectx86Debug";
@@ -20,48 +21,56 @@ public class DesktopCSharpCLITests : CLITestBase
         </RunSettings>
         """;
 
+    [TestMethod]
     public void DiscoverTestsx86Debug()
     {
         string[] sources = [X86DebugTestProject];
         DoDiscoveryAndValidateDiscoveredTests(sources);
     }
 
+    [TestMethod]
     public void DiscoverTestsx64Debug()
     {
         string[] sources = [X64DebugTestProject];
         DoDiscoveryAndValidateDiscoveredTests(sources, RunSetting);
     }
 
+    [TestMethod]
     public void DiscoverTestsx86Release()
     {
         string[] sources = [X86ReleaseTestProject];
         DoDiscoveryAndValidateDiscoveredTests(sources);
     }
 
+    [TestMethod]
     public void DiscoverTestsx64Release()
     {
         string[] sources = [X64ReleaseTestProject];
         DoDiscoveryAndValidateDiscoveredTests(sources, RunSetting);
     }
 
+    [TestMethod]
     public void RunAllTestsx86Debug()
     {
         string[] sources = [X86DebugTestProject];
         RunAllTestsAndValidateResults(sources);
     }
 
+    [TestMethod]
     public void RunAllTestsx64Debug()
     {
         string[] sources = [X64DebugTestProject];
         RunAllTestsAndValidateResults(sources, RunSetting);
     }
 
+    [TestMethod]
     public void RunAllTestsx86Release()
     {
         string[] sources = [X86ReleaseTestProject];
         RunAllTestsAndValidateResults(sources);
     }
 
+    [TestMethod]
     public void RunAllTestsx64Release()
     {
         string[] sources = [X64ReleaseTestProject];

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/FixturesTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/FixturesTests.cs
@@ -5,6 +5,7 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class FixturesTests : CLITestBase
 {
     private const string AssetName = "FixturesTestProject";
@@ -26,6 +27,7 @@ public class FixturesTests : CLITestBase
         PassingTest
     ];
 
+    [TestMethod]
     public void FixturesDisabled_DoesNotReport_FixtureTests()
     {
         string runSettings = GetRunSettings(false, true, true, true, true, true);
@@ -39,6 +41,7 @@ public class FixturesTests : CLITestBase
         ValidatePassedTests([TestMethod, PassingTest]);
     }
 
+    [TestMethod]
     public void FixturesEnabled_DoesReport_FixtureTests()
     {
         string runSettings = GetRunSettings(true, true, true, true, true, true);
@@ -54,6 +57,7 @@ public class FixturesTests : CLITestBase
         ValidatePassedTests(_tests);
     }
 
+    [TestMethod]
     public void AssemblyInitialize_Fails_TestMethod_Class_Skipped()
     {
         string runSettings = GetRunSettings(true, false, true, true, true, true);
@@ -65,6 +69,7 @@ public class FixturesTests : CLITestBase
         ValidateSkippedTests([ClassInitialize, ClassCleanup]);
     }
 
+    [TestMethod]
     public void AssemblyCleanup_OnlyFails_AssemblyCleanup()
     {
         string runSettings = GetRunSettings(true, true, false, true, true, true);
@@ -75,6 +80,7 @@ public class FixturesTests : CLITestBase
         ValidateFailedTests(false, [AssemblyCleanup, TestMethod]);
     }
 
+    [TestMethod]
     public void ClassInitialize_OnlyFails_ClassInitialize()
     {
         string runSettings = GetRunSettings(true, true, true, false, true, true);
@@ -84,6 +90,7 @@ public class FixturesTests : CLITestBase
         ValidatePassedTests([AssemblyInitialize, AssemblyCleanup, ClassCleanup]);
     }
 
+    [TestMethod]
     public void ClassCleanup_OnlyFails_ClassCleanup()
     {
         string runSettings = GetRunSettings(true, true, true, true, false, true);
@@ -94,6 +101,7 @@ public class FixturesTests : CLITestBase
         ValidateFailedTests(false, [ClassCleanup, TestMethod]);
     }
 
+    [TestMethod]
     public void RunOnlyFixtures_DoesNot_Run_Fixtures()
     {
         string runSettings = GetRunSettings(true, true, true, true, true, true);
@@ -110,6 +118,7 @@ public class FixturesTests : CLITestBase
         ValidateSkippedTests([AssemblyCleanup, ClassCleanup]);
     }
 
+    [TestMethod]
     public void RunSingleTest_Runs_Assembly_And_Class_Fixtures()
     {
         string runSettings = GetRunSettings(true, true, true, true, true, true);
@@ -118,6 +127,7 @@ public class FixturesTests : CLITestBase
         ValidatePassedTests([AssemblyInitialize, AssemblyCleanup, ClassInitialize, ClassCleanup, PassingTest]);
     }
 
+    [TestMethod]
     public void RunSingleTest_AssemblyInitialize_Failure_Skips_ClassFixtures()
     {
         string runSettings = GetRunSettings(true, false, true, true, true, true);
@@ -129,6 +139,7 @@ public class FixturesTests : CLITestBase
         ValidateSkippedTests([ClassInitialize, ClassCleanup]);
     }
 
+    [TestMethod]
     public void RunSingleTest_ClassInitialize_Failure_Runs_AssemblyFixtures()
     {
         string runSettings = GetRunSettings(true, true, true, false, true, true);

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests.csproj
@@ -2,14 +2,26 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
-    <UseInternalTestFramework>true</UseInternalTestFramework>
-    <!-- Don't generate MSTest using -->
-    <UseMSTest>false</UseMSTest>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <UseMSTestFromSource>true</UseMSTestFromSource>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)test\Utilities\Automation.CLI\Automation.CLI.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Internal.Analyzers\MSTest.Internal.Analyzers.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/ParallelExecutionTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/ParallelExecutionTests.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions.Execution;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class ParallelExecutionTests : CLITestBase
 {
     private const string ClassParallelTestAssetName = "ParallelClassesTestProject";
@@ -15,6 +14,7 @@ public class ParallelExecutionTests : CLITestBase
     private const int TestMethodWaitTimeInMS = 1000;
     private const int OverheadTimeInMS = 4000;
 
+    [TestMethod]
     public async Task AllMethodsShouldRunInParallel()
     {
         const int maxAttempts = 10;
@@ -31,7 +31,7 @@ public class ParallelExecutionTests : CLITestBase
             }
 
             // Timer validation sometimes get flacky. So retrying the test if it fails.
-            catch (AssertionFailedException ex) when (i != maxAttempts && ex.Message.Contains("Test Run was expected to not exceed"))
+            catch (AssertFailedException ex) when (i != maxAttempts && ex.Message.Contains("Test Run was expected to not exceed"))
             {
                 await Task.Delay(2000);
             }
@@ -48,6 +48,7 @@ public class ParallelExecutionTests : CLITestBase
             "ParallelMethodsTestProject.UnitTest2.SimpleTest22");
     }
 
+    [TestMethod]
     public void AllClassesShouldRunInParallel()
     {
         InvokeVsTestForExecution([ClassParallelTestAssetName]);
@@ -70,6 +71,7 @@ public class ParallelExecutionTests : CLITestBase
             "ParallelClassesTestProject.UnitTest3.SimpleTest32");
     }
 
+    [TestMethod]
     public void NothingShouldRunInParallel()
     {
         const string RunSetting =

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataExtensibilityTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataExtensibilityTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class DataExtensibilityTests : CLITestBase
 {
     private const string TestAssetName = "FxExtensibilityTestProject";
 
+    [TestMethod]
     public void ExecuteTestDataSourceExtensibilityTests()
     {
         InvokeVsTestForExecution([TestAssetName]);
@@ -16,6 +18,7 @@ public class DataExtensibilityTests : CLITestBase
         ValidateFailedTestsContain(false, "FxExtensibilityTestProject.TestDataSourceExTests.CustomEmptyTestDataSourceTestMethod");
     }
 
+    [TestMethod]
     public void ExecuteDynamicDataExtensibilityTests()
     {
         InvokeVsTestForExecution([TestAssetName]);
@@ -41,6 +44,7 @@ public class DataExtensibilityTests : CLITestBase
             "FxExtensibilityTestProject.DynamicDataExMoreTests.DynamicEmptyDataTestMethod6");
     }
 
+    [TestMethod]
     public void ExecuteCustomTestExtensibilityTests()
     {
         InvokeVsTestForExecution([TestAssetName]);
@@ -60,6 +64,7 @@ public class DataExtensibilityTests : CLITestBase
             "CustomTestClass1 - Execution number 3");
     }
 
+    [TestMethod]
     public void ExecuteCustomTestExtensibilityWithTestDataTests()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "FullyQualifiedName~CustomTestExTests.CustomTestMethod2");

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataRowTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataRowTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class DataRowTests : CLITestBase
 {
     private const string TestAssetName = "DataRowTestProject";
 
+    [TestMethod]
     public void ExecuteOnlyDerivedClassDataRowsWhenBothBaseAndDerivedClassHasDataRows_SimpleDataRows()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TestCategory~DataRowSimple");
@@ -26,6 +28,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(5);
     }
 
+    [TestMethod]
     public void GetDisplayName_AfterOverriding_GetsTheNewDisplayName()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TestCategory~OverriddenGetDisplayName");
@@ -36,6 +39,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(1);
     }
 
+    [TestMethod]
     public void ParameterizedTestsWithTestMethodSettingDisplayName_DataIsPrefixWithDisplayName()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TestCategory~OverriddenTestMethodDisplayNameForParameterizedTest");
@@ -47,6 +51,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(2);
     }
 
+    [TestMethod]
     public void ExecuteOnlyDerivedClassDataRowsWhenItOverridesBaseClassDataRows_SimpleDataRows()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "FullyQualifiedName~DerivedClass&TestCategory~DataRowSimple");
@@ -59,6 +64,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(2);
     }
 
+    [TestMethod]
     public void DataRowsExecuteWithRequiredAndOptionalParameters()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TestCategory~DataRowSomeOptional");
@@ -72,6 +78,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(3);
     }
 
+    [TestMethod]
     public void DataRowsExecuteWithAllOptionalParameters()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TestCategory~DataRowAllOptional");
@@ -86,6 +93,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(4);
     }
 
+    [TestMethod]
     public void DataRowsExecuteWithParamsArrayParameter()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TestCategory~DataRowParamsArgument");
@@ -100,6 +108,7 @@ public class DataRowTests : CLITestBase
         ValidatePassedTestsCount(4);
     }
 
+    [TestMethod]
     public void DataRowsFailWhenInvalidArgumentsProvided()
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "FullyQualifiedName~DataRowTests_Regular&TestCategory~DataRowOptionalInvalidArguments");
@@ -114,6 +123,7 @@ public class DataRowTests : CLITestBase
         ValidateFailedTestsCount(3);
     }
 
+    [TestMethod]
     public void ExecuteDataRowTests_Enums()
     {
         // Arrange & Act
@@ -186,6 +196,7 @@ public class DataRowTests : CLITestBase
         ValidateFailedTestsCount(0);
     }
 
+    [TestMethod]
     public void ExecuteDataRowTests_NonSerializablePaths()
     {
         // Arrange & Act
@@ -202,6 +213,7 @@ public class DataRowTests : CLITestBase
         ValidateFailedTestsCount(0);
     }
 
+    [TestMethod]
     public void ExecuteRegular_DataRowTests()
     {
         // Arrange & Act

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataSourceTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DataSourceTests.cs
@@ -5,13 +5,14 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class DataSourceTests : CLITestBase
 {
     private const string TestAssetName = "DataSourceTestProject";
 
-    // TODO @haplois | @evangelink
-    [SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "This test fails under CI - will be fixed in a future PR (marked as private to ignore the test)")]
-    private void ExecuteCsvTestDataSourceTests()
+    [TestMethod]
+    [Ignore("This test fails under CI - will be fixed in a future PR (marked as private to ignore the test)")]
+    public void ExecuteCsvTestDataSourceTests()
     {
         // Arrange & Act
         InvokeVsTestForExecution(

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DynamicDataTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Parameterized tests/DynamicDataTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class DynamicDataTests : CLITestBase
 {
     private const string TestAssetName = "DynamicDataTestProject";
 
+    [TestMethod]
     public void ExecuteDynamicDataTests()
     {
         // Arrange & Act

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Program.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Testing.Extensions;
 
-using TestFramework.ForTestingMSTest;
+[assembly: DoNotParallelize]
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
 
@@ -16,7 +16,7 @@ builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
 
-builder.AddInternalTestFramework();
+builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/SuiteLifeCycleTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/SuiteLifeCycleTests.cs
@@ -1,155 +1,34 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class SuiteLifeCycleTests : CLITestBase
 {
     private const string TestAssetName = "SuiteLifeCycleTestProject";
     private static readonly string[] WindowsLineReturn = ["\r\n"];
 
-    public void ValidateTestRunLifecycle_net6() => ValidateTestRunLifecycle("net6.0");
-
-    public void ValidateTestRunLifecycle_net462() => ValidateTestRunLifecycle("net462");
-
-    public void ValidateInheritanceBehavior()
-    {
-        InvokeVsTestForExecution(
-            [TestAssetName],
-            testCaseFilter: "FullyQualifiedName~LifecycleInheritance",
-            targetFramework: "net462");
-
-        RunEventsHandler.PassedTests.Should().HaveCount(10);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod1 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfClass.TestMethod", StringComparison.Ordinal));
-        testMethod1.Messages[0].Text.Should().Be(
-            """
-            Console: AssemblyInit was called
-            TestClassBaseEndOfClass: ClassInitialize
-            TestClassDerived_EndOfClass: TestMethod
-            TestClassBaseEndOfClass: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod2 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfAssembly.TestMethod", StringComparison.Ordinal));
-        testMethod2.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfAssembly: ClassInitialize
-            TestClassDerived_EndOfAssembly: TestMethod
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod3 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfClassEndOfClass.TestMethod", StringComparison.Ordinal));
-        testMethod3.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfClass: ClassInitialize
-            TestClassIntermediateEndOfClassBaseEndOfClass: ClassInitialize
-            TestClassDerivedEndOfClass_EndOfClassEndOfClass: TestMethod
-            TestClassDerivedEndOfClass_EndOfClassEndOfClass: ClassCleanup
-            TestClassIntermediateEndOfClassBaseEndOfClass: ClassCleanup
-            TestClassBaseEndOfClass: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod4 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfClassEndOfClass.TestMethod", StringComparison.Ordinal));
-        testMethod4.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfClass: ClassInitialize
-            TestClassIntermediateEndOfClassBaseEndOfClass: ClassInitialize
-            TestClassDerived_EndOfClassEndOfClass: TestMethod
-            TestClassIntermediateEndOfClassBaseEndOfClass: ClassCleanup
-            TestClassBaseEndOfClass: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod5 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfClassEndOfAssembly.TestMethod", StringComparison.Ordinal));
-        testMethod5.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfAssembly: ClassInitialize
-            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassInitialize
-            TestClassDerivedEndOfClass_EndOfClassEndOfAssembly: TestMethod
-            TestClassDerivedEndOfClass_EndOfClassEndOfAssembly: ClassCleanup
-            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassCleanup
-            TestClassBaseEndOfAssembly: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod6 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfClassEndOfAssembly.TestMethod", StringComparison.Ordinal));
-        testMethod6.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfAssembly: ClassInitialize
-            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassInitialize
-            TestClassDerived_EndOfClassEndOfAssembly: TestMethod
-            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassCleanup
-            TestClassBaseEndOfAssembly: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod7 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfAssemblyEndOfClass.TestMethod", StringComparison.Ordinal));
-        testMethod7.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfClass: ClassInitialize
-            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassInitialize
-            TestClassDerivedEndOfClass_EndOfAssemblyEndOfClass: TestMethod
-            TestClassDerivedEndOfClass_EndOfAssemblyEndOfClass: ClassCleanup
-            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassCleanup
-            TestClassBaseEndOfClass: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod8 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfAssemblyEndOfClass.TestMethod", StringComparison.Ordinal));
-        testMethod8.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfClass: ClassInitialize
-            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassInitialize
-            TestClassDerived_EndOfAssemblyEndOfClass: TestMethod
-            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassCleanup
-            TestClassBaseEndOfClass: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod9 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfAssemblyEndOfAssembly.TestMethod", StringComparison.Ordinal));
-        testMethod9.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfAssembly: ClassInitialize
-            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassInitialize
-            TestClassDerivedEndOfClass_EndOfAssemblyEndOfAssembly: TestMethod
-            TestClassDerivedEndOfClass_EndOfAssemblyEndOfAssembly: ClassCleanup
-            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassCleanup
-            TestClassBaseEndOfAssembly: ClassCleanup
-
-            """);
-
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult testMethod10 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfAssemblyEndOfAssembly.TestMethod", StringComparison.Ordinal));
-        testMethod10.Messages[0].Text.Should().Be(
-            """
-            TestClassBaseEndOfAssembly: ClassInitialize
-            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassInitialize
-            TestClassDerived_EndOfAssemblyEndOfAssembly: TestMethod
-            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassCleanup
-            TestClassBaseEndOfAssembly: ClassCleanup
-            TestClassBaseEndOfAssembly: ClassCleanup
-            Console: AssemblyCleanup was called
-
-            """);
-    }
-
-    private void ValidateTestRunLifecycle(string targetFramework)
+    [TestMethod]
+    [DataRow("net462")]
+    [DataRow("netcoreapp3.1")]
+    public void ValidateTestRunLifecycle(string targetFramework)
     {
         InvokeVsTestForExecution(
             [TestAssetName],
             testCaseFilter: "FullyQualifiedName~SuiteLifeCycleTestProject",
             targetFramework: targetFramework);
-        RunEventsHandler.PassedTests.Should().HaveCount(27);  // The inherit class tests are called twice.
+        Assert.HasCount(27, RunEventsHandler.PassedTests);  // The inherit class tests are called twice.
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanup = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanup.TestMethod"));
-        caseClassCleanup.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassCleanup.Messages.Should().HaveCount(3);
-        caseClassCleanup.Messages[0].Text.Should().Be(
+        TestResult caseClassCleanup = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanup.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanup.Outcome);
+        Assert.HasCount(3, caseClassCleanup.Messages);
+        Assert.AreEqual(
             $"""
             Console: AssemblyInit was called
             Console: LifeCycleClassCleanup.ClassInitialize was called
@@ -161,8 +40,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanup.DisposeAsync was called\r\nConsole: LifeCycleClassCleanup.Dispose was called"
                 : "Console: LifeCycleClassCleanup.Dispose was called")}
 
-            """);
-        caseClassCleanup.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanup.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -179,8 +59,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanup.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanup.Dispose was called"))}
 
-            """);
-        caseClassCleanup.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanup.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -195,15 +76,16 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanup.DisposeAsync was called\r\nLifeCycleClassCleanup.Dispose was called"
                 : "LifeCycleClassCleanup.Dispose was called")}
 
-            """);
+            """,
+            caseClassCleanup.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanupEndOfAssembly = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfAssembly.TestMethod"));
-        caseClassCleanupEndOfAssembly.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
+        TestResult caseClassCleanupEndOfAssembly = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfAssembly.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanupEndOfAssembly.Outcome);
 
         // We don't see "LifeCycleClassCleanupEndOfAssembly.ClassCleanup was called" because it will be attached to the
         // latest test run.
-        caseClassCleanupEndOfAssembly.Messages.Should().HaveCount(3);
-        caseClassCleanupEndOfAssembly.Messages[0].Text.Should().Be(
+        Assert.HasCount(3, caseClassCleanupEndOfAssembly.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfAssembly.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfAssembly.ctor was called
@@ -214,8 +96,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssembly.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssembly.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssembly.Dispose was called")}
 
-            """);
-        caseClassCleanupEndOfAssembly.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfAssembly.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -231,8 +114,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssembly.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssembly.Dispose was called"))}
 
-            """);
-        caseClassCleanupEndOfAssembly.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfAssembly.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -246,12 +130,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssembly.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssembly.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssembly.Dispose was called")}
 
-            """);
+            """,
+            caseClassCleanupEndOfAssembly.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanupEndOfClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfClass.TestMethod"));
-        caseClassCleanupEndOfClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassCleanupEndOfClass.Messages.Should().HaveCount(3);
-        caseClassCleanupEndOfClass.Messages[0].Text.Should().Be(
+        TestResult caseClassCleanupEndOfClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanupEndOfClass.Outcome);
+        Assert.HasCount(3, caseClassCleanupEndOfClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfClass.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfClass.ctor was called
@@ -263,8 +148,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "Console: LifeCycleClassCleanupEndOfClass.Dispose was called")}
             Console: LifeCycleClassCleanupEndOfClass.ClassCleanup was called
 
-            """);
-        caseClassCleanupEndOfClass.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -281,8 +167,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClass.Dispose was called"))}
             {GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClass.ClassCleanup was called")}
 
-            """);
-        caseClassCleanupEndOfClass.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -297,12 +184,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "LifeCycleClassCleanupEndOfClass.Dispose was called")}
             LifeCycleClassCleanupEndOfClass.ClassCleanup was called
 
-            """);
+            """,
+            caseClassCleanupEndOfClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassInitializeAndCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.TestMethod"));
-        caseClassInitializeAndCleanupBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseClassInitializeAndCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassInitializeAndCleanupBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.ctor was called
@@ -313,8 +201,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -330,8 +219,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -345,12 +235,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseClassInitializeAndCleanupBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassInitializeAndCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeAndCleanupNone.TestMethod"));
-        caseClassInitializeAndCleanupNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassInitializeAndCleanupNone.Messages.Should().HaveCount(3);
-        caseClassInitializeAndCleanupNone.Messages[0].Text.Should().Be(
+        TestResult caseClassInitializeAndCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeAndCleanupNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassInitializeAndCleanupNone.Outcome);
+        Assert.HasCount(3, caseClassInitializeAndCleanupNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeAndCleanupNone.ClassInitialize was called
             Console: LifeCycleClassInitializeAndCleanupNone.ctor was called
@@ -361,8 +252,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeAndCleanupNone.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeAndCleanupNone.Dispose was called"
                 : "Console: LifeCycleClassInitializeAndCleanupNone.Dispose was called")}
 
-            """);
-        caseClassInitializeAndCleanupNone.Messages[1].Text.Should().Be(
+            """,
+            caseClassInitializeAndCleanupNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -378,8 +270,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupNone.Dispose was called"))}
 
-            """);
-        caseClassInitializeAndCleanupNone.Messages[2].Text.Should().Be(
+            """,
+            caseClassInitializeAndCleanupNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -393,12 +286,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeAndCleanupNone.DisposeAsync was called\r\nLifeCycleClassInitializeAndCleanupNone.Dispose was called"
                 : "LifeCycleClassInitializeAndCleanupNone.Dispose was called")}
 
-            """);
+            """,
+            caseClassInitializeAndCleanupNone.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone"));
-        caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages.Should().HaveCount(3);
-        caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[0].Text.Should().Be(
+        TestResult caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Outcome);
+        Assert.HasCount(3, caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.ClassInitialize was called
             Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.ctor was called
@@ -409,8 +303,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"
                 : "Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")}
 
-            """);
-        caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[1].Text.Should().Be(
+            """,
+            caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -426,8 +321,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"))}
 
-            """);
-        caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[2].Text.Should().Be(
+            """,
+            caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -441,12 +337,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DisposeAsync was called\r\nLifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"
                 : "LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")}
 
-            """);
+            """,
+            caseClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass"));
-        caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.ctor was called
@@ -457,8 +354,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -474,8 +372,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -489,12 +388,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.DerivedClassTestMethod"));
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.ClassInitialize was called
@@ -509,8 +409,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -530,8 +431,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -549,13 +451,14 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeAndCleanupBeforeEachDerivedClass.Messages[2].Text);
 
         // Test the parent test method.
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.TestMethod"));
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.ctor was called
             Console: LifeCycleDerivedClassInitializeAndCleanupBeforeEachDerivedClass.ctor was called
@@ -568,8 +471,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -587,8 +491,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -604,12 +509,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassInitializeAndCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeAndCleanupBeforeEachDerivedClassParentTestMethod.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeAndCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupNone.DerivedClassTestMethod"));
-        caseDerivedClassInitializeAndCleanupNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeAndCleanupNone.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeAndCleanupNone.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeAndCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupNone.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeAndCleanupNone.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeAndCleanupNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleDerivedClassInitializeAndCleanupNone.ClassInitialize was called
             Console: LifeCycleClassInitializeAndCleanupNone.ctor was called
@@ -623,8 +529,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeAndCleanupNone.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeAndCleanupNone.Dispose was called"
                 : "Console: LifeCycleClassInitializeAndCleanupNone.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeAndCleanupNone.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -643,8 +550,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeAndCleanupNone.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -661,13 +569,14 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeAndCleanupNone.DisposeAsync was called\r\nLifeCycleClassInitializeAndCleanupNone.Dispose was called"
                 : "LifeCycleClassInitializeAndCleanupNone.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeAndCleanupNone.Messages[2].Text);
 
         // Test the parent test method.
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeAndCleanupNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupNone.TestMethod"));
-        caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeAndCleanupNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeAndCleanupNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeAndCleanupNone.ctor was called
             Console: LifeCycleDerivedClassInitializeAndCleanupNone.ctor was called
@@ -680,8 +589,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeAndCleanupNone.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeAndCleanupNone.Dispose was called"
                 : "Console: LifeCycleClassInitializeAndCleanupNone.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -699,8 +609,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeAndCleanupNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -716,12 +627,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeAndCleanupNone.DisposeAsync was called\r\nLifeCycleClassInitializeAndCleanupNone.Dispose was called"
                 : "LifeCycleClassInitializeAndCleanupNone.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeAndCleanupNoneParentTestMethod.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DerivedClassTestMethod"));
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.ClassInitialize was called
             Console: LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.ClassInitialize was called
@@ -736,8 +648,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"
                 : "Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -757,8 +670,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -776,13 +690,14 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DisposeAsync was called\r\nLifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"
                 : "LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Messages[2].Text);
 
         // Test the parent test method.
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.TestMethod"));
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.ctor was called
             Console: LifeCycleDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNone.ctor was called
@@ -795,8 +710,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"
                 : "Console: LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -814,8 +730,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -831,12 +748,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.DisposeAsync was called\r\nLifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called"
                 : "LifeCycleClassInitializeBeforeEachDerivedClassAndClassCleanupNone.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeBeforeEachDerivedClassAndClassCleanupNoneParentTestMethod.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.DerivedClassTestMethod"));
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.ctor was called
@@ -850,8 +768,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -870,8 +789,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -888,12 +808,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.TestMethod"));
-        caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.ctor was called
@@ -904,8 +825,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -921,8 +843,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -936,12 +859,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanupEndOfAssemblyAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfAssemblyAndNone.TestMethod"));
-        caseClassCleanupEndOfAssemblyAndNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassCleanupEndOfAssemblyAndNone.Messages.Should().HaveCount(3);
-        caseClassCleanupEndOfAssemblyAndNone.Messages[0].Text.Should().Be(
+        TestResult caseClassCleanupEndOfAssemblyAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfAssemblyAndNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanupEndOfAssemblyAndNone.Outcome);
+        Assert.HasCount(3, caseClassCleanupEndOfAssemblyAndNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfAssemblyAndNone.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfAssemblyAndNone.ctor was called
@@ -952,8 +876,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssemblyAndNone.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")}
 
-            """);
-        caseClassCleanupEndOfAssemblyAndNone.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfAssemblyAndNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -969,8 +894,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"))}
 
-            """);
-        caseClassCleanupEndOfAssemblyAndNone.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfAssemblyAndNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -984,12 +910,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssemblyAndNone.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")}
 
-            """);
+            """,
+            caseClassCleanupEndOfAssemblyAndNone.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanupEndOfClassAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.TestMethod"));
-        caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseClassCleanupEndOfClassAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ctor was called
@@ -1001,8 +928,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called")}
             Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called
 
-            """);
-        caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1019,8 +947,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called"))}
             {GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called")}
 
-            """);
-        caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1035,12 +964,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called")}
             LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called
 
-            """);
+            """,
+            caseClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseClassCleanupEndOfClassAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfClassAndNone.TestMethod"));
-        caseClassCleanupEndOfClassAndNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseClassCleanupEndOfClassAndNone.Messages.Should().HaveCount(3);
-        caseClassCleanupEndOfClassAndNone.Messages[0].Text.Should().Be(
+        TestResult caseClassCleanupEndOfClassAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleClassCleanupEndOfClassAndNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseClassCleanupEndOfClassAndNone.Outcome);
+        Assert.HasCount(3, caseClassCleanupEndOfClassAndNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfClassAndNone.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfClassAndNone.ctor was called
@@ -1052,8 +982,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "Console: LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")}
             Console: LifeCycleClassCleanupEndOfClassAndNone.ClassCleanup was called
 
-            """);
-        caseClassCleanupEndOfClassAndNone.Messages[1].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfClassAndNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1070,8 +1001,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndNone.Dispose was called"))}
             {GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndNone.ClassCleanup was called")}
 
-            """);
-        caseClassCleanupEndOfClassAndNone.Messages[2].Text.Should().Be(
+            """,
+            caseClassCleanupEndOfClassAndNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1086,12 +1018,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")}
             LifeCycleClassCleanupEndOfClassAndNone.ClassCleanup was called
 
-            """);
+            """,
+            caseClassCleanupEndOfClassAndNone.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DerivedClassTestMethod"));
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.ctor was called
@@ -1105,8 +1038,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1125,8 +1059,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1143,12 +1078,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfAssemblyAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.DerivedClassTestMethod"));
-        caseDerivedClassCleanupEndOfAssemblyAndNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfAssemblyAndNone.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfAssemblyAndNone.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassCleanupEndOfAssemblyAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfAssemblyAndNone.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfAssemblyAndNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfAssemblyAndNone.ctor was called
@@ -1162,8 +1098,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssemblyAndNone.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndNone.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1182,8 +1119,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndNone.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1200,11 +1138,12 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssemblyAndNone.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")}
 
-            """);
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.DerivedClassTestMethod"));
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[0].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndNone.Messages[2].Text);
+        TestResult caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ctor was called
@@ -1218,8 +1157,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1238,8 +1178,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1256,12 +1197,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfClassAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndNone.DerivedClassTestMethod"));
-        caseDerivedClassCleanupEndOfClassAndNone.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfClassAndNone.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfClassAndNone.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassCleanupEndOfClassAndNone = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndNone.DerivedClassTestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfClassAndNone.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfClassAndNone.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleDerivedClassCleanupEndOfClassAndNone.ClassInitialize was called
             Console: LifeCycleClassCleanupEndOfClassAndNone.ctor was called
@@ -1275,8 +1217,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfClassAndNone.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfClassAndNone.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndNone.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndNone.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1295,8 +1238,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndNone.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndNone.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1313,12 +1257,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfClassAndNone.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfClassAndNone.Dispose was called"
                 : "LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassCleanupEndOfClassAndNone.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.TestMethod"));
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.ctor was called
             Console: LifeCycleDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.ctor was called
@@ -1331,8 +1276,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1350,8 +1296,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1367,12 +1314,13 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssemblyAndBeforeEachDerivedClass.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndBeforeEachDerivedClassParentTestMethod.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.TestMethod"));
-        caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfAssemblyAndNone.ctor was called
             Console: LifeCycleDerivedClassCleanupEndOfAssemblyAndNone.ctor was called
@@ -1385,8 +1333,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfAssemblyAndNone.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1404,8 +1353,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1421,11 +1371,12 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfAssemblyAndNone.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called"
                 : "LifeCycleClassCleanupEndOfAssemblyAndNone.Dispose was called")}
 
-            """);
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.TestMethod"));
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages[0].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfAssemblyAndNoneParentTestMethod.Messages[2].Text);
+        TestResult caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ctor was called
             Console: LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.ctor was called
@@ -1440,8 +1391,9 @@ public class SuiteLifeCycleTests : CLITestBase
             Console: LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called
             Console: LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1461,8 +1413,9 @@ public class SuiteLifeCycleTests : CLITestBase
             {GenerateTraceDebugPrefixedMessage("LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called")}
             {GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1480,12 +1433,13 @@ public class SuiteLifeCycleTests : CLITestBase
             LifeCycleDerivedClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called
             LifeCycleClassCleanupEndOfClassAndBeforeEachDerivedClass.ClassCleanup was called
 
-            """);
+            """,
+            caseDerivedClassCleanupEndOfClassAndBeforeEachDerivedClassParentTestMethod.Messages[2].Text);
 
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndNone.TestMethod"));
-        caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages.Should().HaveCount(3);
-        caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages[0].Text.Should().Be(
+        TestResult caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassCleanupEndOfClassAndNone.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages);
+        Assert.AreEqual(
             $"""
             Console: LifeCycleClassCleanupEndOfClassAndNone.ctor was called
             Console: LifeCycleDerivedClassCleanupEndOfClassAndNone.ctor was called
@@ -1498,8 +1452,9 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "Console: LifeCycleClassCleanupEndOfClassAndNone.DisposeAsync was called\r\nConsole: LifeCycleClassCleanupEndOfClassAndNone.Dispose was called"
                 : "Console: LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages[1].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages[0].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1517,8 +1472,9 @@ public class SuiteLifeCycleTests : CLITestBase
                     + GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassCleanupEndOfClassAndNone.Dispose was called"))}
 
-            """);
-        caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages[2].Text.Should().Be(
+            """,
+            caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages[1].Text);
+        Assert.AreEqual(
             $"""
 
 
@@ -1534,14 +1490,15 @@ public class SuiteLifeCycleTests : CLITestBase
                 ? "LifeCycleClassCleanupEndOfClassAndNone.DisposeAsync was called\r\nLifeCycleClassCleanupEndOfClassAndNone.Dispose was called"
                 : "LifeCycleClassCleanupEndOfClassAndNone.Dispose was called")}
 
-            """);
+            """,
+            caseDerivedClassCleanupEndOfClassAndNoneParentTestMethod.Messages[2].Text);
 
         // Test the parent test method.
         // We are seeing all the ClassCleanup EndOfAssembly (or nothing set - as it's the default) being reported
         // here as this is the last test to run.
-        Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.TestMethod"));
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Outcome.Should().Be(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestOutcome.Passed);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Messages.Should().HaveCount(3);
+        TestResult caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.Contains("LifeCycleDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.TestMethod"));
+        Assert.AreEqual(TestOutcome.Passed, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Outcome);
+        Assert.HasCount(3, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Messages);
 
         // Locally, netfx calls seems to be respecting the order of the cleanup while it is not stable for netcore.
         // But local order is not the same on various machines. I am not sure whether we should be committing to a
@@ -1560,9 +1517,7 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "Console: LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")}
 
             """;
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
-            .Messages[0].Text
-            .Should().StartWith(expectedStart);
+        Assert.StartsWith(expectedStart, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Messages[0].Text);
 
         string[] expectedRemainingMessages =
             """
@@ -1588,11 +1543,12 @@ public class SuiteLifeCycleTests : CLITestBase
 
             """
             .Split(WindowsLineReturn, StringSplitOptions.None);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
-            .Messages[0].Text!
-            .Substring(expectedStart.Length)
-            .Split(WindowsLineReturn, StringSplitOptions.None)
-            .Should().BeEquivalentTo(expectedRemainingMessages);
+        CollectionAssert.AreEquivalent(
+            expectedRemainingMessages,
+            caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
+                .Messages[0].Text!
+                .Substring(expectedStart.Length)
+                .Split(WindowsLineReturn, StringSplitOptions.None));
 
         expectedStart =
             $"""
@@ -1613,9 +1569,7 @@ public class SuiteLifeCycleTests : CLITestBase
                 : GenerateTraceDebugPrefixedMessage("LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called"))}
 
             """;
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
-            .Messages[1].Text
-            .Should().StartWith(expectedStart);
+        Assert.StartsWith(expectedStart, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Messages[1].Text);
 
         expectedRemainingMessages =
             $"""
@@ -1641,11 +1595,12 @@ public class SuiteLifeCycleTests : CLITestBase
 
             """
             .Split(["\r\n"], StringSplitOptions.None);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
-            .Messages[1].Text!
-            .Substring(expectedStart.Length)
-            .Split(["\r\n"], StringSplitOptions.None)
-            .Should().BeEquivalentTo(expectedRemainingMessages);
+        CollectionAssert.AreEquivalent(
+            expectedRemainingMessages,
+            caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
+                .Messages[1].Text!
+                .Substring(expectedStart.Length)
+                .Split(["\r\n"], StringSplitOptions.None));
 
         expectedStart =
             $"""
@@ -1664,9 +1619,7 @@ public class SuiteLifeCycleTests : CLITestBase
                 : "LifeCycleClassInitializeNoneAndClassCleanupBeforeEachDerivedClass.Dispose was called")}
 
             """;
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
-            .Messages[2].Text
-            .Should().StartWith(expectedStart);
+        Assert.StartsWith(expectedStart, caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod.Messages[2].Text);
 
         expectedRemainingMessages =
             """
@@ -1692,11 +1645,145 @@ public class SuiteLifeCycleTests : CLITestBase
 
             """
             .Split(["\r\n"], StringSplitOptions.None);
-        caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
-            .Messages[2].Text!
-            .Substring(expectedStart.Length)
-            .Split(["\r\n"], StringSplitOptions.None)
-            .Should().BeEquivalentTo(expectedRemainingMessages);
+        CollectionAssert.AreEquivalent(
+            expectedRemainingMessages,
+            caseDerivedClassInitializeNoneAndClassCleanupBeforeEachDerivedClassParentTestMethod
+                .Messages[2].Text!
+                .Substring(expectedStart.Length)
+                .Split(["\r\n"], StringSplitOptions.None));
+    }
+
+    [TestMethod]
+    public void ValidateInheritanceBehavior()
+    {
+        InvokeVsTestForExecution(
+            [TestAssetName],
+            testCaseFilter: "FullyQualifiedName~LifecycleInheritance",
+            targetFramework: "net462");
+
+        Assert.HasCount(10, RunEventsHandler.PassedTests);
+
+        TestResult testMethod1 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfClass.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            Console: AssemblyInit was called
+            TestClassBaseEndOfClass: ClassInitialize
+            TestClassDerived_EndOfClass: TestMethod
+            TestClassBaseEndOfClass: ClassCleanup
+
+            """,
+            testMethod1.Messages[0].Text);
+
+        TestResult testMethod2 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfAssembly.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfAssembly: ClassInitialize
+            TestClassDerived_EndOfAssembly: TestMethod
+
+            """,
+            testMethod2.Messages[0].Text);
+
+        TestResult testMethod3 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfClassEndOfClass.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfClass: ClassInitialize
+            TestClassIntermediateEndOfClassBaseEndOfClass: ClassInitialize
+            TestClassDerivedEndOfClass_EndOfClassEndOfClass: TestMethod
+            TestClassDerivedEndOfClass_EndOfClassEndOfClass: ClassCleanup
+            TestClassIntermediateEndOfClassBaseEndOfClass: ClassCleanup
+            TestClassBaseEndOfClass: ClassCleanup
+
+            """,
+            testMethod3.Messages[0].Text);
+
+        TestResult testMethod4 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfClassEndOfClass.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfClass: ClassInitialize
+            TestClassIntermediateEndOfClassBaseEndOfClass: ClassInitialize
+            TestClassDerived_EndOfClassEndOfClass: TestMethod
+            TestClassIntermediateEndOfClassBaseEndOfClass: ClassCleanup
+            TestClassBaseEndOfClass: ClassCleanup
+
+            """,
+            testMethod4.Messages[0].Text);
+
+        TestResult testMethod5 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfClassEndOfAssembly.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfAssembly: ClassInitialize
+            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassInitialize
+            TestClassDerivedEndOfClass_EndOfClassEndOfAssembly: TestMethod
+            TestClassDerivedEndOfClass_EndOfClassEndOfAssembly: ClassCleanup
+            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassCleanup
+            TestClassBaseEndOfAssembly: ClassCleanup
+
+            """,
+            testMethod5.Messages[0].Text);
+
+        TestResult testMethod6 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfClassEndOfAssembly.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfAssembly: ClassInitialize
+            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassInitialize
+            TestClassDerived_EndOfClassEndOfAssembly: TestMethod
+            TestClassIntermediateEndOfClassBaseEndOfAssembly: ClassCleanup
+            TestClassBaseEndOfAssembly: ClassCleanup
+
+            """,
+            testMethod6.Messages[0].Text);
+
+        TestResult testMethod7 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfAssemblyEndOfClass.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfClass: ClassInitialize
+            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassInitialize
+            TestClassDerivedEndOfClass_EndOfAssemblyEndOfClass: TestMethod
+            TestClassDerivedEndOfClass_EndOfAssemblyEndOfClass: ClassCleanup
+            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassCleanup
+            TestClassBaseEndOfClass: ClassCleanup
+
+            """,
+            testMethod7.Messages[0].Text);
+
+        TestResult testMethod8 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfAssemblyEndOfClass.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfClass: ClassInitialize
+            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassInitialize
+            TestClassDerived_EndOfAssemblyEndOfClass: TestMethod
+            TestClassIntermediateEndOfAssemblyBaseEndOfClass: ClassCleanup
+            TestClassBaseEndOfClass: ClassCleanup
+
+            """,
+            testMethod8.Messages[0].Text);
+
+        TestResult testMethod9 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerivedEndOfClass_EndOfAssemblyEndOfAssembly.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfAssembly: ClassInitialize
+            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassInitialize
+            TestClassDerivedEndOfClass_EndOfAssemblyEndOfAssembly: TestMethod
+            TestClassDerivedEndOfClass_EndOfAssemblyEndOfAssembly: ClassCleanup
+            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassCleanup
+            TestClassBaseEndOfAssembly: ClassCleanup
+
+            """,
+            testMethod9.Messages[0].Text);
+
+        TestResult testMethod10 = RunEventsHandler.PassedTests.Single(x => x.TestCase.FullyQualifiedName.EndsWith("TestClassDerived_EndOfAssemblyEndOfAssembly.TestMethod", StringComparison.Ordinal));
+        Assert.AreEqual(
+            """
+            TestClassBaseEndOfAssembly: ClassInitialize
+            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassInitialize
+            TestClassDerived_EndOfAssemblyEndOfAssembly: TestMethod
+            TestClassIntermediateEndOfAssemblyBaseEndOfAssembly: ClassCleanup
+            TestClassBaseEndOfAssembly: ClassCleanup
+            TestClassBaseEndOfAssembly: ClassCleanup
+            Console: AssemblyCleanup was called
+
+            """,
+            testMethod10.Messages[0].Text);
     }
 
     private static string GenerateTraceDebugPrefixedMessage(string message)

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/TestProjectFSharpTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/TestProjectFSharpTests.cs
@@ -5,10 +5,12 @@ using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class TestProjectFSharpTests : CLITestBase
 {
     private const string TestAssetName = "FSharpTestProject";
 
+    [TestMethod]
     public void ExecuteCustomTestExtensibilityTests()
     {
         InvokeVsTestForExecution([TestAssetName], targetFramework: "net472");

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/TimeoutTests.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/TimeoutTests.cs
@@ -1,21 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
 using Microsoft.MSTestV2.CLIAutomation;
 
 namespace MSTest.VstestConsoleWrapper.IntegrationTests;
 
+[TestClass]
 public class TimeoutTests : CLITestBase
 {
     private const string TestAssetName = "TimeoutTestProject";
 
-    public void ValidateTimeoutTests_net462() => ValidateTimeoutTests("net462");
-
-    public void ValidateTimeoutTests_netcoreapp31() => ValidateTimeoutTests("netcoreapp3.1");
-
-    private void ValidateTimeoutTests(string targetFramework)
+    [TestMethod]
+    [DataRow("net462")]
+    [DataRow("netcoreapp3.1")]
+    public void ValidateTimeoutTests(string targetFramework)
     {
         InvokeVsTestForExecution([TestAssetName], testCaseFilter: "TimeoutTest|RegularTest", targetFramework: targetFramework);
 
@@ -42,6 +40,6 @@ public class TimeoutTests : CLITestBase
             GetAssetFullPath(TestAssetName, targetFramework: targetFramework),
             "..",
             "TimeoutTestOutput.txt");
-        File.Exists(timeoutFile).Should().BeTrue();
+        Assert.IsTrue(File.Exists(timeoutFile), $"Timeout output file not found: {timeoutFile}");
     }
 }

--- a/test/Utilities/Automation.CLI/Automation.CLI.csproj
+++ b/test/Utilities/Automation.CLI/Automation.CLI.csproj
@@ -1,19 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.TestPlatform" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework\TestFramework.csproj" PrivateAssets="all" />
-    <ProjectReference Include="$(RepoRoot)test\Utilities\TestFramework.ForTestingMSTest\TestFramework.ForTestingMSTest.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework\TestFramework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Utilities/Automation.CLI/CLITestBase.common.cs
+++ b/test/Utilities/Automation.CLI/CLITestBase.common.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using FluentAssertions;
-
-using TestFramework.ForTestingMSTest;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace Microsoft.MSTestV2.CLIAutomation;
 
-public partial class CLITestBase : TestContainer
+public abstract partial class CLITestBase
 {
     private const string Configuration =
 #if DEBUG
@@ -45,7 +43,7 @@ public partial class CLITestBase : TestContainer
         string assemblyLocation = Assembly.GetExecutingAssembly().Location;
 
         string artifactsBinFolder = Path.GetFullPath(Path.Combine(assemblyLocation, @"..\..\..\.."));
-        Directory.Exists(artifactsBinFolder).Should().BeTrue();
+        Assert.IsTrue(Directory.Exists(artifactsBinFolder));
 
         return artifactsBinFolder;
     }
@@ -55,7 +53,7 @@ public partial class CLITestBase : TestContainer
         string assemblyLocation = Assembly.GetExecutingAssembly().Location;
 
         string artifactsFolder = Path.GetFullPath(Path.Combine(assemblyLocation, @"..\..\..\..\.."));
-        Directory.Exists(artifactsFolder).Should().BeTrue();
+        Assert.IsTrue(Directory.Exists(artifactsFolder));
 
         string testResultsFolder = Path.Combine(artifactsFolder, "TestResults", Configuration);
         Directory.CreateDirectory(testResultsFolder);
@@ -68,7 +66,7 @@ public partial class CLITestBase : TestContainer
         configuration ??= Configuration;
         targetFramework ??= DefaultTargetFramework;
         string assetPath = Path.GetFullPath(Path.Combine(GetArtifactsBinFolderPath(), assetName, configuration, targetFramework, assetName + ".dll"));
-        File.Exists(assetPath).Should().BeTrue($"asset '{assetPath}' should exist");
+        Assert.IsTrue(File.Exists(assetPath), $"asset '{assetPath}' should exist");
 
         return assetPath;
     }


### PR DESCRIPTION
Increase usage of MSTest where we know there will be no conflict. Also favor using MSTest assertion APIs over AwesomeAssertions as it helps with dogfooding and understanding missing APIs.