### PR TITLE
Revert "update to polyfill 9.0.3"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -75,7 +75,7 @@
 
   <!-- Polyfill config -->
   <PropertyGroup>
-    <PolyEnsure>true</PolyEnsure>
+    <PolyGuard>true</PolyGuard>
     <PolyStringInterpolation>true</PolyStringInterpolation>
     <PolyUseEmbeddedAttribute>true</PolyUseEmbeddedAttribute>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
-    <PackageVersion Include="Polyfill" Version="9.0.3" />
+    <PackageVersion Include="Polyfill" Version="9.0.0-beta.19" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup Label="Test dependencies">

--- a/src/Adapter/MSTest.Engine/Engine/TestFixtureManager.cs
+++ b/src/Adapter/MSTest.Engine/Engine/TestFixtureManager.cs
@@ -43,7 +43,7 @@ internal sealed class TestFixtureManager : ITestFixtureManager
     public async Task<TFixture> GetFixtureAsync<TFixture>(string fixtureId)
         where TFixture : notnull
     {
-        Ensure.NotNullOrWhiteSpace(fixtureId);
+        Guard.NotNullOrWhiteSpace(fixtureId);
         if (!_fixtureInstancesByFixtureId.TryGetValue(fixtureId, out Dictionary<Type, AsyncLazy<object>>? fixtureInstancesPerType))
         {
             throw new InvalidOperationException($"Fixture with ID '{fixtureId}' is not registered");
@@ -148,7 +148,7 @@ internal sealed class TestFixtureManager : ITestFixtureManager
     private void TryRegisterFixture<TFixture>(string fixtureId, Func<Task<TFixture>> asyncFactory, Action onTypeExist)
         where TFixture : notnull
     {
-        Ensure.NotNullOrWhiteSpace(fixtureId);
+        Guard.NotNullOrWhiteSpace(fixtureId);
 
         if (_isRegistrationFrozen)
         {

--- a/src/Adapter/MSTest.Engine/Helpers/TestApplicationBuilderExtensions.cs
+++ b/src/Adapter/MSTest.Engine/Helpers/TestApplicationBuilderExtensions.cs
@@ -19,8 +19,8 @@ public static class TestApplicationBuilderExtensions
         TestFrameworkConfiguration? testFrameworkConfiguration = null,
         params ITestNodesBuilder[] testNodesBuilder)
     {
-        Ensure.NotNull(testApplicationBuilder);
-        Ensure.NotNull(testNodesBuilder);
+        Guard.NotNull(testApplicationBuilder);
+        Guard.NotNull(testNodesBuilder);
         ArgumentGuard.Ensure(testNodesBuilder.Length != 0, nameof(testNodesBuilder),
             "At least one test node builder must be provided.");
 

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -43,9 +43,9 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
 
     internal void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, IConfiguration? configuration)
     {
-        Ensure.NotNull(sources);
-        Ensure.NotNull(logger);
-        Ensure.NotNull(discoverySink);
+        Guard.NotNull(sources);
+        Guard.NotNull(logger);
+        Guard.NotNull(discoverySink);
 
         if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext, logger, configuration, _testSourceHandler))
         {

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -86,8 +86,8 @@ internal sealed class MSTestExecutor : ITestExecutor
     internal async Task RunTestsAsync(IEnumerable<TestCase>? tests, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration)
     {
         PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor.RunTests: Running tests from testcases.");
-        Ensure.NotNull(frameworkHandle);
-        Ensure.NotNullOrEmpty(tests);
+        Guard.NotNull(frameworkHandle);
+        Guard.NotNullOrEmpty(tests);
 
         if (!MSTestDiscovererHelpers.InitializeDiscovery(from test in tests select test.Source, runContext, frameworkHandle, configuration, new TestSourceHandler()))
         {
@@ -100,8 +100,8 @@ internal sealed class MSTestExecutor : ITestExecutor
     internal async Task RunTestsAsync(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration)
     {
         PlatformServiceProvider.Instance.AdapterTraceLogger.LogInfo("MSTestExecutor.RunTests: Running tests from sources.");
-        Ensure.NotNull(frameworkHandle);
-        Ensure.NotNullOrEmpty(sources);
+        Guard.NotNull(frameworkHandle);
+        Guard.NotNullOrEmpty(sources);
 
         TestSourceHandler testSourceHandler = new();
         if (!MSTestDiscovererHelpers.InitializeDiscovery(sources, runContext, frameworkHandle, configuration, testSourceHandler))

--- a/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
@@ -99,7 +99,7 @@ internal
     /// </remarks>
     public AssemblyResolver(IList<string> directories)
     {
-        Ensure.NotNullOrEmpty(directories);
+        Guard.NotNullOrEmpty(directories);
 
         _searchDirectories = [.. directories];
         _directoryList = new Queue<RecursiveDirectoryPath>();

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.cs
@@ -82,8 +82,8 @@ internal sealed class TypeCache : MarshalByRefObject
     /// <returns> The <see cref="TestMethodInfo"/>. </returns>
     public TestMethodInfo? GetTestMethodInfo(TestMethod testMethod, ITestContext testContext)
     {
-        Ensure.NotNull(testMethod);
-        Ensure.NotNull(testContext);
+        Guard.NotNull(testMethod);
+        Guard.NotNull(testContext);
 
         // Get the classInfo (This may throw as GetType calls assembly.GetType(..,true);)
         TestClassInfo? testClassInfo = GetClassInfo(testMethod);
@@ -105,7 +105,7 @@ internal sealed class TypeCache : MarshalByRefObject
     /// <returns> The <see cref="TestMethodInfo"/>. </returns>
     public DiscoveryTestMethodInfo? GetTestMethodInfoForDiscovery(TestMethod testMethod)
     {
-        Ensure.NotNull(testMethod);
+        Guard.NotNull(testMethod);
 
         // Get the classInfo (This may throw as GetType calls assembly.GetType(..,true);)
         TestClassInfo? testClassInfo = GetClassInfo(testMethod);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -131,8 +131,8 @@ internal sealed class UnitTestRunner : MarshalByRefObject
     /// <returns> The <see cref="TestResult"/>. </returns>
     internal async Task<TestResult[]> RunSingleTestAsync(TestMethod testMethod, IDictionary<string, object?> testContextProperties, IMessageLogger messageLogger)
     {
-        Ensure.NotNull(testMethod);
-        Ensure.NotNull(testContextProperties);
+        Guard.NotNull(testMethod);
+        Guard.NotNull(testContextProperties);
 
         ITestContext? testContextForTestExecution = null;
         ITestContext? testContextForAssemblyInit = null;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -31,7 +31,7 @@ internal class ReflectHelper : MarshalByRefObject
     public virtual /* for testing */ bool IsAttributeDefined<TAttribute>(MemberInfo memberInfo)
         where TAttribute : Attribute
     {
-        Ensure.NotNull(memberInfo);
+        Guard.NotNull(memberInfo);
 
         // Get all attributes on the member.
         Attribute[] attributes = GetCustomAttributesCached(memberInfo);
@@ -95,8 +95,8 @@ internal class ReflectHelper : MarshalByRefObject
     /// <returns>True if there is a match.</returns>
     internal static bool MatchReturnType(MethodInfo method, Type returnType)
     {
-        Ensure.NotNull(method);
-        Ensure.NotNull(returnType);
+        Guard.NotNull(method);
+        Guard.NotNull(returnType);
         return method.ReturnType.Equals(returnType);
     }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
@@ -382,7 +382,7 @@ internal sealed class MSTestSettings
     /// <returns>An instance of the <see cref="MSTestSettings"/> class.</returns>
     private static MSTestSettings ToSettings(XmlReader reader, IMessageLogger? logger)
     {
-        Ensure.NotNull(reader);
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -38,12 +38,14 @@ internal sealed class TestMethod : ITestMethod
     internal TestMethod(string? managedTypeName, string? managedMethodName, string?[]? hierarchyValues, string name,
         string fullClassName, string assemblyName, string? displayName, string? parameterTypes)
     {
+        Guard.NotNullOrWhiteSpace(assemblyName);
+
         Name = name;
         DisplayName = displayName ?? name;
         FullClassName = fullClassName;
         ParameterTypes = parameterTypes;
 
-        AssemblyName = Ensure.NotNullOrWhiteSpace(assemblyName);
+        AssemblyName = assemblyName;
 
         if (hierarchyValues is null)
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -27,7 +27,7 @@ internal sealed class UnitTestElement
     /// <exception cref="ArgumentNullException"> Thrown when method is null. </exception>
     public UnitTestElement(TestMethod testMethod)
     {
-        Ensure.NotNull(testMethod);
+        Guard.NotNull(testMethod);
 
         DebugEx.Assert(testMethod.FullClassName != null, "Full className cannot be empty");
         TestMethod = testMethod;

--- a/src/Adapter/MSTestAdapter.PlatformServices/RunConfigurationSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/RunConfigurationSettings.cs
@@ -78,7 +78,7 @@ internal sealed class RunConfigurationSettings
     /// <returns>An instance of the <see cref="MSTestSettings"/> class.</returns>
     private static RunConfigurationSettings ToSettings(XmlReader reader)
     {
-        Ensure.NotNull(reader);
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
@@ -57,7 +57,7 @@ internal class MSTestAdapterSettings
     /// <returns>An instance of the <see cref="MSTestAdapterSettings"/> class.</returns>
     public static MSTestAdapterSettings ToSettings(XmlReader reader)
     {
-        Ensure.NotNull(reader);
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //
@@ -342,7 +342,7 @@ internal class MSTestAdapterSettings
 
     private void ReadAssemblyResolutionPath(XmlReader reader)
     {
-        Ensure.NotNull(reader);
+        Guard.NotNull(reader);
 
         // Expected format of the xml is: -
         //

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/SettingsProvider.cs
@@ -52,7 +52,7 @@ internal sealed class MSTestSettingsProvider : ISettingsProvider
     public void Load(XmlReader reader)
     {
 #if !WINDOWS_UWP
-        Ensure.NotNull(reader);
+        Guard.NotNull(reader);
         var settings = MSTestAdapterSettings.ToSettings(reader);
         if (!ReferenceEquals(settings, Settings))
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
@@ -137,8 +137,8 @@ internal abstract class DeploymentUtilityBase
     /// <returns>Returns a list of deployment warnings.</returns>
     protected IEnumerable<string> Deploy(IList<DeploymentItem> deploymentItems, string testSourceHandler, string deploymentDirectory, string resultsDirectory)
     {
-        Ensure.NotNullOrWhiteSpace(deploymentDirectory);
-        Ensure.NotNullOrWhiteSpace(testSourceHandler);
+        Guard.NotNullOrWhiteSpace(deploymentDirectory);
+        Guard.NotNullOrWhiteSpace(testSourceHandler);
         ApplicationStateGuard.Ensure(FileUtility.DoesDirectoryExist(deploymentDirectory), $"Deployment directory {deploymentDirectory} does not exist");
         ApplicationStateGuard.Ensure(FileUtility.DoesFileExist(testSourceHandler), $"TestSource {testSourceHandler} does not exist.");
 
@@ -153,7 +153,7 @@ internal abstract class DeploymentUtilityBase
         // Copy the deployment items. (As deployment item can correspond to directories as well, so each deployment item may map to n files)
         foreach (DeploymentItem deploymentItem in deploymentItems)
         {
-            Ensure.NotNull(deploymentItem);
+            Guard.NotNull(deploymentItem);
 
             // Validate the output directory.
             if (!IsOutputDirectoryValid(deploymentItem, deploymentDirectory, warnings))
@@ -411,7 +411,7 @@ internal abstract class DeploymentUtilityBase
 
     private bool Deploy(string source, IRunContext? runContext, ITestExecutionRecorder testExecutionRecorder, IList<DeploymentItem> deploymentItems, TestRunDirectories runDirectories)
     {
-        Ensure.NotNull(runDirectories);
+        Guard.NotNull(runDirectories);
         if (EqtTrace.IsInfoEnabled)
         {
             EqtTrace.Info("MSTestExecutor: Found that deployment items for source {0} are: ", source);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/FileUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/FileUtility.cs
@@ -224,7 +224,7 @@ internal class FileUtility
     [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Requirement is to handle all kinds of user exceptions and message appropriately.")]
     public virtual void DeleteDirectories(string filePath)
     {
-        Ensure.NotNullOrWhiteSpace(filePath);
+        Guard.NotNullOrWhiteSpace(filePath);
         try
         {
             var root = new DirectoryInfo(filePath);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/XmlUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/XmlUtilities.cs
@@ -100,7 +100,7 @@ internal class XmlUtilities
         string fromVersion,
         string toVersion)
     {
-        Ensure.NotNull(assemblyName);
+        Guard.NotNull(assemblyName);
 
         // Convert the public key token into a string.
         StringBuilder? publicKeyTokenString = null;

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/FlowTestContextCancellationTokenFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/FlowTestContextCancellationTokenFixer.cs
@@ -115,7 +115,7 @@ public sealed class FlowTestContextCancellationTokenFixer : CodeFixProvider
         }
         else
         {
-            Ensure.NotNull(testContextMemberName);
+            Guard.NotNull(testContextMemberName);
             AddCancellationTokenArgument(editor, invocationExpression, testContextMemberName, cancellationTokenParameterName);
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryLifecycleCallbacks.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryLifecycleCallbacks.cs
@@ -46,7 +46,7 @@ internal sealed class RetryLifecycleCallbacks : ITestHostApplicationLifetime, ID
 
         ILogger<RetryLifecycleCallbacks> logger = _serviceProvider.GetLoggerFactory().CreateLogger<RetryLifecycleCallbacks>();
 
-        Ensure.NotNull(pipeName);
+        Guard.NotNull(pipeName);
         ArgumentGuard.Ensure(pipeName.Length == 1, nameof(pipeName), "Pipe name expected");
         logger.LogDebug($"Connecting to pipe '{pipeName[0]}'");
 

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/Condition.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/Condition.cs
@@ -74,7 +74,7 @@ internal sealed class Condition
     /// </summary>
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        Ensure.NotNull(propertyValueProvider);
+        Guard.NotNull(propertyValueProvider);
         bool result = false;
         string[]? multiValue = GetPropertyValue(propertyValueProvider);
         switch (Operation)
@@ -272,7 +272,7 @@ internal sealed class Condition
 
     internal static IEnumerable<string> TokenizeFilterConditionString(string str)
     {
-        return TokenizeFilterConditionStringWorker(Ensure.NotNull(str));
+        return TokenizeFilterConditionStringWorker(Guard.NotNull(str));
 
         static IEnumerable<string> TokenizeFilterConditionStringWorker(string s)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FastFilter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FastFilter.cs
@@ -13,7 +13,7 @@ internal sealed class FastFilter
 {
     internal FastFilter(ImmutableDictionary<string, ISet<string>> filterProperties, Operation filterOperation, Operator filterOperator)
     {
-        Ensure.NotNullOrEmpty(filterProperties);
+        Guard.NotNullOrEmpty(filterProperties);
 
         FilterProperties = filterProperties;
 
@@ -41,7 +41,7 @@ internal sealed class FastFilter
 
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        Ensure.NotNull(propertyValueProvider);
+        Guard.NotNull(propertyValueProvider);
 
         bool matched = false;
         foreach (string name in FilterProperties.Keys)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpression.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpression.cs
@@ -42,15 +42,18 @@ internal sealed partial class FilterExpression
 
     private FilterExpression(FilterExpression left, FilterExpression right, bool areJoinedByAnd)
     {
-        Ensure.NotNull(left);
-        Ensure.NotNull(right);
+        Guard.NotNull(left);
+        Guard.NotNull(right);
         _left = left;
         _right = right;
         _areJoinedByAnd = areJoinedByAnd;
     }
 
-    private FilterExpression(Condition condition) =>
-        _condition = Ensure.NotNull(condition);
+    private FilterExpression(Condition condition)
+    {
+        Guard.NotNull(condition);
+        _condition = condition;
+    }
 
     /// <summary>
     /// Create a new filter expression 'And'ing 'this' with 'filter'.
@@ -145,7 +148,7 @@ internal sealed partial class FilterExpression
     /// </summary>
     internal static FilterExpression Parse(string filterString, out FastFilter? fastFilter)
     {
-        Ensure.NotNull(filterString);
+        Guard.NotNull(filterString);
 
         // Below parsing doesn't error out on pattern (), so explicitly search for that (empty parenthesis).
         Match invalidInput = GetEmptyParenthesisPattern().Match(filterString);
@@ -309,7 +312,7 @@ internal sealed partial class FilterExpression
     /// <returns> True if evaluation is successful. </returns>
     internal bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        Ensure.NotNull(propertyValueProvider);
+        Guard.NotNull(propertyValueProvider);
 
         return IterateFilterExpression<bool>((current, result) =>
         {
@@ -332,7 +335,7 @@ internal sealed partial class FilterExpression
 
     internal static IEnumerable<string> TokenizeFilterExpressionString(string str)
     {
-        Ensure.NotNull(str);
+        Guard.NotNull(str);
         return TokenizeFilterExpressionStringHelper(str);
 
         static IEnumerable<string> TokenizeFilterExpressionStringHelper(string s)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpressionWrapper.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FilterExpressionWrapper.cs
@@ -31,7 +31,9 @@ internal sealed class FilterExpressionWrapper
     /// </summary>
     public FilterExpressionWrapper(string filterString, FilterOptions? options)
     {
-        FilterString = Ensure.NotNullOrEmpty(filterString);
+        Guard.NotNullOrEmpty(filterString);
+
+        FilterString = filterString;
         FilterOptions = options;
 
         try
@@ -107,7 +109,7 @@ internal sealed class FilterExpressionWrapper
     /// </summary>
     public bool Evaluate(Func<string, object?> propertyValueProvider)
     {
-        Ensure.NotNull(propertyValueProvider);
+        Guard.NotNull(propertyValueProvider);
 
         return UseFastFilter
             ? _fastFilter.Evaluate(propertyValueProvider)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseFilterExpression.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseFilterExpression.cs
@@ -27,7 +27,8 @@ internal sealed class TestCaseFilterExpression : ITestCaseFilterExpression
     /// </summary>
     public TestCaseFilterExpression(FilterExpressionWrapper filterWrapper)
     {
-        _filterWrapper = Ensure.NotNull(filterWrapper);
+        Guard.NotNull(filterWrapper);
+        _filterWrapper = filterWrapper;
         _validForMatch = RoslynString.IsNullOrEmpty(filterWrapper.ParseError);
     }
 
@@ -55,8 +56,8 @@ internal sealed class TestCaseFilterExpression : ITestCaseFilterExpression
     /// </summary>
     public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider)
     {
-        Ensure.NotNull(testCase);
-        Ensure.NotNull(propertyValueProvider);
+        Guard.NotNull(testCase);
+        Guard.NotNull(propertyValueProvider);
 
         return _validForMatch && _filterWrapper.Evaluate(propertyValueProvider);
     }

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/VSTestBridgedTestFrameworkBase.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/VSTestBridgedTestFrameworkBase.cs
@@ -29,7 +29,8 @@ public abstract class VSTestBridgedTestFrameworkBase : ITestFramework, IDataProd
     /// <param name="capabilities">The test framework capabilities.</param>
     protected VSTestBridgedTestFrameworkBase(IServiceProvider serviceProvider, ITestFrameworkCapabilities capabilities)
     {
-        ServiceProvider = Ensure.NotNull(serviceProvider);
+        Guard.NotNull(serviceProvider);
+        ServiceProvider = serviceProvider;
         ITrxReportCapability? capability = capabilities.GetCapability<ITrxReportCapability>();
         IsTrxEnabled = capability is IInternalVSTestBridgeTrxReportCapability internalCapability
             ? internalCapability.IsTrxEnabled

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/ConfigurationFileTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/ConfigurationFileTask.cs
@@ -17,8 +17,11 @@ public sealed class ConfigurationFileTask : Build.Utilities.Task
     private const string ConfigurationFileNameSuffix = "testconfig.json";
     private readonly IFileSystem _fileSystem;
 
-    internal ConfigurationFileTask(IFileSystem? fileSystem) =>
-        _fileSystem = Ensure.NotNull(fileSystem);
+    internal ConfigurationFileTask(IFileSystem? fileSystem)
+    {
+        Guard.NotNull(fileSystem);
+        _fileSystem = fileSystem;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConfigurationFileTask"/> class.

--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
@@ -71,8 +71,8 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
         Func<IServiceProvider, ITestFrameworkCapabilities> capabilitiesFactory,
         Func<ITestFrameworkCapabilities, IServiceProvider, ITestFramework> frameworkFactory)
     {
-        Ensure.NotNull(frameworkFactory);
-        Ensure.NotNull(capabilitiesFactory);
+        Guard.NotNull(frameworkFactory);
+        Guard.NotNull(capabilitiesFactory);
 
         if (_testFrameworkFactory is not null)
         {

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineManager.cs
@@ -17,13 +17,13 @@ internal sealed class CommandLineManager(IRuntimeFeature runtimeFeature, ITestAp
 
     public void AddProvider(Func<ICommandLineOptionsProvider> commandLineProviderFactory)
     {
-        Ensure.NotNull(commandLineProviderFactory);
+        Guard.NotNull(commandLineProviderFactory);
         _commandLineProviderFactory.Add(_ => commandLineProviderFactory());
     }
 
     public void AddProvider(Func<IServiceProvider, ICommandLineOptionsProvider> commandLineProviderFactory)
     {
-        Ensure.NotNull(commandLineProviderFactory);
+        Guard.NotNull(commandLineProviderFactory);
         _commandLineProviderFactory.Add(commandLineProviderFactory);
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
@@ -22,8 +22,8 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
     /// <param name="isBuiltIn">Indicates whether the command line option is built-in.</param>
     internal CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden, bool isBuiltIn)
     {
-        Ensure.NotNullOrWhiteSpace(name);
-        Ensure.NotNullOrWhiteSpace(description);
+        Guard.NotNullOrWhiteSpace(name);
+        Guard.NotNullOrWhiteSpace(description);
         ArgumentGuard.Ensure(arity.Max >= arity.Min, nameof(arity), PlatformResources.CommandLineInvalidArityErrorMessage);
 
         string errorMessage = string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineInvalidOptionName, name);

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProxy.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProxy.cs
@@ -16,6 +16,9 @@ internal sealed class CommandLineOptionsProxy : ICommandLineOptions
             ? throw new InvalidOperationException(Resources.PlatformResources.CommandLineOptionsNotReady)
             : _commandLineOptions.TryGetOptionArgumentList(optionName, out arguments);
 
-    public void SetCommandLineOptions(ICommandLineOptions commandLineOptions) =>
-        _commandLineOptions = Ensure.NotNull(commandLineOptions);
+    public void SetCommandLineOptions(ICommandLineOptions commandLineOptions)
+    {
+        Guard.NotNull(commandLineOptions);
+        _commandLineOptions = commandLineOptions;
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
@@ -57,7 +57,7 @@ internal sealed class AggregatedConfiguration(
     }
 
     public /* for testing */ void SetCurrentWorkingDirectory(string workingDirectory) =>
-        _currentWorkingDirectory = Ensure.NotNull(workingDirectory);
+        _currentWorkingDirectory = Guard.NotNull(workingDirectory);
 
     public async Task CheckTestResultsDirectoryOverrideAndCreateItAsync(IFileLoggerProvider? fileLoggerProvider)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationExtensions.cs
@@ -16,7 +16,7 @@ public static class ConfigurationExtensions
     public static string GetTestResultDirectory(this IConfiguration configuration)
     {
         string? resultDirectory = configuration[PlatformConfigurationConstants.PlatformResultDirectory];
-        return Ensure.NotNull(resultDirectory);
+        return Guard.NotNull(resultDirectory);
     }
 
     /// <summary>
@@ -27,6 +27,6 @@ public static class ConfigurationExtensions
     public static string GetCurrentWorkingDirectory(this IConfiguration configuration)
     {
         string? workingDirectory = configuration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory];
-        return Ensure.NotNull(workingDirectory);
+        return Guard.NotNull(workingDirectory);
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationProvider.cs
@@ -74,7 +74,7 @@ internal sealed class EnvironmentVariablesConfigurationProvider : IConfiguration
 
     public bool TryGet(string key, out string? value)
     {
-        Ensure.NotNullOrEmpty(key, nameof(key));
+        Guard.NotNullOrEmpty(key, nameof(key));
         return _data.TryGetValue(key, out value);
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/CompositeExtensionsFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/CompositeExtensionsFactory.cs
@@ -34,15 +34,21 @@ TestHost: IDataConsumer, ITestApplicationLifetime
     /// Initializes a new instance of the <see cref="CompositeExtensionFactory{TExtension}"/> class.
     /// </summary>
     /// <param name="factory">The factory function that creates the extension with a service provider.</param>
-    public CompositeExtensionFactory(Func<IServiceProvider, TExtension> factory) =>
-        _factoryWithServiceProvider = Ensure.NotNull(factory);
+    public CompositeExtensionFactory(Func<IServiceProvider, TExtension> factory)
+    {
+        Guard.NotNull(factory);
+        _factoryWithServiceProvider = factory;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CompositeExtensionFactory{TExtension}"/> class.
     /// </summary>
     /// <param name="factory">The factory function that creates the extension.</param>
-    public CompositeExtensionFactory(Func<TExtension> factory) =>
-        _factory = Ensure.NotNull(factory);
+    public CompositeExtensionFactory(Func<TExtension> factory)
+    {
+        Guard.NotNull(factory);
+        _factory = factory;
+    }
 
     /// <inheritdoc/>
     object ICloneable.Clone()

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ExtensionValidationHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ExtensionValidationHelper.cs
@@ -18,9 +18,9 @@ internal static class ExtensionValidationHelper
     /// <param name="extensionSelector">Function to extract the IExtension from the collection item.</param>
     public static void ValidateUniqueExtension<T>(this IEnumerable<T> existingExtensions, IExtension newExtension, Func<T, IExtension> extensionSelector)
     {
-        Ensure.NotNull(existingExtensions);
-        Ensure.NotNull(newExtension);
-        Ensure.NotNull(extensionSelector);
+        Guard.NotNull(existingExtensions);
+        Guard.NotNull(newExtension);
+        Guard.NotNull(extensionSelector);
 
         T[] duplicates = [.. existingExtensions.Where(x => extensionSelector(x).Uid == newExtension.Uid)];
         if (duplicates.Length > 0)

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -43,7 +43,7 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
 
     public NamedPipeClient(string name, IEnvironment environment)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         _namedPipeClientStream = new(".", name, PipeDirection.InOut, CurrentUserPipeOptions);
         PipeName = name;
         _environment = environment;

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -69,7 +69,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
         int maxNumberOfServerInstances,
         CancellationToken cancellationToken)
     {
-        Ensure.NotNull(pipeNameDescription);
+        Guard.NotNull(pipeNameDescription);
 #pragma warning disable CA1416 // Validate platform compatibility
         _namedPipeServerStream = new((PipeName = pipeNameDescription).Name, PipeDirection.InOut, maxNumberOfServerInstances, PipeTransmissionMode.Byte, AsyncCurrentUserPipeOptions);
 #pragma warning restore CA1416

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryExtensions.cs
@@ -16,7 +16,7 @@ public static class LoggerFactoryExtensions
     /// <returns>A logger instance.</returns>
     public static ILogger<TCategoryName> CreateLogger<TCategoryName>(this ILoggerFactory factory)
     {
-        Ensure.NotNull(factory);
+        Guard.NotNull(factory);
         return new Logger<TCategoryName>(factory);
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryProxy.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryProxy.cs
@@ -11,6 +11,9 @@ internal sealed class LoggerFactoryProxy : ILoggerFactory
             ? throw new InvalidOperationException(Resources.PlatformResources.LoggerFactoryNotReady)
             : _loggerFactory.CreateLogger(categoryName);
 
-    public void SetLoggerFactory(ILoggerFactory loggerFactory) =>
-        _loggerFactory = Ensure.NotNull(loggerFactory);
+    public void SetLoggerFactory(ILoggerFactory loggerFactory)
+    {
+        Guard.NotNull(loggerFactory);
+        _loggerFactory = loggerFactory;
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggingManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggingManager.cs
@@ -12,7 +12,7 @@ internal sealed class LoggingManager : ILoggingManager
 
     public void AddProvider(Func<LogLevel, IServiceProvider, ILoggerProvider> loggerProviderFactory)
     {
-        Ensure.NotNull(loggerProviderFactory);
+        Guard.NotNull(loggerProviderFactory);
         _loggerProviderFullFactories.Add(loggerProviderFactory);
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/MessageBusProxy.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/MessageBusProxy.cs
@@ -19,8 +19,11 @@ internal sealed class MessageBusProxy : BaseMessageBus, IMessageBus
         await _messageBus.InitAsync().ConfigureAwait(false);
     }
 
-    public void SetBuiltMessageBus(BaseMessageBus messageBus) =>
-        _messageBus = Ensure.NotNull(messageBus);
+    public void SetBuiltMessageBus(BaseMessageBus messageBus)
+    {
+        Guard.NotNull(messageBus);
+        _messageBus = messageBus;
+    }
 
     public override async Task PublishAsync(IDataProducer dataProducer, IData data)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.Property.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.Property.cs
@@ -140,8 +140,11 @@ public sealed partial class PropertyBag
     {
         private readonly Property _property;
 
-        public PropertyDebugView(Property property) =>
-            _property = Ensure.NotNull(property);
+        public PropertyDebugView(Property property)
+        {
+            Guard.NotNull(property);
+            _property = property;
+        }
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public IProperty[] Items => [.. _property.AsEnumerable()];

--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
@@ -35,7 +35,7 @@ public sealed partial class PropertyBag
     /// <param name="properties">The collection of properties.</param>
     public PropertyBag(params IProperty[] properties)
     {
-        Ensure.NotNull(properties);
+        Guard.NotNull(properties);
 
         if (properties.Length == 0)
         {
@@ -78,7 +78,7 @@ public sealed partial class PropertyBag
     /// <param name="properties">The collection of properties.</param>
     public PropertyBag(IEnumerable<IProperty> properties)
     {
-        Ensure.NotNull(properties);
+        Guard.NotNull(properties);
 
         foreach (IProperty property in properties)
         {
@@ -123,7 +123,7 @@ public sealed partial class PropertyBag
     /// <param name="property">The property to add.</param>
     public void Add(IProperty property)
     {
-        Ensure.NotNull(property);
+        Guard.NotNull(property);
 
         // Optimized access to the TestNodeStateProperty, it's one of the most used property.
         if (property is TestNodeStateProperty testNodeStateProperty)

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUid.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeUid.cs
@@ -12,7 +12,7 @@ public sealed class TestNodeUid(string value) : IEquatable<TestNodeUid>
     /// <summary>
     /// Gets the UID.
     /// </summary>
-    public string Value { get; init; } = Ensure.NotNullOrWhiteSpace(value);
+    public string Value { get; init; } = Guard.NotNullOrWhiteSpace(value);
 
     /// <summary>
     /// Implicitly converts a <see cref="TestNodeUid"/> to a <see cref="string"/>.

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceManager.cs
@@ -11,8 +11,11 @@ internal sealed class PlatformOutputDeviceManager
 {
     private Func<IServiceProvider, IPlatformOutputDevice>? _platformOutputDeviceFactory;
 
-    public void SetPlatformOutputDevice(Func<IServiceProvider, IPlatformOutputDevice> platformOutputDeviceFactory) =>
-        _platformOutputDeviceFactory = Ensure.NotNull(platformOutputDeviceFactory);
+    public void SetPlatformOutputDevice(Func<IServiceProvider, IPlatformOutputDevice> platformOutputDeviceFactory)
+    {
+        Guard.NotNull(platformOutputDeviceFactory);
+        _platformOutputDeviceFactory = platformOutputDeviceFactory;
+    }
 
     internal async Task<ProxyOutputDevice> BuildAsync(ServiceProvider serviceProvider, bool useServerModeOutputDevice)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -24,7 +24,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
 
     internal TreeNodeFilter(string filter)
     {
-        Filter = Ensure.NotNull(filter);
+        Filter = Guard.NotNull(filter);
         _filters = ParseFilter(filter);
     }
 
@@ -482,7 +482,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
     /// <param name="filterableProperties">The URL encoded node properties.</param>
     public bool MatchesFilter(string testNodeFullPath, PropertyBag filterableProperties)
     {
-        Ensure.NotNullOrEmpty(testNodeFullPath);
+        Guard.NotNullOrEmpty(testNodeFullPath);
         ArgumentGuard.Ensure(testNodeFullPath[0] == PathSeparator, nameof(testNodeFullPath),
             string.Format(CultureInfo.InvariantCulture, PlatformResources.TreeNodeFilterPathShouldStartWithSlashErrorMessage, PathSeparator));
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -234,8 +234,8 @@ internal sealed class DiscoveredTestMessagesSerializer : BaseSerializer, INamedP
                 }
             }
 
-            Ensure.NotNull(key);
-            Ensure.NotNull(value);
+            Guard.NotNull(key);
+            Guard.NotNull(value);
             traits[i] = new TestMetadataProperty(key, value);
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PerRequestServerDataConsumerService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PerRequestServerDataConsumerService.cs
@@ -143,7 +143,7 @@ internal sealed class PerRequestServerDataConsumer(IServiceProvider serviceProvi
             using CancellationTokenRegistration registration = cancellationToken.Register(_testSessionEnd.SetCanceled);
 
             // When batch timer expire or we're at the end of the session we can unblock the message drain
-            Ensure.NotNull(_task);
+            Guard.NotNull(_task);
             await Task.WhenAny(_task.Delay(TimeSpan.FromMilliseconds(TestNodeUpdateDelayInMs), cancellationToken), _testSessionEnd.Task).ConfigureAwait(false);
 
             if (cancellationToken.IsCancellationRequested)

--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceProviderExtensions
     public static TService GetRequiredService<TService>(this IServiceProvider provider)
         where TService : notnull
     {
-        Ensure.NotNull(provider);
+        Guard.NotNull(provider);
 
         object? service = provider.GetService(typeof(TService));
         ApplicationStateGuard.Ensure(service is not null, string.Format(CultureInfo.InvariantCulture, PlatformResources.ServiceProviderCannotFindServiceErrorMessage, typeof(TService)));
@@ -50,7 +50,7 @@ public static class ServiceProviderExtensions
     public static TService? GetService<TService>(this IServiceProvider provider)
         where TService : class
     {
-        Ensure.NotNull(provider);
+        Guard.NotNull(provider);
 
         return provider.GetService(typeof(TService)) as TService;
     }
@@ -108,7 +108,7 @@ public static class ServiceProviderExtensions
     internal static TService GetRequiredServiceInternal<TService>(this IServiceProvider provider)
         where TService : notnull
     {
-        Ensure.NotNull(provider);
+        Guard.NotNull(provider);
 
         object? service = ((ServiceProvider)provider).GetServiceInternal(typeof(TService));
         ApplicationStateGuard.Ensure(service is not null, string.Format(CultureInfo.InvariantCulture, PlatformResources.ServiceProviderCannotFindServiceErrorMessage, typeof(TService)));
@@ -119,7 +119,7 @@ public static class ServiceProviderExtensions
     internal static TService? GetServiceInternal<TService>(this IServiceProvider provider)
         where TService : class
     {
-        Ensure.NotNull(provider);
+        Guard.NotNull(provider);
 
         return ((ServiceProvider)provider).GetServiceInternal(typeof(TService)) as TService;
     }
@@ -127,7 +127,7 @@ public static class ServiceProviderExtensions
     internal static IEnumerable<TService> GetServicesInternal<TService>(this IServiceProvider provider)
         where TService : notnull
     {
-        Ensure.NotNull(provider);
+        Guard.NotNull(provider);
 
         return ((ServiceProvider)provider).GetServicesInternal(typeof(TService)).Cast<TService>();
     }

--- a/src/Platform/Microsoft.Testing.Platform/Telemetry/TelemetryManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Telemetry/TelemetryManager.cs
@@ -24,8 +24,11 @@ internal sealed class TelemetryManager : ITelemetryManager, IOutputDeviceDataPro
 
     public string Description => string.Empty;
 
-    public void AddTelemetryCollectorProvider(Func<IServiceProvider, ITelemetryCollector> telemetryFactory) =>
-        _telemetryFactory = Ensure.NotNull(telemetryFactory);
+    public void AddTelemetryCollectorProvider(Func<IServiceProvider, ITelemetryCollector> telemetryFactory)
+    {
+        Guard.NotNull(telemetryFactory);
+        _telemetryFactory = telemetryFactory;
+    }
 
     public async Task<ITelemetryCollector> BuildAsync(ServiceProvider serviceProvider, ILoggerFactory loggerFactory, TestApplicationOptions testApplicationOptions)
     {

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
@@ -28,7 +28,7 @@ internal sealed class TestHostManager : ITestHostManager
 
     public void AddTestFrameworkInvoker(Func<IServiceProvider, ITestFrameworkInvoker> testFrameworkInvokerFactory)
     {
-        Ensure.NotNull(testFrameworkInvokerFactory);
+        Guard.NotNull(testFrameworkInvokerFactory);
         if (_testFrameworkInvokerFactory is not null)
         {
             throw new InvalidOperationException(PlatformResources.TestAdapterInvokerFactoryAlreadySetErrorMessage);
@@ -59,7 +59,7 @@ internal sealed class TestHostManager : ITestHostManager
 
     public void AddTestExecutionFilterFactory(Func<IServiceProvider, ITestExecutionFilterFactory> testExecutionFilterFactory)
     {
-        Ensure.NotNull(testExecutionFilterFactory);
+        Guard.NotNull(testExecutionFilterFactory);
         if (_testExecutionFilterFactory is not null)
         {
             throw new InvalidOperationException(PlatformResources.TEstExecutionFilterFactoryFactoryAlreadySetErrorMessage);
@@ -90,7 +90,7 @@ internal sealed class TestHostManager : ITestHostManager
 
     public void AddTestHostApplicationLifetime(Func<IServiceProvider, ITestHostApplicationLifetime> testHostApplicationLifetime)
     {
-        Ensure.NotNull(testHostApplicationLifetime);
+        Guard.NotNull(testHostApplicationLifetime);
         _testApplicationLifecycleCallbacksFactories.Add(testHostApplicationLifetime);
     }
 
@@ -119,7 +119,7 @@ internal sealed class TestHostManager : ITestHostManager
 
     public void AddDataConsumer(Func<IServiceProvider, IDataConsumer> dataConsumerFactory)
     {
-        Ensure.NotNull(dataConsumerFactory);
+        Guard.NotNull(dataConsumerFactory);
         _dataConsumerFactories.Add(dataConsumerFactory);
         _factoryOrdering.Add(dataConsumerFactory);
     }
@@ -127,7 +127,7 @@ internal sealed class TestHostManager : ITestHostManager
     public void AddDataConsumer<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, IDataConsumer
     {
-        Ensure.NotNull(compositeServiceFactory);
+        Guard.NotNull(compositeServiceFactory);
         if (_dataConsumersCompositeServiceFactories.Contains(compositeServiceFactory))
         {
             throw new ArgumentException(PlatformResources.CompositeServiceFactoryInstanceAlreadyRegistered);
@@ -205,7 +205,7 @@ internal sealed class TestHostManager : ITestHostManager
 
     public void AddTestSessionLifetimeHandle(Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandleFactory)
     {
-        Ensure.NotNull(testSessionLifetimeHandleFactory);
+        Guard.NotNull(testSessionLifetimeHandleFactory);
         _testSessionLifetimeHandlerFactories.Add(testSessionLifetimeHandleFactory);
         _factoryOrdering.Add(testSessionLifetimeHandleFactory);
     }
@@ -213,7 +213,7 @@ internal sealed class TestHostManager : ITestHostManager
     public void AddTestSessionLifetimeHandle<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestSessionLifetimeHandler
     {
-        Ensure.NotNull(compositeServiceFactory);
+        Guard.NotNull(compositeServiceFactory);
         if (_testSessionLifetimeHandlerCompositeFactories.Contains(compositeServiceFactory))
         {
             throw new ArgumentException(PlatformResources.CompositeServiceFactoryInstanceAlreadyRegistered);

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
@@ -25,7 +25,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
 
     public void AddEnvironmentVariableProvider(Func<IServiceProvider, ITestHostEnvironmentVariableProvider> environmentVariableProviderFactory)
     {
-        Ensure.NotNull(environmentVariableProviderFactory);
+        Guard.NotNull(environmentVariableProviderFactory);
         _environmentVariableProviderFactories.Add(environmentVariableProviderFactory);
         _factoryOrdering.Add(environmentVariableProviderFactory);
     }
@@ -33,7 +33,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddEnvironmentVariableProvider<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestHostEnvironmentVariableProvider
     {
-        Ensure.NotNull(compositeServiceFactory);
+        Guard.NotNull(compositeServiceFactory);
         if (_environmentVariableProviderCompositeFactories.Contains(compositeServiceFactory))
         {
             throw new ArgumentException(PlatformResources.CompositeServiceFactoryInstanceAlreadyRegistered);
@@ -45,7 +45,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
 
     public void AddProcessLifetimeHandler(Func<IServiceProvider, ITestHostProcessLifetimeHandler> lifetimeHandler)
     {
-        Ensure.NotNull(lifetimeHandler);
+        Guard.NotNull(lifetimeHandler);
         _lifetimeHandlerFactories.Add(lifetimeHandler);
         _factoryOrdering.Add(lifetimeHandler);
     }
@@ -53,7 +53,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddProcessLifetimeHandler<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestHostProcessLifetimeHandler
     {
-        Ensure.NotNull(compositeServiceFactory);
+        Guard.NotNull(compositeServiceFactory);
         if (_lifetimeHandlerCompositeFactories.Contains(compositeServiceFactory))
         {
             throw new ArgumentException(PlatformResources.CompositeServiceFactoryInstanceAlreadyRegistered);
@@ -66,7 +66,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddDataConsumer<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, IDataConsumer
     {
-        Ensure.NotNull(compositeServiceFactory);
+        Guard.NotNull(compositeServiceFactory);
         if (_dataConsumersCompositeServiceFactories.Contains(compositeServiceFactory))
         {
             throw new ArgumentException(PlatformResources.CompositeServiceFactoryInstanceAlreadyRegistered);

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrcherstrator/TestHostOrchestratorManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrcherstrator/TestHostOrchestratorManager.cs
@@ -13,7 +13,7 @@ internal sealed class TestHostOrchestratorManager : ITestHostOrchestratorManager
 
     public void AddTestHostOrchestrator(Func<IServiceProvider, ITestHostOrchestrator> factory)
     {
-        Ensure.NotNull(factory);
+        Guard.NotNull(factory);
         _factories ??= [];
         _factories.Add(factory);
     }
@@ -48,7 +48,7 @@ internal sealed class TestHostOrchestratorManager : ITestHostOrchestratorManager
 
     public void AddTestHostOrchestratorApplicationLifetime(Func<IServiceProvider, ITestHostOrchestratorApplicationLifetime> testHostOrchestratorApplicationLifetimeFactory)
     {
-        Ensure.NotNull(testHostOrchestratorApplicationLifetimeFactory);
+        Guard.NotNull(testHostOrchestratorApplicationLifetimeFactory);
         _testHostOrchestratorApplicationLifetimeFactories.Add(testHostOrchestratorApplicationLifetimeFactory);
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Tools/ToolsManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Tools/ToolsManager.cs
@@ -11,7 +11,7 @@ internal sealed class ToolsManager : IToolsManager
 
     public void AddTool(Func<IServiceProvider, ITool> toolFactory)
     {
-        Ensure.NotNull(toolFactory);
+        Guard.NotNull(toolFactory);
         _toolsFactories.Add(toolFactory);
     }
 

--- a/src/TestFramework/TestFramework.Extensions/Attributes/WinUITestTargetAttribute.cs
+++ b/src/TestFramework/TestFramework.Extensions/Attributes/WinUITestTargetAttribute.cs
@@ -19,7 +19,7 @@ public class WinUITestTargetAttribute : Attribute
     /// </param>
     public WinUITestTargetAttribute(Type applicationType)
     {
-        Ensure.NotNull(applicationType);
+        Guard.NotNull(applicationType);
 
         if (!typeof(UI.Xaml.Application).IsAssignableFrom(applicationType))
         {

--- a/src/TestFramework/TestFramework.Extensions/PrivateObject.cs
+++ b/src/TestFramework/TestFramework.Extensions/PrivateObject.cs
@@ -32,7 +32,7 @@ public class PrivateObject
     [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "We don't know anything about the object other than that it's an object, so 'obj' seems reasonable")]
     public PrivateObject(object obj, string memberToAccess)
     {
-        Ensure.NotNull(obj);
+        Guard.NotNull(obj);
         ValidateAccessString(memberToAccess);
 
         var temp = obj as PrivateObject;
@@ -75,8 +75,8 @@ public class PrivateObject
     public PrivateObject(string assemblyName, string typeName, Type[]? parameterTypes, object?[]? args)
         : this(Type.GetType(string.Format(CultureInfo.InvariantCulture, "{0}, {1}", typeName, assemblyName), false), parameterTypes, args)
     {
-        Ensure.NotNull(assemblyName);
-        Ensure.NotNull(typeName);
+        Guard.NotNull(assemblyName);
+        Guard.NotNull(typeName);
     }
 
     /// <summary>
@@ -87,7 +87,7 @@ public class PrivateObject
     /// <param name="args">Arguments to pass to the constructor.</param>
     public PrivateObject(Type type, params object?[]? args)
         : this(type, null, args) =>
-        Ensure.NotNull(type);
+        Guard.NotNull(type);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PrivateObject"/> class that wraps the
@@ -98,7 +98,7 @@ public class PrivateObject
     /// <param name="args">Arguments to pass to the constructor.</param>
     public PrivateObject(Type type, Type[]? parameterTypes, object?[]? args)
     {
-        Ensure.NotNull(type);
+        Guard.NotNull(type);
         object? o;
         if (parameterTypes != null)
         {
@@ -124,7 +124,8 @@ public class PrivateObject
             o = Activator.CreateInstance(type, ConstructorFlags, null, args, null);
         }
 
-        _target = Ensure.NotNull(o);
+        Guard.NotNull(o);
+        _target = o;
         RealType = o.GetType();
     }
 
@@ -136,7 +137,8 @@ public class PrivateObject
     [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "We don't know anything about the object other than that it's an object, so 'obj' seems reasonable")]
     public PrivateObject(object obj)
     {
-        _target = Ensure.NotNull(obj);
+        Guard.NotNull(obj);
+        _target = obj;
         RealType = obj.GetType();
     }
 
@@ -149,7 +151,8 @@ public class PrivateObject
     [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "We don't know anything about the object other than that it's an object, so 'obj' seems reasonable")]
     public PrivateObject(object obj, PrivateType type)
     {
-        _target = Ensure.NotNull(type);
+        Guard.NotNull(type);
+        _target = obj;
         RealType = type.ReferencedType;
     }
 
@@ -163,7 +166,8 @@ public class PrivateObject
         get => _target;
         set
         {
-            _target = Ensure.NotNull(value);
+            Guard.NotNull(value);
+            _target = value;
             RealType = value.GetType();
         }
     }
@@ -226,7 +230,7 @@ public class PrivateObject
     /// <returns>Result of method call.</returns>
     public object? Invoke(string name, params object?[]? args)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return Invoke(name, null, args, CultureInfo.InvariantCulture);
     }
 
@@ -320,7 +324,7 @@ public class PrivateObject
     /// <returns>Result of method call.</returns>
     public object? Invoke(string name, BindingFlags bindingFlags, Type[]? parameterTypes, object?[]? args, CultureInfo? culture, Type[]? typeArguments)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         if (parameterTypes == null)
         {
             return InvokeHelper(name, bindingFlags | BindingFlags.InvokeMethod, args, culture);
@@ -381,7 +385,7 @@ public class PrivateObject
     /// <returns>An array of elements.</returns>
     public object GetArrayElement(string name, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return GetArrayElement(name, BindToEveryThing, indices);
     }
 
@@ -393,7 +397,7 @@ public class PrivateObject
     /// <param name="indices">the indices of array.</param>
     public void SetArrayElement(string name, object value, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         SetArrayElement(name, BindToEveryThing, value, indices);
     }
 
@@ -406,7 +410,7 @@ public class PrivateObject
     /// <returns>An array of elements.</returns>
     public object GetArrayElement(string name, BindingFlags bindingFlags, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         var arr = (Array?)InvokeHelper(name, BindingFlags.GetField | bindingFlags, null, CultureInfo.InvariantCulture);
         DebugEx.Assert(arr is not null, "arr should not be null");
         return arr.GetValue(indices);
@@ -421,7 +425,7 @@ public class PrivateObject
     /// <param name="indices">the indices of array.</param>
     public void SetArrayElement(string name, BindingFlags bindingFlags, object value, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         var arr = (Array?)InvokeHelper(name, BindingFlags.GetField | bindingFlags, null, CultureInfo.InvariantCulture);
         DebugEx.Assert(arr is not null, "arr should not be null");
         arr.SetValue(value, indices);
@@ -434,7 +438,7 @@ public class PrivateObject
     /// <returns>The field.</returns>
     public object? GetField(string name)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return GetField(name, BindToEveryThing);
     }
 
@@ -445,7 +449,7 @@ public class PrivateObject
     /// <param name="value">value to set.</param>
     public void SetField(string name, object value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         SetField(name, BindToEveryThing, value);
     }
 
@@ -457,7 +461,7 @@ public class PrivateObject
     /// <returns>The field.</returns>
     public object? GetField(string name, BindingFlags bindingFlags)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return InvokeHelper(name, BindingFlags.GetField | bindingFlags, null, CultureInfo.InvariantCulture);
     }
 
@@ -469,7 +473,7 @@ public class PrivateObject
     /// <param name="value">value to set.</param>
     public void SetField(string name, BindingFlags bindingFlags, object? value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         InvokeHelper(name, BindingFlags.SetField | bindingFlags, [value], CultureInfo.InvariantCulture);
     }
 
@@ -480,7 +484,7 @@ public class PrivateObject
     /// <returns>The field or property.</returns>
     public object? GetFieldOrProperty(string name)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return GetFieldOrProperty(name, BindToEveryThing);
     }
 
@@ -491,7 +495,7 @@ public class PrivateObject
     /// <param name="value">value to set.</param>
     public void SetFieldOrProperty(string name, object value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         SetFieldOrProperty(name, BindToEveryThing, value);
     }
 
@@ -503,7 +507,7 @@ public class PrivateObject
     /// <returns>The field or property.</returns>
     public object? GetFieldOrProperty(string name, BindingFlags bindingFlags)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return InvokeHelper(name, BindingFlags.GetField | BindingFlags.GetProperty | bindingFlags, null, CultureInfo.InvariantCulture);
     }
 
@@ -515,7 +519,7 @@ public class PrivateObject
     /// <param name="value">value to set.</param>
     public void SetFieldOrProperty(string name, BindingFlags bindingFlags, object? value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         InvokeHelper(name, BindingFlags.SetField | BindingFlags.SetProperty | bindingFlags, [value], CultureInfo.InvariantCulture);
     }
 
@@ -572,7 +576,7 @@ public class PrivateObject
     /// <returns>The property.</returns>
     public object? GetProperty(string name, BindingFlags bindingFlags, Type[]? parameterTypes, object?[]? args)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         if (parameterTypes == null)
         {
             return InvokeHelper(name, bindingFlags | BindingFlags.GetProperty, args, null);
@@ -602,7 +606,7 @@ public class PrivateObject
     /// <param name="args">Arguments to pass to the member to invoke.</param>
     public void SetProperty(string name, BindingFlags bindingFlags, object? value, Type[]? parameterTypes, object?[]? args)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
 
         if (parameterTypes == null)
         {
@@ -627,7 +631,7 @@ public class PrivateObject
     /// <param name="access"> access string.</param>
     private static void ValidateAccessString(string access)
     {
-        Ensure.NotNull(access);
+        Guard.NotNull(access);
         if (access.Length == 0)
         {
             throw new ArgumentException(FrameworkMessages.AccessStringInvalidSyntax);
@@ -653,7 +657,7 @@ public class PrivateObject
     /// <returns>Result of the invocation.</returns>
     private object? InvokeHelper(string name, BindingFlags bindingFlags, object?[]? args, CultureInfo? culture)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         DebugEx.Assert(_target != null, "Internal Error: Null reference is returned for internal object");
 
         // Invoke the actual Method

--- a/src/TestFramework/TestFramework.Extensions/PrivateType.cs
+++ b/src/TestFramework/TestFramework.Extensions/PrivateType.cs
@@ -24,8 +24,8 @@ public class PrivateType
     /// <param name="typeName">fully qualified name of the. </param>
     public PrivateType(string assemblyName, string typeName)
     {
-        Ensure.NotNull(typeName);
-        Ensure.NotNull(assemblyName);
+        Guard.NotNull(typeName);
+        Guard.NotNull(assemblyName);
         var asm = Assembly.Load(assemblyName);
 
         ReferencedType = asm.GetType(typeName, true);
@@ -37,7 +37,7 @@ public class PrivateType
     /// </summary>
     /// <param name="type">The wrapped Type to create.</param>
     public PrivateType(Type type) =>
-        ReferencedType = Ensure.NotNull(type);
+        ReferencedType = Guard.NotNull(type);
 
     /// <summary>
     /// Gets the referenced type.
@@ -142,7 +142,7 @@ public class PrivateType
     /// <returns>Result of invocation.</returns>
     public object InvokeStatic(string name, BindingFlags bindingFlags, Type[]? parameterTypes, object?[]? args, CultureInfo? culture, Type[]? typeArguments)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         if (parameterTypes == null)
         {
             return InvokeHelperStatic(name, bindingFlags | BindingFlags.InvokeMethod, args, culture);
@@ -185,7 +185,7 @@ public class PrivateType
     /// <returns>element at the specified location.</returns>
     public object GetStaticArrayElement(string name, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return GetStaticArrayElement(name, BindToEveryThing, indices);
     }
 
@@ -200,7 +200,7 @@ public class PrivateType
     /// </param>
     public void SetStaticArrayElement(string name, object value, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         SetStaticArrayElement(name, BindToEveryThing, value, indices);
     }
 
@@ -216,7 +216,7 @@ public class PrivateType
     /// <returns>element at the specified location.</returns>
     public object GetStaticArrayElement(string name, BindingFlags bindingFlags, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         var arr = (Array)InvokeHelperStatic(name, BindingFlags.GetField | BindingFlags.GetProperty | bindingFlags, null, CultureInfo.InvariantCulture);
         return arr.GetValue(indices);
     }
@@ -233,7 +233,7 @@ public class PrivateType
     /// </param>
     public void SetStaticArrayElement(string name, BindingFlags bindingFlags, object value, params int[] indices)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         var arr = (Array)InvokeHelperStatic(name, BindingFlags.GetField | BindingFlags.GetProperty | BindingFlags.Static | bindingFlags, null, CultureInfo.InvariantCulture);
         arr.SetValue(value, indices);
     }
@@ -245,7 +245,7 @@ public class PrivateType
     /// <returns>The static field.</returns>
     public object GetStaticField(string name)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return GetStaticField(name, BindToEveryThing);
     }
 
@@ -256,7 +256,7 @@ public class PrivateType
     /// <param name="value">Argument to the invocation.</param>
     public void SetStaticField(string name, object value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         SetStaticField(name, BindToEveryThing, value);
     }
 
@@ -268,7 +268,7 @@ public class PrivateType
     /// <returns>The static field.</returns>
     public object GetStaticField(string name, BindingFlags bindingFlags)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return InvokeHelperStatic(name, BindingFlags.GetField | BindingFlags.Static | bindingFlags, null, CultureInfo.InvariantCulture);
     }
 
@@ -280,7 +280,7 @@ public class PrivateType
     /// <param name="value">Argument to the invocation.</param>
     public void SetStaticField(string name, BindingFlags bindingFlags, object value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         InvokeHelperStatic(name, BindingFlags.SetField | bindingFlags | BindingFlags.Static, [value], CultureInfo.InvariantCulture);
     }
 
@@ -291,7 +291,7 @@ public class PrivateType
     /// <returns>The static field or property.</returns>
     public object GetStaticFieldOrProperty(string name)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return GetStaticFieldOrProperty(name, BindToEveryThing);
     }
 
@@ -302,7 +302,7 @@ public class PrivateType
     /// <param name="value">Value to be set to field or property.</param>
     public void SetStaticFieldOrProperty(string name, object value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         SetStaticFieldOrProperty(name, BindToEveryThing, value);
     }
 
@@ -314,7 +314,7 @@ public class PrivateType
     /// <returns>The static field or property.</returns>
     public object GetStaticFieldOrProperty(string name, BindingFlags bindingFlags)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         return InvokeHelperStatic(name, BindingFlags.GetField | BindingFlags.GetProperty | BindingFlags.Static | bindingFlags, null, CultureInfo.InvariantCulture);
     }
 
@@ -326,7 +326,7 @@ public class PrivateType
     /// <param name="value">Value to be set to field or property.</param>
     public void SetStaticFieldOrProperty(string name, BindingFlags bindingFlags, object value)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         InvokeHelperStatic(name, BindingFlags.SetField | BindingFlags.SetProperty | bindingFlags | BindingFlags.Static, [value], CultureInfo.InvariantCulture);
     }
 
@@ -374,7 +374,7 @@ public class PrivateType
     /// <returns>The static property.</returns>
     public object GetStaticProperty(string name, BindingFlags bindingFlags, Type[]? parameterTypes, object?[]? args)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         if (parameterTypes == null)
         {
             return InvokeHelperStatic(name, bindingFlags | BindingFlags.GetProperty, args, null);
@@ -404,7 +404,7 @@ public class PrivateType
     /// <param name="args">Arguments to pass to the member to invoke.</param>
     public void SetStaticProperty(string name, BindingFlags bindingFlags, object value, Type[]? parameterTypes, object?[]? args)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
 
         if (parameterTypes != null)
         {
@@ -431,7 +431,7 @@ public class PrivateType
     /// <returns>Result of invocation.</returns>
     private object InvokeHelperStatic(string name, BindingFlags bindingFlags, object?[]? args, CultureInfo? culture)
     {
-        Ensure.NotNull(name);
+        Guard.NotNull(name);
         try
         {
             return ReferencedType.InvokeMember(name, bindingFlags | BindToEveryThing | BindingFlags.Static, null, null, args, culture);

--- a/src/TestFramework/TestFramework.Extensions/RuntimeTypeHelper.cs
+++ b/src/TestFramework/TestFramework.Extensions/RuntimeTypeHelper.cs
@@ -113,7 +113,7 @@ internal sealed class RuntimeTypeHelper
     [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Reviewed. Suppression is OK here.")]
     internal static MethodBase? SelectMethod(MethodBase[] match, Type[] types)
     {
-        Ensure.NotNull(match);
+        Guard.NotNull(match);
 
         int i;
         int j;

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -208,7 +208,7 @@ public sealed partial class Assert
 
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? expected, string? actual, bool ignoreCase, CultureInfo culture, out bool shouldAppend)
         {
-            Ensure.NotNull(culture);
+            Guard.NotNull(culture);
             shouldAppend = AreEqualFailing(expected, actual, ignoreCase, culture);
             if (shouldAppend)
             {
@@ -314,7 +314,7 @@ public sealed partial class Assert
 
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? notExpected, string? actual, bool ignoreCase, CultureInfo culture, out bool shouldAppend)
         {
-            Ensure.NotNull(culture);
+            Guard.NotNull(culture);
             shouldAppend = AreNotEqualFailing(notExpected, actual, ignoreCase, culture);
             if (shouldAppend)
             {

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
@@ -321,8 +321,8 @@ public sealed partial class Assert
     private static TException ThrowsException<TException>(Action action, bool isStrictType, string? message, string actionExpression, [CallerMemberName] string assertMethodName = "")
         where TException : Exception
     {
-        Ensure.NotNull(action);
-        Ensure.NotNull(message);
+        Guard.NotNull(action);
+        Guard.NotNull(message);
 
         ThrowsExceptionState state = IsThrowsFailing<TException>(action, isStrictType, assertMethodName);
         if (state.FailAction is not null)
@@ -341,8 +341,8 @@ public sealed partial class Assert
     private static TException ThrowsException<TException>(Action action, bool isStrictType, Func<Exception?, string> messageBuilder, string actionExpression, [CallerMemberName] string assertMethodName = "")
         where TException : Exception
     {
-        Ensure.NotNull(action);
-        Ensure.NotNull(messageBuilder);
+        Guard.NotNull(action);
+        Guard.NotNull(messageBuilder);
 
         ThrowsExceptionState state = IsThrowsFailing<TException>(action, isStrictType, assertMethodName);
         if (state.FailAction is not null)
@@ -477,8 +477,8 @@ public sealed partial class Assert
     private static async Task<TException> ThrowsExceptionAsync<TException>(Func<Task> action, bool isStrictType, string? message, string actionExpression, [CallerMemberName] string assertMethodName = "")
         where TException : Exception
     {
-        Ensure.NotNull(action);
-        Ensure.NotNull(message);
+        Guard.NotNull(action);
+        Guard.NotNull(message);
 
         ThrowsExceptionState state = await IsThrowsAsyncFailingAsync<TException>(action, isStrictType, assertMethodName).ConfigureAwait(false);
         if (state.FailAction is not null)
@@ -497,8 +497,8 @@ public sealed partial class Assert
     private static async Task<TException> ThrowsExceptionAsync<TException>(Func<Task> action, bool isStrictType, Func<Exception?, string> messageBuilder, string actionExpression, [CallerMemberName] string assertMethodName = "")
         where TException : Exception
     {
-        Ensure.NotNull(action);
-        Ensure.NotNull(messageBuilder);
+        Guard.NotNull(action);
+        Guard.NotNull(messageBuilder);
 
         ThrowsExceptionState state = await IsThrowsAsyncFailingAsync<TException>(action, isStrictType, assertMethodName).ConfigureAwait(false);
         if (state.FailAction is not null)

--- a/src/TestFramework/TestFramework/Logger.cs
+++ b/src/TestFramework/TestFramework/Logger.cs
@@ -33,8 +33,8 @@ public class Logger
             return;
         }
 
-        Ensure.NotNull(format);
-        Ensure.NotNull(args);
+        Guard.NotNull(format);
+        Guard.NotNull(args);
 
         string message = args.Length == 0
             ? format

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/TestCaseFilterFactory.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/TestCaseFilterFactory.cs
@@ -19,7 +19,7 @@ internal static class TestCaseFilterFactory
 
     public static ITestCaseFilterExpression ParseTestFilter(string filterString)
     {
-        Ensure.NotNullOrEmpty(filterString);
+        Guard.NotNullOrEmpty(filterString);
         if (Regex.IsMatch(filterString, @"\(\s*\)"))
         {
             throw new FormatException($"Invalid filter, empty parenthesis: {filterString}");
@@ -119,7 +119,7 @@ internal static class TestCaseFilterFactory
 
     private static void MergeExpression(Stack<Expression<Func<Func<string, object?>, bool>>> exp, Operator op)
     {
-        Ensure.NotNull(exp);
+        Guard.NotNull(exp);
         if (op is not Operator.And and not Operator.Or)
         {
             throw new ArgumentException($"Unexpected operator: {op}", nameof(op));
@@ -190,7 +190,7 @@ internal static class TestCaseFilterFactory
 
     private static IEnumerable<string> TokenizeCondition(string conditionString)
     {
-        Ensure.NotNullOrEmpty(conditionString);
+        Guard.NotNullOrEmpty(conditionString);
         var token = new StringBuilder(conditionString.Length);
 
         for (int i = 0; i < conditionString.Length; i++)
@@ -286,7 +286,7 @@ internal static class TestCaseFilterFactory
 
     private static Expression<Func<Func<string, object?>, bool>> ConditionExpression(string conditionString)
     {
-        Ensure.NotNull(conditionString);
+        Guard.NotNull(conditionString);
 
         string[] condition = [.. TokenizeCondition(conditionString)];
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/ProjectSystem.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/ProjectSystem.cs
@@ -38,8 +38,8 @@ EndGlobal
     public VSSolution(string? solutionFolder, string? solutionName)
         : base(solutionFolder)
     {
-        Ensure.NotNullOrWhiteSpace(solutionFolder);
-        Ensure.NotNullOrWhiteSpace(solutionName);
+        Guard.NotNullOrWhiteSpace(solutionFolder);
+        Guard.NotNullOrWhiteSpace(solutionName);
 
         _solutionFileName = $"{solutionName}.sln";
         SolutionFile = Path.Combine(FolderPath, _solutionFileName);
@@ -82,9 +82,9 @@ public class CSharpProject : Project
     public CSharpProject(string solutionFolder, string projectName, params string[]? tfms)
        : base(Path.Combine(solutionFolder, projectName))
     {
-        Ensure.NotNullOrWhiteSpace(solutionFolder);
-        Ensure.NotNullOrWhiteSpace(projectName);
-        Ensure.NotNullOrEmpty(tfms);
+        Guard.NotNullOrWhiteSpace(solutionFolder);
+        Guard.NotNullOrWhiteSpace(projectName);
+        Guard.NotEmpty(tfms);
 
         _projectFileName = $"{projectName}.csproj";
         ProjectFile = Path.Combine(FolderPath, _projectFileName);


### PR DESCRIPTION
Reverts microsoft/testfx#6941

That PR introduced binary incompatibility when old VSTestBridge requests `Guard` from core MTP via IVT. So reverting for now. We will consider re-reverting back again later.