### PR TITLE
Avoid LINQ in TryExecuteFoldedDataDrivenTestsAsync

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -263,14 +263,15 @@ internal sealed class TestMethodRunner
 
     private async Task<bool> TryExecuteFoldedDataDrivenTestsAsync(List<TestResult> results)
     {
-        IEnumerable<UTF.ITestDataSource>? testDataSources = _testMethodInfo.GetAttributes<Attribute>(false)?.OfType<UTF.ITestDataSource>();
-        if (testDataSources?.Any() != true)
+        bool hasTestDataSource = false;
+        foreach (Attribute attribute in ReflectHelper.Instance.GetCustomAttributesCached(_testMethodInfo.MethodInfo, false))
         {
-            return false;
-        }
+            if (attribute is not UTF.ITestDataSource testDataSource)
+            {
+                continue;
+            }
 
-        foreach (UTF.ITestDataSource testDataSource in testDataSources)
-        {
+            hasTestDataSource = true;
             if (testDataSource is ITestDataSourceIgnoreCapability { IgnoreMessage: { } ignoreMessage })
             {
                 results.Add(TestResult.CreateIgnoredResult(ignoreMessage));
@@ -313,7 +314,7 @@ internal sealed class TestMethodRunner
             }
         }
 
-        return true;
+        return hasTestDataSource;
     }
 
     private async Task ExecuteTestFromDataSourceAttributeAsync(List<TestResult> results)


### PR DESCRIPTION
Very minor improvement here though:

<img width="2399" height="347" alt="image" src="https://github.com/user-attachments/assets/747fbe09-d444-4816-89bf-515a43cd6ce2" />
