### PR TITLE
Remove incorrect DefaultHangTimeSpanTimeout in HangDumpActivityIndicator

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
@@ -213,7 +213,7 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
             }
 
             _activityIndicatorMutex.ReleaseMutex();
-            _activityIndicatorMutex.WaitOne(TimeoutHelper.DefaultHangTimeSpanTimeout);
+            _activityIndicatorMutex.WaitOne();
 
             if (_traceLevelEnabled)
             {


### PR DESCRIPTION
- We should never timeout during this call.
- In the current implementation, if we ever hit it, we will crash anyways because we will attempt to later release the mutex when we didn't own it.
- If we really want to handle timeout, we should check the return value of the `WaitOne` call and explicitly throw an exception indicating that we did timeout.
- NOTE: This does **not** fix the hangdump bug we have on macOS.