### PR TITLE
Cleanup TestMethod creation

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestCaseExtensions.cs
@@ -86,9 +86,8 @@ internal static class TestCaseExtensions
         string? testClassName = testCase.GetPropertyValue(EngineConstants.TestClassNameProperty) as string;
         string name = testCase.GetTestName(testClassName);
 
-        TestMethod testMethod = testCase.ContainsManagedMethodAndType()
-            ? new(testCase.GetManagedType(), testCase.GetManagedMethod(), testCase.GetHierarchy()!, name, testClassName!, source, testCase.DisplayName, testCase.GetPropertyValue<string>(EngineConstants.ParameterTypesProperty, null))
-            : new(name, testClassName!, source, testCase.DisplayName);
+        var testMethod = new TestMethod(testCase.GetManagedType(), testCase.GetManagedMethod(), testCase.GetHierarchy(), name, testClassName!, source, testCase.DisplayName, testCase.GetPropertyValue<string>(EngineConstants.ParameterTypesProperty, null));
+
         var dataType = (DynamicDataType)testCase.GetPropertyValue(EngineConstants.TestDynamicDataTypeProperty, (int)DynamicDataType.None);
         if (dataType != DynamicDataType.None)
         {
@@ -138,13 +137,9 @@ internal static class TestCaseExtensions
 
     internal static string? GetManagedType(this TestCase testCase) => testCase.GetPropertyValue<string>(ManagedTypeProperty, null);
 
-    internal static void SetManagedType(this TestCase testCase, string value) => testCase.SetPropertyValue(ManagedTypeProperty, value);
-
     internal static string? GetManagedMethod(this TestCase testCase) => testCase.GetPropertyValue<string>(ManagedMethodProperty, null);
-
-    internal static bool ContainsManagedMethodAndType(this TestCase testCase) => !StringEx.IsNullOrWhiteSpace(testCase.GetManagedMethod()) && !StringEx.IsNullOrWhiteSpace(testCase.GetManagedType());
 
     internal static string[]? GetHierarchy(this TestCase testCase) => testCase.GetPropertyValue<string[]>(HierarchyProperty, null);
 
-    internal static void SetHierarchy(this TestCase testCase, params string?[] value) => testCase.SetPropertyValue(HierarchyProperty, value);
+    internal static void SetHierarchy(this TestCase testCase, string?[] value) => testCase.SetPropertyValue(HierarchyProperty, value);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -30,13 +30,21 @@ internal sealed class TestMethod : ITestMethod
     /// <param name="fullClassName">The full name of the class declaring the method.</param>
     /// <param name="assemblyName">The full assembly name.</param>
     /// <param name="displayName">The display name of the test method.</param>
+    // This constructor is used in testing only, and we should remove it in the future and update the tests.
     internal TestMethod(string name, string fullClassName, string assemblyName, string? displayName)
-        : this(null, null, null, name, fullClassName, assemblyName, displayName, null)
+        : this(fullClassName, null, null, name, fullClassName, assemblyName, displayName, null)
     {
     }
 
-    internal TestMethod(string? managedTypeName, string? managedMethodName, string?[]? hierarchyValues, string name,
-        string fullClassName, string assemblyName, string? displayName, string? parameterTypes)
+    internal TestMethod(
+        string? managedTypeName,
+        string? managedMethodName,
+        string?[]? hierarchyValues,
+        string name,
+        string fullClassName,
+        string assemblyName,
+        string? displayName,
+        string? parameterTypes)
     {
         Guard.NotNullOrWhiteSpace(assemblyName);
 


### PR DESCRIPTION
`ContainsManagedMethodAndType` is always true. So cleaned that up. This also avoids calling into VSTest's GetPropertyValue multiple times unnecessarily (previously `ContainsManagedMethodAndType` would call into it, then on the true path we call again)