### PR TITLE
Don't store fixture tests when the feature isn't used

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -172,8 +172,11 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 DebugEx.Assert(testMethodInfo is not null, "testMethodInfo should not be null.");
 
                 // Keep track of all non-runnable methods so that we can return the appropriate result at the end.
-                _assemblyFixtureTests.TryAdd(testMethod.AssemblyName, testMethodInfo.Parent.Parent);
-                _classFixtureTests.TryAdd(testMethod.AssemblyName + testMethod.FullClassName, testMethodInfo.Parent);
+                if (MSTestSettings.CurrentSettings.ConsiderFixturesAsSpecialTests)
+                {
+                    _assemblyFixtureTests.TryAdd(testMethod.AssemblyName, testMethodInfo.Parent.Parent);
+                    _classFixtureTests.TryAdd(testMethod.AssemblyName + testMethod.FullClassName, testMethodInfo.Parent);
+                }
 
                 testContextForAssemblyInit = PlatformServiceProvider.Instance.GetTestContext(testMethod, testContextProperties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
 


### PR DESCRIPTION
String concatenation in this code path is responsible for 1.7% of allocations on current main.

<img width="2399" height="927" alt="image" src="https://github.com/user-attachments/assets/570c52ea-1cbd-4acf-9604-3fbf89c4735a" />
