### PR TITLE
Cleanup vstest.TestCase.StandardError/vstest.TestCase.StandardOutput

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -189,22 +189,12 @@ internal static class ObjectModelConverters
             if (testResultMessage.Category == TestResultMessage.StandardErrorCategory)
             {
                 string message = testResultMessage.Text ?? string.Empty;
-                if (addVSTestProviderProperties)
-                {
-                    testNode.Properties.Add(new SerializableKeyValuePairStringProperty("vstest.TestCase.StandardError", message));
-                }
-
                 (standardErrorMessages ??= []).Add(message);
             }
 
             if (testResultMessage.Category == TestResultMessage.StandardOutCategory)
             {
                 string message = testResultMessage.Text ?? string.Empty;
-                if (addVSTestProviderProperties)
-                {
-                    testNode.Properties.Add(new SerializableKeyValuePairStringProperty("vstest.TestCase.StandardOutput", message));
-                }
-
                 (standardOutputMessages ??= []).Add(message);
             }
         }


### PR DESCRIPTION
Related to https://github.com/microsoft/testfx/issues/3933

The first MSTest version that supported stdout/stderr for MTP in Test Explorer is MSTest 3.6.

This was done in two PRs: https://github.com/microsoft/testfx/pull/3486 and https://github.com/microsoft/testfx/pull/3749.

The first PR was a hacky approach that couldn't work for xunit.v3 (see https://github.com/microsoft/testfx/issues/3740). So a better approach was introduced in the other PR.

When the first testfx PR was done, we followed-up with a corresponding change on Test Explorer side that got in 17.12.

Later on, when the second testfx PR was done, we also followed-up with a change on Test Explorer side that was done also for 17.12.

What we ended up with is two known properties for specifying stdout/stderr, and serializing the information twice. This PR cleans that up.

I also have a similar PR on VSU to clean this up for Test Explorer.