### PR TITLE
Rework NuGet PACKAGE.md for Microsoft.Testing.Platform and extensions

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.AzureDevOpsReport is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that reports individual test failures as errors or warnings in Azure DevOps CI builds, with file/line annotations when available.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.AzureDevOpsReport` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.AzureDevOpsReport` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.AzureFoundry is an AI provider extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that integrates with Azure AI Foundry (Azure OpenAI) to enable AI-powered testing capabilities.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.AzureFoundry` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.AzureFoundry) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.AzureFoundry` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -25,8 +25,6 @@ This package is a reference implementation of the [Microsoft.Testing.Platform.AI
 - [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/Microsoft.Testing.Platform.AI): AI extensibility abstractions for the testing platform
 
 ## Documentation
-
-For this extension, see <https://github.com/microsoft/testfx/blob/main/docs/microsoft.testing.platform/001-AI-Extensibility.md>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.CrashDump is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that captures a crash dump of the test host process when an unhandled exception or crash occurs.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.CrashDump` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.CrashDump) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.CrashDump` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -16,6 +16,7 @@ This package extends Microsoft.Testing.Platform with:
 
 - **Crash dump collection**: automatically captures a memory dump when the test process crashes
 - **Post-mortem debugging**: collected dumps can be analyzed with tools like Visual Studio, WinDbg, or `dotnet-dump`
+- **Cross-platform**: supported on Windows, Linux, and macOS. Note that dumps collected on macOS can only be analyzed on macOS
 - **Runtime behavior**: supported for .NET 6+; on .NET Framework this extension is ignored
 
 Enable crash dump collection via the `--crashdump` command line option.
@@ -26,7 +27,7 @@ Enable crash dump collection via the `--crashdump` command line option.
 
 ## Documentation
 
-For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions-diagnostics#crash-dump>.
+For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-crash-hang-dumps#crash-dump>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.HangDump is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that captures a memory dump when the test host process appears to be hung (exceeds a configurable timeout).
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.HangDump` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.HangDump) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.HangDump` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -28,7 +28,7 @@ Enable hang dump collection via the `--hangdump` command line option, and config
 
 ## Documentation
 
-For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions-diagnostics#hang-dump>.
+For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-crash-hang-dumps#hang-dump>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.HotReload is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that enables Hot Reload support, allowing you to apply code changes to your running tests without restarting the test host process.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.HotReload` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.HotReload) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.HotReload` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -22,7 +22,7 @@ Enable Hot Reload support by setting `TESTINGPLATFORM_HOTRELOAD_ENABLED=1`.
 
 ## Documentation
 
-For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions-hosting#hot-reload>.
+For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-hot-reload>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.OpenTelemetry is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that instruments test execution with [OpenTelemetry](https://opentelemetry.io/)-compatible traces and metrics.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.OpenTelemetry` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.OpenTelemetry` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -20,7 +20,7 @@ This package extends Microsoft.Testing.Platform with:
 
 ## Documentation
 
-For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions>.
+For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-open-telemetry>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.Retry is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that provides test resilience and transient-fault handling by rerunning failed tests.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.Retry` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.Retry) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.Retry` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -22,7 +22,7 @@ Configure retry using `--retry-failed-tests <retries>`, and optionally limit ret
 
 ## Documentation
 
-For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions-policy#retry>.
+For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.Telemetry is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that collects usage telemetry to help the Microsoft.Testing.Platform team improve the product.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.Telemetry` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.Telemetry) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.Telemetry` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.TrxReport.Abstractions provides the interfaces and data objects for extensions that need to interoperate with TRX report functionality in [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform).
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.TrxReport.Abstractions` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.TrxReport.Abstractions` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Extensions.TrxReport is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that generates TRX (Visual Studio Test Results) report files.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.TrxReport` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.TrxReport) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.TrxReport` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -27,7 +27,7 @@ Enable TRX report generation via the `--report-trx` command line option.
 
 ## Documentation
 
-For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions-test-reports#visual-studio-test-reports>.
+For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-extensions-test-reports#visual-studio-test-reports-trx>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/PACKAGE.md
@@ -4,7 +4,7 @@ Microsoft.Testing.Extensions.VSTestBridge is a **test framework author** extensi
 
 > **Note**: This package is **not intended for end-user test projects**. It is designed for framework and adapter maintainers who need compatibility with both VSTest and Microsoft.Testing.Platform.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.VSTestBridge` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Extensions.VSTestBridge) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.VSTestBridge` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 

--- a/src/Platform/Microsoft.Testing.Platform.AI/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.AI/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Platform.AI provides the AI extensibility abstractions for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform), enabling test frameworks and extensions to leverage Large Language Models (LLMs) and AI capabilities for intelligent testing activities.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platform.AI` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform.AI) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platform.AI` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -25,8 +25,6 @@ This package provides:
 - [Microsoft.Testing.Extensions.AzureFoundry](https://www.nuget.org/packages/Microsoft.Testing.Extensions.AzureFoundry): Azure AI Foundry (Azure OpenAI) provider implementation
 
 ## Documentation
-
-For this package, see <https://github.com/microsoft/testfx/blob/main/docs/microsoft.testing.platform/001-AI-Extensibility.md>.
 
 For comprehensive documentation, see <https://aka.ms/testingplatform>.
 

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/PACKAGE.md
@@ -1,8 +1,8 @@
 # Microsoft.Testing.Platform.MSBuild
 
-Microsoft.Testing.Platform.MSBuild provides the MSBuild integration for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform), including entry-point generation, test configuration file support, and compatibility with `dotnet test`.
+Microsoft.Testing.Platform.MSBuild provides the MSBuild tasks needed for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform), including entry-point generation and test configuration file support.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platform.MSBuild` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform.MSBuild) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platform.MSBuild` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -16,7 +16,7 @@ This package provides:
 
 - **Entry-point generation**: generates the required entry point for Microsoft.Testing.Platform test projects
 - **Configuration file support**: copies `testconfig.json` from the project into the output directory as `$(AssemblyName).testconfig.json`
