### PR TITLE
macos investigation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,13 +269,6 @@ stages:
               NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
               DOTNET_CLI_CONTEXT_VERBOSE: 1
 
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Test Results folders'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-              ArtifactName: TestResults_MacOs_$(_BuildConfig)_Attempt$(System.JobAttempt)
-            condition: always()
-
           - task: CopyFiles@2
             displayName: 'Copy binlogs'
             inputs:

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -14,7 +14,7 @@
 
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --diagnostic --diagnostic-output-directory $(RepoRoot)artifacts/log/$(Configuration) --diagnostic-file-prefix $(ModuleName) --diagnostic-verbosity trace</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments Condition="!$([MSBuild]::IsOSPlatform('OSX'))">$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>
 


### PR DESCRIPTION
A draft for me to investigate #6998.

The dumps are extremely large, and uploading them can actually time out the job. We could increase the timeout of the job to be able to get the dumps, but I don't need them actually and want to save time. I want to get the diagnostic logs for both the testhost and testhost controller. 