### PR TITLE
[main] Update dependencies from devdiv/DevDiv/vs-code-coverage

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,9 +13,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>47a8a69721dfea57b82121ac1458d2f5bba6abd2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.0-preview.25615.2">
+    <Dependency Name="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.0-preview.26062.2">
       <Uri>https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage</Uri>
-      <Sha>d6fad4ec212e65323a99f3367bc90ee840fac267</Sha>
+      <Sha>74ce4948abff2b900d035bf7fd3a09f4b76f4e62</Sha>
     </Dependency>
     <Dependency Name="MSTest" Version="4.1.0-preview.26063.3">
       <Uri>https://github.com/microsoft/testfx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.25617.1</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftTestingExtensionsCodeCoverageVersion>18.3.0-preview.25615.2</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.4.0-preview.26062.2</MicrosoftTestingExtensionsCodeCoverageVersion>
     <!-- empty line to avoid merge conflicts for darc PRs to update CC and MSTest+MTP -->
     <MSTestVersion>4.1.0-preview.26063.3</MSTestVersion>
     <MicrosoftTestingPlatformVersion>2.1.0-preview.26063.3</MicrosoftTestingPlatformVersion>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:80f35d75-3aef-4935-4458-08dc8b6ac1be)
## From https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage
- **Subscription**: [80f35d75-3aef-4935-4458-08dc8b6ac1be](https://maestro.dot.net/subscriptions?search=80f35d75-3aef-4935-4458-08dc8b6ac1be)
- **Build**: [20260112.2](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=13078753) ([296890](https://maestro.dot.net/channel/551/azdo:devdiv:DevDiv:vs-code-coverage/build/296890))
- **Date Produced**: January 12, 2026 12:40:48 PM UTC
- **Commit**: [74ce4948abff2b900d035bf7fd3a09f4b76f4e62](https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage?_a=history&version=GC74ce4948abff2b900d035bf7fd3a09f4b76f4e62)
- **Branch**: [refs/heads/main](https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage?version=GBrefs/heads/main)

[DependencyUpdate]: <> (Begin)

- **Dependency Updates**:
  - From [18.3.0-preview.25615.2 to 18.4.0-preview.26062.2][14]
     - Microsoft.Testing.Extensions.CodeCoverage

[14]: https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage/branches?baseVersion=GCd6fad4ec212e65323a99f3367bc90ee840fac267&targetVersion=GC74ce4948abff2b900d035bf7fd3a09f4b76f4e62&_a=files

[DependencyUpdate]: <> (End)


[marker]: <> (End:80f35d75-3aef-4935-4458-08dc8b6ac1be)
