### PR TITLE
A bit of TestContextImplementation cleanup

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -98,20 +98,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// <param name="properties">Properties/configuration passed in.</param>
     /// <param name="messageLogger">The message logger to use.</param>
     /// <param name="testRunCancellationToken">The global test run cancellation token.</param>
-    internal TestContextImplementation(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, TestRunCancellationToken? testRunCancellationToken)
-        : this(testMethod, testClassFullName, properties)
-    {
-        _messageLogger = messageLogger;
-        _cancellationTokenRegistration = testRunCancellationToken?.Register(CancelDelegate, this);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TestContextImplementation"/> class.
-    /// </summary>
-    /// <param name="testMethod">The test method.</param>
-    /// <param name="testClassFullName">The test class full name.</param>
-    /// <param name="properties">Properties/configuration passed in.</param>
-    internal TestContextImplementation(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties)
+    internal TestContextImplementation(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger? messageLogger, TestRunCancellationToken? testRunCancellationToken)
     {
         // testMethod can be null when running ForceCleanup (done when reaching --maximum-failed-tests.
         DebugEx.Assert(properties != null, "properties is not null");
@@ -139,6 +126,9 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
                 _properties.Add(TestNameLabel, testMethod.Name);
             }
         }
+
+        _messageLogger = messageLogger;
+        _cancellationTokenRegistration = testRunCancellationToken?.Register(CancelDelegate, this);
     }
 
     internal static TestContextImplementation? CurrentTestContext => CurrentTestContextAsyncLocal.Value;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
@@ -310,7 +310,7 @@ public class TestAssemblyInfoTests : TestContainer
     }
 
     private static TestContextImplementation GetTestContext()
-        => new(null, null, new Dictionary<string, object?>());
+        => new(null, null, new Dictionary<string, object?>(), null, null);
 
     #endregion
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
@@ -125,6 +125,9 @@ public class TestClassInfoTests : TestContainer
         VerifyThrows<TypeInspectionException>(Action);
     }
 
+    private static TestContextImplementation CreateDummyTestContextImplementation()
+        => new(null, null, new Dictionary<string, object?>(), null, null);
+
     public async Task TestClassInfoClassCleanupMethodShouldNotInvokeWhenNoTestClassInitializedIsCalled()
     {
         int classCleanupCallCount = 0;
@@ -133,7 +136,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod")!;
         _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod")!;
 
-        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>())); // call cleanup without calling init
+        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation()); // call cleanup without calling init
         Verify(ex is null);
         Verify(classCleanupCallCount == 0);
     }
@@ -147,7 +150,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod("ClassInitializeMethod")!;
 
         GetResultOrRunClassInitialize();
-        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>())); // call cleanup without calling init
+        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation()); // call cleanup without calling init
 
         Verify(ex is null);
         Verify(classCleanupCallCount == 1);
@@ -162,7 +165,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.BaseClassCleanupMethods.Add(typeof(DummyBaseTestClass).GetMethod("CleanupClassMethod")!);
 
         GetResultOrRunClassInitialize();
-        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         Verify(ex is null);
         Verify(classCleanupCallCount == 1);
@@ -466,7 +469,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(ex is null);
@@ -481,7 +484,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = null;
 
         // Act
-        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(ex is null);
@@ -496,7 +499,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(classCleanupException is not null);
@@ -518,7 +521,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(classCleanupException is not null);
@@ -539,7 +542,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(classCleanupException is not null);
@@ -558,7 +561,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(classCleanupException is not null);
@@ -577,7 +580,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.BaseClassCleanupMethods.Add(baseClassCleanupMethod);
 
         // Act
-        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert
         Verify(ex is null);
@@ -586,7 +589,7 @@ public class TestClassInfoTests : TestContainer
 
         // Act 2
         GetResultOrRunClassInitialize(null);
-        ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert 2
         Verify(ex is null);
@@ -595,7 +598,7 @@ public class TestClassInfoTests : TestContainer
         Verify(classCleanupCallCount == 1, "DummyBaseTestClass.CleanupClassMethod call count");
 
         // Act 3
-        ex = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        ex = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         // Assert 3
         Verify(ex is null);
