### PR TITLE
Avoid warning in integration test asset

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SynchronizationContextTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SynchronizationContextTests.cs
@@ -81,7 +81,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class UnitTest1
 {
-    private static UnitTestSynchronizationContext? _syncContext;
+    private static UnitTestSynchronizationContext _syncContext;
 
     [GlobalTestInitialize]
     public static void GlobalTestInit(TestContext _)


### PR DESCRIPTION
Nullability not enabled for that test asset and the compiler produces a warning.