### PR TITLE
Add clarifying comments for command-line arg escaping

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -170,8 +170,13 @@ internal sealed class RetryOrchestrator : ITestHostOrchestrator, IOutputDeviceDa
             finalArguments.Add(retryFailedTestsPipeServer.PipeName);
 
 #if NET8_0_OR_GREATER
+            // On net8.0+, we can pass the arguments as a collection directly to ProcessStartInfo.
+            // When passing the collection, it's expected to be unescaped, so we pass what we have directly.
             List<string> arguments = finalArguments;
 #else
+            // Current target framework (.NET Framework and .NET Standard 2.0) only supports arguments as a single string.
+            // In this case, escaping is essential. For example, one of the arguments could already contain spaces.
+            // PasteArguments is borrowed from dotnet/runtime.
             var builder = new StringBuilder();
             foreach (string arg in finalArguments)
             {

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -102,8 +102,13 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
             testHostControllerIpc.RegisterAllSerializers();
 
 #if NET8_0_OR_GREATER
+            // On net8.0+, we can pass the arguments as a collection directly to ProcessStartInfo.
+            // When passing the collection, it's expected to be unescaped, so we pass what we have directly.
             IEnumerable<string> arguments = partialCommandLine;
 #else
+            // Current target framework (.NET Framework and .NET Standard 2.0) only supports arguments as a single string.
+            // In this case, escaping is essential. For example, one of the arguments could already contain spaces.
+            // PasteArguments is borrowed from dotnet/runtime.
             var builder = new StringBuilder();
             foreach (string arg in partialCommandLine)
             {


### PR DESCRIPTION
Follow-up per https://github.com/microsoft/testfx/pull/6462#pullrequestreview-3168081208