### PR TITLE
Implement assert contains key and contains value for keypair non generic collections

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -179,12 +179,20 @@ public sealed partial class Assert
         => Contains(expected, collection, string.Empty, null);
 
     /// <summary>
-    /// Tests whether the specified non-generic collection contains the given element.
+    /// Tests whether the specified non-generic key/value pair collection contains the given key.
     /// </summary>
     /// <param name="expectedKey">The expected item.</param>
-    /// <param name="collection">The non-generic collection (like ArrayList).</param>
+    /// <param name="collection">The non-generic key/value pair collection (like Hashset).</param>
     public static void ContainsKey(object expectedKey, IEnumerable collection)
         => ContainsKey(expectedKey, collection, string.Empty);
+
+    /// <summary>
+    /// Tests whether the specified non-generic key/value pair collection contains the given value.
+    /// </summary>
+    /// <param name="expectedValue">The expected item.</param>
+    /// <param name="collection">The non-generic key/value pair collection (like Hashset).</param>
+    public static void ContainsValue(object expectedValue, IEnumerable collection)
+        => ContainsValue(expectedValue, collection, string.Empty);
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -257,7 +265,7 @@ public sealed partial class Assert
     /// Specifically for non-generic key/value pair collections like Hashtable.
     /// </summary>
     /// <param name="expectedKey">The expected key.</param>