@@ -612,7 +615,7 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.ClassCleanupMethod = typeof(DummyTestClass).GetMethod("ClassCleanupMethod")!;
 
         GetResultOrRunClassInitialize(null);
-        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(new TestContextImplementation(null, null, new Dictionary<string, object?>()));
+        TestFailedException? classCleanupException = await _testClassInfo.ExecuteClassCleanupAsync(CreateDummyTestContextImplementation());
 
         Verify(classCleanupException is not null);
         Verify(classCleanupException.Message.StartsWith("Class Cleanup method DummyTestClass.ClassCleanupMethod failed. Error Message: System.InvalidOperationException: I fail..", StringComparison.Ordinal));

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -47,7 +47,7 @@ public class TestMethodInfoTests : TestContainer
 
         _testAssemblyInfo = new TestAssemblyInfo(typeof(DummyTestClass).Assembly);
         var testMethod = new TestMethod("dummyTestName", "dummyClassName", "dummyAssemblyName", false);
-        _testContextImplementation = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
+        _testContextImplementation = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>(), null, null);
         _testClassInfo = new TestClassInfo(typeof(DummyTestClass), _constructorInfo, true, _classAttribute, _testAssemblyInfo);
 
         _testMethodInfo = new TestMethodInfo(

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
@@ -40,7 +40,7 @@ public class TestMethodRunnerTests : TestContainer
         _testMethodAttribute = new TestMethodAttribute();
 
         _testMethod = new TestMethod("dummyTestName", "dummyClassName", "dummyAssemblyName", false);
-        _testContextImplementation = new TestContextImplementation(_testMethod, null, new Dictionary<string, object?>());
+        _testContextImplementation = new TestContextImplementation(_testMethod, null, new Dictionary<string, object?>(), null, null);
         _testClassInfo = GetTestClassInfo<DummyTestClass>();
 
         _testMethodOptions = new TestMethodOptions(TimeoutInfo.FromTimeout(200), _testContextImplementation, _testMethodAttribute);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestPropertyAttributeTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestPropertyAttributeTests.cs
@@ -40,12 +40,15 @@ public class TestPropertyAttributeTests : TestContainer
 
     #region GetTestMethodInfo tests
 
+    private static TestContextImplementation CreateTestContextImplementationForMethod(TestMethod testMethod)
+        => new(testMethod, null, new Dictionary<string, object?>(), null, null);
+
     public void GetTestMethodInfoShouldAddPropertiesFromContainingClassCorrectly()
     {
         string className = typeof(DummyTestClassBase).FullName!;
         var testMethod = new TestMethod(nameof(DummyTestClassBase.VirtualTestMethodInBaseAndDerived), className, typeof(DummyTestClassBase).Assembly.GetName().Name!, isAsync: false);
 
-        var testContext = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         _ = _typeCache.GetTestMethodInfo(
             testMethod,
@@ -75,7 +78,7 @@ public class TestPropertyAttributeTests : TestContainer
         string className = typeof(DummyTestClassDerived).FullName!;
         var testMethod = new TestMethod(nameof(DummyTestClassDerived.VirtualTestMethodInBaseAndDerived), className, typeof(DummyTestClassBase).Assembly.GetName().Name!, isAsync: false);
 
-        var testContext = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         _ = _typeCache.GetTestMethodInfo(
             testMethod,
@@ -120,7 +123,7 @@ public class TestPropertyAttributeTests : TestContainer
         string className = typeof(DummyTestClassDerived).FullName!;
         var testMethod = new TestMethod(nameof(DummyTestClassDerived.VirtualTestMethodInDerivedButNotTestMethodInBase), className, typeof(DummyTestClassBase).Assembly.GetName().Name!, isAsync: false);
 
-        var testContext = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         _ = _typeCache.GetTestMethodInfo(
             testMethod,

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
@@ -52,11 +52,14 @@ public class TypeCacheTests : TestContainer
 
     #region GetTestMethodInfo tests
 
+    private static TestContextImplementation CreateTestContextImplementationForMethod(TestMethod testMethod)
+        => new(testMethod, null, new Dictionary<string, object?>(), null, null);
+
     public void GetTestMethodInfoShouldThrowIfTestMethodIsNull()
     {
         var testMethod = new TestMethod("M", "C", "A", isAsync: false);
 
-        var context = new TestContextImplementation(testMethod, null, new Dictionary<string, object?>());
+        TestContextImplementation context = CreateTestContextImplementationForMethod(testMethod);
         VerifyThrows<ArgumentNullException>(() => _typeCache.GetTestMethodInfo(null!, context));
     }
 
@@ -73,7 +76,7 @@ public class TypeCacheTests : TestContainer
         Verify(
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>())) is null);
+                CreateTestContextImplementationForMethod(testMethod)) is null);
     }
 
     public void GetTestMethodInfoShouldReturnNullIfLoadingTypeThrowsTypeLoadException()
