### PR TITLE
Fix missing "throw" for unreachable code path in FormatStringComparisonMessage

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -723,7 +723,7 @@ public sealed partial class Assert
         if (diffIndex == -1)
         {
             // Strings are equal - should not happen in practice, we call this method only when they are not equal.
-            ApplicationStateGuard.Unreachable();
+            throw ApplicationStateGuard.Unreachable();
         }
 
         // Format the enhanced string comparison message


### PR DESCRIPTION
`ApplicationStateGuard.Unreachable` only creates an instance of UnreachableException, but it doesn't throw.