### PR TITLE
Fix drain loop test

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -51,7 +51,7 @@ public sealed class AsynchronousMessageBusTests
 
         await proxy.PublishAsync(consumerA, new LoopDataA());
 
-        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(asynchronousMessageBus.DrainDataAsync);
+        InvalidOperationException ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(asynchronousMessageBus.DrainDataAsync);
         Assert.Contains("Publisher/Consumer loop detected during the drain after", ex.Message);
 
         // Prevent loop to continue


### PR DESCRIPTION
The test was using the try catch pattern that we now detect by analyzer. It won't fail the test when there is no exception thrown.

Luckily this is error in the test code and not in the tested code. 

There are producers A and B, which produce messages which the other reacts to, so we create a consumer producer loop that never ends.

BUT the producers were using the same Uid, and so we thought that both A and B are the same producer and never put the values to the pipe, so no loop ever happened.

https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Platform/Messages/ConsumingEnumerableConsumerDataProcessor.cs#L55-L58

Fix #6892
