### PR TITLE
Stabilize HangDump_PathWithSpaces_CreateDump

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
@@ -99,7 +99,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
             new Dictionary<string, string?>
             {
                 { "SLEEPTIMEMS1", "4000" },
-                { "SLEEPTIMEMS2", "20000" },
+                { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);


### PR DESCRIPTION
The test has a race condition, where a hang gets detected, but taking a dump takes long enough that the tests finish while the dump is being taken. Increasing the sleep similar to the other tests should hopefully stabilize the test which often fails in CI, especially for macOS.