### PR TITLE
Delete deadcode in VSTestBridge

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/VSTestBridgedTestFrameworkBase.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/VSTestBridgedTestFrameworkBase.cs
@@ -4,15 +4,12 @@
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
 using Microsoft.Testing.Extensions.VSTestBridge.Helpers;
-using Microsoft.Testing.Extensions.VSTestBridge.ObjectModel;
 using Microsoft.Testing.Extensions.VSTestBridge.Requests;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
-using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.Requests;
-using Microsoft.Testing.Platform.Services;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.Testing.Extensions.VSTestBridge;


### PR DESCRIPTION
`ExecuteRequestAsync(ExecuteRequestContext)` is ONLY ever called by core MTP. Core MTP never passes VSTestDiscoverTestExecutionRequest or VSTestRunTestExecutionRequest.

The flow currently goes like:

- MTP calls `ExecuteRequestAsync(ExecuteRequestContext)`, where the request is either `DiscoverTestExecutionRequest` or `RunTestExecutionRequest`
- In the bridge, we always get to the TestExecutionRequest branch of the switch, and call `ExecuteRequestAsync(TestExecutionRequest,IMessageBus,CancellationToken)`.
- `ExecuteRequestAsync(TestExecutionRequest,IMessageBus,CancellationToken)` is abstract and is overridden by `SynchronizedSingleSessionVSTestBridgedTestFramework`. The implementation of the override handles `DiscoverTestExecutionRequest` and `RunTestExecutionRequest` by transforming them to `VSTestDiscoverTestExecutionRequest` and `VSTestRunTestExecutionRequest` and then calls either `SynchronizedDiscoverTestsAsync` or `SynchronizedRunTestsAsync`
- `SynchronizedDiscoverTestsAsync` and `SynchronizedRunTestsAsync` are abstract and are implementable by frameworks outside the bridge (e.g, MSTest, NUnit, Expecto). Those methods take the concrete `VSTestDiscoverTestExecutionRequest` and `VSTestRunTestExecutionRequest` as parameters.

Additional cleanup that can be done but is breaking change:

- `VSTestDiscoverTestExecutionRequest` and `VSTestRunTestExecutionRequest` don't need to inherit `DiscoverTestExecutionRequest` and `RunTestExecutionRequest`. In fact, I tend to think that MTP should have made `DiscoverTestExecutionRequest` and `RunTestExecutionRequest` sealed.
- The methods `DiscoverTestsAsync` and `RunTestsAsync` implemented in `SynchronizedSingleSessionVSTestBridgedTestFramework` are dead and are never called.