### PR TITLE
Add support for treenode-filter on internal framework

### DIFF
--- a/test/Utilities/TestFramework.ForTestingMSTest/TestApplicationBuilderExtensions.cs
+++ b/test/Utilities/TestFramework.ForTestingMSTest/TestApplicationBuilderExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Builder;
-using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Services;
 
 namespace TestFramework.ForTestingMSTest;
@@ -12,8 +12,11 @@ public static class TestApplicationBuilderExtensions
     public static void AddInternalTestFramework(this ITestApplicationBuilder testApplicationBuilder)
     {
         TestFrameworkExtension extension = new();
+        TrxReportCapability trxReportCapability = new();
         testApplicationBuilder.RegisterTestFramework(
-            _ => new TestFrameworkCapabilities(new TrxReportCapability()),
+            _ => new TestFrameworkCapabilities(trxReportCapability),
             (capabilities, serviceProvider) => new TestFramework(extension, serviceProvider.GetLoggerFactory()));
+        testApplicationBuilder.AddTreeNodeFilterService(extension);
+        testApplicationBuilder.AddMaximumFailedTestsService(extension);
     }
 }

--- a/test/Utilities/TestFramework.ForTestingMSTest/TestFrameworkCapabilities.cs
+++ b/test/Utilities/TestFramework.ForTestingMSTest/TestFrameworkCapabilities.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+
+namespace TestFramework.ForTestingMSTest;
+
+internal sealed class TestFrameworkCapabilities : ITestFrameworkCapabilities
+{
+    private readonly ITrxReportCapability _trxReportCapability;
+    private readonly ITestFrameworkCapability _treeNodeFilterCapability;
+
+    public TestFrameworkCapabilities(ITrxReportCapability trxReportCapability)
+    {
+        _trxReportCapability = trxReportCapability;
+        _treeNodeFilterCapability = new TestNodesTreeFilterTestFrameworkCapability();
+    }
+
+    public IReadOnlyCollection<ITestFrameworkCapability> Capabilities
+        => [_treeNodeFilterCapability, _trxReportCapability];
+}
+
+internal sealed class TestNodesTreeFilterTestFrameworkCapability : ITestNodesTreeFilterTestFrameworkCapability
+{
+    bool ITestNodesTreeFilterTestFrameworkCapability.IsSupported => true;
+}


### PR DESCRIPTION
Helps with running smaller set of tests. Next step will be to update the copilot instructions so that it knows well how to run the tests as it works on these test projects.