### PR TITLE
Rename abort asset in MSTest integration test

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AbortionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AbortionTests.cs
@@ -39,7 +39,7 @@ public sealed class AbortionTests : AcceptanceTestBase<AbortionTests.TestAssetFi
     public sealed class TestAssetFixture() : TestAssetFixtureBase(AcceptanceFixture.NuGetGlobalPackagesFolder)
     {
         private const string Sources = """
-#file Abort.csproj
+#file AbortMSTestAsset.csproj
 <Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
     <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>


### PR DESCRIPTION
We have the following flakiness:

```
MSBUILD : Logger error MSB4104: Failed to write to log file "D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\Abort-1.binlog". The process cannot access the file 'D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\Abort-1.binlog' because it is being used by another process.
System.IO.IOException: The process cannot access the file 'D:\a\_work\1\s\artifacts\tmp\Debug\testsuite\Abort-1.binlog' because it is being used by another process.
```

This is because both MTP and MSTest integration tests have an asset called Abort. When both tests start concurrently (in different processes), they get the same binlog file name and we have a race between the two processes. Renaming the asset should resolve it.