### PR TITLE
Obsolete AddTestSessionLifetimeHandle in favor of AddTestSessionLifetimeHandler

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpExtensions.cs
@@ -69,6 +69,6 @@ public static class HangDumpExtensions
                 serviceProvider.GetClock()));
 
         builder.TestHost.AddDataConsumer(hangDumpActivityIndicatorComposite);
-        builder.TestHost.AddTestSessionLifetimeHandle(hangDumpActivityIndicatorComposite);
+        builder.TestHost.AddTestSessionLifetimeHandler(hangDumpActivityIndicatorComposite);
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildExtensions.cs
@@ -42,6 +42,6 @@ public static class MSBuildExtensions
                 serviceProvider.GetCommandLineOptions()));
 
         builder.TestHost.AddDataConsumer(compositeExtensionFactory);
-        builder.TestHost.AddTestSessionLifetimeHandle(compositeExtensionFactory);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeExtensionFactory);
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryExtensions.cs
@@ -35,7 +35,7 @@ public static class RetryExtensions
         CompositeExtensionFactory<RetryDataConsumer> compositeExtensionFactory
             = new(serviceProvider => new RetryDataConsumer(serviceProvider));
         builder.TestHost.AddDataConsumer(compositeExtensionFactory);
-        builder.TestHost.AddTestSessionLifetimeHandle(compositeExtensionFactory);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeExtensionFactory);
 
         if (builder is not TestApplicationBuilder testApplicationBuilder)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportExtensions.cs
@@ -57,7 +57,7 @@ public static class TrxReportExtensions
         }
 
         builder.TestHost.AddDataConsumer(compositeTestSessionTrxService);
-        builder.TestHost.AddTestSessionLifetimeHandle(compositeTestSessionTrxService);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeTestSessionTrxService);
 
         builder.CommandLine.AddProvider(() => commandLine);
 

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.CommandLineO
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.ObsolescenceMessage.get -> string?
 Microsoft.Testing.Platform.Requests.NopFilter
 Microsoft.Testing.Platform.Requests.NopFilter.NopFilter() -> void
+Microsoft.Testing.Platform.TestHost.ITestHostManager.AddTestSessionLifetimeHandler(System.Func<System.IServiceProvider!, Microsoft.Testing.Platform.Extensions.TestHost.ITestSessionLifetimeHandler!>! testSessionLifetimeHandleFactory) -> void
+Microsoft.Testing.Platform.TestHost.ITestHostManager.AddTestSessionLifetimeHandler<T>(Microsoft.Testing.Platform.Extensions.CompositeExtensionFactory<T!>! compositeServiceFactory) -> void

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/ITestHostManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/ITestHostManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 
@@ -35,6 +37,8 @@ public interface ITestHostManager
     /// Adds a test session lifetime handle.
     /// </summary>
     /// <param name="testSessionLifetimeHandleFactory">The factory method for creating the test session lifetime handle.</param>
