### PR TITLE
Cleanup test/Directory.Build.targets

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -3,7 +3,7 @@
 
   <Import Project="../Directory.Build.targets" />
 
-  <PropertyGroup Condition=" '$(EnableMSTestRunner)' == 'true' OR '$(UseInternalTestFramework)' == 'true' ">
+  <PropertyGroup>
     <GenerateProgramFile>false</GenerateProgramFile>
     <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
     <Architecture Condition=" '$(Architecture)' == '' ">$(PlatformTarget)</Architecture>


### PR DESCRIPTION
Let's always set the relevant properties. At least if a project is messed up we have better opportunity to know.