### PR TITLE
Avoid iterator allocations

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
@@ -815,17 +815,26 @@ internal sealed class TypeCache : MarshalByRefObject
         DebugEx.Assert(testMethodInfo != null, "testMethodInfo is Null");
         DebugEx.Assert(testMethodInfo.MethodInfo != null, "testMethodInfo.TestMethod is Null");
 
-        IEnumerable<TestPropertyAttribute> attributes = _reflectionHelper.GetAttributes<TestPropertyAttribute>(testMethodInfo.MethodInfo, inherit: true);
-        DebugEx.Assert(attributes != null, "attributes is null");
+        // Avoid calling GetAttributes<T> to prevent iterator state machine allocations.
+        _ = ValidateAttributes(_reflectionHelper.GetCustomAttributesCached(testMethodInfo.MethodInfo, inherit: true), testMethodInfo, testContext) &&
+            ValidateAttributes(_reflectionHelper.GetCustomAttributesCached(testMethodInfo.Parent.ClassType, inherit: true), testMethodInfo, testContext);
 
-        attributes = attributes.Concat(_reflectionHelper.GetAttributes<TestPropertyAttribute>(testMethodInfo.Parent.ClassType, inherit: true));
-
-        foreach (TestPropertyAttribute attribute in attributes)
+        static bool ValidateAttributes(Attribute[] attributes, TestMethodInfo testMethodInfo, ITestContext testContext)
         {
-            if (!ValidateAndAssignTestProperty(testMethodInfo, testContext, attribute.Name, attribute.Value, isPredefinedAttribute: attribute is OwnerAttribute or PriorityAttribute))
+            foreach (Attribute attribute in attributes)
             {
-                break;
+                if (attribute is not TestPropertyAttribute testPropertyAttribute)
+                {
+                    continue;
+                }
+
+                if (!ValidateAndAssignTestProperty(testMethodInfo, testContext, testPropertyAttribute.Name, testPropertyAttribute.Value, isPredefinedAttribute: attribute is OwnerAttribute or PriorityAttribute))
+                {
+                    return false;
+                }
             }
+
+            return true;
         }
     }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -217,20 +217,52 @@ internal class ReflectHelper : MarshalByRefObject
     /// </summary>
     /// <param name="testPropertyProvider">The member to inspect.</param>
     /// <returns>List of traits.</returns>
-    internal virtual IEnumerable<Trait> GetTestPropertiesAsTraits(MemberInfo testPropertyProvider)
+    internal Trait[] GetTestPropertiesAsTraits(MethodInfo testPropertyProvider)
     {
-        IEnumerable<TestPropertyAttribute> testPropertyAttributes = GetAttributes<TestPropertyAttribute>(testPropertyProvider, inherit: true);
-
-        if (testPropertyProvider.DeclaringType is { } testClass)
+        Attribute[] attributesFromMethod = GetCustomAttributesCached(testPropertyProvider, inherit: true);
+        Attribute[] attributesFromClass = testPropertyProvider.ReflectedType is { } testClass ? GetCustomAttributesCached(testClass, inherit: true) : [];
+        int countTestPropertyAttribute = 0;
+        foreach (Attribute attribute in attributesFromMethod)
         {
-            testPropertyAttributes = testPropertyAttributes.Concat(GetAttributes<TestPropertyAttribute>(testClass, inherit: true));
+            if (attribute is TestPropertyAttribute)
+            {
+                countTestPropertyAttribute++;
+            }
         }
 
-        foreach (TestPropertyAttribute testProperty in testPropertyAttributes)
+        foreach (Attribute attribute in attributesFromClass)
         {
-            var testPropertyPair = new Trait(testProperty.Name, testProperty.Value);
-            yield return testPropertyPair;
+            if (attribute is TestPropertyAttribute)
+            {
+                countTestPropertyAttribute++;
+            }
         }
+
+        if (countTestPropertyAttribute == 0)
+        {
+            // This is the common case that we optimize for. This method used to be an iterator (uses yield return) which is allocating unnecessarily in common cases.
+            return [];
+        }
+
+        var traits = new Trait[countTestPropertyAttribute];
+        int index = 0;
+        foreach (Attribute attribute in attributesFromMethod)
+        {
+            if (attribute is TestPropertyAttribute testProperty)
+            {
+                traits[index++] = new Trait(testProperty.Name, testProperty.Value);
+            }
+        }
+
+        foreach (Attribute attribute in attributesFromClass)
+        {
+            if (attribute is TestPropertyAttribute testProperty)
+            {
+                traits[index++] = new Trait(testProperty.Name, testProperty.Value);
+            }
+        }
+
+        return traits;
     }
 
     /// <summary>
@@ -253,6 +285,30 @@ internal class ReflectHelper : MarshalByRefObject
             if (attribute is TAttributeType attributeAsAttributeType)
             {
                 yield return attributeAsAttributeType;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get attribute defined on a method which is of given type of subtype of given type.
+    /// </summary>
+    /// <typeparam name="TAttributeType">The attribute type.</typeparam>
+    /// <typeparam name="TState">The type of state to be passed to Action.</typeparam>
+    /// <param name="attributeProvider">The member to inspect.</param>
+    /// <param name="inherit">Look at inheritance chain.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="state">The state to pass to action.</param>
+    internal void PerformActionOnAttribute<TAttributeType, TState>(ICustomAttributeProvider attributeProvider, bool inherit, Action<TAttributeType, TState?> action, TState? state)
+        where TAttributeType : Attribute
+    {
+        Attribute[] attributes = GetCustomAttributesCached(attributeProvider, inherit);
+        foreach (Attribute attribute in attributes)
+        {
+            DebugEx.Assert(attribute != null, "ReflectHelper.DefinesAttributeDerivedFrom: internal error: wrong value in the attributes dictionary.");
+
+            if (attribute is TAttributeType attributeAsAttributeType)
+            {
+                action(attributeAsAttributeType, state);
             }
         }
     }


### PR DESCRIPTION
About 4.5% of allocations are iterator allocations when running 10k tests in a test class.

<img width="2395" height="579" alt="image" src="https://github.com/user-attachments/assets/a5c672cd-3b29-4c68-8a91-784ccb038204" />