+    [Obsolete("Use AddTestSessionLifetimeHandler instead.", error: true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     void AddTestSessionLifetimeHandle(Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandleFactory);
 
     /// <summary>
@@ -42,6 +46,22 @@ public interface ITestHostManager
     /// </summary>
     /// <typeparam name="T">The type of the test session lifetime handle.</typeparam>
     /// <param name="compositeServiceFactory">The composite extension factory for creating the test session lifetime handle.</param>
+    [Obsolete("Use AddTestSessionLifetimeHandler instead.", error: true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     void AddTestSessionLifetimeHandle<T>(CompositeExtensionFactory<T> compositeServiceFactory)
+        where T : class, ITestSessionLifetimeHandler;
+
+    /// <summary>
+    /// Adds a test session lifetime handle.
+    /// </summary>
+    /// <param name="testSessionLifetimeHandleFactory">The factory method for creating the test session lifetime handle.</param>
+    void AddTestSessionLifetimeHandler(Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandleFactory);
+
+    /// <summary>
+    /// Adds a test session lifetime handle of type T.
+    /// </summary>
+    /// <typeparam name="T">The type of the test session lifetime handle.</typeparam>
+    /// <param name="compositeServiceFactory">The composite extension factory for creating the test session lifetime handle.</param>
+    void AddTestSessionLifetimeHandler<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestSessionLifetimeHandler;
 }

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
@@ -203,14 +205,25 @@ internal sealed class TestHostManager : ITestHostManager
         return [.. dataConsumers];
     }
 
+    [Obsolete("Use AddTestSessionLifetimeHandler instead.", error: true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void AddTestSessionLifetimeHandle(Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandleFactory)
+        => AddTestSessionLifetimeHandler(testSessionLifetimeHandleFactory);
+
+    [Obsolete("Use AddTestSessionLifetimeHandler instead.", error: true)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void AddTestSessionLifetimeHandle<T>(CompositeExtensionFactory<T> compositeServiceFactory)
+        where T : class, ITestSessionLifetimeHandler
+        => AddTestSessionLifetimeHandler(compositeServiceFactory);
+
+    public void AddTestSessionLifetimeHandler(Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandleFactory)
     {
         Guard.NotNull(testSessionLifetimeHandleFactory);
         _testSessionLifetimeHandlerFactories.Add(testSessionLifetimeHandleFactory);
         _factoryOrdering.Add(testSessionLifetimeHandleFactory);
     }
 
-    public void AddTestSessionLifetimeHandle<T>(CompositeExtensionFactory<T> compositeServiceFactory)
+    public void AddTestSessionLifetimeHandler<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestSessionLifetimeHandler
     {
         Guard.NotNull(compositeServiceFactory);

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Program.cs
@@ -26,7 +26,7 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 using ITestApplication app = await builder.BuildAsync();
 int returnValue = await app.RunAsync();
 Console.WriteLine($"Process started: {CommandLine.TotalProcessesAttempt}");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Program.cs
@@ -27,7 +27,7 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 using ITestApplication app = await builder.BuildAsync();
 int returnValue = await app.RunAsync();
 Console.WriteLine($"Process started: {CommandLine.TotalProcessesAttempt}");

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/Program.cs
@@ -22,6 +22,6 @@ builder.AddAzureDevOpsProvider();
 // Custom suite tools
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/MSTest.Engine.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.Engine.UnitTests/Program.cs
@@ -23,7 +23,7 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/Program.cs
@@ -23,7 +23,7 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Program.cs
@@ -23,6 +23,6 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Program.cs
@@ -34,6 +34,6 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Program.cs
@@ -20,6 +20,6 @@ builder.AddAzureDevOpsProvider();
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
     = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
@@ -30,6 +30,6 @@ builder.AddAzureDevOpsProvider();
 // Custom suite tools
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory = new(_ => new SlowestTestsConsumer());
 builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandle(slowestTestCompositeServiceFactory);
+builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestApplicationBuilderTests.cs
@@ -62,8 +62,8 @@ public sealed class TestApplicationBuilderTests
     public async Task TestSessionLifetimeHandle_DuplicatedId_ShouldFail()
     {
         TestHostManager testHostManager = new();
-        testHostManager.AddTestSessionLifetimeHandle(_ => new TestSessionLifetimeHandler("duplicatedId"));
-        testHostManager.AddTestSessionLifetimeHandle(_ => new TestSessionLifetimeHandler("duplicatedId"));
+        testHostManager.AddTestSessionLifetimeHandler(_ => new TestSessionLifetimeHandler("duplicatedId"));
+        testHostManager.AddTestSessionLifetimeHandler(_ => new TestSessionLifetimeHandler("duplicatedId"));
         InvalidOperationException invalidOperationException = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => testHostManager.BuildTestSessionLifetimeHandleAsync(_serviceProvider, []));
         Assert.IsTrue(invalidOperationException.Message.Contains("duplicatedId") && invalidOperationException.Message.Contains(typeof(TestSessionLifetimeHandler).ToString()));
     }
@@ -73,8 +73,8 @@ public sealed class TestApplicationBuilderTests
     {
         TestHostManager testHostManager = new();
         CompositeExtensionFactory<TestSessionLifetimeHandler> compositeExtensionFactory = new(() => new TestSessionLifetimeHandler("duplicatedId"));
-        testHostManager.AddTestSessionLifetimeHandle(_ => new TestSessionLifetimeHandler("duplicatedId"));
-        testHostManager.AddTestSessionLifetimeHandle(compositeExtensionFactory);
+        testHostManager.AddTestSessionLifetimeHandler(_ => new TestSessionLifetimeHandler("duplicatedId"));
+        testHostManager.AddTestSessionLifetimeHandler(compositeExtensionFactory);
         InvalidOperationException invalidOperationException = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => testHostManager.BuildTestSessionLifetimeHandleAsync(_serviceProvider, []));
         Assert.IsTrue(invalidOperationException.Message.Contains("duplicatedId") && invalidOperationException.Message.Contains(typeof(TestSessionLifetimeHandler).ToString()));
     }
@@ -89,7 +89,7 @@ public sealed class TestApplicationBuilderTests
             withParameter
             ? new(sp => new TestSessionLifetimeHandlerPlusConsumer(sp))
             : new(() => new TestSessionLifetimeHandlerPlusConsumer());
-        testHostManager.AddTestSessionLifetimeHandle(compositeExtensionFactory);
+        testHostManager.AddTestSessionLifetimeHandler(compositeExtensionFactory);
         testHostManager.AddDataConsumer(compositeExtensionFactory);
         List<ICompositeExtensionFactory> compositeExtensions = [];
         IDataConsumer[] consumers = [.. (await testHostManager.BuildDataConsumersAsync(_serviceProvider, compositeExtensions)).Select(x => (IDataConsumer)x.Consumer)];


### PR DESCRIPTION
Related to #7063
Issue is kept open for MTP v3 to remove the obsolete API completely.