### PR TITLE
Assembly.Load cant be null

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
@@ -592,10 +592,7 @@ internal
 
                     assembly = Assembly.ReflectionOnlyLoad(assemblyNameToLoad);
 
-                    if (assembly != null)
-                    {
-                        _reflectionOnlyResolvedAssemblies[assemblyNameToLoad] = assembly;
-                    }
+                    _reflectionOnlyResolvedAssemblies[assemblyNameToLoad] = assembly;
 
                     return assembly;
                 }
@@ -607,10 +604,7 @@ internal
 
                 assembly = Assembly.Load(assemblyNameToLoad);
 
-                if (assembly != null)
-                {
-                    _resolvedAssemblies[assemblyNameToLoad] = assembly;
-                }
+                _resolvedAssemblies[assemblyNameToLoad] = assembly;
 
                 return assembly;
             }


### PR DESCRIPTION
AFAIK `Assembly.Load` and `Assembly.ReflectionOnlyLoad` cant return null?