### PR TITLE
remove redundant searchDirectorypaths null check

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
@@ -327,7 +327,7 @@ internal
 #endif
     Assembly? SearchAssembly(List<string> searchDirectorypaths, string name, bool isReflectionOnly)
     {
-        if (searchDirectorypaths == null || searchDirectorypaths.Count == 0)
+        if (searchDirectorypaths.Count == 0)
         {
             return null;
         }


### PR DESCRIPTION
looking at the usages, it cant be null