@@ -83,7 +86,7 @@ public class TypeCacheTests : TestContainer
         Verify(
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>())) is null);
+                CreateTestContextImplementationForMethod(testMethod)) is null);
     }
 
     public void GetTestMethodInfoShouldThrowIfLoadingTypeThrowsException()
@@ -96,7 +99,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
 
@@ -111,7 +114,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
         Verify(exception.Message.StartsWith("Cannot find a valid constructor for test class 'Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution.TypeCacheTests+DummyTestClassWithNoDefaultConstructor'. Valid constructors are 'public' and either parameterless or with one parameter of type 'TestContext'.", StringComparison.Ordinal));
@@ -125,7 +128,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
         Verify(exception.Message.StartsWith($"The {className}.TestContext has incorrect type.", StringComparison.Ordinal));
@@ -139,7 +142,7 @@ public class TypeCacheTests : TestContainer
         void Action() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(Action);
         Verify(exception.Message.StartsWith($"Unable to find property {className}.TestContext. Error:Ambiguous match found", StringComparison.Ordinal));
@@ -156,7 +159,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                                     testMethod,
-                                    new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                                    CreateTestContextImplementationForMethod(testMethod));
 
         Verify(testMethodInfo is not null);
         Verify(testMethodInfo.Parent.TestContextProperty is not null);
@@ -173,7 +176,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                                 testMethod,
-                                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(testMethodInfo is not null);
         Verify(testMethodInfo.Parent.TestContextProperty is null);
@@ -192,7 +195,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
     }
@@ -211,7 +214,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
     }
@@ -229,7 +232,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyInit")! == _typeCache.AssemblyInfoCache.First().AssemblyInitializeMethod);
@@ -248,7 +251,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyCleanup")! == _typeCache.AssemblyInfoCache.First().AssemblyCleanupMethod);
@@ -269,7 +272,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyCleanup")! == _typeCache.AssemblyInfoCache.First().AssemblyCleanupMethod);
@@ -290,7 +293,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -319,7 +322,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -345,11 +348,11 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         _mockReflectHelper.Verify(rh => rh.IsAttributeDefined<TestClassAttribute>(type), Times.Once);
         Verify(_typeCache.AssemblyInfoCache.Count == 1);
@@ -370,7 +373,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.TestInitializeMethod is null);
@@ -390,7 +393,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.BaseClassInitMethods.Count == 0);
@@ -418,7 +421,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
             testMethod,
-            new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+            CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.BaseClassCleanupMethods.Count == 0, "No base class cleanup");
@@ -438,7 +441,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyCleanup")! == _typeCache.ClassInfoCache.First()!.ClassCleanupMethod);
@@ -461,7 +464,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
             testMethod,
-            new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+            CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(_typeCache.ClassInfoCache.First()!.BaseClassInitMethods.Count == 0, "No base class init");
@@ -482,7 +485,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyInit")! == _typeCache.ClassInfoCache.First()!.ClassInitializeMethod);
@@ -519,7 +522,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("AssemblyInit")! == _typeCache.ClassInfoCache.First()!.ClassInitializeMethod);
@@ -575,7 +578,7 @@ public class TypeCacheTests : TestContainer
         var testMethod = new TestMethod("TestMethod", type.FullName!, "A", isAsync: false);
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TestClassInfo? classInfo = _typeCache.ClassInfoCache.FirstOrDefault();
         Verify(_typeCache.ClassInfoCache.Count == 1);
