### PR TITLE
Revert Add timeout tests for GlobalTestInitializeAttribute and GlobalTestCleanupAttribute

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutTests.cs
@@ -1067,4 +1067,6 @@ public class UnitTest1
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
         }
     }
+
+    public TestContext TestContext { get; set; }
 }


### PR DESCRIPTION
Reverts #6200

The tests were added without being verified that they are correct as the whole class is ignored.

We should first try to unskip the existing tests and make them stable, then add those new tests back.

This revert ensures we have less burden when trying to unskip the existing tests.