### PR TITLE
Fix internal binary break

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
@@ -48,6 +48,19 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
     /// <param name="description">The description of the command line option.</param>
     /// <param name="arity">The arity of the command line option.</param>
     /// <param name="isHidden">Indicates whether the command line option is hidden.</param>
+    /// <param name="isBuiltIn">Indicates whether the command line option is built-in.</param>
+    internal CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden, bool isBuiltIn)
+        : this(name, description, arity, isHidden, isBuiltIn, null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandLineOption"/> class.
+    /// </summary>
+    /// <param name="name">The name of the command line option.</param>
+    /// <param name="description">The description of the command line option.</param>
+    /// <param name="arity">The arity of the command line option.</param>
+    /// <param name="isHidden">Indicates whether the command line option is hidden.</param>
     /// <param name="obsolescenceMessage">The obsolescence message for the command line option.</param>
     /// <remarks>
     /// This ctor is public and used by non built-in extension, we need to know if the extension is built-in or not


### PR DESCRIPTION
When mixing versions it's possible to end up with a binary break like in https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12954271&view=logs&j=5adb70e3-8c2c-5291-ad7b-3f10ff4ab08d&t=5715a75d-a714-582b-08e9-cd84db6896fb

cc @fhnaseer