### PR TITLE
Avoid ManagedNameHelper when possible

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -303,7 +303,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
         {
             string methodName = GetMethodName(methodInfo);
             string[] hierarchy = [null!, assemblyName, EngineConstants.AssemblyFixturesHierarchyClassName, methodName];
-            return GetFixtureTest(classFullName, assemblyLocation, fixtureType, methodName, hierarchy);
+            return GetFixtureTest(classFullName, assemblyLocation, fixtureType, methodName, hierarchy, methodInfo);
         }
 
         static UnitTestElement GetClassFixtureTest(MethodInfo methodInfo, string classFullName,
@@ -311,7 +311,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
         {
             string methodName = GetMethodName(methodInfo);
             string[] hierarchy = [null!, classFullName, methodName];
-            return GetFixtureTest(classFullName, assemblyLocation, fixtureType, methodName, hierarchy);
+            return GetFixtureTest(classFullName, assemblyLocation, fixtureType, methodName, hierarchy, methodInfo);
         }
 
         static string GetMethodName(MethodInfo methodInfo)
@@ -322,9 +322,12 @@ internal class AssemblyEnumerator : MarshalByRefObject
                 : methodInfo.Name;
         }
 
-        static UnitTestElement GetFixtureTest(string classFullName, string assemblyLocation, string fixtureType, string methodName, string[] hierarchy)
+        static UnitTestElement GetFixtureTest(string classFullName, string assemblyLocation, string fixtureType, string methodName, string[] hierarchy, MethodInfo methodInfo)
         {
-            var method = new TestMethod(classFullName, methodName, hierarchy, methodName, classFullName, assemblyLocation, null, TestIdGenerationStrategy.FullyQualified);
+            var method = new TestMethod(classFullName, methodName, hierarchy, methodName, classFullName, assemblyLocation, null, TestIdGenerationStrategy.FullyQualified)
+            {
+                MethodInfo = methodInfo,
+            };
             return new UnitTestElement(method)
             {
                 DisplayName = $"[{fixtureType}] {methodName}",

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -324,13 +324,14 @@ internal class AssemblyEnumerator : MarshalByRefObject
 
         static UnitTestElement GetFixtureTest(string classFullName, string assemblyLocation, string fixtureType, string methodName, string[] hierarchy, MethodInfo methodInfo)
         {
-            var method = new TestMethod(classFullName, methodName, hierarchy, methodName, classFullName, assemblyLocation, null, TestIdGenerationStrategy.FullyQualified)
+            string displayName = $"[{fixtureType}] {methodName}";
+            var method = new TestMethod(classFullName, methodName, hierarchy, methodName, classFullName, assemblyLocation, displayName, TestIdGenerationStrategy.FullyQualified)
             {
                 MethodInfo = methodInfo,
             };
             return new UnitTestElement(method)
             {
-                DisplayName = $"[{fixtureType}] {methodName}",
+                DisplayName = displayName,
                 Traits = [new Trait(EngineConstants.FixturesTestTrait, fixtureType)],
             };
         }
@@ -426,7 +427,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
             discoveredTest.TestMethod.DataType = DynamicDataType.None;
             discoveredTest.TestMethod.TestDataSourceIgnoreMessage = testDataSourceIgnoreMessage;
             discoveredTest.DisplayName = dataSource.GetDisplayName(methodInfo, null) ?? discoveredTest.DisplayName;
-
+            discoveredTest.TestMethod.DisplayName = discoveredTest.DisplayName ?? discoveredTest.TestMethod.DisplayName;
             tests.Add(discoveredTest);
 
             return true;
@@ -467,6 +468,7 @@ internal class AssemblyEnumerator : MarshalByRefObject
 
             UnitTestElement discoveredTest = test.Clone();
             discoveredTest.DisplayName = displayNameFromTestDataRow ?? dataSource.GetDisplayName(methodInfo, d) ?? discoveredTest.DisplayName;
+            discoveredTest.TestMethod.DisplayName = discoveredTest.DisplayName ?? discoveredTest.TestMethod.DisplayName;
 
             // Merge test categories from the test data row with the existing categories
             if (testCategoriesFromTestDataRow is { Count: > 0 })

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
@@ -192,6 +192,7 @@ internal class TypeEnumerator
 
         // get DisplayName from TestMethodAttribute (or any inherited attribute)
         testElement.DisplayName = testMethodAttribute?.DisplayName ?? method.Name;
+        testMethod.DisplayName = testElement.DisplayName;
 
         return testElement;
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
@@ -130,7 +130,10 @@ internal class TypeEnumerator
 
         ManagedNameHelper.GetManagedName(method, out string managedType, out string managedMethod, out string?[]? hierarchyValues);
         hierarchyValues[HierarchyConstants.Levels.ContainerIndex] = null; // This one will be set by test windows to current test project name.
-        var testMethod = new TestMethod(managedType, managedMethod, hierarchyValues, method.Name, _type.FullName!, _assemblyFilePath, null, _testIdGenerationStrategy);
+        var testMethod = new TestMethod(managedType, managedMethod, hierarchyValues, method.Name, _type.FullName!, _assemblyFilePath, null, _testIdGenerationStrategy)
+        {
+            MethodInfo = method,
+        };
 
         if (!string.Equals(method.DeclaringType!.FullName, _type.FullName, StringComparison.Ordinal))
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -85,13 +85,6 @@ internal class UnitTestDiscoverer
         SendTestCases(source, testElements, discoverySink, discoveryContext, logger);
     }
 
-#pragma warning disable IDE0028 // Collection initialization can be simplified - cannot be done for all TFMs. So suppressing.
-    private static readonly ConditionalWeakTable<TestCase, object?[]> TestCaseToDataDictionary = new();
-#pragma warning restore IDE0028 // Collection initialization can be simplified
-
-    internal static bool TryGetActualData(TestCase testCase, [NotNullWhen(true)] out object?[]? actualData)
-        => TestCaseToDataDictionary.TryGetValue(testCase, out actualData);
-
     internal void SendTestCases(string source, IEnumerable<UnitTestElement> testElements, ITestCaseDiscoverySink discoverySink, IDiscoveryContext? discoveryContext, IMessageLogger logger)
     {
         bool shouldCollectSourceInformation = MSTestSettings.RunConfigurationSettings.CollectSourceInformation;
@@ -128,11 +121,6 @@ internal class UnitTestDiscoverer
                     }
 
                     continue;
-                }
-
-                if (testElement.TestMethod.ActualData is { } actualData)
-                {
-                    TestCaseToDataDictionary.Add(testCase, actualData);
                 }
 
                 if (!hasAnyRunnableTests)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
