### PR TITLE
Remove timeout in test infra

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -112,7 +112,6 @@ public class UnitTest1
                 DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
                     $"publish -m:1 -nodeReuse:false {generator.TargetAssetPath} -r {RID}",
                     AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
-                    timeoutInSeconds: 90,
                     retryCount: 0);
                 compilationResult.AssertOutputContains("Generating native code");
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -311,8 +311,7 @@ namespace MSTestSdkTest
                     $"publish -r {RID} -f net9.0 {testAsset.TargetAssetPath}",
                     AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
                     // We prefer to use the outer retry mechanism as we need some extra checks
-                    retryCount: 0,
-                    timeoutInSeconds: 180);
+                    retryCount: 0);
                 compilationResult.AssertOutputContains("Generating native code");
                 compilationResult.AssertOutputDoesNotContain("warning");
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -54,7 +54,6 @@ public static class DotnetCli
         Dictionary<string, string?>? environmentVariables = null,
         bool failIfReturnValueIsNotZero = true,
         bool disableTelemetry = true,
-        int timeoutInSeconds = 10000,
         int retryCount = 5,
         bool disableCodeCoverage = true,
         bool warnAsError = true,
@@ -110,7 +109,7 @@ public static class DotnetCli
 
             if (DoNotRetry)
             {
-                return await CallTheMuxerAsync(args, environmentVariables, workingDirectory, timeoutInSeconds, failIfReturnValueIsNotZero, callerMemberName);
+                return await CallTheMuxerAsync(args, environmentVariables, workingDirectory, failIfReturnValueIsNotZero, callerMemberName);
             }
             else
             {
@@ -118,7 +117,7 @@ public static class DotnetCli
                 return await Policy
                     .Handle<Exception>()
                     .WaitAndRetryAsync(delay)
-                    .ExecuteAsync(async () => await CallTheMuxerAsync(args, environmentVariables, workingDirectory, timeoutInSeconds, failIfReturnValueIsNotZero, callerMemberName));
+                    .ExecuteAsync(async () => await CallTheMuxerAsync(args, environmentVariables, workingDirectory, failIfReturnValueIsNotZero, callerMemberName));
             }
         }
         finally
@@ -131,13 +130,13 @@ public static class DotnetCli
         => args.StartsWith("test ", StringComparison.Ordinal) && (args.Contains(".dll") || args.Contains(".exe"));
 
     // Workaround NuGet issue https://github.com/NuGet/Home/issues/14064
-    private static async Task<DotnetMuxerResult> CallTheMuxerAsync(string args, Dictionary<string, string?> environmentVariables, string? workingDirectory, int timeoutInSeconds, bool failIfReturnValueIsNotZero, string binlogBaseFileName)
+    private static async Task<DotnetMuxerResult> CallTheMuxerAsync(string args, Dictionary<string, string?> environmentVariables, string? workingDirectory, bool failIfReturnValueIsNotZero, string binlogBaseFileName)
         => await Policy
             .Handle<InvalidOperationException>(ex => ex.Message.Contains("MSB4236"))
             .WaitAndRetryAsync(retryCount: 3, sleepDurationProvider: static _ => TimeSpan.FromSeconds(2))
-            .ExecuteAsync(async () => await CallTheMuxerCoreAsync(args, environmentVariables, workingDirectory, timeoutInSeconds, failIfReturnValueIsNotZero, binlogBaseFileName));
+            .ExecuteAsync(async () => await CallTheMuxerCoreAsync(args, environmentVariables, workingDirectory, failIfReturnValueIsNotZero, binlogBaseFileName));
 
-    private static async Task<DotnetMuxerResult> CallTheMuxerCoreAsync(string args, Dictionary<string, string?> environmentVariables, string? workingDirectory, int timeoutInSeconds, bool failIfReturnValueIsNotZero, string binlogBaseFileName)
+    private static async Task<DotnetMuxerResult> CallTheMuxerCoreAsync(string args, Dictionary<string, string?> environmentVariables, string? workingDirectory, bool failIfReturnValueIsNotZero, string binlogBaseFileName)
     {
         if (args.StartsWith("dotnet ", StringComparison.OrdinalIgnoreCase))
         {
@@ -161,7 +160,7 @@ public static class DotnetCli
         }
 
         using DotnetMuxer dotnet = new(environmentVariables);
-        int exitCode = await dotnet.ExecuteAsync(args, workingDirectory, timeoutInSeconds);
+        int exitCode = await dotnet.ExecuteAsync(args, workingDirectory);
 
         if (dotnet.StandardError.Contains("Invalid runtimeconfig.json"))
         {

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetMuxer.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetMuxer.cs
@@ -92,20 +92,18 @@ public class DotnetMuxer : IDisposable
         _isDisposed = true;
     }
 
-    public async Task<int> ExecuteAsync(string arguments, string? workingDirectory = null, int timeoutInSeconds = 10000)
-        => await ExecuteAsync(arguments, workingDirectory, _environmentVariables, timeoutInSeconds);
+    public async Task<int> ExecuteAsync(string arguments, string? workingDirectory = null)
+        => await ExecuteAsync(arguments, workingDirectory, _environmentVariables);
 
     public async Task<int> ExecuteAsync(
         string arguments,
         string? workingDirectory,
-        IDictionary<string, string?> environmentVariables,
-        int timeoutInSeconds = 10000)
+        IDictionary<string, string?> environmentVariables)
         => await _commandLine.RunAsyncAndReturnExitCodeAsync(
             $"{_dotnet} {arguments}",
             environmentVariables,
             workingDirectory: workingDirectory,
-            cleanDefaultEnvironmentVariableIfCustomAreProvided: true,
-            timeoutInSeconds: timeoutInSeconds);
+            cleanDefaultEnvironmentVariableIfCustomAreProvided: true);
 
     private static IDictionary<string, string?> MergeEnvironmentVariables(
         IDictionary<string, string?> environmentVariables1,

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestHost.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestHost.cs
@@ -40,8 +40,7 @@ public sealed class TestHost
     public async Task<TestHostResult> ExecuteAsync(
         string? command = null,
         Dictionary<string, string?>? environmentVariables = null,
-        bool disableTelemetry = true,
-        int timeoutSeconds = 10000)
+        bool disableTelemetry = true)
     {
         await s_maxOutstandingExecutions_semaphore.WaitAsync();
         try
@@ -93,8 +92,7 @@ public sealed class TestHost
                         $"{FullName} --no-ansi --no-progress {finalArguments}",
                         environmentVariables: environmentVariables,
                         workingDirectory: null,
-                        cleanDefaultEnvironmentVariableIfCustomAreProvided: true,
-                        timeoutInSeconds: timeoutSeconds);
+                        cleanDefaultEnvironmentVariableIfCustomAreProvided: true);
                     string fullCommand = command is not null ? $"{FullName} {command}" : FullName;
                     return new TestHostResult(fullCommand, exitCode, commandLine.StandardOutput, commandLine.StandardOutputLines, commandLine.ErrorOutput, commandLine.ErrorOutputLines);
                 });


### PR DESCRIPTION
Everything is okay so far with the reasonable infinite timeout. I think it's safe to remove it. If anything bad goes on, hang dump should be our saver.