### PR TITLE
Disable progress on non-capable terminals

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterOptions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterOptions.cs
@@ -16,7 +16,8 @@ internal sealed class TerminalTestReporterOptions
     public int MinimumExpectedTests { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether we should write the progress periodically to screen. When ANSI is allowed we update the progress as often as we can. When ANSI is not allowed we update it every 3 seconds.
+    /// Gets a value indicating whether we should write the progress periodically to screen. When ANSI is allowed we update the progress as often as we can.
+    /// When ANSI is not allowed we never have progress.
     /// This is a callback to nullable bool, because we don't know if we are running as test host controller until after we setup the console. So we should be polling for the value, until we get non-null boolean
     /// and then cache that value.
     /// </summary>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -152,9 +152,11 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
             showPassed = () => true;
         }
 
-        Func<bool?> shouldShowProgress = noProgress
+        Func<bool?> shouldShowProgress = noProgress || ansiMode is AnsiMode.NoAnsi or AnsiMode.SimpleAnsi
             // User preference is to not show progress.
-            ? () => false
+            // Or, we are in terminal that's not capable of changing cursor and we can't update progress in-place.
+            // In that case, we force disable progress as well.
+            ? static () => false
             // User preference is to allow showing progress, figure if we should actually show it based on whether or not we are a testhost controller.
             //
             // TestHost controller is not running any tests and it should not be writing progress.


### PR DESCRIPTION
On every repo I migrated to MTP, I have always added `--no-progress` in CI. This PR makes that a default behavior. When not using a terminal that is capable of writing the progress in place, we don't write progress altogether. IMO, it's never useful to keep writing progress every 3 seconds and always results in a messy output. We will need to also make a similar change to dotnet/sdk.

Related to https://github.com/microsoft/testfx/issues/7056 and other similar issues (not closing any until work is done for dotnet test).