### PR TITLE
Cleanup TestApplication

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Testing.Platform.Builder;
 /// Represents a test application.
 /// </summary>
 public sealed class TestApplication : ITestApplication
-#if NETCOREAPP
-#pragma warning disable SA1001 // Commas should be spaced correctly
-    , IAsyncDisposable
-#pragma warning restore SA1001 // Commas should be spaced correctly
-#endif
 {
     private readonly IHost _host;
     private static UnhandledExceptionHandler? s_unhandledExceptionHandler;
@@ -41,6 +36,7 @@ public sealed class TestApplication : ITestApplication
     /// <param name="args">The command line arguments.</param>
     /// <param name="testApplicationOptions">The test application options.</param>
     /// <returns>The task representing the asynchronous operation.</returns>
+    [Obsolete("This method is obsolete. Use CreateBuilderAsync instead.")]
     public static Task<ITestApplicationBuilder> CreateServerModeBuilderAsync(string[] args, TestApplicationOptions? testApplicationOptions = null)
     {
         if (args.Contains($"--{PlatformCommandLineProvider.ServerOptionKey}") || args.Contains($"-{PlatformCommandLineProvider.ServerOptionKey}"))
@@ -213,14 +209,6 @@ public sealed class TestApplication : ITestApplication
     /// <inheritdoc />
     public void Dispose()
         => (_host as IDisposable)?.Dispose();
-
-#if NETCOREAPP
-    /// <inheritdoc />
-    public ValueTask DisposeAsync()
-        => _host is IAsyncDisposable asyncDisposable
-            ? asyncDisposable.DisposeAsync()
-            : ValueTask.CompletedTask;
-#endif
 
     /// <inheritdoc />
     public async Task<int> RunAsync()

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/net/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/net/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+*REMOVED*Microsoft.Testing.Platform.Builder.TestApplication.DisposeAsync() -> System.Threading.Tasks.ValueTask


### PR DESCRIPTION
- IAsyncDisposable implementation is very unnecessary here and is mostly dead code. It's technically binary breaking, but it's not expected that this API was used by any one. Our generated entry point disposes `ITestApplication` and not the concrete `TestApplication`. We dispose via the sync `Dispose` (the interface doesn't actually implement IAsyncDisposable). While binary breaking and should have been figured out before we ship 2.0.0, I think it only affects the case where users cast `ITestApplication` to `TestApplication` and calls `DisposeAsync` which is extremely unlikely.
    - Fixes https://github.com/microsoft/testfx/issues/6726
- `CreateServerModeBuilderAsync` is also mostly an unused public API. We don't use it in our generated entrypoint and I don't think there are any usages calling it. I went with obsoletion though instead of breaking. I would personally be fine taking a binary break here though. It's expected to affect literally zero users.