@@ -605,7 +608,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -634,7 +637,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -662,7 +665,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("TestInit")! == _typeCache.ClassInfoCache.First()!.TestInitializeMethod);
@@ -681,7 +684,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(type.GetMethod("TestCleanup")! == _typeCache.ClassInfoCache.First()!.TestCleanupMethod);
@@ -701,7 +704,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -730,7 +733,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(baseType.GetMethod("TestInit")! == _typeCache.ClassInfoCache.First()!.BaseTestInitializeMethodsQueue.Peek());
@@ -750,7 +753,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(_typeCache.ClassInfoCache.Count == 1);
         Verify(baseType.GetMethod("TestCleanup")! == _typeCache.ClassInfoCache.First()!.BaseTestCleanupMethodsQueue.Peek());
@@ -767,11 +770,11 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         _testablePlatformServiceProvider.MockFileOperations.Verify(fo => fo.LoadAssembly(It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
         Verify(_typeCache.ClassInfoCache.Count == 1);
@@ -790,7 +793,7 @@ public class TypeCacheTests : TestContainer
         void A() =>
             _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -812,7 +815,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -832,7 +835,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TimeoutAttribute>(methodInfo)).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 10);
@@ -853,7 +856,7 @@ public class TypeCacheTests : TestContainer
 
         void A() => _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Exception exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -880,7 +883,7 @@ public class TypeCacheTests : TestContainer
 
         void A() => _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         TypeInspectionException exception = VerifyThrows<TypeInspectionException>(A);
 
@@ -913,7 +916,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(testMethodInfo!.TimeoutInfo.Timeout == 4000);
     }
@@ -942,7 +945,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(testMethodInfo!.TimeoutInfo.Timeout == 10);
     }
@@ -966,7 +969,7 @@ public class TypeCacheTests : TestContainer
 
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(testMethodInfo!.TimeoutInfo.Timeout == 0);
     }
@@ -980,7 +983,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -997,10 +1000,8 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithCustomProperty")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         typeCache.GetTestMethodInfo(testMethod, testContext);
         KeyValuePair<string, object?> customProperty = testContext.Properties.FirstOrDefault(p => p.Key.Equals("WhoAmI", StringComparison.Ordinal));
@@ -1017,10 +1018,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithTestCategoryAsCustomProperty")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1041,10 +1039,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithOwnerAsCustomProperty")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1065,10 +1060,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithPriorityAsCustomProperty")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1089,10 +1081,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithActualOwnerAttribute")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1111,10 +1100,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithActualPriorityAttribute")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1134,10 +1120,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithEmptyCustomPropertyName")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1158,10 +1141,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithNullCustomPropertyName")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1182,10 +1162,7 @@ public class TypeCacheTests : TestContainer
         Type type = typeof(DummyTestClassWithTestMethods);
         MethodInfo methodInfo = type.GetMethod("TestMethodWithDuplicateCustomPropertyNames")!;
         var testMethod = new TestMethod(methodInfo.Name, type.FullName!, "A", isAsync: false);
-        var testContext = new TestContextImplementation(
-            testMethod,
-            null,
-            new Dictionary<string, object?>());
+        TestContextImplementation testContext = CreateTestContextImplementationForMethod(testMethod);
 
         TestMethodInfo? testMethodInfo = typeCache.GetTestMethodInfo(testMethod, testContext);
 
@@ -1205,7 +1182,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -1222,7 +1199,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         Verify(methodInfo == testMethodInfo!.MethodInfo);
         Verify(testMethodInfo.TimeoutInfo.Timeout == 0);
@@ -1243,7 +1220,7 @@ public class TypeCacheTests : TestContainer
         _mockReflectHelper.Setup(rh => rh.GetFirstAttributeOrDefault<TestMethodAttribute>(It.IsAny<MethodInfo>())).CallBase();
         TestMethodInfo? testMethodInfo = _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         // The two MethodInfo instances will have different ReflectedType properties,
         // so cannot be compared directly. Use MethodHandle to verify it's the same.
@@ -1280,7 +1257,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         IEnumerable<TestClassInfo> cleanupMethods = _typeCache.ClassInfoListWithExecutableCleanupMethods;
 
