### PR TITLE
Reduce allocations from properties dictionary of TestContextImplemention

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextDictionary.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextDictionary.cs
@@ -30,19 +30,19 @@ internal sealed class TestContextDictionary : IDictionary<string, object?>
         {
             if (key == TestContext.FullyQualifiedTestClassNameLabel)
             {
-                return _testMethod?.FullClassName;
+                return _testMethod?.FullClassName ?? throw new KeyNotFoundException();
             }
             else if (key == TestContext.ManagedTypeLabel)
             {
-                return _testMethod?.ManagedTypeName;
+                return _testMethod?.ManagedTypeName ?? throw new KeyNotFoundException();
             }
             else if (key == TestContext.ManagedMethodLabel)
             {
-                return _testMethod?.ManagedMethodName;
+                return _testMethod?.ManagedMethodName ?? throw new KeyNotFoundException();
             }
             else if (key == TestContext.TestNameLabel)
             {
-                return _testMethod?.Name;
+                return _testMethod?.Name ?? throw new KeyNotFoundException();
             }
 
             return _currentDictionary[key];
@@ -50,19 +50,8 @@ internal sealed class TestContextDictionary : IDictionary<string, object?>
 
         set
         {
-            if (key == TestContext.FullyQualifiedTestClassNameLabel ||
-                key == TestContext.ManagedTypeLabel ||
-                key == TestContext.ManagedMethodLabel ||
-                key == TestContext.TestNameLabel)
-            {
-                throw new InvalidOperationException();
-            }
-
-            if (_isOriginalDictionary)
-            {
-                _currentDictionary = new Dictionary<string, object?>(_currentDictionary);
-                _isOriginalDictionary = false;
-            }
+            ThrowIfKnownKey(key);
+            CloneDictionaryIfNeeded();
 
             _currentDictionary[key] = value;
         }
@@ -124,7 +113,13 @@ internal sealed class TestContextDictionary : IDictionary<string, object?>
 
     public bool IsReadOnly => _currentDictionary.IsReadOnly;
 
-    public void Add(string key, object? value) => throw new NotImplementedException();
+    public void Add(string key, object? value)
+    {
+        ThrowIfKnownKey(key);
+        CloneDictionaryIfNeeded();
+
+        _currentDictionary.Add(key, value);
+    }
 
     public void Add(KeyValuePair<string, object?> item)
         => Add(item.Key, item.Value);
@@ -172,11 +167,60 @@ internal sealed class TestContextDictionary : IDictionary<string, object?>
 
     public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => throw new NotImplementedException();
 
-    public bool Remove(string key) => throw new NotImplementedException();
+    public bool Remove(string key)
+    {
+        ThrowIfKnownKey(key);
+        CloneDictionaryIfNeeded();
+        return _currentDictionary.Remove(key);
+    }
 
     public bool Remove(KeyValuePair<string, object?> item) => throw new NotImplementedException();
 
-    public bool TryGetValue(string key, out object? value) => throw new NotImplementedException();
+    public bool TryGetValue(string key, out object? value)
+    {
+        if (key == TestContext.FullyQualifiedTestClassNameLabel)
+        {
+            value = _testMethod?.FullClassName;
+            return value is not null;
+        }
+        else if (key == TestContext.ManagedTypeLabel)
+        {
+            value = _testMethod?.ManagedTypeName;
+            return value is not null;
+        }
+        else if (key == TestContext.ManagedMethodLabel)
+        {
+            value = _testMethod?.ManagedMethodName;
+            return value is not null;
+        }
+        else if (key == TestContext.TestNameLabel)
+        {
+            value = _testMethod?.Name;
+            return value is not null;
+        }
+
+        return _currentDictionary.TryGetValue(key, out value);
+    }
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private static void ThrowIfKnownKey(string key)
+    {
+        if (key == TestContext.FullyQualifiedTestClassNameLabel ||
+                key == TestContext.ManagedTypeLabel ||
+                key == TestContext.ManagedMethodLabel ||
+                key == TestContext.TestNameLabel)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+
+    private void CloneDictionaryIfNeeded()
+    {
+        if (_isOriginalDictionary)
+        {
+            _currentDictionary = new Dictionary<string, object?>(_currentDictionary);
+            _isOriginalDictionary = false;
+        }
+    }
 }


### PR DESCRIPTION
Not yet complete.

On a scenario using 10k tests in a test class, I see:

<img width="2396" height="949" alt="image" src="https://github.com/user-attachments/assets/b452e6af-ffe8-4db2-b143-13432568a926" />


TestContextImplementation constructor receives already an `IDictionary<string, object?>`. However, we clone the dictionary to add 4 more properties to it, without affecting the original dictionary. This causes many allocations. The approach I'm taking here is to create our own dictionary type, which tracks the four extra values we need + the original dictionary. Then, only if the user attempts to mutate the original dictionary, we clone.