### PR TITLE
Fix Assert.Contains/DoesNotContain regression in v4 for collections with custom comparers

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -188,7 +188,13 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(T expected, IEnumerable<T> collection, string message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => Contains(expected, collection, EqualityComparer<T>.Default, message, expectedExpression, collectionExpression);
+    {
+        if (!collection.Contains(expected))
+        {
+            string userMessage = BuildUserMessageForExpectedExpressionAndCollectionExpression(message, expectedExpression, collectionExpression);
+            ThrowAssertContainsItemFailed(userMessage);
+        }
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -335,7 +341,13 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(T expected, IEnumerable<T> collection, string message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => DoesNotContain(expected, collection, EqualityComparer<T>.Default, message, expectedExpression, collectionExpression);
+    {
+        if (collection.Contains(expected))
+        {
+            string userMessage = BuildUserMessageForExpectedExpressionAndCollectionExpression(message, expectedExpression, collectionExpression);
+            ThrowAssertDoesNotContainItemFailed(userMessage);
+        }
+    }
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
@@ -443,6 +443,16 @@ public partial class AssertTests : TestContainer
         action.Should().Throw<AssertFailedException>().WithMessage("*lazy*");
     }
 
+    public void Contains_HashSetWithCustomComparer_ItemExists_DoesNotThrow()
+    {
+        var collection = new HashSet<string>(AlwaysTrueEqualityComparer.Instance) { "1" };
+
+        // This call shouldn't use EqualityComparer<string>.Default.
+        Action action = () => Assert.Contains("2", collection);
+        action.Should().NotThrow<AssertFailedException>();
+        action();
+    }
+
     #endregion
 
     #region DoesNotContain Tests
@@ -876,9 +886,45 @@ public partial class AssertTests : TestContainer
         action.Should().Throw<AssertFailedException>().WithMessage("*Expected no items to match the predicate*");
     }
 
+    public void DoesNotContains_HashSetWithCustomComparer_ItemDoesNotExist_DoesNotThrow()
+    {
+        var collection = new HashSet<string>(AlwaysFalseEqualityComparer.Instance) { "1" };
+
+        // This call shouldn't use EqualityComparer<string>.Default.
+        Action action = () => Assert.DoesNotContain("1", collection);
+        action.Should().NotThrow<AssertFailedException>();
+        action();
+    }
+
     #endregion
 
     private record Person(string Name, int Age);
+
+    private sealed class AlwaysTrueEqualityComparer : IEqualityComparer<string>
+    {
+        private AlwaysTrueEqualityComparer()
+        {
+        }
+
+        public static AlwaysTrueEqualityComparer Instance { get; } = new();
+
+        public bool Equals(string? x, string? y) => true;
+
+        public int GetHashCode([DisallowNull] string obj) => 0;
+    }
+
+    private sealed class AlwaysFalseEqualityComparer : IEqualityComparer<string>
+    {
+        private AlwaysFalseEqualityComparer()
+        {
+        }
+
+        public static AlwaysFalseEqualityComparer Instance { get; } = new();
+
+        public bool Equals(string? x, string? y) => false;
+
+        public int GetHashCode([DisallowNull] string obj) => 0;
+    }
 
     #endregion
 }


### PR DESCRIPTION
This worked correctly in 3.10 and was broken with some refactorings in rel/4.0 branch.