### PR TITLE
Cleanup unneeded setting `EnableBaseClassTestMethodsFromOtherAssemblies`

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
@@ -69,14 +69,6 @@ internal class TypeEnumerator
         // if we rely on analyzers to identify all invalid methods on build, we can change this to fit the current settings.
         foreach (MethodInfo method in PlatformServiceProvider.Instance.ReflectionOperations.GetRuntimeMethods(_type))
         {
-            bool isMethodDeclaredInTestTypeAssembly = _reflectHelper.IsMethodDeclaredInSameAssemblyAsType(method, _type);
-            bool enableMethodsFromOtherAssemblies = MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies;
-
-            if (!isMethodDeclaredInTestTypeAssembly && !enableMethodsFromOtherAssemblies)
-            {
-                continue;
-            }
-
             if (_testMethodValidator.IsValidTestMethod(method, _type, warnings))
             {
                 // ToString() outputs method name and its signature. This is necessary for overloaded methods to be recognized as distinct tests.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -137,15 +137,6 @@ internal class ReflectHelper : MarshalByRefObject
     }
 
     /// <summary>
-    /// Returns true when the method is declared in the assembly where the type is declared.
-    /// </summary>
-    /// <param name="method">The method to check for.</param>
-    /// <param name="type">The type declared in the assembly to check.</param>
-    /// <returns>True if the method is declared in the assembly where the type is declared.</returns>
-    internal virtual bool IsMethodDeclaredInSameAssemblyAsType(MethodInfo method, Type type)
-        => method.DeclaringType!.Assembly.Equals(type.Assembly); // TODO: Investigate if we rely on NRE
-
-    /// <summary>
     /// Get categories applied to the test method.
     /// </summary>
     /// <param name="categoryAttributeProvider">The member to inspect.</param>

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
@@ -52,7 +52,6 @@ internal sealed class MSTestSettings
         MapInconclusiveToFailed = false;
         MapNotRunnableToFailed = true;
         TreatDiscoveryWarningsAsErrors = true;
-        EnableBaseClassTestMethodsFromOtherAssemblies = true;
         TestSettingsFile = null;
         DisableParallelization = false;
         ConsiderEmptyDataSourceAsInconclusive = false;
@@ -112,11 +111,6 @@ internal sealed class MSTestSettings
     /// Gets a value indicating whether or not test discovery warnings should be treated as errors.
     /// </summary>
     public bool TreatDiscoveryWarningsAsErrors { get; private set; }
-
-    /// <summary>
-    /// Gets a value indicating whether to enable discovery of test methods from base classes in a different assembly from the inheriting test class.
-    /// </summary>
-    public bool EnableBaseClassTestMethodsFromOtherAssemblies { get; private set; }
 
     /// <summary>
     /// Gets the number of threads/workers to be used for parallelization.
@@ -205,7 +199,6 @@ internal sealed class MSTestSettings
         CurrentSettings.ConsiderEmptyDataSourceAsInconclusive = settings.ConsiderEmptyDataSourceAsInconclusive;
         CurrentSettings.CooperativeCancellationTimeout = settings.CooperativeCancellationTimeout;
         CurrentSettings.DisableParallelization = settings.DisableParallelization;
-        CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies = settings.EnableBaseClassTestMethodsFromOtherAssemblies;
         CurrentSettings.MapInconclusiveToFailed = settings.MapInconclusiveToFailed;
         CurrentSettings.MapNotRunnableToFailed = settings.MapNotRunnableToFailed;
         CurrentSettings.OrderTestsByNameInClass = settings.OrderTestsByNameInClass;
@@ -385,7 +378,6 @@ internal sealed class MSTestSettings
         //     <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
         //     <MapNotRunnableToFailed>false</MapNotRunnableToFailed>
         //     <TreatDiscoveryWarningsAsErrors>true</TreatDiscoveryWarningsAsErrors>
-        //     <EnableBaseClassTestMethodsFromOtherAssemblies>false</EnableBaseClassTestMethodsFromOtherAssemblies>
         //     <TestTimeout>5000</TestTimeout>
         //     <Parallelize>
         //        <Workers>4</Workers>
@@ -424,21 +416,6 @@ internal sealed class MSTestSettings
                             else
                             {
                                 logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, "CaptureTraceOutput"));
