### PR TITLE
Cleanup dead properties in TestMethod

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
@@ -83,7 +83,7 @@ internal class TypeEnumerator
             {
                 // ToString() outputs method name and its signature. This is necessary for overloaded methods to be recognized as distinct tests.
                 foundDuplicateTests = foundDuplicateTests || !foundTests.Add(method.ToString() ?? method.Name);
-                UnitTestElement testMethod = GetTestFromMethod(method, isMethodDeclaredInTestTypeAssembly, warnings);
+                UnitTestElement testMethod = GetTestFromMethod(method, warnings);
 
                 tests.Add(testMethod);
             }
@@ -117,10 +117,9 @@ internal class TypeEnumerator
     /// Gets a UnitTestElement from a MethodInfo object filling it up with appropriate values.
     /// </summary>
     /// <param name="method">The reflected method.</param>
-    /// <param name="isDeclaredInTestTypeAssembly">True if the reflected method is declared in the same assembly as the current type.</param>
     /// <param name="warnings">Contains warnings if any, that need to be passed back to the caller.</param>
     /// <returns> Returns a UnitTestElement.</returns>
-    internal UnitTestElement GetTestFromMethod(MethodInfo method, bool isDeclaredInTestTypeAssembly, ICollection<string> warnings)
+    internal UnitTestElement GetTestFromMethod(MethodInfo method, ICollection<string> warnings)
     {
         // null if the current instance represents a generic type parameter.
         DebugEx.Assert(_type.AssemblyQualifiedName != null, "AssemblyQualifiedName for method is null.");
@@ -135,13 +134,6 @@ internal class TypeEnumerator
         if (!string.Equals(method.DeclaringType!.FullName, _type.FullName, StringComparison.Ordinal))
         {
             testMethod.DeclaringClassFullName = method.DeclaringType.FullName;
-        }
-
-        if (!isDeclaredInTestTypeAssembly)
-        {
-            testMethod.DeclaringAssemblyName =
-                PlatformServiceProvider.Instance.FileOperations.GetAssemblyPath(
-                    method.DeclaringType.Assembly);
         }
 
         var testElement = new UnitTestElement(testMethod)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IFileOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IFileOperations.cs
@@ -26,13 +26,6 @@ internal interface IFileOperations
     Assembly LoadAssembly(string assemblyName, bool isReflectionOnly);
 
     /// <summary>
-    /// Gets the path to the .DLL of the assembly.
-    /// </summary>
-    /// <param name="assembly">The assembly.</param>
-    /// <returns>Path to the .DLL of the assembly.</returns>
-    string? GetAssemblyPath(Assembly assembly);
-
-    /// <summary>
     /// Verify if a file exists in the current context.
     /// </summary>
     /// <param name="assemblyFileName"> The assembly file name. </param>

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -77,22 +77,6 @@ internal sealed class TestMethod : ITestMethod
     public string? ParameterTypes { get; }
 
     /// <summary>
-    /// Gets or sets the declaring assembly full name. This will be used while getting navigation data.
-    /// This will be null if AssemblyName is same as DeclaringAssemblyName.
-    /// Reason to set to null in the above case is to minimize the transfer of data across appdomains and not have a performance hit.
-    /// </summary>
-    public string? DeclaringAssemblyName
-    {
-        get;
-
-        set
-        {
-            DebugEx.Assert(value != AssemblyName, "DeclaringAssemblyName should not be the same as AssemblyName.");
-            field = value;
-        }
-    }
-
-    /// <summary>
     /// Gets or sets the declaring class full name.
     /// This will be used to resolve overloads and while getting navigation data.
     /// This will be null if FullClassName is same as DeclaringClassFullName.
@@ -153,11 +137,6 @@ internal sealed class TestMethod : ITestMethod
     /// The test is ignored if this is set to non-null.
     /// </remarks>
     internal string? TestDataSourceIgnoreMessage { get; set; }
-
-    /// <summary>
-    /// Gets or sets the test group set during discovery.
-    /// </summary>
-    internal string? TestGroup { get; set; }
 
     /// <summary>
     /// Gets or sets the display name set during discovery.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/FileOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/FileOperations.cs
@@ -61,21 +61,6 @@ internal sealed class FileOperations : IFileOperations
     }
 
     /// <summary>
-    /// Gets the path to the .DLL of the assembly.
-    /// </summary>
-    /// <param name="assembly">The assembly.</param>
-    /// <returns>Path to the .DLL of the assembly.</returns>
-    public string? GetAssemblyPath(Assembly assembly)
-#if NETSTANDARD || (NETCOREAPP && !WINDOWS_UWP) || NETFRAMEWORK
-        // This method will never be called in source generator mode, we are providing a different provider for file operations.
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
-        => assembly.Location;
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
-#elif WINDOWS_UWP
-        => null; // TODO: what are the options here?
-#endif
-
-    /// <summary>
     /// Verifies if file exists in context.
     /// </summary>
     /// <param name="assemblyFileName"> The assembly file name. </param>

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/TypeEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/TypeEnumeratorTests.cs
@@ -267,7 +267,7 @@ public partial class TypeEnumeratorTests : TestContainer
         SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.TestMethod.Name == "MethodWithVoidReturnType");
