### PR TITLE
Add default settings for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "dotnet.automaticallyCreateSolutionInWorkspace": false,
+    "dotnet.enableWorkspaceBasedDevelopment": false,
+    "dotnet.solution.autoOpen": "TestFx.slnx",
+}


### PR DESCRIPTION
Disable using workspace generated solution in VSCode, and prefer our own existing solution, to shorten restore, and avoid including sample projects that are not included.

Uses testfx slnx by default to avoid always waiting and having to choose one.

Workaround for https://github.com/microsoft/vscode-dotnettools/issues/2805

<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->