### PR TITLE
Run CI on xlf changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ pr:
       - CONTRIBUTING.md
       - README.md
       - SECURITY.md
-      - src/**/*.xlf
       - azure-pipelines-official.yml
 
 parameters:


### PR DESCRIPTION
Wrong XLF changes might fail the build. It's best to be safe and ensure that CI is run.