### PR TITLE
Cleanup Dispose implementations

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
@@ -18,10 +18,9 @@ namespace Microsoft.Testing.Extensions.Diagnostics;
 
 internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLifetimeHandler,
 #if NETCOREAPP
-    IAsyncDisposable
-#else
-    IDisposable
+    IAsyncDisposable,
 #endif
+    IDisposable
 {
     private readonly ICommandLineOptions _commandLineOptions;
     private readonly IEnvironment _environment;
@@ -267,7 +266,7 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
 #if NETCOREAPP
     public async ValueTask DisposeAsync()
     {
-        await DisposeHelper.DisposeAsync(_namedPipeClient).ConfigureAwait(false);
+        _namedPipeClient?.Dispose();
 
         // If the OnTestSessionFinishingAsync is not called means that something unhandled happened
         // and we didn't correctly coordinate the shutdown with the HangDumpProcessLifetimeHandler.
@@ -277,12 +276,12 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
             await DisposeHelper.DisposeAsync(_singleConnectionNamedPipeServer).ConfigureAwait(false);
         }
 
-        _pipeNameDescription?.Dispose();
         _mutexCreated.Dispose();
         _signalActivity.Dispose();
         _activityIndicatorMutex?.Dispose();
     }
-#else
+#endif
+
     public void Dispose()
     {
         _namedPipeClient?.Dispose();
@@ -295,10 +294,8 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
             _singleConnectionNamedPipeServer?.Dispose();
         }
 
-        _pipeNameDescription?.Dispose();
         _mutexCreated.Dispose();
         _signalActivity.Dispose();
         _activityIndicatorMutex?.Dispose();
     }
-#endif
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -25,10 +25,9 @@ namespace Microsoft.Testing.Extensions.Diagnostics;
 
 internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeHandler, IOutputDeviceDataProducer, IDataProducer,
 #if NETCOREAPP
-    IAsyncDisposable
-#else
-    IDisposable
+    IAsyncDisposable,
 #endif
+    IDisposable
 {
     private readonly IMessageBus _messageBus;
     private readonly OutputDeviceWriter _outputDisplay;
@@ -140,14 +139,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         {
             await _logger.LogDebugAsync("Session end received by the test host").ConfigureAwait(false);
             _exitActivityIndicatorTask = true;
-#if NET
-            if (_namedPipeClient is not null)
-            {
-                await _namedPipeClient.DisposeAsync().ConfigureAwait(false);
-            }
-#else
             _namedPipeClient?.Dispose();
-#endif
             return VoidResponse.CachedInstance;
         }
         else if (request is ConsumerPipeNameRequest consumerPipeNameRequest)
@@ -519,7 +511,6 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         _waitConsumerPipeName.Dispose();
         _mutexNameReceived.Dispose();
         _singleConnectionNamedPipeServer?.Dispose();
-        _pipeNameDescription.Dispose();
     }
 
 #if NETCOREAPP
@@ -534,7 +525,6 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
         _waitConsumerPipeName.Dispose();
         _mutexNameReceived.Dispose();
         _singleConnectionNamedPipeServer?.Dispose();
-        _pipeNameDescription.Dispose();
     }
 #endif
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryFailedTestsPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryFailedTestsPipeServer.cs
@@ -45,10 +45,7 @@ internal sealed class RetryFailedTestsPipeServer : IDisposable
         => _singleConnectionNamedPipeServer.WaitConnectionAsync(cancellationToken);
 
     public void Dispose()
-    {
-        _singleConnectionNamedPipeServer.Dispose();
-        _pipeNameDescription.Dispose();
-    }
+        => _singleConnectionNamedPipeServer.Dispose();
 
     private Task<IResponse> CallbackAsync(IRequest request)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryLifecycleCallbacks.cs
@@ -14,12 +14,7 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.Policy;
 
-internal sealed class RetryLifecycleCallbacks : ITestHostApplicationLifetime,
-#if NETCOREAPP
-    IAsyncDisposable
-#else
-    IDisposable
-#endif
+internal sealed class RetryLifecycleCallbacks : ITestHostApplicationLifetime, IDisposable
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ICommandLineOptions _commandLineOptions;
@@ -73,15 +68,5 @@ internal sealed class RetryLifecycleCallbacks : ITestHostApplicationLifetime,
     public Task AfterRunAsync(int exitCode, CancellationToken cancellation)
         => Task.CompletedTask;
 
