### PR TITLE
Optimize tcm properties

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TcmTestPropertiesProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TcmTestPropertiesProvider.cs
@@ -17,35 +17,36 @@ internal static class TcmTestPropertiesProvider
     /// </summary>
     /// <param name="testCase">Test case.</param>
     /// <returns>Tcm properties.</returns>
-    public static IDictionary<TestPlatformObjectModel.TestProperty, object?> GetTcmProperties(TestPlatformObjectModel.TestCase? testCase)
+    public static IDictionary<TestPlatformObjectModel.TestProperty, object?>? GetTcmProperties(TestPlatformObjectModel.TestCase? testCase)
     {
-        var tcmProperties = new Dictionary<TestPlatformObjectModel.TestProperty, object?>();
-
         // Return empty properties when testCase is null or when test case id is zero.
         if (testCase == null ||
             testCase.GetPropertyValue<int>(EngineConstants.TestCaseIdProperty, default) == 0)
         {
-            return tcmProperties;
+            return null;
         }
 
-        // Step 1: Add common properties.
-        tcmProperties[EngineConstants.TestRunIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestRunIdProperty, default);
-        tcmProperties[EngineConstants.TestPlanIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestPlanIdProperty, default);
-        tcmProperties[EngineConstants.BuildConfigurationIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.BuildConfigurationIdProperty, default);
-        tcmProperties[EngineConstants.BuildDirectoryProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildDirectoryProperty, default);
-        tcmProperties[EngineConstants.BuildFlavorProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildFlavorProperty, default);
-        tcmProperties[EngineConstants.BuildNumberProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildNumberProperty, default);
-        tcmProperties[EngineConstants.BuildPlatformProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildPlatformProperty, default);
-        tcmProperties[EngineConstants.BuildUriProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildUriProperty, default);
-        tcmProperties[EngineConstants.TfsServerCollectionUrlProperty] = testCase.GetPropertyValue<string>(EngineConstants.TfsServerCollectionUrlProperty, default);
-        tcmProperties[EngineConstants.TfsTeamProjectProperty] = testCase.GetPropertyValue<string>(EngineConstants.TfsTeamProjectProperty, default);
-        tcmProperties[EngineConstants.IsInLabEnvironmentProperty] = testCase.GetPropertyValue<bool>(EngineConstants.IsInLabEnvironmentProperty, default);
+        var tcmProperties = new Dictionary<TestPlatformObjectModel.TestProperty, object?>(capacity: 15)
+        {
+            // Step 1: Add common properties.
+            [EngineConstants.TestRunIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestRunIdProperty, default),
+            [EngineConstants.TestPlanIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestPlanIdProperty, default),
+            [EngineConstants.BuildConfigurationIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.BuildConfigurationIdProperty, default),
+            [EngineConstants.BuildDirectoryProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildDirectoryProperty, default),
+            [EngineConstants.BuildFlavorProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildFlavorProperty, default),
+            [EngineConstants.BuildNumberProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildNumberProperty, default),
+            [EngineConstants.BuildPlatformProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildPlatformProperty, default),
+            [EngineConstants.BuildUriProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildUriProperty, default),
+            [EngineConstants.TfsServerCollectionUrlProperty] = testCase.GetPropertyValue<string>(EngineConstants.TfsServerCollectionUrlProperty, default),
+            [EngineConstants.TfsTeamProjectProperty] = testCase.GetPropertyValue<string>(EngineConstants.TfsTeamProjectProperty, default),
+            [EngineConstants.IsInLabEnvironmentProperty] = testCase.GetPropertyValue<bool>(EngineConstants.IsInLabEnvironmentProperty, default),
 
-        // Step 2: Add test case specific properties.
-        tcmProperties[EngineConstants.TestCaseIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestCaseIdProperty, default);
-        tcmProperties[EngineConstants.TestConfigurationIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestConfigurationIdProperty, default);
-        tcmProperties[EngineConstants.TestConfigurationNameProperty] = testCase.GetPropertyValue<string>(EngineConstants.TestConfigurationNameProperty, default);
-        tcmProperties[EngineConstants.TestPointIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestPointIdProperty, default);
+            // Step 2: Add test case specific properties.
+            [EngineConstants.TestCaseIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestCaseIdProperty, default),
+            [EngineConstants.TestConfigurationIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestConfigurationIdProperty, default),
+            [EngineConstants.TestConfigurationNameProperty] = testCase.GetPropertyValue<string>(EngineConstants.TestConfigurationNameProperty, default),
+            [EngineConstants.TestPointIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestPointIdProperty, default),
+        };
 
         return tcmProperties;
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -549,7 +549,7 @@ public class TestExecutionManager
             PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("Executing test {0}", unitTestElement.TestMethod.Name);
 
             // Run single test passing test context properties to it.
-            IDictionary<TestProperty, object?> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
+            IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
             Dictionary<string, object?> testContextProperties = GetTestContextProperties(tcmProperties, sourceLevelParameters);
 
             TestTools.UnitTesting.TestResult[] unitTestResult;
@@ -618,9 +618,14 @@ public class TestExecutionManager
     /// <param name="sourceLevelParameters">Source level parameters.</param>
     /// <returns>Test context properties.</returns>
     private static Dictionary<string, object?> GetTestContextProperties(
-        IDictionary<TestProperty, object?> tcmProperties,
+        IDictionary<TestProperty, object?>? tcmProperties,
         IDictionary<string, object> sourceLevelParameters)
     {
+        if (tcmProperties is null)
+        {
+            return new Dictionary<string, object?>(sourceLevelParameters!);
+        }
+
         // This dictionary will have *at least* 8 entries. Those are the sourceLevelParameters
         // which were originally calculated from TestDeployment.GetDeploymentInformation.
         var testContextProperties = new Dictionary<string, object?>(capacity: 8);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
@@ -32,8 +32,8 @@ public class TcmTestPropertiesProviderTests : TestContainer
 
     public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIsNull()
     {
-        IDictionary<TestProperty, object?> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(null);
-        Verify(tcmProperties.Count == 0);
+        IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(null);
+        Verify(tcmProperties is null);
     }
 
     public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIdIsZero()
@@ -59,8 +59,8 @@ public class TcmTestPropertiesProviderTests : TestContainer
         ];
         SetTestCaseProperties(testCase, propertiesValue);
 
-        IDictionary<TestProperty, object?> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
-        Verify(tcmProperties.Count == 0);
+        IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        Verify(tcmProperties is null);
     }
 
     public void GetTcmPropertiesShouldGetAllPropertiesFromTestCase()
