### PR TITLE
Add VisualStudio requirement to build uap10 adapter

### DIFF
--- a/global.json
+++ b/global.json
@@ -19,7 +19,10 @@
       ]
     },
     "vs": {
-      "version": "17.14.10"
+      "version": "17.14.10",
+      "components": [
+        "Microsoft.VisualStudio.Workload.Universal"
+      ]
     }
   },
   "sdk": {


### PR DESCRIPTION
Select Visual Studio with the workload that is required to build uap10.0 adapter. To build the adapter you need WinUI application development workload, that includes UWP.

And Windows SDK that we install automatically.

This change will select visual studio that has the needed component installed, rather then just taking the latest version.