### PR TITLE
Follow-up on disable progress on non-capable terminal

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -86,6 +86,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         _testApplicationCancellationTokenSource = testApplicationCancellationTokenSource;
         _options = options;
 
+        Func<bool?> showProgress = options.ShowProgress;
         ITerminal terminal;
         if (_options.AnsiMode == AnsiMode.SimpleAnsi)
         {
@@ -106,9 +107,13 @@ internal sealed partial class TerminalTestReporter : IDisposable
             };
 
             terminal = useAnsi ? new AnsiTerminal(console) : new NonAnsiTerminal(console);
+            if (!useAnsi)
+            {
+                showProgress = () => false;
+            }
         }
 
-        _terminalWithProgress = new TestProgressStateAwareTerminal(terminal, _options.ShowProgress);
+        _terminalWithProgress = new TestProgressStateAwareTerminal(terminal, showProgress);
     }
 
     public void TestExecutionStarted(DateTimeOffset testStartTime, int workerCount, bool isDiscovery)


### PR DESCRIPTION
In #7248, it was handled that when we detect a CI environment and we use simple ansi, we disable progress. We also detect when `--no-ansi` is used and we disable progress.

But a missed case was when ansi is preferred but cannot be used. Disabling progress also in that case.