### PR TITLE
Rename ReadShort and WriteShort to ReadUShort and WriteUShort

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -117,7 +117,7 @@ internal abstract class BaseSerializer
         stream.Write(bytes);
     }
 
-    protected static void WriteShort(Stream stream, ushort value)
+    protected static void WriteUShort(Stream stream, ushort value)
     {
         Span<byte> bytes = stackalloc byte[sizeof(ushort)];
         ApplicationStateGuard.Ensure(BitConverter.TryWriteBytes(bytes, value), PlatformResources.UnexpectedExceptionDuringByteConversionErrorMessage);
@@ -147,7 +147,7 @@ internal abstract class BaseSerializer
         return BitConverter.ToInt64(bytes);
     }
 
-    protected static ushort ReadShort(Stream stream)
+    protected static ushort ReadUShort(Stream stream)
     {
         Span<byte> bytes = stackalloc byte[sizeof(ushort)];
         stream.ReadExactly(bytes);
@@ -229,7 +229,7 @@ internal abstract class BaseSerializer
         stream.Write(bytes, 0, bytes.Length);
     }
 
-    protected static void WriteShort(Stream stream, ushort value)
+    protected static void WriteUShort(Stream stream, ushort value)
     {
         byte[] bytes = BitConverter.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
@@ -242,7 +242,7 @@ internal abstract class BaseSerializer
         return BitConverter.ToInt64(bytes, 0);
     }
 
-    protected static ushort ReadShort(Stream stream)
+    protected static ushort ReadUShort(Stream stream)
     {
         byte[] bytes = new byte[sizeof(ushort)];
         _ = stream.Read(bytes, 0, bytes.Length);
@@ -274,7 +274,7 @@ internal abstract class BaseSerializer
             return;
         }
 
-        WriteShort(stream, id);
+        WriteUShort(stream, id);
         WriteStringSize(stream, value);
         WriteStringValue(stream, value);
     }
@@ -286,7 +286,7 @@ internal abstract class BaseSerializer
             return;
         }
 
-        WriteShort(stream, id);
+        WriteUShort(stream, id);
         WriteSize<long>(stream);
         WriteLong(stream, value.Value);
     }
@@ -298,7 +298,7 @@ internal abstract class BaseSerializer
             return;
         }
 
-        WriteShort(stream, id);
+        WriteUShort(stream, id);
         WriteSize<int>(stream);
         WriteInt(stream, value.Value);
     }
@@ -330,7 +330,7 @@ internal abstract class BaseSerializer
             return;
         }
 
-        WriteShort(stream, id);
+        WriteUShort(stream, id);
         WriteSize<bool>(stream);
         WriteBool(stream, value.Value);
     }
@@ -342,7 +342,7 @@ internal abstract class BaseSerializer
             return;
         }
 
-        WriteShort(stream, id);
+        WriteUShort(stream, id);
         WriteSize<byte>(stream);
         WriteByte(stream, value.Value);
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -45,11 +45,11 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
         string? moduleName = null;
         List<CommandLineOptionMessage>? commandLineOptionMessages = null;
 
-        ushort fieldCount = ReadShort(stream);
+        ushort fieldCount = ReadUShort(stream);
 
         for (int i = 0; i < fieldCount; i++)
         {
-            int fieldId = ReadShort(stream);
+            int fieldId = ReadUShort(stream);
             int fieldSize = ReadInt(stream);
 
             switch (fieldId)
@@ -82,11 +82,11 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
             string? name = null, description = null;
             bool? isHidden = null, isBuiltIn = null;
 
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -125,7 +125,7 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
 
         var commandLineOptionMessages = (CommandLineOptionMessages)objectToSerialize;
 
-        WriteShort(stream, GetFieldCount(commandLineOptionMessages));
+        WriteUShort(stream, GetFieldCount(commandLineOptionMessages));
 
         WriteField(stream, CommandLineOptionMessagesFieldsId.ModulePath, commandLineOptionMessages.ModulePath);
         WriteCommandLineOptionMessagesPayload(stream, commandLineOptionMessages.CommandLineOptionMessageList);
@@ -138,7 +138,7 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
             return;
         }
 
