### PR TITLE
Fix handshake serialization if properties dictionary is null or empty

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/HandshakeMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/HandshakeMessageSerializer.cs
@@ -29,12 +29,15 @@ internal sealed class HandshakeMessageSerializer : BaseSerializer, INamedPipeSer
 
         var handshakeMessage = (HandshakeMessage)objectToSerialize;
 
-        if (handshakeMessage.Properties is null || handshakeMessage.Properties.Count == 0)
+        // Deserializer always expected fieldCount to be present.
+        // We must write the count even if Properties is null or empty.
+        WriteShort(stream, (ushort)(handshakeMessage.Properties?.Count ?? 0));
+
+        if (handshakeMessage.Properties is null)
         {
             return;
         }
 
-        WriteShort(stream, (ushort)handshakeMessage.Properties.Count);
         foreach ((byte key, string value) in handshakeMessage.Properties)
         {
             WriteField(stream, key);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -69,4 +69,68 @@ public sealed class ProtocolTests
             }
         }
     }
+
+    [TestMethod]
+    public void HandshakeMessageWithProperties()
+    {
+        var message = new HandshakeMessage(new Dictionary<byte, string>
+        {
+            { 10, "Ten" },
+            { 35, "ThirtyFive" },
+            { 48, "FortyEight" },
+        });
+
+        var stream = new MemoryStream();
+        new HandshakeMessageSerializer().Serialize(message, stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        var actual = (HandshakeMessage)new HandshakeMessageSerializer().Deserialize(stream);
+
+        Assert.IsNotNull(actual.Properties);
+        Assert.IsNotNull(message.Properties);
+
+        Assert.HasCount(3, actual.Properties);
+        Assert.HasCount(3, message.Properties);
+
+        Assert.AreEqual("Ten", actual.Properties[10]);
+        Assert.AreEqual("Ten", message.Properties[10]);
+
+        Assert.AreEqual("ThirtyFive", actual.Properties[35]);
+        Assert.AreEqual("ThirtyFive", message.Properties[35]);
+
+        Assert.AreEqual("FortyEight", actual.Properties[48]);
+        Assert.AreEqual("FortyEight", message.Properties[48]);
+    }
+
+    [TestMethod]
+    public void HandshakeMessageWithEmptyProperties()
+    {
+        var message = new HandshakeMessage([]);
+
+        var stream = new MemoryStream();
+        new HandshakeMessageSerializer().Serialize(message, stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        var actual = (HandshakeMessage)new HandshakeMessageSerializer().Deserialize(stream);
+
+        Assert.IsNotNull(actual.Properties);
+        Assert.IsNotNull(message.Properties);
+
+        Assert.IsEmpty(actual.Properties);
+        Assert.IsEmpty(message.Properties);
+    }
+
+    [TestMethod]
+    public void HandshakeMessageWithNullProperties()
+    {
+        var message = new HandshakeMessage(null);
+
+        var stream = new MemoryStream();
+        new HandshakeMessageSerializer().Serialize(message, stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        var actual = (HandshakeMessage)new HandshakeMessageSerializer().Deserialize(stream);
+
+        Assert.IsNotNull(actual.Properties);
+        Assert.IsNull(message.Properties);
+
+        Assert.IsEmpty(actual.Properties);
+    }
 }


### PR DESCRIPTION
Today, the dictionary is never null or empty, so we can never encounter the bug.

However, let's keep the implementation correct in all cases.