### PR TITLE
Dump child process on hang

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpExtensions.cs
@@ -36,7 +36,6 @@ public static class HangDumpExtensions
                 serviceProvider.GetTask(),
                 serviceProvider.GetEnvironment(),
                 serviceProvider.GetLoggerFactory(),
-                serviceProvider.GetTestApplicationModuleInfo(),
                 serviceProvider.GetConfiguration(),
                 serviceProvider.GetProcessHandler(),
                 serviceProvider,

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -351,7 +351,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         await _outputDisplay.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.HangDumpTimeoutExpired, _activityTimerValue))).ConfigureAwait(false);
 
         IProcess process = _processHandler.GetProcessById(_testHostProcessInformation.PID);
-        var processTree = process.GetProcessTree().Where(p => p.Process?.Name is not null and not "conhost" and not "WerFault").ToList();
+        var processTree = process.GetProcessTree(_logger).Where(p => p.Process?.Name is not null and not "conhost" and not "WerFault").ToList();
         IEnumerable<IProcess> bottomUpTree = processTree.OrderByDescending(t => t.Level).Select(t => t.Process).OfType<IProcess>();
 
         try
@@ -367,7 +367,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
             }
             else
             {
-                await _outputDisplay.DisplayAsync(this, new ErrorMessageOutputDeviceData($"Blame: Dumping {process.Id} - {process.Name}")).ConfigureAwait(false);
+                await _outputDisplay.DisplayAsync(this, new ErrorMessageOutputDeviceData($"Dumping {process.Id} - {process.Name}")).ConfigureAwait(false);
             }
 
             await _logger.LogInformationAsync($"Hang dump timeout({_activityTimerValue}) expired.").ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -485,7 +485,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
 
         try
         {
-            diagnosticsClient.WriteDump(dumpType, finalDumpFileName, logDumpGeneration: true);
+            diagnosticsClient.WriteDump(dumpType, finalDumpFileName, logDumpGeneration: false);
         }
         catch (Exception e)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -351,7 +351,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         await _outputDisplay.DisplayAsync(new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.HangDumpTimeoutExpired, _activityTimerValue))).ConfigureAwait(false);
 
         IProcess process = _processHandler.GetProcessById(_testHostProcessInformation.PID);
-        var processTree = process.GetProcessTree(_logger, _outputDisplay).Where(p => p.Process?.Name is not null and not "conhost" and not "WerFault").ToList();
+        var processTree = (await process.GetProcessTreeAsync(_logger, _outputDisplay).ConfigureAwait(false)).Where(p => p.Process?.Name is not null and not "conhost" and not "WerFault").ToList();
         IEnumerable<IProcess> bottomUpTree = processTree.OrderByDescending(t => t.Level).Select(t => t.Process).OfType<IProcess>();
 
         try

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -67,7 +67,6 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         ITask task,
         IEnvironment environment,
         ILoggerFactory loggerFactory,
-        ITestApplicationModuleInfo testApplicationModuleInfo,
         IConfiguration configuration,
         IProcessHandler processHandler,
         IServiceProvider serviceProvider,
@@ -351,7 +350,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         await _logger.LogInformationAsync($"Hang dump timeout({_activityTimerValue}) expired.").ConfigureAwait(false);
         await _outputDisplay.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.HangDumpTimeoutExpired, _activityTimerValue))).ConfigureAwait(false);
 
