### PR TITLE
Downgrade some analyzers back to info

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,3 +10,12 @@ MSTEST0059 | Usage | Warning | DoNotUseParallelizeAndDoNotParallelizeTogetherAna
 MSTEST0060 | Usage | Warning | DuplicateTestMethodAttributeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0060)
 MSTEST0061 | Usage | Info | UseOSConditionAttributeInsteadOfRuntimeCheckAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0061)
 MSTEST0062 | Usage | Info | AvoidOutRefTestMethodParametersAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0062)
+
+### Changed Rules
+
+Rule ID | New Category | New Severity | Old Category | Old Severity | Notes
+--------|--------------|--------------|--------------|--------------|-------
+MSTEST0001 | Performance | Info | Performance | Warning | UseParallelizeAttributeAnalyzer
+MSTEST0023 | USage | Info | Usage | Warning | DoNotNegateBooleanAssertionAnalyzer
+MSTEST0037 | USage | Info | Usage | Warning | UseProperAssertMethodsAnalyzer
+MSTEST0045 | USage | Info | Usage | Warning | UseCooperativeCancellationForTimeoutAnalyzer

--- a/src/Analyzers/MSTest.Analyzers/DoNotNegateBooleanAssertionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DoNotNegateBooleanAssertionAnalyzer.cs
@@ -31,7 +31,7 @@ public sealed class DoNotNegateBooleanAssertionAnalyzer : DiagnosticAnalyzer
         MessageFormat,
         null,
         Category.Usage,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         isEnabledByDefault: true);
 
     /// <inheritdoc />

--- a/src/Analyzers/MSTest.Analyzers/UseCooperativeCancellationForTimeoutAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseCooperativeCancellationForTimeoutAnalyzer.cs
@@ -28,7 +28,7 @@ public sealed class UseCooperativeCancellationForTimeoutAnalyzer : DiagnosticAna
         MessageFormat,
         Description,
         Category.Design,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         isEnabledByDefault: true);
 
     /// <inheritdoc />

--- a/src/Analyzers/MSTest.Analyzers/UseParallelizeAttributeAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseParallelizeAttributeAnalyzer.cs
@@ -34,7 +34,7 @@ public sealed class UseParallelizeAttributeAnalyzer : DiagnosticAnalyzer
         MessageFormat,
         Description,
         Category.Performance,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         isEnabledByDefault: true);
 
     /// <inheritdoc cref="Resources.DoNotUseParallelizeAndDoNotParallelizeTogetherTitle" />

--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.cs
@@ -238,7 +238,7 @@ public sealed class UseProperAssertMethodsAnalyzer : DiagnosticAnalyzer
         MessageFormat,
         null,
         Category.Usage,
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Info,
         isEnabledByDefault: true);
 
     /// <inheritdoc />


### PR DESCRIPTION
Reduces a bit of friction for updating to MSTest v4.

Additional candidates but I'm waiting for more evidence or user feedback:

- MSTEST0044: Prefer TestMethod over DataTestMethod
- MSTEST0052: Avoid passing DynamicDataSourceType explicitly