### PR TITLE
Modify internal GetRequiredService call of GetOutputDevice/GetClientInfo APIs

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -93,7 +93,7 @@ public static class ServiceProviderExtensions
     /// <param name="serviceProvider">The service provider.</param>
     /// <returns>The output device.</returns>
     public static IOutputDevice GetOutputDevice(this IServiceProvider serviceProvider)
-        => serviceProvider.GetRequiredServiceInternal<IOutputDevice>();
+        => serviceProvider.GetRequiredService<IOutputDevice>();
 
     /// <summary>
     /// Gets the IClientInfo from the <see cref="IServiceProvider"/>.
@@ -102,7 +102,7 @@ public static class ServiceProviderExtensions
     /// <returns>The IClientInfo object.</returns>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public static IClientInfo GetClientInfo(this IServiceProvider serviceProvider)
-        => serviceProvider.GetRequiredServiceInternal<IClientInfo>();
+        => serviceProvider.GetRequiredService<IClientInfo>();
 
     // Internals extensions
     internal static TService GetRequiredServiceInternal<TService>(this IServiceProvider provider)


### PR DESCRIPTION
This PR modify existing `GetOutputDevice`/ `GetClientInfo`  extension method APIs to use build-in `GetRequiredService` instead of `GetRequiredServiceInternal` ,

**Background**
I want to wrap following two providers to single `IServiceProvider`.
1. MTP's `IServiceProvider` 
2. Custom IServiceProvider that created by `Microsoft.Extensions.Dependency`.

But  currently `GetOutputDevice`/ `GetClientInfo`  extension method assume IServiceProvider is `ServiceProvider` instance.
And throw exception when using these API via **wrapped** IServiceProvider.

As far as I've confirmed.
`GetRequiredService`/`GetRequiredServiceInternal` APIs difference is `skipInternalOnlyExtensions` flag only.
And it's not affect result when resolving `GetOutputDevice`/ `GetClientInfo`.
