### PR TITLE
Re-enable tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
@@ -71,7 +71,6 @@ public sealed class TaskExtensionsTests
     }
 
     [TestMethod]
-    [Ignore("https://github.com/microsoft/testfx/issues/6907")]
     public async Task CancellationAsync_ObserveException_Succeeds()
     {
         ManualResetEvent waitException = new(false);
@@ -91,7 +90,6 @@ public sealed class TaskExtensionsTests
     }
 
     [TestMethod]
-    [Ignore("https://github.com/microsoft/testfx/issues/6907")]
     public async Task CancellationAsyncWithReturnValue_ObserveException_Succeeds()
     {
         ManualResetEvent waitException = new(false);


### PR DESCRIPTION
Underlying flakiness cause should now be fixed. Tests were disabled in #6908, this relates to #6907
