### PR TITLE
[rel/4.0] Fix MSTest.Sdk bug for setting TestingPlatformDotnetTestSupport

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Runner/Common.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/Common.targets
@@ -10,8 +10,8 @@
   <PropertyGroup Condition=" '$(IsTestApplication)' == 'true' ">
     <OutputType>Exe</OutputType>
     <_SdkMajorVersion>$(NETCoreSdkVersion.Split('.')[0])</_SdkMajorVersion>
-    <_SupportsDotnetConfig Condition="'$(NETCoreSdkVersion)' != '' AND '$(_SdkMajorVersion)' >= '10'">true</_SupportsDotnetConfig>
-    <TestingPlatformDotnetTestSupport Condition=" '$(TestingPlatformDotnetTestSupport)' == '' AND '$(_SupportsDotnetConfig)' == 'true' ">true</TestingPlatformDotnetTestSupport>
+    <_SupportsGlobalJsonTestRunner Condition="'$(NETCoreSdkVersion)' != '' AND '$(_SdkMajorVersion)' >= '10'">true</_SupportsGlobalJsonTestRunner>
+    <TestingPlatformDotnetTestSupport Condition=" '$(TestingPlatformDotnetTestSupport)' == '' AND '$(_SupportsGlobalJsonTestRunner)' != 'true' ">true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <Target Name="_MSTestSDKValidateTestingExtensionsProfile" BeforeTargets="Build">

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -257,11 +257,11 @@
   <Target Name="_MTPBeforeVSTest" BeforeTargets="VSTest">
     <PropertyGroup>
       <_SdkMajorVersion>$(NETCoreSdkVersion.Split('.')[0])</_SdkMajorVersion>
-      <_SupportsDotnetConfig Condition="'$(NETCoreSdkVersion)' != '' AND '$(_SdkMajorVersion)' >= '10'">true</_SupportsDotnetConfig>
+      <_SupportsGlobalJsonTestRunner Condition="'$(NETCoreSdkVersion)' != '' AND '$(_SdkMajorVersion)' >= '10'">true</_SupportsGlobalJsonTestRunner>
     </PropertyGroup>
 
     <Error Text="Testing with VSTest target is no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and later. If you use dotnet test, you should opt-in to the new dotnet test experience. For more information, see https://aka.ms/dotnet-test-mtp-error"
-           Condition="'$(IsTestingPlatformApplication)'=='true' AND '$(TargetFramework)'!='' AND '$(_SupportsDotnetConfig)'=='true'" />
+           Condition="'$(IsTestingPlatformApplication)'=='true' AND '$(TargetFramework)'!='' AND '$(_SupportsGlobalJsonTestRunner)'=='true'" />
 
     <CallTarget Condition="'$(VSTestNoBuild)' != 'true' AND '$(TargetFramework)'!=''" Targets="BuildProject" />
 


### PR DESCRIPTION
- nit: rename `_SupportsDotnetConfig` to `_SupportsGlobalJsonTestRunner`
- Bug fix: `TestingPlatformDotnetTestSupport` should be set to true if **not** .NET 10. The condition was reversed.