### PR TITLE
Fix broken official build

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/BrowserOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/BrowserOutputDevice.cs
@@ -151,7 +151,7 @@ internal sealed partial class BrowserOutputDevice : IPlatformOutputDevice,
 
             if (_platformInformation.BuildDate is { } buildDate)
             {
-                stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime.ToShortDateString()})");
+                stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime:d})");
             }
 
             if (_runtimeFeature.IsDynamicCodeSupported)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -234,7 +234,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
                     if (_platformInformation.BuildDate is { } buildDate)
                     {
-                        stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime.ToShortDateString()})");
+                        stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime:d})");
                     }
 
                     if (_runtimeFeature.IsDynamicCodeSupported)


### PR DESCRIPTION
```
##[error]src\Platform\Microsoft.Testing.Platform\OutputDevice\TerminalOutputDevice.cs(237,106): error IDE0071: (NETCORE_ENGINEERING_TELEMETRY=Build) Interpolation can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071)
##[error]src\Platform\Microsoft.Testing.Platform\OutputDevice\BrowserOutputDevice.cs(154,98): error IDE0071: (NETCORE_ENGINEERING_TELEMETRY=Build) Interpolation can be simplified (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0071)
```