-- **`dotnet test` compatibility**: enables running MTP-based test projects through the VSTest-based `dotnet test` command on .NET 8/9 SDKs
+- **`dotnet test` compatibility**: enables running MTP-based test projects through the VSTest-based `dotnet test` command on .NET SDKs
 
 This package is typically **not referenced directly**. Instead, test framework packages (such as [MSTest](https://www.nuget.org/packages/MSTest)) reference it automatically.
 

--- a/src/Platform/Microsoft.Testing.Platform/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform/PACKAGE.md
@@ -2,7 +2,7 @@
 
 Microsoft.Testing.Platform is a lightweight and portable alternative to [VSTest](https://github.com/microsoft/vstest) for running tests in CLI, continuous integration (CI) pipelines, Visual Studio Test Explorer, and Visual Studio Code Test Explorer. Microsoft.Testing.Platform is embedded directly in your test projects and test applications can be run directly.
 
-Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platform` code in the [microsoft/testfx](https://github.com/microsoft/testfx/tree/main/src/Platform/Microsoft.Testing.Platform) GitHub repository.
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platform` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
 ## Install the package
 
@@ -16,7 +16,7 @@ This package provides the core platform and the .NET implementation of the testi
 
 - **Test application host**: test projects are built as executables that can be run directly
 - **Extensibility model**: a rich extensibility model allowing test frameworks, tools and extensions to interoperate
-- **Protocol**: the `.NET Testing Protocol` enabling communication between the test host and external consumers (e.g. IDE, CI)
+- **Protocol**: the `Microsoft Testing Platform protocol` enabling communication between the test host and external consumers (e.g. IDE, CI)
 
 This package is typically **not referenced directly**. Instead, test framework packages (such as [MSTest](https://www.nuget.org/packages/MSTest)) reference it automatically.
 


### PR DESCRIPTION
Rework all NuGet README files (PACKAGE.md) for Microsoft.Testing.Platform and its extensions with a unified, detailed style:

- Use the actual package name as the title instead of generic 'Microsoft.Testing'
- Add a descriptive introduction paragraph with a NuGet link to Microsoft.Testing.Platform
- Add 'Install the package' section with dotnet CLI command
- Add detailed 'About' section with key features as bullet points
- Add 'Related packages' cross-references for closely related extensions (diagnostics: CrashDump/HangDump, reporting: TrxReport/TrxReport.Abstractions/AzureDevOpsReport, AI: Platform.AI/AzureFoundry)
- Add 'Documentation' and 'Feedback & contributing' sections with links
- Add missing PACKAGE.md for Microsoft.Testing.Platform.AI and Microsoft.Testing.Extensions.AzureFoundry
- Clarify VSTestBridge is a test framework author extension, not for end-user projects
- Clarify OpenTelemetry extension sends data only to user-configured endpoints, not to Microsoft