@@ -747,6 +747,9 @@ internal sealed class TypeCache : MarshalByRefObject
         MethodBase? methodBase = null;
         try
         {
+            // testMethod.MethodInfo can be null if 'TestMethod' instance crossed app domain boundaries.
+            // This happens on .NET Framework when app domain is enabled, and the MethodInfo is calculated and set during discovery.
+            // Then, execution will cause TestMethod to cross to a different app domain, and MethodInfo will be null.
             methodBase = testMethod.MethodInfo ?? ManagedNameHelper.GetMethod(testClassInfo.Parent.Assembly, testMethod.ManagedTypeName!, testMethod.ManagedMethodName!);
         }
         catch (InvalidManagedNameException)
@@ -773,6 +776,11 @@ internal sealed class TypeCache : MarshalByRefObject
 
     private static MethodInfo? GetMethodInfoUsingRuntimeMethods(TestMethod testMethod, TestClassInfo testClassInfo, bool discoverInternals)
     {
+        // testMethod.MethodInfo can be null if 'TestMethod' instance crossed app domain boundaries.
+        // This happens on .NET Framework when app domain is enabled, and the MethodInfo is calculated and set during discovery.
+        // Then, execution will cause TestMethod to cross to a different app domain, and MethodInfo will be null.
+        // Note: This whole GetMethodInfoUsingRuntimeMethods is likely never reachable.
+        // It's called if HasManagedMethodAndTypeProperties is false, but it should always be true per the current implementation.
         if (testMethod.MethodInfo is { } methodInfo)
         {
             return methodInfo.HasCorrectTestMethodSignature(true, discoverInternals) ? methodInfo : null;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
@@ -747,7 +747,7 @@ internal sealed class TypeCache : MarshalByRefObject
         MethodBase? methodBase = null;
         try
         {
-            methodBase = ManagedNameHelper.GetMethod(testClassInfo.Parent.Assembly, testMethod.ManagedTypeName!, testMethod.ManagedMethodName!);
+            methodBase = testMethod.MethodInfo ?? ManagedNameHelper.GetMethod(testClassInfo.Parent.Assembly, testMethod.ManagedTypeName!, testMethod.ManagedMethodName!);
         }
         catch (InvalidManagedNameException)
         {
@@ -773,6 +773,11 @@ internal sealed class TypeCache : MarshalByRefObject
 
     private static MethodInfo? GetMethodInfoUsingRuntimeMethods(TestMethod testMethod, TestClassInfo testClassInfo, bool discoverInternals)
     {
+        if (testMethod.MethodInfo is { } methodInfo)
+        {
+            return methodInfo.HasCorrectTestMethodSignature(true, discoverInternals) ? methodInfo : null;
+        }
+
         IEnumerable<MethodInfo> methods = PlatformServiceProvider.Instance.ReflectionOperations.GetRuntimeMethods(testClassInfo.ClassType)
             .Where(method => method.Name == testMethod.Name &&
                              method.HasCorrectTestMethodSignature(true, discoverInternals));

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
@@ -70,6 +70,11 @@ internal static class TestCaseExtensions
     /// <returns> The converted <see cref="UnitTestElement"/>. </returns>
     internal static UnitTestElement ToUnitTestElement(this TestCase testCase, string source)
     {
+        if (testCase.LocalExtensionData is UnitTestElement unitTestElement)
+        {
+            return unitTestElement;
+        }
+
         string? testClassName = testCase.GetPropertyValue(EngineConstants.TestClassNameProperty) as string;
         string name = testCase.GetTestName(testClassName);
         var testIdGenerationStrategy = (TestIdGenerationStrategy)testCase.GetPropertyValue(
@@ -86,10 +91,6 @@ internal static class TestCaseExtensions
 
             testMethod.DataType = dataType;
             testMethod.SerializedData = data;
-            if (UnitTestDiscoverer.TryGetActualData(testCase, out object?[]? actualData))
-            {
-                testMethod.ActualData = actualData;
-            }
 
             testMethod.TestDataSourceIgnoreMessage = testCase.GetPropertyValue(EngineConstants.TestDataSourceIgnoreMessageProperty) as string;
         }

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -170,9 +170,9 @@ public sealed class TestMethod : ITestMethod
     internal string? TestGroup { get; set; }
 
     /// <summary>
-    /// Gets the display name set during discovery.
+    /// Gets or sets the display name set during discovery.
     /// </summary>
-    internal string DisplayName { get; }
+    internal string DisplayName { get; set; }
 
     internal TestMethod Clone() => (TestMethod)MemberwiseClone();
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -153,6 +153,9 @@ public sealed class TestMethod : ITestMethod
     [field: NonSerialized]
     internal object?[]? ActualData { get; set; }
 
+    [field: NonSerialized]
+    internal MethodInfo? MethodInfo { get; set; }
+
     /// <summary>
     /// Gets or sets the test data source ignore message.
     /// </summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -111,6 +111,7 @@ internal sealed class UnitTestElement
         TestCase testCase = new(testFullName, EngineConstants.ExecutorUri, TestMethod.AssemblyName)
         {
             DisplayName = GetDisplayName(),
+            LocalExtensionData = this,
         };
 
         if (TestMethod.HasManagedMethodAndTypeProperties)

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -62,6 +62,7 @@ internal sealed class UnitTestElement
     /// <summary>
     /// Gets or sets the DisplayName.
     /// </summary>
+    // TODO: Remove this property and simply use TestMethod.DisplayName
     public string? DisplayName { get; set; }
 
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -118,15 +118,18 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
         DebugEx.Assert(properties != null, "properties is not null");
 
         _stringWriter = stringWriter;
-        _properties = testMethod is null
-            ? new Dictionary<string, object?>(properties)
-            : new Dictionary<string, object?>(properties)
+        if (testMethod is null)
+        {
+            _properties = new Dictionary<string, object?>(properties);
+        }
+        else
+        {
+            _properties = new Dictionary<string, object?>(properties.Count + 4);
+            foreach (KeyValuePair<string, object?> kvp in properties)
             {
-                [FullyQualifiedTestClassNameLabel] = testMethod.FullClassName,
-                [ManagedTypeLabel] = testMethod.ManagedTypeName,
-                [ManagedMethodLabel] = testMethod.ManagedMethodName,
-                [TestNameLabel] = testMethod.Name,
-            };
+                _properties.Add(kvp.Key, kvp.Value);
+            }
+        }
 
         _testResultFiles = [];
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -118,18 +118,15 @@ public class TestContextImplementation : TestContext, ITestContext, IDisposable
         DebugEx.Assert(properties != null, "properties is not null");
 
         _stringWriter = stringWriter;
-        if (testMethod is null)
-        {
-            _properties = new Dictionary<string, object?>(properties);
-        }
-        else
-        {
-            _properties = new Dictionary<string, object?>(properties.Count + 4);
-            foreach (KeyValuePair<string, object?> kvp in properties)
+        _properties = testMethod is null
+            ? new Dictionary<string, object?>(properties)
+            : new Dictionary<string, object?>(properties)
             {
-                _properties.Add(kvp.Key, kvp.Value);
-            }
-        }
+                [FullyQualifiedTestClassNameLabel] = testMethod.FullClassName,
+                [ManagedTypeLabel] = testMethod.ManagedTypeName,
+                [ManagedMethodLabel] = testMethod.ManagedMethodName,
+                [TestNameLabel] = testMethod.Name,
+            };
 
         _testResultFiles = [];
     }


### PR DESCRIPTION
Part of #6317

We still cannot remove it entirely because of appdomains...

### Scenario

Adding 10k empty test methods in Playground, using MTP, and parallelization not enabled. Executing the "exe" directly from `artifacts/bin/Playground/Debug/net9.0/Playground.exe`

### Before

```
Test run summary: Passed! - C:\Users\ygerges\Desktop\testfx\artifacts\bin\Playground\Debug\net9.0\Playground.dll (net9.0|x64)
  total: 10000
  failed: 0
  succeeded: 10000
  skipped: 0
  duration: 11s 881ms
```

<img width="1439" height="75" alt="image" src="https://github.com/user-attachments/assets/f328224d-db7b-4610-8c01-c20e80458df3" />

- Process wall-time: 15s
- Process CPU time: 13s

CPU stacks sorted by exclusive time:

<img width="2399" height="991" alt="image" src="https://github.com/user-attachments/assets/498fb0ea-b39d-4cae-a0c7-ff848d841cec" />

(NOTE: ManagedNameHelper.GetMethod inclusive CPU time is 6.5s, around 50% of total CPU time)

Memory:

<img width="2394" height="1366" alt="image" src="https://github.com/user-attachments/assets/8901c1a1-88f9-4a0c-a8a6-1a3583f4153c" />


### After

```
Test run summary: Passed! - C:\Users\ygerges\Desktop\testfx\artifacts\bin\Playground\Debug\net9.0\Playground.dll (net9.0|x64)
  total: 10000
  failed: 0
  succeeded: 10000
  skipped: 0
  duration: 4s 056ms
```

<img width="1368" height="71" alt="image" src="https://github.com/user-attachments/assets/9cd17f49-3bb6-43b8-b286-4091e83fd9f3" />

- Process wall-time: 5.6sec
- Process CPU time: 5.7sec

CPU stacks sorted by exclusive time:

<img width="2393" height="986" alt="image" src="https://github.com/user-attachments/assets/d2943294-b85f-4859-b521-65632e9d8519" />

Memory:

<img width="2391" height="1091" alt="image" src="https://github.com/user-attachments/assets/c41739f1-5f87-4857-a29c-acffbc55a575" />

The current highest allocation is resizing of dictionary in TestContexetImplementation ctor:

<img width="2398" height="948" alt="image" src="https://github.com/user-attachments/assets/7f7698a9-8abb-4ced-be9a-24ed59d94648" />