-                            }
-
-                            break;
-                        }
-
-                    case "ENABLEBASECLASSTESTMETHODSFROMOTHERASSEMBLIES":
-                        {
-                            string value = reader.ReadInnerXml();
-                            if (bool.TryParse(value, out result))
-                            {
-                                settings.EnableBaseClassTestMethodsFromOtherAssemblies = result;
-                            }
-                            else
-                            {
-                                logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, "EnableBaseClassTestMethodsFromOtherAssemblies"));
                             }
 
                             break;
@@ -877,7 +854,6 @@ internal sealed class MSTestSettings
         //  }
         //  ... remaining settings
         // }
-        ParseBooleanSetting(configuration, "enableBaseClassTestMethodsFromOtherAssemblies", logger, value => settings.EnableBaseClassTestMethodsFromOtherAssemblies = value);
         ParseBooleanSetting(configuration, "orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
 
         ParseBooleanSetting(configuration, "output:captureTrace", logger, value => settings.CaptureDebugTraces = value);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/TypeEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/TypeEnumeratorTests.cs
@@ -61,7 +61,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void EnumerateShouldReturnEmptyCollectionWhenNoValidTestMethodsExist()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: false, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: false);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), string.Empty);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -76,7 +76,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestsShouldReturnDeclaredTestMethods()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyBaseTestClass), Assembly.GetExecutingAssembly().FullName!);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -89,7 +89,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestsShouldReturnBaseTestMethodsInSameAssembly()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyDerivedTestClass), Assembly.GetExecutingAssembly().FullName!);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -108,7 +108,6 @@ public partial class TypeEnumeratorTests : TestContainer
               <MSTestV2>
                 <CaptureTraceOutput>true</CaptureTraceOutput>
                 <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTestV2>
             </RunSettings>
             """;
@@ -119,7 +118,7 @@ public partial class TypeEnumeratorTests : TestContainer
         mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
 
         MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object, null);
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: false);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
 
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyDerivedTestClass), Assembly.GetExecutingAssembly().FullName!);
 
@@ -139,7 +138,6 @@ public partial class TypeEnumeratorTests : TestContainer
               <MSTestV2>
                 <CaptureTraceOutput>true</CaptureTraceOutput>
                 <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTestV2>
             </RunSettings>
             """;
@@ -150,7 +148,7 @@ public partial class TypeEnumeratorTests : TestContainer
         mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
 
         MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object, null);
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyDerivedTestClass), Assembly.GetExecutingAssembly().FullName!);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -158,44 +156,13 @@ public partial class TypeEnumeratorTests : TestContainer
         tests.Should().NotBeNull();
 
         // DummyDerivedFromRemoteTestClass inherits DummyRemoteBaseTestClass from different assembly.
-        // BestTestMethod from DummyRemoteBaseTestClass should be discovered when RunSettings MSTestV2 specifies EnableBaseClassTestMethodsFromOtherAssemblies = true.
+        // BestTestMethod from DummyRemoteBaseTestClass should be discovered.
         tests.Should().Contain(t => t.TestMethod.Name == "BaseTestMethod");
-    }
-
-    public void GetTestsShouldNotReturnBaseTestMethodsFromAnotherAssemblyByConfiguration()
-    {
-        string runSettingsXml =
-            """
-            <RunSettings>
-              <MSTestV2>
-                <CaptureTraceOutput>true</CaptureTraceOutput>
-                <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>false</EnableBaseClassTestMethodsFromOtherAssemblies>
-              </MSTestV2>
-            </RunSettings>
-            """;
-
-        var mockRunContext = new Mock<IRunContext>();
-        var mockRunSettings = new Mock<IRunSettings>();
-        mockRunContext.Setup(dc => dc.RunSettings).Returns(mockRunSettings.Object);
-        mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-
-        MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object, null);
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: false);
-        TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyDerivedTestClass), Assembly.GetExecutingAssembly().FullName!);
-
-        ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
-
-        tests.Should().NotBeNull();
-
-        // DummyDerivedFromRemoteTestClass inherits DummyRemoteBaseTestClass from different assembly.
-        // BestTestMethod from DummyRemoteBaseTestClass should not be discovered when RunSettings MSTestV2 specifies EnableBaseClassTestMethodsFromOtherAssemblies = false.
-        tests.Should().NotContain(t => t.TestMethod.Name == "BaseTestMethod");
     }
 
     public void GetTestsShouldNotReturnHiddenTestMethods()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyHidingTestClass), Assembly.GetExecutingAssembly().FullName!);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -211,7 +178,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestsShouldReturnOverriddenTestMethods()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyOverridingTestClass), Assembly.GetExecutingAssembly().FullName!);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -227,7 +194,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestsShouldNotReturnHiddenTestMethodsFromAnyLevel()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummySecondHidingTestClass), Assembly.GetExecutingAssembly().FullName!);
 
         ICollection<MSTest.TestAdapter.ObjectModel.UnitTestElement>? tests = typeEnumerator.Enumerate(_warnings);
