### PR TITLE
Avoid accessing TestCase.Traits when possible

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -109,7 +109,7 @@ internal class UnitTestDiscoverer
             foreach (UnitTestElement testElement in testElements)
             {
                 var testCase = testElement.ToTestCase();
-                bool hasFixtureTraits = testCase.Traits.Any(t => t.Name == EngineConstants.FixturesTestTrait);
+                bool hasFixtureTraits = testElement.Traits?.Any(t => t.Name == EngineConstants.FixturesTestTrait) == true;
 
                 // Filter tests based on test case filters
                 if (filterExpression != null && !filterExpression.MatchTestCase(testCase, p => _testMethodFilter.PropertyValueProvider(testCase, p)))


### PR DESCRIPTION
In a scenario with too many tests:

<img width="1199" height="470" alt="image" src="https://github.com/user-attachments/assets/ee2b960d-efdf-496e-8ec1-bf64cb573192" />

Accessing `Traits` property on `TestCase` causes VSTest to force materializing a TraitCollection, even if we don't have any traits. Accessing the traits from MSTest model is cheaper.