### PR TITLE
Stabilize the multi-data consumer perf test

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DataConsumerThroughputTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DataConsumerThroughputTests.cs
@@ -21,7 +21,7 @@ public class DataConsumerThroughputTests : AcceptanceTestBase<DataConsumerThroug
         testHostResult.AssertExitCodeIs(ExitCodes.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
 
-        Assert.IsLessThan(5, stopwatch.Elapsed.TotalSeconds);
+        Assert.IsLessThan(7, stopwatch.Elapsed.TotalSeconds, testHostResult.ToString());
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase(AcceptanceFixture.NuGetGlobalPackagesFolder)


### PR DESCRIPTION
With 5, it's somewhat flaky.
Original issue was that we are 20 seconds or more. So the test is still not bad. Also the overhead of opening and creating the new process is included in the measurement. Probably it's best in future to extract the duration from the process standard output and assert against it instead.