### PR TITLE
Remove experimental attr from NopFilter

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Shipped.txt
@@ -45,8 +45,8 @@
 [TPEXP]Microsoft.Testing.Platform.Logging.ILoggingManager.AddProvider(System.Func<Microsoft.Testing.Platform.Logging.LogLevel, System.IServiceProvider!, Microsoft.Testing.Platform.Logging.ILoggerProvider!>! loggerProviderFactory) -> void
 [TPEXP]Microsoft.Testing.Platform.Requests.IExecuteRequestCompletionNotifier
 [TPEXP]Microsoft.Testing.Platform.Requests.IExecuteRequestCompletionNotifier.Complete() -> void
-Microsoft.Testing.Platform.Requests.NopFilter
-Microsoft.Testing.Platform.Requests.NopFilter.NopFilter() -> void
+[TPEXP]Microsoft.Testing.Platform.Requests.NopFilter
+[TPEXP]Microsoft.Testing.Platform.Requests.NopFilter.NopFilter() -> void
 [TPEXP]Microsoft.Testing.Platform.Requests.TreeNodeFilter
 [TPEXP]Microsoft.Testing.Platform.Requests.TreeNodeFilter.Filter.get -> string!
 [TPEXP]Microsoft.Testing.Platform.Requests.TreeNodeFilter.MatchesFilter(string! testNodeFullPath, Microsoft.Testing.Platform.Extensions.Messages.PropertyBag! filterableProperties) -> bool

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 #nullable enable
+*REMOVED*[TPEXP]Microsoft.Testing.Platform.Requests.NopFilter
+*REMOVED*[TPEXP]Microsoft.Testing.Platform.Requests.NopFilter.NopFilter() -> void
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.CommandLineOption(string! name, string! description, Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity arity, bool isHidden, string? obsolescenceMessage = null) -> void
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.ObsolescenceMessage.get -> string?
+Microsoft.Testing.Platform.Requests.NopFilter
+Microsoft.Testing.Platform.Requests.NopFilter.NopFilter() -> void


### PR DESCRIPTION
This pull request makes a minor change to the `NopFilter` class by removing the `[Experimental("TPEXP", ...)]` attribute from its declaration. The class remains part of the public API.

- Removed the `[Experimental("TPEXP", ...)]` attribute from the `NopFilter` class in `NopFilter.cs`, making it no longer marked as experimental.
- Updated the `PublicAPI.Shipped.txt` to reflect that `NopFilter` is no longer tagged as experimental.

Fixes https://github.com/microsoft/testfx/issues/7162