### PR TITLE
Stabilize SystemAsyncMonitorTests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/SystemAsyncMonitorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/SystemAsyncMonitorTests.cs
@@ -24,7 +24,7 @@ public sealed class SystemAsyncMonitorTests
 
         await Task.WhenAll([.. tasks]);
 
-        Assert.IsGreaterThanOrEqualTo(3000, stopwatch.ElapsedMilliseconds);
+        Assert.IsGreaterThanOrEqualTo(2900, stopwatch.ElapsedMilliseconds);
 
         async Task TestLock()
         {


### PR DESCRIPTION
This test became unstable starting with https://github.com/microsoft/testfx/pull/6861.
Instead of adding unnecessary sleep that slows us down, relaxing the assert to some room of timing error.