@@ -86,7 +86,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
         ];
         SetTestCaseProperties(testCase, propertiesValue);
 
-        IDictionary<TestProperty, object?> tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
 
         VerifyTcmProperties(tcmProperties, testCase);
     }
@@ -114,7 +114,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             345
         ];
         SetTestCaseProperties(testCase1, propertiesValue1);
-        IDictionary<TestProperty, object?> tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+        IDictionary<TestProperty, object?>? tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
         VerifyTcmProperties(tcmProperties1, testCase1);
 
         // Verify 2nd call.
@@ -138,7 +138,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             346
         ];
         SetTestCaseProperties(testCase2, propertiesValue2);
-        IDictionary<TestProperty, object?> tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+        IDictionary<TestProperty, object?>? tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
         VerifyTcmProperties(tcmProperties2, testCase2);
     }
 
@@ -165,7 +165,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             345
         ];
         SetTestCaseProperties(testCase1, propertiesValue1);
-        IDictionary<TestProperty, object?> tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+        IDictionary<TestProperty, object?>? tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
         VerifyTcmProperties(tcmProperties1, testCase1);
 
         // Verify 2nd call.
@@ -189,7 +189,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             346
         ];
         SetTestCaseProperties(testCase2, propertiesValue2);
-        IDictionary<TestProperty, object?> tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+        IDictionary<TestProperty, object?>? tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
         VerifyTcmProperties(tcmProperties2, testCase2);
 
         // Verify 3rd call.
@@ -213,7 +213,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             347
         ];
         SetTestCaseProperties(testCase3, propertiesValue3);
-        IDictionary<TestProperty, object?> tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
+        IDictionary<TestProperty, object?>? tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
         VerifyTcmProperties(tcmProperties3, testCase3);
     }
 
@@ -230,8 +230,9 @@ public class TcmTestPropertiesProviderTests : TestContainer
         }
     }
 
-    private void VerifyTcmProperties(IDictionary<TestProperty, object?> tcmProperties, TestCase testCase)
+    private void VerifyTcmProperties(IDictionary<TestProperty, object?>? tcmProperties, TestCase testCase)
     {
+        Verify(tcmProperties is not null);
         foreach (TestProperty property in _tcmKnownProperties)
         {
             Verify(testCase.GetPropertyValue(property)!.Equals(tcmProperties[property]));


### PR DESCRIPTION
Unnecessary empty dictionary allocation is 3.1% of allocations when running 10k tests in a test class:

<img width="2399" height="920" alt="image" src="https://github.com/user-attachments/assets/05a59d21-66a3-47d1-ab87-a47f917f563f" />

`null` can be used instead of the empty dictionary, and null-check is done on the callsite.