### PR TITLE
Copy per-test result files to results directory in TRX reports

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -473,11 +473,11 @@ public class TrxTests
         string trxContentsPattern = @"
     <UnitTestResult .* testName=""TestMethod"" .* outcome=""Passed"" .*>
       <ResultFiles>
-        <ResultFile path=.*fileName"" />
+        <ResultFile path=""MachineName[/\\]fileName"" />
       </ResultFiles>
     </UnitTestResult>
  ";
-        Assert.IsTrue(Regex.IsMatch(trxContent, trxContentsPattern));
+        Assert.IsTrue(Regex.IsMatch(trxContent, trxContentsPattern), trxContent);
     }
 
     [TestMethod]


### PR DESCRIPTION
When using MTP, files added via TestContext.AddResultFile were not copied to the results directory. The TRX file referenced them with absolute paths, making the results directory non-self-contained and causing warnings in Azure DevOps builds.

Changes:
- Copy per-test FileArtifactProperty files into the results directory under {runDeploymentRoot}/In/{executionId}/{MachineName}/
- Use relative paths in TRX <ResultFile> elements instead of absolute paths
- Replace unbounded while(true) loops with bounded for loops (max 10 attempts) when resolving duplicate file names, in both the new and existing artifact copy methods

Fixes #6782