### PR TITLE
Revert "Automate publishing to test-tools feed for RTM, but require explicit manual validation"

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -107,9 +107,7 @@ extends:
           enableTelemetry: true
           jobs:
           - job: Windows
-            # Allow build, test, publishing, etc to take 90 minutes, plus allow for 2 hours of manual validation.
-            # We will only publish to test-tools feed if manual validation passes and is manually approved.
-            timeoutInMinutes: 210
+            timeoutInMinutes: 90
             pool:
               name: $(DncEngInternalBuildPool)
               image: windows.vs2026preview.scout.amd64
@@ -197,27 +195,20 @@ extends:
                   ArtifactName: TestResults_Windows_Attempt$(System.JobAttempt)
                 condition: always()
 
-            # Manual validation is only needed for RTM.
-            # This allows us to keep re-building the same RTM version until it passes manual validation, then we publish it to test-tools, where we have only one chance at publishing the final (RTM) package.
-            - ${{ if ne(parameters.isRTM, False) }}:
-              - task: ManualValidation@0
-                displayName: 'Wait for manual validation before publishing to test-tools feed'
-                timeoutInMinutes: 120
-                inputs:
-                    notifyUsers: ''
-                    instructions: 'Please validate the build configuration and resume'
-                    onTimeout: 'reject'
-
             - task: NuGetAuthenticate@1
               displayName: 'NuGet Authenticate to test-tools feed'
 
-            - task: 1ES.PublishNuget@1
-              displayName: 'Publish NuGet packages to test-tools feed'
-              inputs:
-                # Do not push symbol packages nor Microsoft.Testing.Platform package
-                packageParentPath: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
-                packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/**/*.symbols.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping/Microsoft.Testing.Platform.*.nupkg'
-                publishVstsFeed: 'public/test-tools'
+              # Final builds should not go into test-tools package feed, so we can keep re-building them until we are ready to ship to nuget.org.
+              # This has to depend on the parameter and not on variable, variables are not defined early enough to be used in templating condition.
+              # We still need the final builds on test-tools so that internal repos can consume it, so we will publish it manually.
+            - ${{ if eq(parameters.isRTM, False) }}:
+              - task: 1ES.PublishNuget@1
+                displayName: 'Publish NuGet packages to test-tools feed'
+                inputs:
+                  # Do not push symbol packages nor Microsoft.Testing.Platform package
+                  packageParentPath: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+                  packagesToPush: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/**/*.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/**/*.symbols.nupkg;!$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping/Microsoft.Testing.Platform.*.nupkg'
+                  publishVstsFeed: 'public/test-tools'
 
           - job: Linux
             timeoutInMinutes: 90


### PR DESCRIPTION
Reverts microsoft/testfx#7203

This is failing when running the pipeline internally with:

```
Encountered error(s) while parsing pipeline YAML:
Job Windows: Step  references task 'ManualValidation' at version '0.244.0' which is not valid for the given job target.
```