@@ -247,7 +214,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldInitiateTestMethodWithCorrectParameters()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
 
         MSTest.TestAdapter.ObjectModel.UnitTestElement testElement = typeEnumerator.GetTestFromMethod(typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!, _warnings);
@@ -260,7 +227,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldInitializeAsyncTypeNameCorrectly()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("AsyncMethodWithTaskReturnType")!;
 
@@ -271,7 +238,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetTestCategory()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestCategoryAttribute("foo"), new TestCategoryAttribute("bar"));
@@ -285,7 +252,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetDoNotParallelize()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new DoNotParallelizeAttribute());
@@ -298,7 +265,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldFillTraitsWithTestProperties()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(
@@ -319,7 +286,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldFillTraitsWithTestOwnerPropertyIfPresent()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(
@@ -343,7 +310,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldFillTraitsWithTestPriorityPropertyIfPresent()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestPropertyAttribute("foo", "bar"), new TestPropertyAttribute("fooprime", "barprime"), new PriorityAttribute(1));
@@ -362,7 +329,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetPriority()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new PriorityAttribute(1));
@@ -375,7 +342,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetDescription()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new DescriptionAttribute("Dummy description"));
@@ -388,7 +355,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetWorkItemIds()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new WorkItemAttribute(123), new WorkItemAttribute(345));
@@ -400,7 +367,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetWorkItemIdsToNullIfNotAny()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
 
@@ -412,7 +379,7 @@ public partial class TypeEnumeratorTests : TestContainer
 #if !WINDOWS_UWP && !WIN_UI
     public void GetTestFromMethodShouldSetDeploymentItemsToNullIfNotPresent()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
 
@@ -429,7 +396,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetDeploymentItems()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod("MethodWithVoidReturnType")!;
         KeyValuePair<string, string>[] deploymentItems = [new KeyValuePair<string, string>("C:\\temp", string.Empty)];
@@ -448,7 +415,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetDisplayNameToTestMethodNameIfDisplayNameIsNotPresent()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType))!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestMethodAttribute());
@@ -460,7 +427,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetDisplayNameFromTestMethodAttribute()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType))!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new TestMethodAttribute() { DisplayName = "Test method display name." });
@@ -472,7 +439,7 @@ public partial class TypeEnumeratorTests : TestContainer
 
     public void GetTestFromMethodShouldSetDisplayNameFromDataTestMethodAttribute()
     {
-        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true, isMethodFromSameAssembly: true);
+        SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyTestClass), "DummyAssemblyName");
         MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.MethodWithVoidReturnType))!;
         methodInfo = new MockedMethodInfoWithExtraAttributes(methodInfo, new DataTestMethodAttribute() { DisplayName = "Test method display name." });
@@ -486,14 +453,12 @@ public partial class TypeEnumeratorTests : TestContainer
 
     #region private methods
 
-    private void SetupTestClassAndTestMethods(bool isValidTestClass, bool isValidTestMethod, bool isMethodFromSameAssembly)
+    private void SetupTestClassAndTestMethods(bool isValidTestClass, bool isValidTestMethod)
     {
         _mockTypeValidator.Setup(tv => tv.IsValidTestClass(It.IsAny<Type>(), It.IsAny<List<string>>()))
             .Returns(isValidTestClass);
         _mockTestMethodValidator.Setup(
             tmv => tmv.IsValidTestMethod(It.IsAny<MethodInfo>(), It.IsAny<Type>(), It.IsAny<ICollection<string>>())).Returns(isValidTestMethod);
-        _mockReflectHelper.Setup(
-            rh => rh.IsMethodDeclaredInSameAssemblyAsType(It.IsAny<MethodInfo>(), It.IsAny<Type>())).Returns(isMethodFromSameAssembly);
     }
 
     private TypeEnumerator GetTypeEnumeratorInstance(Type type, string assemblyName)

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -112,7 +112,6 @@ public class MSTestSettingsTests : TestContainer
                     <MapInconclusiveToFailed>3</MapInconclusiveToFailed>
                     <MapNotRunnableToFailed>3</MapNotRunnableToFailed>
                     <TreatDiscoveryWarningsAsErrors>3</TreatDiscoveryWarningsAsErrors>
