### PR TITLE
MTP extensions cleanup for cancellation

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -107,10 +107,7 @@ internal sealed class AzureDevOpsReporter :
 
     public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (value is not TestNodeUpdateMessage nodeUpdateMessage)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpProcessLifetimeHandler.cs
@@ -55,8 +55,8 @@ internal sealed class CrashDumpProcessLifetimeHandler : ITestHostProcessLifetime
 
     public async Task OnTestHostProcessExitedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested
-            || testHostProcessInformation.HasExitedGracefully
+        cancellationToken.ThrowIfCancellationRequested();
+        if (testHostProcessInformation.HasExitedGracefully
             || (AppDomain.CurrentDomain.GetData("ProcessKilledByHangDump") is string processKilledByHangDump && processKilledByHangDump == "true"))
         {
             return;

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
@@ -83,11 +83,7 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
     {
         CancellationToken cancellationToken = testSessionContext.CancellationToken;
         ApplicationStateGuard.Ensure(_namedPipeClient is not null);
-
-        if (!await IsEnabledAsync().ConfigureAwait(false) || cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         try
         {
@@ -139,8 +135,8 @@ internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLif
 
     public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested
-            || value is not TestNodeUpdateMessage nodeChangedMessage)
+        cancellationToken.ThrowIfCancellationRequested();
+        if (value is not TestNodeUpdateMessage nodeChangedMessage)
         {
             return;
         }

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs
@@ -62,10 +62,7 @@ internal sealed class MSBuildConsumer : IDataConsumer, ITestSessionLifetimeHandl
 
     public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         // Avoid processing messages if the session has ended.
         if (_sessionEnded)

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxDataConsumer.cs
@@ -104,10 +104,7 @@ internal sealed class TrxReportGenerator :
 
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
-        if (!_isEnabled || cancellationToken.IsCancellationRequested)
-        {
-            return Task.CompletedTask;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         try
         {
@@ -168,10 +165,7 @@ internal sealed class TrxReportGenerator :
     public async Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
     {
         CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        if (!_isEnabled || cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -198,7 +192,7 @@ TrxReportGeneratorCommandLine.IsTrxReportEnabled: {_commandLineOptionsService.Is
         }
 
         ITrxReportCapability? trxCapability = _testFrameworkCapabilities.GetCapability<ITrxReportCapability>();
-        if (_isEnabled && trxCapability is not null && trxCapability.IsSupported)
+        if (trxCapability is not null && trxCapability.IsSupported)
         {
             _adapterSupportTrxCapability = true;
             trxCapability.Enable();
@@ -210,10 +204,7 @@ TrxReportGeneratorCommandLine.IsTrxReportEnabled: {_commandLineOptionsService.Is
     public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
     {
         CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        if (!_isEnabled || cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         try
         {

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
@@ -148,10 +148,7 @@ internal sealed class TrxProcessLifetimeHandler :
 
     public async Task OnTestHostProcessExitedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         Dictionary<IExtension, List<SessionFileArtifact>> artifacts = [];
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -233,10 +233,8 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
 
     public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
     {
-        if (testSessionContext.CancellationToken.IsCancellationRequested)
-        {
-            return Task.CompletedTask;
-        }
+        CancellationToken cancellationToken = testSessionContext.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
 
         // We implement IDataConsumerService and IOutputDisplayService.
         // So the engine is calling us before as IDataConsumerService and after as IOutputDisplayService.

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -337,7 +337,9 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
     public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
     {
-        if (_isServerMode || testSessionContext.CancellationToken.IsCancellationRequested)
+        CancellationToken cancellationToken = testSessionContext.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_isServerMode)
         {
             return Task.CompletedTask;
         }
@@ -398,8 +400,8 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
     public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
         RoslynDebug.Assert(_terminalTestReporter is not null);
-
-        if (_isServerMode || cancellationToken.IsCancellationRequested)
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_isServerMode)
         {
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Closes #5063

This is more aligned with the usual cancellation behavior of most BCL APIs, and in many cases we already pass the token to BCL APIs, so we at least now guarantee having a unified behavior (if there are any noticeable behavior differences).