### PR TITLE
Rename ReflectionUtility to ensure usage only in ReflectionOperations

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs
@@ -24,7 +24,7 @@ internal sealed class ReflectionOperations : IReflectionOperations
     [return: NotNullIfNotNull(nameof(memberInfo))]
     public object[]? GetCustomAttributes(MemberInfo memberInfo)
 #if NETFRAMEWORK
-         => [.. ReflectionUtility.GetCustomAttributes(memberInfo)];
+         => [.. ReflectionOperationsNetFrameworkAttributeHelpers.GetCustomAttributes(memberInfo)];
 #else
     {
         object[] attributes = memberInfo.GetCustomAttributes(typeof(Attribute), inherit: true);
@@ -46,7 +46,7 @@ internal sealed class ReflectionOperations : IReflectionOperations
     /// <returns> The list of attributes of the given type on the member. Empty list if none found. </returns>
     public object[] GetCustomAttributes(Assembly assembly, Type type) =>
 #if NETFRAMEWORK
-        ReflectionUtility.GetCustomAttributes(assembly, type).ToArray();
+        ReflectionOperationsNetFrameworkAttributeHelpers.GetCustomAttributes(assembly, type).ToArray();
 #else
         assembly.GetCustomAttributes(type, inherit: true);
 #endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/ReflectionOperationsNetFrameworkAttributeHelpers.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/ReflectionOperationsNetFrameworkAttributeHelpers.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if !WINDOWS_UWP
+#if NETFRAMEWORK
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
 
 /// <summary>
-/// Utility for reflection API's.
+/// This class is only intended to be used by ReflectionOperations on .NET Framework.
+/// TODO: Investigate why we need complicated logic under .NET Framework, and whether it
+/// can be simplified to have unified simple logic for .NET Core and .NET Framework.
 /// </summary>
-[SuppressMessage("Performance", "CA1852: Seal internal types", Justification = "Overrides required for testability")]
-internal class ReflectionUtility
+internal static class ReflectionOperationsNetFrameworkAttributeHelpers
 {
     /// <summary>
     /// Gets all the custom attributes adorned on a member.
@@ -29,7 +30,6 @@ internal class ReflectionUtility
     private static IReadOnlyList<object> GetCustomAttributesCore(MemberInfo memberInfo, Type? type)
 #pragma warning restore CA1859
     {
-#if NETFRAMEWORK
         bool shouldGetAllAttributes = type == null;
 
         if (!IsReflectionOnlyLoad(memberInfo))
@@ -105,14 +105,8 @@ internal class ReflectionUtility
             nonUniqueAttributes.AddRange(uniqueAttributes.Values);
             return nonUniqueAttributes;
         }
-#else
-        return type == null
-            ? memberInfo.GetCustomAttributes(inherit: true)
-            : memberInfo.GetCustomAttributes(type, inherit: true);
-#endif
     }
 
-#if NETFRAMEWORK
     internal static List<Attribute> GetCustomAttributes(Assembly assembly, Type type)
     {
         if (!assembly.ReflectionOnly)
@@ -273,7 +267,6 @@ internal class ReflectionUtility
 
         return false;
     }
-#endif
 }
 
 #endif


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->