-                    <EnableBaseClassTestMethodsFromOtherAssemblies>3</EnableBaseClassTestMethodsFromOtherAssemblies>
                     <TestTimeout>timeout</TestTimeout>
                </MSTestV2>
             </RunSettings>
@@ -120,14 +119,13 @@ public class MSTestSettingsTests : TestContainer
 
         var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
 
-        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(15));
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(14));
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'CooperativeCancellationTimeout', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'TestCleanupTimeout', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'ClassCleanupTimeout', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'AssemblyCleanupTimeout', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'CaptureTraceOutput', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'MapNotRunnableToFailed', setting will be ignored."), Times.Once);
-        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'EnableBaseClassTestMethodsFromOtherAssemblies', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'TestInitializeTimeout', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'ClassInitializeTimeout', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'AssemblyInitializeTimeout', setting will be ignored."), Times.Once);
@@ -183,37 +181,6 @@ public class MSTestSettingsTests : TestContainer
         MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object)!;
 
         adapterSettings.TestSettingsFile.Should().NotBeNull();
-    }
-
-    public void EnableBaseClassTestMethodsFromOtherAssembliesIsByDefaulTrueWhenNotSpecified()
-    {
-        string runSettingsXml =
-            """
-            <RunSettings>
-              <MSTestV2>
-              </MSTestV2>
-            </RunSettings>
-            """;
-
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
-
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
-    }
-
-    public void EnableBaseClassTestMethodsFromOtherAssembliesShouldBeConsumedFromRunSettingsWhenSpecified()
-    {
-        string runSettingsXml =
-            """
-            <RunSettings>
-              <MSTestV2>
-                  <EnableBaseClassTestMethodsFromOtherAssemblies>True</EnableBaseClassTestMethodsFromOtherAssemblies>
-              </MSTestV2>
-            </RunSettings>
-            """;
-
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
-
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
     }
 
     public void CaptureDebugTracesShouldBeTrueByDefault()
@@ -728,7 +695,6 @@ public class MSTestSettingsTests : TestContainer
                 <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
                 <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                 <UnReadableSetting>foobar</UnReadableSetting>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
                 <DummyPlatformSpecificSetting>True</DummyPlatformSpecificSetting>
                 <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
               </MSTest>
@@ -770,7 +736,6 @@ public class MSTestSettingsTests : TestContainer
         dummyPlatformSpecificSetting.Should().BeTrue();
         adapterSettings.MapInconclusiveToFailed.Should().BeTrue();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.TestSettingsFile.Should().Be("DummyPath\\\\TestSettings1.testsettings");
     }
 
@@ -831,8 +796,6 @@ public class MSTestSettingsTests : TestContainer
                 <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
                 <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                 <DummyPlatformSpecificSetting>True</DummyPlatformSpecificSetting>
-                <!-- Enable base class test methods from other assemblies -->
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTest>
               <BadElement>Bad</BadElement>
             </RunSettings>
@@ -873,7 +836,6 @@ public class MSTestSettingsTests : TestContainer
         dummyPlatformSpecificSetting.Should().BeTrue();
         adapterSettings.MapInconclusiveToFailed.Should().BeTrue();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
     }
 
     #endregion
@@ -929,7 +891,6 @@ public class MSTestSettingsTests : TestContainer
                 <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
                 <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                 <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTest>
             </RunSettings>
             """;
@@ -941,7 +902,6 @@ public class MSTestSettingsTests : TestContainer
         MSTestSettings.CurrentSettings.CaptureDebugTraces.Should().BeFalse();
         MSTestSettings.CurrentSettings.MapInconclusiveToFailed.Should().BeTrue();
         MSTestSettings.CurrentSettings.MapNotRunnableToFailed.Should().BeTrue();
-        MSTestSettings.CurrentSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         MSTestSettings.CurrentSettings.TestSettingsFile.Should().NotBeNullOrEmpty();
     }
 
@@ -953,7 +913,6 @@ public class MSTestSettingsTests : TestContainer
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
         adapterSettings.MapInconclusiveToFailed.Should().BeFalse();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.TreatDiscoveryWarningsAsErrors.Should().BeTrue();
     }
 
@@ -965,7 +924,6 @@ public class MSTestSettingsTests : TestContainer
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
         adapterSettings.MapInconclusiveToFailed.Should().BeFalse();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.TreatDiscoveryWarningsAsErrors.Should().BeTrue();
     }
 
@@ -978,7 +936,6 @@ public class MSTestSettingsTests : TestContainer
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
         adapterSettings.MapInconclusiveToFailed.Should().BeFalse();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.TreatDiscoveryWarningsAsErrors.Should().BeTrue();
     }
 
@@ -1014,7 +971,6 @@ public class MSTestSettingsTests : TestContainer
                 <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
                 <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                 <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTest>
             </RunSettings>
             """;