@@ -1301,7 +1278,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         IEnumerable<TestClassInfo> cleanupMethods = _typeCache.ClassInfoListWithExecutableCleanupMethods;
 
@@ -1334,7 +1311,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         IEnumerable<TestAssemblyInfo> cleanupMethods = _typeCache.AssemblyInfoListWithExecutableCleanupMethods;
 
@@ -1355,7 +1332,7 @@ public class TypeCacheTests : TestContainer
 
         _typeCache.GetTestMethodInfo(
                 testMethod,
-                new TestContextImplementation(testMethod, null, new Dictionary<string, object?>()));
+                CreateTestContextImplementationForMethod(testMethod));
 
         IEnumerable<TestAssemblyInfo> cleanupMethods = _typeCache.AssemblyInfoListWithExecutableCleanupMethods;
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -33,9 +33,12 @@ public class TestContextImplementationTests : TestContainer
         _properties = new Dictionary<string, object?>();
     }
 
+    private TestContextImplementation CreateTestContextImplementation(IMessageLogger? messageLogger = null)
+        => new(_testMethod.Object, null, _properties, messageLogger, null);
+
     public void TestContextConstructorShouldInitializeProperties()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.Properties is not null);
     }
@@ -45,7 +48,7 @@ public class TestContextImplementationTests : TestContainer
         _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.Properties is not null);
 
@@ -55,14 +58,14 @@ public class TestContextImplementationTests : TestContainer
 
     public void CurrentTestOutcomeShouldReturnDefaultOutcome()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.CurrentTestOutcome == UnitTestOutcome.Failed);
     }
 
     public void CurrentTestOutcomeShouldReturnOutcomeSet()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.SetOutcome(UnitTestOutcome.InProgress);
 
@@ -73,7 +76,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.FullyQualifiedTestClassName == "A.C.M");
     }
@@ -82,7 +85,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.TestName == "M");
     }
@@ -95,7 +98,7 @@ public class TestContextImplementationTests : TestContainer
         _properties.Add(property1);
         _properties.Add(property2);
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.Properties[property1.Key] == property1.Value);
         Verify(_testContextImplementation.Properties[property2.Key] == property2.Value);
@@ -105,7 +108,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.Context is not null);
         Verify(_testContextImplementation.Context.TestName == "M");
@@ -115,7 +118,7 @@ public class TestContextImplementationTests : TestContainer
     {
         _testMethod.Setup(tm => tm.Name).Returns("M");
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(_testContextImplementation.TryGetPropertyValue("TestName", out object? propValue));
         Verify("M".Equals(propValue));
@@ -123,7 +126,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void TryGetPropertyValueShouldReturnFalseIfPropertyIsNotPresent()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         Verify(!_testContextImplementation.TryGetPropertyValue("Random", out object? propValue));
         Verify(propValue is null);
@@ -131,7 +134,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddPropertyShouldAddPropertiesToThePropertyBag()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
         var property = new KeyValuePair<string, string>("SomeNewProperty", "SomeValue");
         _testContextImplementation.AddProperty(property.Key, property.Value);
 
@@ -140,7 +143,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldThrowIfFileNameIsNull()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         ArgumentException exception = VerifyThrows<ArgumentException>(() => _testContextImplementation.AddResultFile(null!));
         Verify(exception.Message.Contains(Resource.Common_CannotBeNullOrEmpty));
@@ -148,7 +151,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldThrowIfFileNameIsEmpty()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         ArgumentException exception = VerifyThrows<ArgumentException>(() => _testContextImplementation.AddResultFile(string.Empty));
         Verify(exception.Message.Contains(Resource.Common_CannotBeNullOrEmpty));
@@ -156,7 +159,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldAddFileToResultsFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.AddResultFile("C:\\temp.txt");
 
@@ -167,7 +170,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void AddResultFileShouldAddMultipleFilesToResultsFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.AddResultFile("C:\\files\\file1.txt");
         _testContextImplementation.AddResultFile("C:\\files\\files2.html");
@@ -180,35 +183,35 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
         _testContextImplementation.Write("{0} Testing write", 1);
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing write"));
     }
 
     public void WriteShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
         _testContextImplementation.Write("{0} Testing \0 write \0", 1);
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing \\0 write \\0"));
     }
 
     public void WriteWithMessageShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
         _testContextImplementation.Write("1 Testing write");
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing write"));
     }
 
     public void WriteWithMessageShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
         _testContextImplementation.Write("1 Testing \0 write \0");
         Verify(_testContextImplementation.GetDiagnosticMessages()!.Contains("1 Testing \\0 write \\0"));
     }
 
     public void WriteWithMessageShouldWriteToStringWriterForReturnCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
         _testContextImplementation.Write("2 Testing write \n\r");
         _testContextImplementation.Write("3 Testing write\n\r");
         Verify(_testContextImplementation.GetDiagnosticMessages() == "2 Testing write \n\r3 Testing write\n\r");
