### PR TITLE
Clean TestProgressState on TestExecutionCompleted

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -159,6 +159,11 @@ internal sealed partial class TerminalTestReporter : IDisposable
         _terminalWithProgress.WriteToTerminal(_isDiscovery ? AppendTestDiscoverySummary : AppendTestRunSummary);
 
         NativeMethods.RestoreConsoleMode(_originalConsoleMode);
+
+        // This is relevant for HotReload scenarios. We want the next test sessions to start
+        // on a new TestProgressState
+        _testProgressState = null;
+
         _buildErrorsCount = 0;
         _testExecutionStartTime = null;
         _testExecutionEndTime = null;


### PR DESCRIPTION
Possibly fixes https://github.com/microsoft/testfx/issues/6492 which likely regressed in https://github.com/microsoft/testfx/pull/6037