-    /// <param name="collection">The key/value collection.</param>
+    /// <param name="collection">The non-generic key/value pair collection.</param>
     /// <param name="message">The message format to display when the assertion fails.</param>
     public static void ContainsKey(object expectedKey, IEnumerable collection, string? message)
     {
@@ -268,6 +276,36 @@ public sealed partial class Assert
             if (item is DictionaryEntry dictEntry)
             {
                 if (object.Equals(expectedKey, dictEntry.Key))
+                {
+                    isFound = true;
+                    break;
+                }
+            }
+        }
+
+        if (!isFound)
+        {
+            string userMessage = BuildUserMessage(message);
+            ThrowAssertContainsItemFailed(userMessage);
+        }
+    }
+
+    /// <summary>
+    /// Tests whether the specified collection contains the given key.
+    /// Specifically for non-generic key/value pair collections like Hashtable.
+    /// </summary>
+    /// <param name="expectedValue">The expected value.</param>
+    /// <param name="collection">The non-generic key/value pair collection.</param>
+    /// <param name="message">The message format to display when the assertion fails.</param>
+    public static void ContainsValue(object expectedValue, IEnumerable collection, string? message)
+    {
+        bool isFound = false;
+
+        foreach (object? item in collection)
+        {
+            if (item is DictionaryEntry dictEntry)
+            {
+                if (object.Equals(expectedValue, dictEntry.Value))
                 {
                     isFound = true;
                     break;

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceType.Field = 3 -> Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceType
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ContainsKey(object! expectedKey, System.Collections.IEnumerable! collection) -> void
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ContainsKey(object! expectedKey, System.Collections.IEnumerable! collection, string? message) -> void
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ContainsValue(object! expectedValue, System.Collections.IEnumerable! collection) -> void
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ContainsValue(object! expectedValue, System.Collections.IEnumerable! collection, string? message) -> void
 *REMOVED*static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.Instance.get -> Microsoft.VisualStudio.TestTools.UnitTesting.Assert!
 *REMOVED*static Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.Instance.get -> Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert!
 *REMOVED*static Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert.Instance.get -> Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert!

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
@@ -378,6 +378,21 @@ public partial class AssertTests : TestContainer
     }
 
     /// <summary>
+    /// Tests the ContainsKey method (value overload) when the expected key is present.
+    /// </summary>
+    public void ContainsKey_InNonGenericKeyValueCollection_KeyExpected_KeyExists_DoesNotThrow2()
+    {
+        // Arrange
+        var collection = new Hashtable { { "key1", "value1" }, { "key2", "value2" }, { 3, "value3" } };
+
+        // Act
+        Action action = () => Assert.ContainsKey(3, collection, "No failure expected");
+
+        // Assert
+        action.Should().NotThrow<AssertFailedException>();
+    }
+
+    /// <summary>
     /// Tests the ContainsKey method (value overload) when the expected key is not present.
     /// Expects an exception.
     /// </summary>
@@ -392,6 +407,52 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>().WithMessage($"*Item {expectedKey} not found*");
+    }
+
+    /// <summary>
+    /// Tests the ContainsValue method (value overload) when the expected value is present.
+    /// </summary>
+    public void ContainsValue_InNonGenericKeyValueCollection_ValueExpected_ValueExists_DoesNotThrow()
+    {
+        // Arrange
+        var collection = new Hashtable { { "key1", 1 }, { "key2", "value2" }, { 3, "value3" } };
+
+        // Act
+        Action action = () => Assert.ContainsValue("value2", collection, "No failure expected");
+
+        // Assert
+        action.Should().NotThrow<AssertFailedException>();
+    }
+
+    /// <summary>
+    /// Tests the ContainsValue method (value overload) when the expected value is present.
+    /// </summary>
+    public void ContainsValue_InNonGenericKeyValueCollection_ValueExpected_ValueExists_DoesNotThrow2()
+    {
+        // Arrange
+        var collection = new Hashtable { { "key1", 1 }, { "key2", "value2" }, { 3, "value3" } };
+
+        // Act
+        Action action = () => Assert.ContainsValue(1, collection, "No failure expected");
+
+        // Assert
+        action.Should().NotThrow<AssertFailedException>();
+    }
+
+    /// <summary>
+    /// Tests the ContainsValue method (value overload) when the expected value is not present.
+    /// </summary>
+    public void ContainsValue_InNonGenericKeyValueCollection_ValueExpected_ValueDoesNotExists_ThrowException()
+    {
+        // Arrange
+        var collection = new Hashtable { { "key1", 1 }, { "key2", "value2" }, { 3, "value3" } };
+        object expectedValue = "value1";
+
+        // Act
+        Action action = () => Assert.ContainsValue(expectedValue, collection, $"Item {expectedValue} not found");
+
+        // Assert
+        action.Should().Throw<AssertFailedException>().WithMessage($"*Item {expectedValue} not found*");
     }
 
     /// <summary>


### PR DESCRIPTION
This Pull Request fixes [Collection assert methods should accept IEnumerable collections](https://github.com/microsoft/testfx/issues/6184) #6184 

This implementation creating a new of `Assert` member which are `Assert.ContainsKey` and `Assert.ContainsValue`  which accepts non-generic IEnumerable key/value pair collection like HashTable.

**Expected Behaviour of `Assert.ContainsKey`**
These screenshots are examples of how `Assert.ContainsKey` can be used for non-generic key/value pair collection like HashTable

<img width="727" height="242" alt="image" src="https://github.com/user-attachments/assets/af36f2ce-051d-4da2-a1bf-90f5b88fc6a2" />

<img width="759" height="237" alt="image" src="https://github.com/user-attachments/assets/587c79c5-3e42-4deb-ac96-3465de12ba54" />

<img width="750" height="273" alt="image" src="https://github.com/user-attachments/assets/dd6b50c9-2df5-4fa3-9e94-23fde941d6b6" />


**Expected Behaviour of `Assert.ContainsValue`**
These screenshots are examples of how `Assert.ContainsValue` can be used for non-generic key/value pair collection like HashTable

<img width="715" height="239" alt="image" src="https://github.com/user-attachments/assets/bb281ece-1da1-4b91-b3be-312cda894c17" />

<img width="762" height="240" alt="image" src="https://github.com/user-attachments/assets/45167b17-b86b-4ad6-bbbc-ebebce31066b" />

<img width="806" height="249" alt="image" src="https://github.com/user-attachments/assets/fdaa053e-5c72-47d0-a48a-c4057c01e574" />




