### PR TITLE
Fix terminal reporter when architecture is null

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -557,7 +557,10 @@ internal sealed partial class TerminalTestReporter : IDisposable
         if (_targetFramework != null)
         {
             terminal.Append(_targetFramework);
-            terminal.Append('|');
+            if (_architecture != null)
+            {
+                terminal.Append('|');
+            }
         }
 
         if (_architecture != null)


### PR DESCRIPTION
Follow-up from #6281 issue