### PR TITLE
Remove extra reference to MSTest.Analyzers

### DIFF
--- a/src/Package/MSTest/MSTest.csproj
+++ b/src/Package/MSTest/MSTest.csproj
@@ -46,7 +46,6 @@
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework.Extensions\TestFramework.Extensions.csproj" />
-    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.Package\MSTest.Analyzers.Package.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" Condition=" '$(TargetFramework)' != '$(UwpMinimum)' " />
 
     <!-- CodeCoverage 17.14 doesn't support netcoreapp3.1. -->


### PR DESCRIPTION
MSTest.TestFramework already brings MSTest.Analyzers. It's unnecessary to have this reference in the MSTest metapackage.