-        WriteShort(stream, CommandLineOptionMessagesFieldsId.CommandLineOptionMessageList);
+        WriteUShort(stream, CommandLineOptionMessagesFieldsId.CommandLineOptionMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -148,7 +148,7 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
         WriteInt(stream, commandLineOptionMessageList.Length);
         foreach (CommandLineOptionMessage commandLineOptionMessage in commandLineOptionMessageList)
         {
-            WriteShort(stream, GetFieldCount(commandLineOptionMessage));
+            WriteUShort(stream, GetFieldCount(commandLineOptionMessage));
 
             WriteField(stream, CommandLineOptionMessageFieldsId.Name, commandLineOptionMessage.Name);
             WriteField(stream, CommandLineOptionMessageFieldsId.Description, commandLineOptionMessage.Description);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -78,11 +78,11 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
         string? instanceId = null;
         DiscoveredTestMessage[]? discoveredTestMessages = [];
 
-        ushort fieldCount = ReadShort(stream);
+        ushort fieldCount = ReadUShort(stream);
 
         for (int i = 0; i < fieldCount; i++)
         {
-            int fieldId = ReadShort(stream);
+            int fieldId = ReadUShort(stream);
             int fieldSize = ReadInt(stream);
 
             switch (fieldId)
@@ -124,11 +124,11 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
             string? methodName = null;
             TestMetadataProperty[] traits = [];
 
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -185,11 +185,11 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
         {
             string? key = null;
             string? value = null;
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -222,7 +222,7 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
 
         var discoveredTestMessages = (DiscoveredTestMessages)objectToSerialize;
 
-        WriteShort(stream, GetFieldCount(discoveredTestMessages));
+        WriteUShort(stream, GetFieldCount(discoveredTestMessages));
 
         WriteField(stream, DiscoveredTestMessagesFieldsId.ExecutionId, discoveredTestMessages.ExecutionId);
         WriteField(stream, DiscoveredTestMessagesFieldsId.InstanceId, discoveredTestMessages.InstanceId);
@@ -236,7 +236,7 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
             return;
         }
 
-        WriteShort(stream, DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList);
+        WriteUShort(stream, DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -246,7 +246,7 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
         WriteInt(stream, discoveredTestMessageList.Length);
         foreach (DiscoveredTestMessage discoveredTestMessage in discoveredTestMessageList)
         {
-            WriteShort(stream, GetFieldCount(discoveredTestMessage));
+            WriteUShort(stream, GetFieldCount(discoveredTestMessage));
 
             WriteField(stream, DiscoveredTestMessageFieldsId.Uid, discoveredTestMessage.Uid);
             WriteField(stream, DiscoveredTestMessageFieldsId.DisplayName, discoveredTestMessage.DisplayName);
@@ -271,7 +271,7 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
             return;
         }
 
-        WriteShort(stream, DiscoveredTestMessageFieldsId.Traits);
+        WriteUShort(stream, DiscoveredTestMessageFieldsId.Traits);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -281,7 +281,7 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
         WriteInt(stream, traits.Length);
         foreach (TestMetadataProperty trait in traits)
         {
-            WriteShort(stream, GetFieldCount(trait));
+            WriteUShort(stream, GetFieldCount(trait));
 
             WriteField(stream, TraitMessageFieldsId.Key, trait.Key);
             WriteField(stream, TraitMessageFieldsId.Value, trait.Value);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -58,11 +58,11 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         string? instanceId = null;
         List<FileArtifactMessage>? fileArtifactMessages = null;
 
-        ushort fieldCount = ReadShort(stream);
+        ushort fieldCount = ReadUShort(stream);
 
         for (int i = 0; i < fieldCount; i++)
         {
-            int fieldId = ReadShort(stream);
+            int fieldId = ReadUShort(stream);
             int fieldSize = ReadInt(stream);
 
             switch (fieldId)
@@ -98,11 +98,11 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         {
             string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null;
 
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -149,7 +149,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
 
         var fileArtifactMessages = (FileArtifactMessages)objectToSerialize;
 
-        WriteShort(stream, GetFieldCount(fileArtifactMessages));
+        WriteUShort(stream, GetFieldCount(fileArtifactMessages));
 
         WriteField(stream, FileArtifactMessagesFieldsId.ExecutionId, fileArtifactMessages.ExecutionId);
         WriteField(stream, FileArtifactMessagesFieldsId.InstanceId, fileArtifactMessages.InstanceId);
@@ -163,7 +163,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
             return;
         }
 
-        WriteShort(stream, FileArtifactMessagesFieldsId.FileArtifactMessageList);
+        WriteUShort(stream, FileArtifactMessagesFieldsId.FileArtifactMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -173,7 +173,7 @@ internal sealed class FileArtifactMessagesSerializer : BaseSerializer, INamedPip
         WriteInt(stream, fileArtifactMessageList.Length);
         foreach (FileArtifactMessage fileArtifactMessage in fileArtifactMessageList)
         {
-            WriteShort(stream, GetFieldCount(fileArtifactMessage));
+            WriteUShort(stream, GetFieldCount(fileArtifactMessage));
 
             WriteField(stream, FileArtifactMessageFieldsId.FullPath, fileArtifactMessage.FullPath);
             WriteField(stream, FileArtifactMessageFieldsId.DisplayName, fileArtifactMessage.DisplayName);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/HandshakeMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/HandshakeMessageSerializer.cs
@@ -13,7 +13,7 @@ internal sealed class HandshakeMessageSerializer : BaseSerializer, INamedPipeSer
     {
         Dictionary<byte, string> properties = [];
 
-        ushort fieldCount = ReadShort(stream);
+        ushort fieldCount = ReadUShort(stream);
 
         for (int i = 0; i < fieldCount; i++)
         {
@@ -34,7 +34,7 @@ internal sealed class HandshakeMessageSerializer : BaseSerializer, INamedPipeSer
             return;
         }
 
-        WriteShort(stream, (ushort)handshakeMessage.Properties.Count);
+        WriteUShort(stream, (ushort)handshakeMessage.Properties.Count);
         foreach ((byte key, string value) in handshakeMessage.Properties)
         {
             WriteField(stream, key);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -114,11 +114,11 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
         List<SuccessfulTestResultMessage>? successfulTestResultMessages = null;
         List<FailedTestResultMessage>? failedTestResultMessages = null;
 
-        ushort fieldCount = ReadShort(stream);
+        ushort fieldCount = ReadUShort(stream);
 
         for (int i = 0; i < fieldCount; i++)
         {
-            int fieldId = ReadShort(stream);
+            int fieldId = ReadUShort(stream);
             int fieldSize = ReadInt(stream);
 
             switch (fieldId)
@@ -164,11 +164,11 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
             byte? state = null;
             long? duration = null;
 
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -229,11 +229,11 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
             byte? state = null;
             long? duration = null;
 
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -293,7 +293,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
         int length = ReadInt(stream);
         for (int i = 0; i < length; i++)
         {
-            int fieldCount = ReadShort(stream);
+            int fieldCount = ReadUShort(stream);
 
             string? errorMessage = null;
             string? errorType = null;
@@ -301,7 +301,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
 
             for (int j = 0; j < fieldCount; j++)
             {
-                int fieldId = ReadShort(stream);
+                int fieldId = ReadUShort(stream);
                 int fieldSize = ReadInt(stream);
 
                 switch (fieldId)
@@ -332,7 +332,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
 
         var testResultMessages = (TestResultMessages)objectToSerialize;
 
-        WriteShort(stream, GetFieldCount(testResultMessages));
+        WriteUShort(stream, GetFieldCount(testResultMessages));
 
         WriteField(stream, TestResultMessagesFieldsId.ExecutionId, testResultMessages.ExecutionId);
         WriteField(stream, TestResultMessagesFieldsId.InstanceId, testResultMessages.InstanceId);
@@ -347,7 +347,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
             return;
         }
 
-        WriteShort(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList);
+        WriteUShort(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -357,7 +357,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
         WriteInt(stream, successfulTestResultMessages.Length);
         foreach (SuccessfulTestResultMessage successfulTestResultMessage in successfulTestResultMessages)
         {
-            WriteShort(stream, GetFieldCount(successfulTestResultMessage));
+            WriteUShort(stream, GetFieldCount(successfulTestResultMessage));
 
             WriteField(stream, SuccessfulTestResultMessageFieldsId.Uid, successfulTestResultMessage.Uid);
             WriteField(stream, SuccessfulTestResultMessageFieldsId.DisplayName, successfulTestResultMessage.DisplayName);
@@ -381,7 +381,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
             return;
         }
 
-        WriteShort(stream, TestResultMessagesFieldsId.FailedTestMessageList);
+        WriteUShort(stream, TestResultMessagesFieldsId.FailedTestMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -391,7 +391,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
         WriteInt(stream, failedTestResultMessages.Length);
         foreach (FailedTestResultMessage failedTestResultMessage in failedTestResultMessages)
         {
-            WriteShort(stream, GetFieldCount(failedTestResultMessage));
+            WriteUShort(stream, GetFieldCount(failedTestResultMessage));
 
             WriteField(stream, FailedTestResultMessageFieldsId.Uid, failedTestResultMessage.Uid);
             WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, failedTestResultMessage.DisplayName);
@@ -416,7 +416,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
             return;
         }
 
-        WriteShort(stream, FailedTestResultMessageFieldsId.ExceptionMessageList);
+        WriteUShort(stream, FailedTestResultMessageFieldsId.ExceptionMessageList);
 
         // We will reserve an int (4 bytes)
         // so that we fill the size later, once we write the payload
@@ -426,7 +426,7 @@ internal sealed class TestResultMessagesSerializer : BaseSerializer, INamedPipeS
         WriteInt(stream, exceptionMessages.Length);
         foreach (ExceptionMessage exceptionMessage in exceptionMessages)
         {
-            WriteShort(stream, GetFieldCount(exceptionMessage));
+            WriteUShort(stream, GetFieldCount(exceptionMessage));
 
             WriteField(stream, ExceptionMessageFieldsId.ErrorMessage, exceptionMessage.ErrorMessage);
             WriteField(stream, ExceptionMessageFieldsId.ErrorType, exceptionMessage.ErrorType);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestSessionEventSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestSessionEventSerializer.cs
@@ -31,11 +31,11 @@ internal sealed class TestSessionEventSerializer : BaseSerializer, INamedPipeSer
         string? sessionUid = null;
         string? executionId = null;
 
-        ushort fieldCount = ReadShort(stream);
+        ushort fieldCount = ReadUShort(stream);
 
         for (int i = 0; i < fieldCount; i++)
         {
-            ushort fieldId = ReadShort(stream);
+            ushort fieldId = ReadUShort(stream);
             int fieldSize = ReadInt(stream);
 
             switch (fieldId)
@@ -68,7 +68,7 @@ internal sealed class TestSessionEventSerializer : BaseSerializer, INamedPipeSer
 
         var testSessionEvent = (TestSessionEvent)objectToSerialize;
 
-        WriteShort(stream, GetFieldCount(testSessionEvent));
+        WriteUShort(stream, GetFieldCount(testSessionEvent));
 
         WriteField(stream, TestSessionEventFieldsId.SessionType, testSessionEvent.SessionType);
         WriteField(stream, TestSessionEventFieldsId.SessionUid, testSessionEvent.SessionUid);


### PR DESCRIPTION
This rename reflects the actual semantics of the method.
A similar change is needed on dotnet/sdk too.