@@ -1029,7 +985,6 @@ public class MSTestSettingsTests : TestContainer
 
         adapterSettings.MapInconclusiveToFailed.Should().BeTrue();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.TestSettingsFile.Should().NotBeNullOrEmpty();
     }
 
@@ -1042,7 +997,6 @@ public class MSTestSettingsTests : TestContainer
                 <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
                 <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
                 <SettingsFile>DummyPath\\TestSettings1.testsettings</SettingsFile>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTestV2>
             </RunSettings>
             """;
@@ -1057,7 +1011,6 @@ public class MSTestSettingsTests : TestContainer
 
         adapterSettings.MapInconclusiveToFailed.Should().BeTrue();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.TestSettingsFile.Should().NotBeNullOrEmpty();
     }
 
@@ -1069,7 +1022,6 @@ public class MSTestSettingsTests : TestContainer
               <MSTestV2>
                 <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
                 <MapNotRunnableToFailed>True</MapNotRunnableToFailed>
-                <EnableBaseClassTestMethodsFromOtherAssemblies>true</EnableBaseClassTestMethodsFromOtherAssemblies>
               </MSTestV2>
               <MSTest>
                 <CaptureDebugTraces>False</CaptureDebugTraces>
@@ -1088,7 +1040,6 @@ public class MSTestSettingsTests : TestContainer
 
         adapterSettings.MapInconclusiveToFailed.Should().BeTrue();
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
-        adapterSettings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
         adapterSettings.TestSettingsFile.Should().BeNullOrEmpty();
     }
@@ -1172,7 +1123,6 @@ public class MSTestSettingsTests : TestContainer
             { "mstest:execution:mapNotRunnableToFailed", "3" },
             { "mstest:execution:treatDiscoveryWarningsAsErrors", "3" },
             { "mstest:execution:considerEmptyDataSourceAsInconclusive", "3" },
-            { "mstest:enableBaseClassTestMethodsFromOtherAssemblies", "3" },
         };
 
         var mockConfig = new Mock<IConfiguration>();
@@ -1182,13 +1132,12 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
         MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
 
-        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(13));
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(12));
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'timeout:useCooperativeCancellation', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'timeout:assemblyInitialize', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'timeout:assemblyCleanup', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'timeout:classInitialize', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'execution:mapNotRunnableToFailed', setting will be ignored."), Times.Once);
-        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'enableBaseClassTestMethodsFromOtherAssemblies', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'timeout:classCleanup', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'timeout:testInitialize', setting will be ignored."), Times.Once);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'timeout' for runsettings entry 'timeout:testCleanup', setting will be ignored."), Times.Once);
@@ -1218,7 +1167,6 @@ public class MSTestSettingsTests : TestContainer
             { "mstest:execution:mapNotRunnableToFailed", "true" },
             { "mstest:execution:treatDiscoveryWarningsAsErrors", "true" },
             { "mstest:execution:considerEmptyDataSourceAsInconclusive", "true" },
-            { "mstest:enableBaseClassTestMethodsFromOtherAssemblies", "true" },
             { "mstest:orderTestsByNameInClass", "true" },
             { "mstest:output:captureTrace", "true" },
         };
@@ -1233,7 +1181,6 @@ public class MSTestSettingsTests : TestContainer
         MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
 
         // Assert
-        settings.EnableBaseClassTestMethodsFromOtherAssemblies.Should().BeTrue();
         settings.OrderTestsByNameInClass.Should().BeTrue();
         settings.CaptureDebugTraces.Should().BeTrue();
         settings.CooperativeCancellationTimeout.Should().BeTrue();


### PR DESCRIPTION
The flag used to be false in the past, and was changed to be true in https://github.com/microsoft/testfx/pull/204. I think the linked PR should have simply just removed the flag altogether instead of switching the default value. The removal of the feature flag is unlikely to affect anyone in a negative way. So moving forward with a cleanup.