-        IProcess process = new SystemProcess(Process.GetProcessById(_testHostProcessInformation.PID));
+        IProcess process = _processHandler.GetProcessById(_testHostProcessInformation.PID);
         var processTree = process.GetProcessTree().Where(p => p.Process?.Name is not null and not "conhost" and not "WerFault").ToList();
         IEnumerable<IProcess> bottomUpTree = processTree.OrderByDescending(t => t.Level).Select(t => t.Process).OfType<IProcess>();
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/Class1.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/Class1.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Extensions.Diagnostics.Helpers;
+
+/// <summary>
+/// Helper functions for process info.
+/// </summary>
+internal static class ProcessCodeMethods
+{
+    private const int InvalidProcessId = -1;
+
+    public static List<ProcessTreeNode> GetProcessTree(this IProcess process)
+    {
+        var childProcesses = Process.GetProcesses()
+            .Where(p => IsChildCandidate(p, process))
+            .ToList();
+
+        var acc = new List<ProcessTreeNode>();
+        foreach (Process c in childProcesses)
+        {
+            try
+            {
+                int parentId = GetParentPid(c);
+
+                // c.ParentId = parentId;
+                acc.Add(new ProcessTreeNode { ParentId = parentId, Process = new SystemProcess(c) });
+            }
+            catch
+            {
+                // many things can go wrong with this
+                // just ignore errors
+            }
+        }
+
+        int level = 1;
+        int limit = 10;
+        ResolveChildren(process, acc, level, limit);
+
+        return [new() { Process = process, Level = 0 }, .. acc.Where(a => a.Level > 0)];
+    }
+
+    /// <summary>
+    /// Returns the parent id of a process or -1 if it fails.
+    /// </summary>
+    /// <param name="process">The process to find parent of.</param>
+    /// <returns>The pid of the parent process.</returns>
+    internal static int GetParentPid(Process process)
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? GetParentPidWindows(process)
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                ? GetParentPidLinux(process)
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                    GetParentPidMacOs(process)
+                    : throw new PlatformNotSupportedException();
+
+    internal static int GetParentPidWindows(Process process)
+    {
+        try
+        {
+            IntPtr handle = process.Handle;
+            int res = NtQueryInformationProcess(handle, 0, out var pbi, Marshal.SizeOf<ProcessBasicInformation>(), out int size);
+
+            int p = res != 0 ? InvalidProcessId : pbi.InheritedFromUniqueProcessId.ToInt32();
+
+            return p;
+        }
+        catch (Exception ex)
+        {
+            // EqtTrace.Verbose($"ProcessCodeMethods.GetParentPidLinux: Error getting parent of process {process.Id} - {process.ProcessName}, {ex}.");
+            return InvalidProcessId;
+        }
+    }
+
+    /// <summary>Read the /proc file system for information about the parent.</summary>
+    /// <param name="process">The process to get the parent process from.</param>
+    /// <returns>The process id.</returns>
+    internal static int GetParentPidLinux(Process process)
+    {
+        int pid = process.Id;
+
+        // read /proc/<pid>/stat
+        // 4th column will contain the ppid, 92 in the example below
+        // ex: 93 (bash) S 92 93 2 4294967295 ...
+        string path = $"/proc/{pid}/stat";
+        try
+        {
+            string stat = File.ReadAllText(path);
+            string[] parts = stat.Split(' ');
+
+            return parts.Length < 5 ? InvalidProcessId : int.Parse(parts[3], CultureInfo.CurrentCulture);
+        }
+        catch (Exception ex)
+        {
+            // EqtTrace.Verbose($"ProcessCodeMethods.GetParentPidLinux: Error getting parent of process {process.Id} - {process.ProcessName}, {ex}.");
+            return InvalidProcessId;
+        }
+    }
+
+    internal static int GetParentPidMacOs(Process process)
+    {
+        try
+        {
+            var output = new StringBuilder();
+            var err = new StringBuilder();
+            Process ps = new();
+            ps.StartInfo.FileName = "ps";
+            ps.StartInfo.Arguments = $"-o ppid= {process.Id}";
+            ps.StartInfo.UseShellExecute = false;
+            ps.StartInfo.RedirectStandardOutput = true;
+            ps.OutputDataReceived += (_, e) => output.Append(e.Data);
+            ps.ErrorDataReceived += (_, e) => err.Append(e.Data);
+            ps.Start();
+            ps.BeginOutputReadLine();
+            ps.WaitForExit(5_000);
+
+            string o = output.ToString();
+            int parent = int.TryParse(o.Trim(), out int ppid) ? ppid : InvalidProcessId;
+
+            if (err.ToString() is string error && !RoslynString.IsNullOrWhiteSpace(error))
+            {
+                // EqtTrace.Verbose($"ProcessCodeMethods.GetParentPidMacOs: Error getting parent of process {process.Id} - {process.ProcessName}, {error}.");
+            }
+
+            return parent;
+        }
+        catch (Exception ex)
+        {
+            // EqtTrace.Verbose($"ProcessCodeMethods.GetParentPidMacOs: Error getting parent of process {process.Id} - {process.ProcessName}, {ex}.");
+            return InvalidProcessId;
+        }
+    }
+
+    private static void ResolveChildren(IProcess parent, List<ProcessTreeNode> acc, int level, int limit)
+    {
+        if (limit < 0)
+        {
+            // hit recursion limit, just returning
+            return;
+        }
+
+        // only take children that are newer than the parent, because process ids (PIDs) get recycled
+        var children = acc.Where(p => p.ParentId == parent.Id && p.Process?.StartTime > parent.StartTime).ToList();
+
+        foreach (ProcessTreeNode child in children)
+        {
+            child.Level = level;
+            ResolveChildren(child.Process!, acc, level + 1, limit);
+        }
+    }
+
+    private static bool IsChildCandidate(Process child, IProcess parent)
+    {
+        // this is extremely slow under debugger, but fast without it
+        try
+        {
+            return child.StartTime > parent.StartTime && child.Id != parent.Id;
+        }
+        catch
+        {
+            /* access denied or process has exits most likely */
+            return false;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcessBasicInformation
+    {
+        public readonly IntPtr ExitStatus;
+        public readonly IntPtr PebBaseAddress;
+        public readonly IntPtr AffinityMask;
+        public readonly IntPtr BasePriority;
+        public readonly IntPtr UniqueProcessId;
+        public IntPtr InheritedFromUniqueProcessId;
+    }
+
+    [DllImport("ntdll.dll", SetLastError = true)]
+    private static extern int NtQueryInformationProcess(
+        IntPtr processHandle,
+        int processInformationClass,
+        out ProcessBasicInformation processInformation,
+        int processInformationLength,
+        out int returnLength);
+}
+
+internal class ProcessTreeNode
+{
+    public IProcess? Process { get; set; }
+
+    public int Level { get; set; }
+
+    public int ParentId { get; set; }
+
+    public Process? ParentProcess { get; set; }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -30,10 +30,9 @@ internal static class IProcessExtensions
                 // c.ParentId = parentId;
                 acc.Add(new ProcessTreeNode { ParentId = parentId, Process = new SystemProcess(c) });
             }
-            catch
+            catch (Exception e)
             {
-                // many things can go wrong with this
-                // just ignore errors
+                logger.LogError($"Failed to get parent for process {c.Id} - {c.ProcessName}", e);
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -97,14 +97,18 @@ internal static class IProcessExtensions
         ps.StartInfo.Arguments = $"-o ppid= {process.Id}";
         ps.StartInfo.UseShellExecute = false;
         ps.StartInfo.RedirectStandardOutput = true;
+        ps.StartInfo.RedirectStandardError = true;
         ps.OutputDataReceived += (_, e) => output.Append(e.Data);
         ps.ErrorDataReceived += (_, e) => err.Append(e.Data);
         ps.Start();
         ps.BeginOutputReadLine();
+        ps.BeginErrorReadLine();
         ps.WaitForExit(5_000);
 
         string o = output.ToString();
-        outputDisplay.DisplayAsync(new WarningMessageOutputDeviceData($"ps output: {o}")).Wait();
+        string e = err.ToString();
+        outputDisplay.DisplayAsync(new WarningMessageOutputDeviceData($"parent of {process.Id} - {process.ProcessName}  ps output: {o}")).Wait();
+        outputDisplay.DisplayAsync(new WarningMessageOutputDeviceData($"ps err: {e}")).Wait();
         int parent = int.TryParse(o.Trim(), out int ppid) ? ppid : InvalidProcessId;
 
         if (err.ToString() is string error && !RoslynString.IsNullOrWhiteSpace(error))

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -50,7 +50,7 @@ internal static class IProcessExtensions
     /// </summary>
     /// <param name="process">The process to find parent of.</param>
     /// <param name="logger">The logger.</param>
-    /// <param name="outputDisplay">The output display.git </param>
+    /// <param name="outputDisplay">The output display.git.</param>
     /// <returns>The pid of the parent process.</returns>
     internal static int GetParentPid(Process process, ILogger logger, OutputDeviceWriter outputDisplay)
         => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Extensions.Diagnostics.Resources;
 using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
@@ -121,14 +122,13 @@ internal static class IProcessExtensions
 
         string o = output.ToString();
         string e = err.ToString();
-        await outputDisplay.DisplayAsync(new WarningMessageOutputDeviceData($"parent of {process.Id} - {process.ProcessName}  ps output: {o}")).ConfigureAwait(false);
-        await outputDisplay.DisplayAsync(new WarningMessageOutputDeviceData($"ps err: {e}")).ConfigureAwait(false);
+
         int parent = int.TryParse(o.Trim(), out int ppid) ? ppid : InvalidProcessId;
 
         if (err.ToString() is string error && !RoslynString.IsNullOrWhiteSpace(error))
         {
             logger.LogError($"Error getting parent of process {process.Id} - {process.ProcessName}, {error}.");
-            await outputDisplay.DisplayAsync(new ErrorMessageOutputDeviceData($"Error getting parent of process {process.Id} - {process.ProcessName}, {error}.")).ConfigureAwait(false);
+            await outputDisplay.DisplayAsync(new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.ErrorGettingParentOfProcess, process.Id, process.ProcessName, error))).ConfigureAwait(false);
         }
 
         return parent;

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -50,7 +50,7 @@ internal static class IProcessExtensions
     /// </summary>
     /// <param name="process">The process to find parent of.</param>
     /// <param name="logger">The logger.</param>
-    /// <param name="outputDisplay">The output display.</param>
+    /// <param name="outputDisplay">The output display.git </param>
     /// <returns>The pid of the parent process.</returns>
     internal static int GetParentPid(Process process, ILogger logger, OutputDeviceWriter outputDisplay)
         => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -104,6 +104,7 @@ internal static class IProcessExtensions
         ps.WaitForExit(5_000);
 
         string o = output.ToString();
+        outputDisplay.DisplayAsync(new WarningMessageOutputDeviceData($"ps output: {o}")).Wait();
         int parent = int.TryParse(o.Trim(), out int ppid) ? ppid : InvalidProcessId;
 
         if (err.ToString() is string error && !RoslynString.IsNullOrWhiteSpace(error))

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/ProcessTreeNode.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/ProcessTreeNode.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Extensions.Diagnostics.Helpers;
+
+internal sealed class ProcessTreeNode
+{
+    public IProcess? Process { get; set; }
+
+    public int Level { get; set; }
+
+    public int ParentId { get; set; }
+
+    public Process? ParentProcess { get; set; }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/ExtensionResources.resx
@@ -120,6 +120,25 @@
   <data name="CreatingDumpFile" xml:space="preserve">
     <value>Creating dump file '{0}'</value>
   </data>
+  <data name="DumpingProcess" xml:space="preserve">
+    <value>Dumping process {0} - {1}</value>
+    <comment>0 is pid, 1 is the name of the process</comment>
+  </data>
+  <data name="DumpingProcessTree" xml:space="preserve">
+    <value>Dumping this process tree (from bottom):</value>
+  </data>
+  <data name="ErrorGettingParentOfProcess" xml:space="preserve">
+    <value>Error getting parent of process {0} - {1}: {2}"</value>
+    <comment>0 is pid, 1 is name, 2 is the exception</comment>
+  </data>
+  <data name="ErrorKillingProcess" xml:space="preserve">
+    <value>Error while killing process {0} - {1}: {2}</value>
+    <comment>0 is pid, 1 is name, 2 is the exception</comment>
+  </data>
+  <data name="ErrorWhileDumpingProcess" xml:space="preserve">
+    <value>Error while taking dump of process {0} - {1}: {2}</value>
+    <comment>0 is pid, 1 is name, 2 is the exception from the system</comment>
+  </data>
   <data name="HangDumpArtifactDescription" xml:space="preserve">
     <value>The hang dump file</value>
   </data>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.cs.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Vytváří se soubor výpisu paměti {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Soubor výpisu paměti při zablokování</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.de.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Speicherabbilddatei "{0}" wird erstellt</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Die Absturzspeicherabbilddatei</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.es.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Creando archivo de volcado '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">El archivo de volcado de memoria</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.fr.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Création du fichier de vidage «{0}»</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Fichier de vidage de blocage</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.it.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Creazione del file di dump '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Il file di dump di blocco</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ja.xlf
@@ -7,6 +7,31 @@
         <target state="translated">ダンプ ファイル '{0}' を作成しています</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">ハング ダンプ ファイル</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ko.xlf
@@ -7,6 +7,31 @@
         <target state="translated">덤프 파일 '{0}'을(를) 만드는 중</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">중단 덤프 파일</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pl.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Tworzenie pliku zrzutu „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Plik zrzutu zawieszenia</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Criando arquivo de despejo ''{0}''</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">O arquivo de despejo de travamento</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.ru.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Создание файла дампа "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Файл дампа зависания</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.tr.xlf
@@ -7,6 +7,31 @@
         <target state="translated">Döküm dosyası '{0}' oluşturuluyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">Askıda kalma dökümü dosyası</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -7,6 +7,31 @@
         <target state="translated">正在创建转储文件“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">挂起转储文件</target>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -7,6 +7,31 @@
         <target state="translated">正在建立傾印檔案 '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DumpingProcess">
+        <source>Dumping process {0} - {1}</source>
+        <target state="new">Dumping process {0} - {1}</target>
+        <note>0 is pid, 1 is the name of the process</note>
+      </trans-unit>
+      <trans-unit id="DumpingProcessTree">
+        <source>Dumping this process tree (from bottom):</source>
+        <target state="new">Dumping this process tree (from bottom):</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorGettingParentOfProcess">
+        <source>Error getting parent of process {0} - {1}: {2}"</source>
+        <target state="new">Error getting parent of process {0} - {1}: {2}"</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorKillingProcess">
+        <source>Error while killing process {0} - {1}: {2}</source>
+        <target state="new">Error while killing process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception</note>
+      </trans-unit>
+      <trans-unit id="ErrorWhileDumpingProcess">
+        <source>Error while taking dump of process {0} - {1}: {2}</source>
+        <target state="new">Error while taking dump of process {0} - {1}: {2}</target>
+        <note>0 is pid, 1 is name, 2 is the exception from the system</note>
+      </trans-unit>
       <trans-unit id="HangDumpArtifactDescription">
         <source>The hang dump file</source>
         <target state="translated">擱置傾印檔案</target>

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
@@ -33,6 +33,14 @@ internal interface IProcess : IDisposable
     /// <inheritdoc cref="Process.WaitForExit()" />
     void WaitForExit();
 
-    /// <inheritdoc cref="Process.Kill()" />
+    /// <summary>
+    /// Kills the process and its child processes.
+    /// </summary>
     void Kill();
+
+
+    /// <summary>
+    /// Kills the process without killing its child processes.
+    /// </summary>
+    void KillWithoutKillingChildProcesses();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
@@ -38,7 +38,6 @@ internal interface IProcess : IDisposable
     /// </summary>
     void Kill();
 
-
     /// <summary>
     /// Kills the process without killing its child processes.
     /// </summary>

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
@@ -34,12 +34,7 @@ internal interface IProcess : IDisposable
     void WaitForExit();
 
     /// <summary>
-    /// Kills the process and its child processes.
+    /// Kills the process and try to kill all child processes.
     /// </summary>
     void Kill();
-
-    /// <summary>
-    /// Kills the process without killing its child processes.
-    /// </summary>
-    void KillWithoutKillingChildProcesses();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IProcess.cs
@@ -22,6 +22,9 @@ internal interface IProcess : IDisposable
     /// <inheritdoc cref="Process.MainModule" />
     IMainModule? MainModule { get; }
 
+    /// <inheritdoc cref="Process.StartTime" />
+    DateTime StartTime { get; }
+
     /// <summary>
     /// Instructs the Process component to wait for the associated process to exit, or for the cancellationToken to be canceled.
     /// </summary>

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
@@ -24,6 +24,8 @@ internal sealed class SystemProcess : IProcess, IDisposable
 
     public int ExitCode => _process.ExitCode;
 
+    public DateTime StartTime => _process.StartTime;
+
     public IMainModule? MainModule
         => _process.MainModule is null
             ? null
@@ -38,6 +40,9 @@ internal sealed class SystemProcess : IProcess, IDisposable
     public Task WaitForExitAsync()
         => _process.WaitForExitAsync();
 
+    /// <summary>
+    /// Kills the process and all child processes.
+    /// </summary>
     public void Kill()
         => _process.Kill(true);
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
@@ -40,14 +40,8 @@ internal sealed class SystemProcess : IProcess, IDisposable
     public Task WaitForExitAsync()
         => _process.WaitForExitAsync();
 
-    /// <summary>
-    /// Kills the process and all child processes.
-    /// </summary>
     public void Kill()
         => _process.Kill(entireProcessTree: true);
-
-    public void KillWithoutKillingChildProcesses()
-        => _process.Kill(entireProcessTree: false);
 
     public void Dispose() => _process.Dispose();
 #pragma warning restore CA1416

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcess.cs
@@ -44,7 +44,10 @@ internal sealed class SystemProcess : IProcess, IDisposable
     /// Kills the process and all child processes.
     /// </summary>
     public void Kill()
-        => _process.Kill(true);
+        => _process.Kill(entireProcessTree: true);
+
+    public void KillWithoutKillingChildProcesses()
+        => _process.Kill(entireProcessTree: false);
 
     public void Dispose() => _process.Dispose();
 #pragma warning restore CA1416

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -22,7 +22,7 @@ public sealed class HangDumpProcessTreeTests : AcceptanceTestBase<HangDumpProces
             cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
-        Assert.HasCount(48, dumpFiles, $"There should be 4 dumps, one for each process in the tree. {testHostResult}");
+        Assert.HasCount(4, dumpFiles, $"There should be 4 dumps, one for each process in the tree. {testHostResult}");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase(AcceptanceFixture.NuGetGlobalPackagesFolder)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -13,7 +13,7 @@ public sealed class HangDumpProcessTreeTests : AcceptanceTestBase<HangDumpProces
         string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"), tfm);
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "HangDumpWithChild", tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
-            $"--hangdump --hangdump-timeout 8s --results-directory {resultDirectory}",
+            $"--hangdump --hangdump-timeout 8s --hangdump-type mini --results-directory {resultDirectory}",
             new Dictionary<string, string?>
             {
                         { "SLEEPTIMEMS1", "4000" },

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class HangDumpProcessTreeTests : AcceptanceTestBase<HangDumpProcessTreeTests.TestAssetFixture>
+{
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task HangDump_DumpAllChildProcesses_CreateDump(string tfm)
+    {
+        string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"), tfm);
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "HangDumpWithChild", tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--hangdump --hangdump-timeout 8s --results-directory {resultDirectory}",
+            new Dictionary<string, string?>
+            {
+                        { "SLEEPTIMEMS1", "4000" },
+                        { "SLEEPTIMEMS2", "600000" },
+            },
+            cancellationToken: TestContext.CancellationToken);
+        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
+        Assert.HasCount(4, dumpFiles, "There should be 4 dumps, one for each process in the tree.");
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase(AcceptanceFixture.NuGetGlobalPackagesFolder)
+    {
+        private const string AssetName = "AssetFixture";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override IEnumerable<(string ID, string Name, string Code)> GetAssetsToGenerate()
+        {
+            yield return (AssetName, AssetName,
+                Sources
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+        }
+
+        private const string Sources = """
+#file HangDumpWithChild.csproj
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>true</UseAppHost>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$MicrosoftTestingPlatformVersion$" />
+  </ItemGroup>
+</Project>
+
+#file Program.cs
+using System;
+using System.Linq;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Globalization;
+using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Requests;
+using Microsoft.Testing.Platform.Services;
+
+public class Startup
+{
+    public static async Task<int> Main(string[] args)
+    {
+        Process self = Process.GetCurrentProcess();
+        string path = self.MainModule!.FileName!;
+
+        if (args[0] == "--child")
+        {
+            int child = int.Parse(args[1], CultureInfo.InvariantCulture);
+
+            if (child != 0)
+            {
+                var process = Process.Start(new ProcessStartInfo(path, $"--child {child - 1}")
+                {
+                    UseShellExecute = false,
+                });
+
+                // Wait for the child to exit, to make sure we dumping the process in order that will
+                // end up with multiple dumps. Because typically the parent starts the child and waits for it.
+                process!.WaitForExit();
+                return 0;
+            }
+            else
+            {        
+                // Just sleep for a long time.
+                Thread.Sleep(25_000);
+                return 0;
+            }
+        }
+
+        // We are running under testhost controller, don't start extra processes when we are the controller.
+        if (args.Any(a => a == "--internal-testhostcontroller-pid"))
+        {
+
+            Process.Start(new ProcessStartInfo(path, $"--child 2")
+            {
+                UseShellExecute = false,
+            });
+        }
+
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_,__) => new DummyTestFramework());
+        builder.AddHangDumpProvider();
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public class DummyTestFramework : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DummyTestFramework);
+
+    public string Version => "2.0.0";
+
+    public string DisplayName => nameof(DummyTestFramework);
+
+    public string Description => nameof(DummyTestFramework);
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+
+        Thread.Sleep(int.Parse(Environment.GetEnvironmentVariable("SLEEPTIMEMS1")!, CultureInfo.InvariantCulture));
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Test1",
+            DisplayName = "Test1",
+            Properties = new PropertyBag(new PassedTestNodeStateProperty()),
+        }));
+
+        Thread.Sleep(int.Parse(Environment.GetEnvironmentVariable("SLEEPTIMEMS2")!, CultureInfo.InvariantCulture));
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Test2",
+            DisplayName = "Test2",
+            Properties = new PropertyBag(new PassedTestNodeStateProperty()),
+        }));
+
+        context.Complete();
+    }
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -22,7 +22,7 @@ public sealed class HangDumpProcessTreeTests : AcceptanceTestBase<HangDumpProces
             cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
-        Assert.HasCount(4, dumpFiles, "There should be 4 dumps, one for each process in the tree.");
+        Assert.HasCount(48, dumpFiles, $"There should be 4 dumps, one for each process in the tree. {testHostResult}");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase(AcceptanceFixture.NuGetGlobalPackagesFolder)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -98,7 +99,7 @@ public class Startup
             else
             {        
                 // Just sleep for a long time.
-                Thread.Sleep(25_000);
+                Thread.Sleep(600_000);
                 return 0;
             }
         }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -1,5 +1,4 @@
-﻿
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -98,7 +98,7 @@ public class Startup
             else
             {        
                 // Just sleep for a long time.
-                Thread.Sleep(600_000);
+                Thread.Sleep(3_600_000);
                 return 0;
             }
         }


### PR DESCRIPTION
Collect tree of processes and dump them from the bottom up, skipping werFault (dump reporter on windows) and conhost (console host on windows). 

Report all dumps that were collected, together with the tree of processes that we will dump.

Reduce verbosity of the dumper, to not show thousands of lines per dump, seeing memory addresses etc. is not usually useful, and makes it really hard to see what actually happened when stuff goes wrong, e.g. when the process completes after the hang timeout, and so we cannot dump it anymore. (We cannot suspend the processes while dumping them - on .net core dumper it prevents the dumper from working, on .net framework, we don't have documented api to do this, and so we get flagged by compliance).

The way dumps are created depends on the testhost process, if it is .NET it will use the .NET dumper and will assume all the children are .NET.

If it if .NET Framework it will use windows minidump and will try to dump all children using that. Limitation of windows minidump is that it can only produce usable dumps when the dumping process (testhost controller) is the same architecture as the dumped process (testhost). In other cases it will produce a dump that is not usable, and we cannot work around it without shipping additional executables, which would broke the premise of MTP, that all stuff is done via the same process.

Fix https://github.com/microsoft/testfx/issues/4187