### PR TITLE
Revert "Re-enable tests"

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
@@ -71,6 +71,7 @@ public sealed class TaskExtensionsTests
     }
 
     [TestMethod]
+    [Ignore("https://github.com/microsoft/testfx/issues/6907")]
     public async Task CancellationAsync_ObserveException_Succeeds()
     {
         ManualResetEvent waitException = new(false);
@@ -90,6 +91,7 @@ public sealed class TaskExtensionsTests
     }
 
     [TestMethod]
+    [Ignore("https://github.com/microsoft/testfx/issues/6907")]
     public async Task CancellationAsyncWithReturnValue_ObserveException_Succeeds()
     {
         ManualResetEvent waitException = new(false);


### PR DESCRIPTION
Reverts microsoft/testfx#7313

Tests are still flaky.

```
failed CancellationAsyncWithReturnValue_ObserveException_Succeeds (10s 154ms)
  from D:\a\_work\1\s\artifacts\bin\Microsoft.Testing.Platform.UnitTests\Debug\net462\Microsoft.Testing.Platform.UnitTests.exe (net48|x64)
  Assert.ThrowsAsync failed. Expected exception type:<System.OperationCanceledException>. Actual exception type:<System.InvalidOperationException>. 'action' expression: 'async ()
              => await Task.Run(async () =>
              {
                  await Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
                  try
                  {
                      return 2;
                  }
                  finally
                  {
                      waitException.Set();
  #pragma warning disable CA2219 // Do not raise exceptions in finally clauses
                      throw new InvalidOperationException();
  #pragma warning restore CA2219 // Do not raise exceptions in finally clauses
                  }
              }).WithCancellationAsync(token)'.
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowAssertFailed(String assertionName, String message)
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.<>c__DisplayClass244_1`1.<IsThrowsAsyncFailingAsync>b__1(String userMessage)
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.<ThrowsExceptionAsync>d__242`1.MoveNext()
    --- End of stack trace from previous location where exception was thrown ---
    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
    at Microsoft.Testing.Platform.UnitTests.TaskExtensionsTests.<CancellationAsyncWithReturnValue_ObserveException_Succeeds>d__12.MoveNext()
    --- End of stack trace from previous location where exception was thrown ---
    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    at Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.<ExecuteInternalAsync>d__50.MoveNext()

```