-#if NETCOREAPP
-    public async ValueTask DisposeAsync()
-    {
-        if (Client is not null)
-        {
-            await Client.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-#else
     public void Dispose() => Client?.Dispose();
-#endif
 }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
@@ -28,10 +28,9 @@ internal sealed class TrxProcessLifetimeHandler :
     IDataProducer,
     IOutputDeviceDataProducer,
 #if NETCOREAPP
-    IAsyncDisposable
-#else
-    IDisposable
+    IAsyncDisposable,
 #endif
+    IDisposable
 {
     private readonly ICommandLineOptions _commandLineOptions;
     private readonly IEnvironment _environment;
@@ -231,21 +230,11 @@ internal sealed class TrxProcessLifetimeHandler :
 
 #if NETCOREAPP
     public async ValueTask DisposeAsync()
-    {
-        await DisposeHelper.DisposeAsync(_singleConnectionNamedPipeServer).ConfigureAwait(false);
-
-        // Dispose the pipe descriptor after the server to ensure the pipe is closed.
-        _pipeNameDescription.Dispose();
-    }
-#else
-    public void Dispose()
-    {
-        _singleConnectionNamedPipeServer?.Dispose();
-
-        // Dispose the pipe descriptor after the server to ensure the pipe is closed.
-        _pipeNameDescription.Dispose();
-    }
+        => await DisposeHelper.DisposeAsync(_singleConnectionNamedPipeServer).ConfigureAwait(false);
 #endif
+
+    public void Dispose()
+        => _singleConnectionNamedPipeServer?.Dispose();
 
     private sealed class ExtensionInfo : IExtension
     {

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/InformativeCommandLineTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/InformativeCommandLineTestHost.cs
@@ -8,11 +8,6 @@ using Microsoft.Testing.Platform.Services;
 namespace Microsoft.Testing.Platform.CommandLine;
 
 internal sealed class InformativeCommandLineHost(int returnValue, IServiceProvider serviceProvider) : IHost, IDisposable
-#if NETCOREAPP
-#pragma warning disable SA1001 // Commas should be spaced correctly
-    , IAsyncDisposable
-#pragma warning restore SA1001 // Commas should be spaced correctly
-#endif
 {
     private readonly int _returnValue = returnValue;
 
@@ -21,14 +16,4 @@ internal sealed class InformativeCommandLineHost(int returnValue, IServiceProvid
     public Task<int> RunAsync() => Task.FromResult(_returnValue);
 
     public void Dispose() => PushOnlyProtocol?.Dispose();
-
-#if NETCOREAPP
-    public async ValueTask DisposeAsync()
-    {
-        if (PushOnlyProtocol is not null)
-        {
-            await PushOnlyProtocol.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-#endif
 }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControlledHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControlledHost.cs
@@ -47,7 +47,7 @@ internal sealed class TestHostControlledHost(NamedPipeClient testHostControllerP
     public async ValueTask DisposeAsync()
     {
         await DisposeHelper.DisposeAsync(_innerHost).ConfigureAwait(false);
-        await _namedPipeClient.DisposeAsync().ConfigureAwait(false);
+        _namedPipeClient.Dispose();
     }
 #endif
 }

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -239,6 +239,11 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
     }
 
 #if NETCOREAPP
+    [Obsolete("All owned fields are disposed synchronously. Introduction of DisposeAsync here is unnecessary complexity.")]
+    // NOTE: While NamedPipeClient is internal API, it's breaking to change it as it's consumed via IVT by MTP extensions.
+    // If we removed DisposeAsync in newer MTP version, but an old MTP extension is used with newer MTP version, we will get MissingMethodException.
+    // It might be more safe to obsolete for now, and potentially remove after few versions are released when most users will
+    // already be on those newer versions, and the risk of break is reduced.
     public async ValueTask DisposeAsync()
     {
         if (_disposed)

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -325,7 +325,6 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
         }
 
         _namedPipeServerStream.Dispose();
-        PipeName.Dispose();
 
         _disposed = true;
     }
@@ -356,7 +355,6 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
         }
 
         _namedPipeServerStream.Dispose();
-        PipeName.Dispose();
 
         _disposed = true;
     }

--- a/src/Platform/Microsoft.Testing.Platform/IPC/PipeNameDescription.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/PipeNameDescription.cs
@@ -9,6 +9,7 @@ internal sealed class PipeNameDescription(string name) : IDisposable
 
     // This is available via IVT.
     // Avoid removing it as it can be seen as a binary breaking change when users use newer version of core MTP but older version of one of the extensions.
+    [Obsolete("No-op.")]
     public void Dispose()
     {
     }

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactory.cs
@@ -61,15 +61,22 @@ internal sealed class LoggerFactory(ILoggerProvider[] loggerProviders, LogLevel 
 #if NETCOREAPP
     public async ValueTask DisposeAsync()
     {
-        foreach (IAsyncDisposable asyncDisposable in _loggerProviders.OfType<IAsyncDisposable>())
+        foreach (ILoggerProvider loggerProvider in _loggerProviders)
         {
             // FileLoggerProvider is special and needs to be disposed manually.
-            if (asyncDisposable is FileLoggerProvider)
+            if (loggerProvider is FileLoggerProvider)
             {
                 continue;
             }
 
-            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            if (loggerProvider is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else if (loggerProvider is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
     }
 #endif

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -13,11 +13,7 @@ using Microsoft.Testing.Platform.Tools;
 
 namespace Microsoft.Testing.Platform;
 
-internal sealed class DotnetTestConnection : IPushOnlyProtocol,
-#if NETCOREAPP
-    IAsyncDisposable,
-#endif
-    IDisposable
+internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
 {
     private readonly CommandLineHandler _commandLineHandler;
     private readonly IEnvironment _environment;
@@ -147,15 +143,4 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol,
     public Task OnExitAsync() => Task.CompletedTask;
 
     public void Dispose() => _dotnetTestPipeClient?.Dispose();
-
-#if NETCOREAPP
-    public async ValueTask DisposeAsync()
-    {
-        if (_dotnetTestPipeClient is not null)
-        {
-            await _dotnetTestPipeClient.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-#endif
-
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
@@ -3,11 +3,7 @@
 
 namespace Microsoft.Testing.Platform.ServerMode;
 
-internal interface IPushOnlyProtocol :
-#if NETCOREAPP
-    IAsyncDisposable,
-#endif
-    IDisposable
+internal interface IPushOnlyProtocol : IDisposable
 {
     bool IsServerMode { get; }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
@@ -65,23 +65,21 @@ public sealed class IPCTests
 
         await waitTask;
 #if NETCOREAPP
-        await namedPipeClient1.DisposeAsync();
+        namedPipeClient1.Dispose();
         await openedPipe[0].DisposeAsync();
 #else
         namedPipeClient1.Dispose();
         openedPipe[0].Dispose();
 #endif
-        pipeNameDescription.Dispose();
 
         // Verify double dispose
 #if NETCOREAPP
-        await namedPipeClient1.DisposeAsync();
+        namedPipeClient1.Dispose();
         await openedPipe[0].DisposeAsync();
 #else
         namedPipeClient1.Dispose();
         openedPipe[0].Dispose();
 #endif
-        pipeNameDescription.Dispose();
     }
 
     [TestMethod]
@@ -159,14 +157,12 @@ public sealed class IPCTests
         }
 
 #if NETCOREAPP
-        await namedPipeClient.DisposeAsync();
+        namedPipeClient.Dispose();
         await singleConnectionNamedPipeServer.DisposeAsync();
 #else
         namedPipeClient.Dispose();
         singleConnectionNamedPipeServer.Dispose();
 #endif
-
-        pipeNameDescription.Dispose();
     }
 
     [TestMethod]


### PR DESCRIPTION
- Implementing `IAsyncDisposable` without `IDisposable` doesn't look like a good pattern. I changed those to always implement `IDisposable`, and then implement `IAsyncDisposable` when on .NET (Core)
- Cleaned up unnecessary DisposeAsync of NamedPipeClient.
- Cleaned up unnecessary calls of PipeNameDescription.Dispose.