### PR TITLE
Avoid unnecessary `List<string>` allocations in ObjectModelConverters

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -194,7 +194,7 @@ internal static class ObjectModelConverters
                     testNode.Properties.Add(new SerializableKeyValuePairStringProperty("vstest.TestCase.StandardError", message));
                 }
 
-                (standardErrorMessages ??= new()).Add(message);
+                (standardErrorMessages ??= []).Add(message);
             }
 
             if (testResultMessage.Category == TestResultMessage.StandardOutCategory)
@@ -205,7 +205,7 @@ internal static class ObjectModelConverters
                     testNode.Properties.Add(new SerializableKeyValuePairStringProperty("vstest.TestCase.StandardOutput", message));
                 }
 
-                (standardOutputMessages ??= new()).Add(message);
+                (standardOutputMessages ??= []).Add(message);
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -181,8 +181,8 @@ internal static class ObjectModelConverters
 
         testNode.Properties.Add(new TimingProperty(new(testResult.StartTime, testResult.EndTime, testResult.Duration), []));
 
-        var standardErrorMessages = new List<string>();
-        var standardOutputMessages = new List<string>();
+        List<string>? standardErrorMessages = null;
+        List<string>? standardOutputMessages = null;
         bool addVSTestProviderProperties = ShouldAddVSTestProviderProperties(namedFeatureCapability, commandLineOptions);
         foreach (TestResultMessage testResultMessage in testResult.Messages)
         {
@@ -194,7 +194,7 @@ internal static class ObjectModelConverters
                     testNode.Properties.Add(new SerializableKeyValuePairStringProperty("vstest.TestCase.StandardError", message));
                 }
 
-                standardErrorMessages.Add(message);
+                (standardErrorMessages ??= new()).Add(message);
             }
 
             if (testResultMessage.Category == TestResultMessage.StandardOutCategory)
@@ -205,7 +205,7 @@ internal static class ObjectModelConverters
                     testNode.Properties.Add(new SerializableKeyValuePairStringProperty("vstest.TestCase.StandardOutput", message));
                 }
 
-                standardOutputMessages.Add(message);
+                (standardOutputMessages ??= new()).Add(message);
             }
         }
 
@@ -217,12 +217,12 @@ internal static class ObjectModelConverters
             }
         }
 
-        if (standardErrorMessages.Count > 0)
+        if (standardErrorMessages is { Count: > 0 })
         {
             testNode.Properties.Add(new StandardErrorProperty(string.Join(Environment.NewLine, standardErrorMessages)));
         }
 
-        if (standardOutputMessages.Count > 0)
+        if (standardOutputMessages is { Count: > 0 })
         {
             testNode.Properties.Add(new StandardOutputProperty(string.Join(Environment.NewLine, standardOutputMessages)));
         }


### PR DESCRIPTION
Scenario: 100 test class, each containing 2000 test method.

<img width="2395" height="575" alt="image" src="https://github.com/user-attachments/assets/0bd2fc00-2bd6-48d3-90b6-04256d43ab92" />