@@ -216,7 +219,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.WriteLine("{0} Testing write", 1);
 
@@ -225,7 +228,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.WriteLine("{0} Testing \0 write \0", 1);
 
@@ -234,7 +237,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineWithMessageShouldWriteToStringWriter()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.WriteLine("1 Testing write");
 
@@ -243,7 +246,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WriteLineWithMessageShouldWriteToStringWriterForNullCharacters()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.WriteLine("1 Testing \0 write \0");
 
@@ -252,7 +255,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void GetDiagnosticMessagesShouldReturnMessagesFromWriteLine()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.WriteLine("1 Testing write");
         _testContextImplementation.WriteLine("2 Its a happy day");
@@ -263,7 +266,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void ClearDiagnosticMessagesShouldClearMessagesFromWriteLine()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.WriteLine("1 Testing write");
         _testContextImplementation.WriteLine("2 Its a happy day");
@@ -276,7 +279,7 @@ public class TestContextImplementationTests : TestContainer
 #if NETFRAMEWORK
     public void SetDataRowShouldSetDataRowObjectForCurrentRun()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         DataTable dataTable = new();
 
@@ -294,7 +297,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void SetDataConnectionShouldSetDbConnectionForFetchingData()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         DbProviderFactory factory = DbProviderFactories.GetFactory("System.Data.Odbc");
         DbConnection connection = factory.CreateConnection();
@@ -310,7 +313,7 @@ public class TestContextImplementationTests : TestContainer
 #if NETCOREAPP
     public void GetResultFilesShouldReturnNullIfNoAddedResultFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         IList<string>? resultFiles = _testContextImplementation.GetResultFiles();
 
@@ -319,7 +322,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void GetResultFilesShouldReturnListOfAddedResultFiles()
     {
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties);
+        _testContextImplementation = CreateTestContextImplementation();
 
         _testContextImplementation.AddResultFile("C:\\files\\myfile.txt");
         _testContextImplementation.AddResultFile("C:\\files\\myfile2.txt");
@@ -339,7 +342,7 @@ public class TestContextImplementationTests : TestContainer
         messageLoggerMock
             .Setup(l => l.SendMessage(It.IsAny<TestMessageLevel>(), It.IsAny<string>()));
 
-        _testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties, messageLoggerMock.Object, testRunCancellationToken: null);
+        _testContextImplementation = CreateTestContextImplementation(messageLoggerMock.Object);
         _testContextImplementation.DisplayMessage(MessageLevel.Informational, "InfoMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Warning, "WarningMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Error, "ErrorMessage");
@@ -351,7 +354,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WritesFromBackgroundThreadShouldNotThrow()
     {
-        var testContextImplementation = new TestContextImplementation(_testMethod.Object, null, _properties, new Mock<IMessageLogger>().Object, testRunCancellationToken: null);
+        TestContextImplementation testContextImplementation = CreateTestContextImplementation(new Mock<IMessageLogger>().Object);
         var t = new Thread(() =>
         {
             for (int i = 0; i < 100; i++)


### PR DESCRIPTION
Consolidates the two constructors of TestContextImplementation.

Historically, one of the constructors was public, and we kept it for backcompat only.

Also, cleaned up the tests so that there is a common helper in test classes to reduce the number of callers to TestContextImplementation. This makes it easier to update the tests if we make any changes to the internal API in future.