### PR TITLE
Add requires to script to make it work constistently

### DIFF
--- a/eng/mark-shipped.ps1
+++ b/eng/mark-shipped.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7.0
+
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 


### PR DESCRIPTION
Utf8 encoding means utf8 with BOM in the old windows powershell, modern powershell makes that mean utf8 without BOM.

Require powershell 7 to run the script.