@@ -281,7 +281,7 @@ public partial class TypeEnumeratorTests : TestContainer
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("AsyncMethodWithTaskReturnType")!;
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         string? expectedAsyncTaskName = methodInfo.GetCustomAttribute<AsyncStateMachineAttribute>()!.StateMachineType.FullName;
 
@@ -297,7 +297,7 @@ public partial class TypeEnumeratorTests : TestContainer
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestCategoryAttribute("foo"), new TestCategoryAttribute("bar"));
         string[] testCategories = ["foo", "bar"];
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testCategories.SequenceEqual(testElement.TestCategory));
@@ -310,7 +310,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new DoNotParallelizeAttribute());
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.DoNotParallelize);
@@ -327,7 +327,7 @@ public partial class TypeEnumeratorTests : TestContainer
             new TestPropertyAttribute("foo", "bar"),
             new TestPropertyAttribute("fooprime", "barprime"));
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.Traits!.Length == 2);
@@ -349,7 +349,7 @@ public partial class TypeEnumeratorTests : TestContainer
             new TestPropertyAttribute("fooprime", "barprime"),
             new OwnerAttribute("mike"));
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.Traits!.Length == 3);
@@ -368,7 +368,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestPropertyAttribute("foo", "bar"), new TestPropertyAttribute("fooprime", "barprime"), new PriorityAttribute(1));
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.Traits!.Length == 3);
@@ -387,7 +387,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new PriorityAttribute(1));
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.Priority == 1);
@@ -400,7 +400,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new DescriptionAttribute("Dummy description"));
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement.Traits is not null);
         Verify(testElement.Traits.Any(t => t.Name == "Description" && t.Value == "Dummy description"));
@@ -413,7 +413,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new WorkItemAttribute(123), new WorkItemAttribute(345));
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(new string[] { "123", "345" }.SequenceEqual(testElement.WorkItemIds));
     }
@@ -424,7 +424,7 @@ public partial class TypeEnumeratorTests : TestContainer
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement.WorkItemIds is null);
     }
@@ -440,7 +440,7 @@ public partial class TypeEnumeratorTests : TestContainer
             td => td.GetDeploymentItems(It.IsAny<MethodInfo>(), It.IsAny<Type>(), _warnings))
             .Returns((KeyValuePair<string, string>[])null!);
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.DeploymentItems is null);
@@ -457,29 +457,11 @@ public partial class TypeEnumeratorTests : TestContainer
         _testablePlatformServiceProvider.MockTestDeployment.Setup(
             td => td.GetDeploymentItems(methodInfo, typeof(DummyTestClass), _warnings)).Returns(deploymentItems);
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.DeploymentItems is not null);
         Verify(deploymentItems.SequenceEqual(testElement.DeploymentItems));
-    }
-
-    public void GetTestFromMethodShouldSetDeclaringAssemblyName()
-    {
-        const bool isMethodFromSameAssembly = false;
-
-        TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
-        MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
-
-        // Setup mocks
-        string otherAssemblyName = "ADifferentAssembly";
-        _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.GetAssemblyPath(It.IsAny<Assembly>()))
-            .Returns(otherAssemblyName);
-
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, isMethodFromSameAssembly, _warnings);
-
-        Verify(testElement is not null);
-        Verify(otherAssemblyName == testElement.TestMethod.DeclaringAssemblyName);
     }
 
     public void GetTestFromMethodShouldSetDisplayNameToTestMethodNameIfDisplayNameIsNotPresent()
@@ -489,7 +471,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType))!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestMethodAttribute());
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.DisplayName == "MethodWithVoidReturnType");
@@ -502,7 +484,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType))!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestMethodAttribute() { DisplayName = "Test method display name." });
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.DisplayName == "Test method display name.");
@@ -515,7 +497,7 @@ public partial class TypeEnumeratorTests : TestContainer
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType))!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new DataTestMethodAttribute() { DisplayName = "Test method display name." });
 
-        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, true, _warnings);
+        MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(methodInfo, _warnings);
 
         Verify(testElement is not null);
         Verify(testElement.DisplayName == "Test method display name.");


### PR DESCRIPTION
- `DeclaringAssemblyName` was never read. It was only set. So cleaned it up.
- After the removal of `DeclaringAssemblyName`, `GetAssemblyPath` method became unused. So removed it as well.
- Then, `isDeclaredInTestTypeAssembly` parameter of `GetTestFromMethod` became unused. Cleaned it up as well.
- Additionally, `TestGroup` property was never accessed. So removed it too.