### PR TITLE
Early exit RunTestCleanupMethodAsync if no cleanups

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -719,7 +719,10 @@ public class TestMethodInfo : ITestMethod
     {
         DebugEx.Assert(result != null, "result != null");
 
-        if (_classInstance is null || !_isTestContextSet || _isTestCleanupInvoked)
+        if (_classInstance is null || !_isTestContextSet || _isTestCleanupInvoked ||
+            // Fast check to see if we can return early.
+            // This avoids the code below that allocates CancellationTokenSource
+            !HasCleanupsToInvoke())
         {
 #if NET6_0_OR_GREATER
             return;
@@ -813,6 +816,15 @@ public class TestMethodInfo : ITestMethod
         return Task.CompletedTask;
 #endif
     }
+
+    private bool HasCleanupsToInvoke() =>
+        Parent.TestCleanupMethod is not null ||
+        Parent.BaseTestCleanupMethodsQueue is { Count: > 0 } ||
+        _classInstance is IDisposable ||
+#if NET6_0_OR_GREATER
+        _classInstance is IAsyncDisposable ||
+#endif
+        Parent.Parent.GlobalTestCleanups is { Count: > 0 };
 
     /// <summary>
     /// Runs TestInitialize methods of parent TestClass and the base classes.


### PR DESCRIPTION
Addresses 0.7% of allocations when running 10k test methods in a test class:

<img width="1198" height="355" alt="image" src="https://github.com/user-attachments/assets/62111f53-16e3-4a3f-8048-95727358f7d6" />
