### PR TITLE
VSTestBridge: Cleanup FixUpTestCase

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FrameworkHandlerAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/FrameworkHandlerAdapter.cs
@@ -33,7 +33,6 @@ internal sealed class FrameworkHandlerAdapter : IFrameworkHandle
     private readonly CancellationToken _cancellationToken;
     private readonly bool _isTrxEnabled;
     private readonly MessageLoggerAdapter _comboMessageLogger;
-    private readonly string _testAssemblyPath;
     private readonly INamedFeatureCapability? _namedFeatureCapability;
     private readonly ICommandLineOptions _commandLineOptions;
     private readonly IClientInfo _clientInfo;
@@ -59,16 +58,12 @@ internal sealed class FrameworkHandlerAdapter : IFrameworkHandle
         }
         else if (testAssemblyPaths.Length > 1)
         {
-            _testAssemblyPath = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
+            string testAssemblyPath = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
 
-            if (!testAssemblyPaths.Contains(_testAssemblyPath))
+            if (!testAssemblyPaths.Contains(testAssemblyPath))
             {
                 throw new ArgumentException("None of the test assemblies are the test application.");
             }
-        }
-        else
-        {
-            _testAssemblyPath = testAssemblyPaths[0];
         }
 
         _namedFeatureCapability = namedFeatureCapability;
@@ -119,7 +114,7 @@ internal sealed class FrameworkHandlerAdapter : IFrameworkHandle
 
         _cancellationToken.ThrowIfCancellationRequested();
 
-        testCase.FixUpTestCase(_testAssemblyPath);
+        testCase.FixUpTestCase();
 
         // Forward call to VSTest
         _frameworkHandle?.RecordEnd(testCase, outcome);
@@ -132,7 +127,7 @@ internal sealed class FrameworkHandlerAdapter : IFrameworkHandle
 
         _cancellationToken.ThrowIfCancellationRequested();
 
-        testResult.TestCase.FixUpTestCase(_testAssemblyPath);
+        testResult.TestCase.FixUpTestCase();
 
         // Forward call to VSTest
         _frameworkHandle?.RecordResult(testResult);
@@ -151,7 +146,7 @@ internal sealed class FrameworkHandlerAdapter : IFrameworkHandle
 
         _cancellationToken.ThrowIfCancellationRequested();
 
-        testCase.FixUpTestCase(_testAssemblyPath);
+        testCase.FixUpTestCase();
 
         // Forward call to VSTest
         _frameworkHandle?.RecordStart(testCase);

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -286,15 +286,8 @@ internal static class ObjectModelConverters
         }
     }
 
-    internal static void FixUpTestCase(this TestCase testCase, string? testAssemblyPath = null)
+    internal static void FixUpTestCase(this TestCase testCase)
     {
-        // To help framework authors using code generator, we replace the Source property of the test case with the
-        // test assembly path.
-        if (RoslynString.IsNullOrEmpty(testCase.Source) && !RoslynString.IsNullOrEmpty(testAssemblyPath))
-        {
-            testCase.Source = testAssemblyPath;
-        }
-
         // Because this project is the actually registered test adapter, we need to replace test framework executor
         // URI by ours.
         if (!testCase.Properties.Any(x => x.Id == OriginalExecutorUriProperty.Id))

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseDiscoverySinkAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseDiscoverySinkAdapter.cs
@@ -33,7 +33,6 @@ internal sealed class TestCaseDiscoverySinkAdapter : ITestCaseDiscoverySink
     private readonly VSTestBridgedTestFrameworkBase _adapterExtension;
     private readonly TestSessionContext _session;
     private readonly CancellationToken _cancellationToken;
-    private readonly string? _testAssemblyPath;
 
     public TestCaseDiscoverySinkAdapter(
         VSTestBridgedTestFrameworkBase adapterExtension,
@@ -55,16 +54,12 @@ internal sealed class TestCaseDiscoverySinkAdapter : ITestCaseDiscoverySink
         }
         else if (testAssemblyPaths.Length > 1)
         {
-            _testAssemblyPath = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
+            string testAssemblyPath = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
 
-            if (!testAssemblyPaths.Contains(_testAssemblyPath))
+            if (!testAssemblyPaths.Contains(testAssemblyPath))
             {
                 throw new ArgumentException("None of the test assemblies are the test application.");
             }
-        }
-        else
-        {
-            _testAssemblyPath = testAssemblyPaths[0];
         }
 
         _testCaseDiscoverySink = testCaseDiscoverySink;
@@ -86,7 +81,7 @@ internal sealed class TestCaseDiscoverySinkAdapter : ITestCaseDiscoverySink
 
         _cancellationToken.ThrowIfCancellationRequested();
 
-        discoveredTest.FixUpTestCase(_testAssemblyPath);
+        discoveredTest.FixUpTestCase();
 
         // Forward call to VSTest
         _testCaseDiscoverySink?.SendTestCase(discoveredTest);


### PR DESCRIPTION
The VSTest TestCase should have the proper Source property. We shouldn't do any fixup there ourselves. In addition, attempts to fixups are not possible to be correct when multiple assemblies are requested to run. Previously we used to take only the first assembly, but that looks very fragile.