### PR TITLE
Copy per-test result files to results directory

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
@@ -352,19 +352,11 @@ internal sealed partial class TrxReportEngine
         string fileName = artifact.Name;
 
         string destination = Path.Combine(artifactDirectory, fileName);
-        int nameCounter = 0;
 
         // If the file already exists, append a number to the end of the file name
-        while (true)
+        for (int nameCounter = 1; File.Exists(destination) && nameCounter <= 10; nameCounter++)
         {
-            if (File.Exists(destination))
-            {
-                nameCounter++;
-                destination = Path.Combine(artifactDirectory, $"{Path.GetFileNameWithoutExtension(fileName)}_{nameCounter}{Path.GetExtension(fileName)}");
-                continue;
-            }
-
-            break;
+            destination = Path.Combine(artifactDirectory, $"{Path.GetFileNameWithoutExtension(fileName)}_{nameCounter}{Path.GetExtension(fileName)}");
         }
 
         await CopyFileAsync(artifact, new FileInfo(destination)).ConfigureAwait(false);
@@ -536,7 +528,7 @@ internal sealed partial class TrxReportEngine
                 resultFiles ??= new XElement("ResultFiles");
                 resultFiles.Add(new XElement(
                     "ResultFile",
-                    new XAttribute("path", testFileArtifact.FileInfo.FullName)));
+                    new XAttribute("path", testFileArtifact.FileInfo.Name)));
             }
 
             if (resultFiles is not null)

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -720,6 +720,9 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         await RegisterAsServiceOrConsumerOrBothAsync(testFrameworkBuilderData.TestExecutionRequestInvoker, serviceProvider, dataConsumersBuilder).ConfigureAwait(false);
         await RegisterAsServiceOrConsumerOrBothAsync(testFrameworkBuilderData.TestExecutionFilterFactory, serviceProvider, dataConsumersBuilder).ConfigureAwait(false);
 
+        // Register consumer that copies per-test file artifacts to the results directory.
+        dataConsumersBuilder.Add(new FileArtifactCopyDataConsumer(serviceProvider.GetConfiguration()));
+
         // Create the test framework adapter
         ITestFrameworkCapabilities testFrameworkCapabilities = serviceProvider.GetTestFrameworkCapabilities();
         ITestFramework testFramework = testFrameworkBuilderData.TestFrameworkManager.TestFrameworkFactory(testFrameworkCapabilities, serviceProvider);

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -746,4 +746,10 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
   <data name="WaitDebuggerAttachNotSupportedInBrowserErrorMessage" xml:space="preserve">
     <value>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported in browser environments.</value>
   </data>
+  <data name="FileArtifactCopyDataConsumerDisplayName" xml:space="preserve">
+    <value>File artifact copy</value>
+  </data>
+  <data name="FileArtifactCopyDataConsumerDescription" xml:space="preserve">
+    <value>Copies per-test file artifacts to the test results directory.</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -296,6 +296,16 @@
         <target state="translated">selhalo s {0} upozorněním(i).</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Testovací relace byla dokončena.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -296,6 +296,16 @@
         <target state="translated">fehlerhaft mit {0} Warnung(en)</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Die Testsitzung wurde beendet.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -296,6 +296,16 @@
         <target state="translated">error con {0} advertencias</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Finalizó la sesión de prueba.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -296,6 +296,16 @@
         <target state="translated">a échoué avec {0} avertissement(s)</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Session de test terminée.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -296,6 +296,16 @@
         <target state="translated">non riuscito con {0} avvisi</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Sessione di test completata.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -296,6 +296,16 @@
         <target state="translated">{0} 件の警告付きで失敗しました</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">テスト セッションを終了しました。</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -296,6 +296,16 @@
         <target state="translated">{0} 경고와 함께 실패</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">테스트 세션을 마쳤습니다.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -296,6 +296,16 @@
         <target state="translated">zakończono niepowodzeniem, z ostrzeżeniami w liczbie: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Zakończono sesję testą.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -296,6 +296,16 @@
         <target state="translated">falhou com {0} aviso(s)</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Sessão de teste concluída.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -296,6 +296,16 @@
         <target state="translated">сбой с предупреждениями ({0})</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Тестовый сеанс завершен.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -296,6 +296,16 @@
         <target state="translated">{0} uyarıyla başarısız oldu</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">Test oturumu bitti.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -296,6 +296,16 @@
         <target state="translated">失败，出现 {0} 警告</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">已完成测试会话。</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -296,6 +296,16 @@
         <target state="translated">失敗，有 {0} 個警告</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDescription">
+        <source>Copies per-test file artifacts to the test results directory.</source>
+        <target state="new">Copies per-test file artifacts to the test results directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileArtifactCopyDataConsumerDisplayName">
+        <source>File artifact copy</source>
+        <target state="new">File artifact copy</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FinishedTestSession">
         <source>Finished test session.</source>
         <target state="translated">已完成測試會話。</target>

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/FileArtifactCopyDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/FileArtifactCopyDataConsumer.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Resources;
+
+namespace Microsoft.Testing.Platform.TestHost;
+
+/// <summary>
+/// Copies per-test file artifacts to the test results directory so that the
+/// results directory is self-contained.
+/// </summary>
+internal sealed class FileArtifactCopyDataConsumer : IDataConsumer
+{
+    private readonly IConfiguration _configuration;
+
+    public FileArtifactCopyDataConsumer(IConfiguration configuration)
+        => _configuration = configuration;
+
+    public Type[] DataTypesConsumed => [typeof(TestNodeUpdateMessage)];
+
+    public string Uid => nameof(FileArtifactCopyDataConsumer);
+
+    public string Version => AppVersion.DefaultSemVer;
+
+    public string DisplayName => PlatformResources.FileArtifactCopyDataConsumerDisplayName;
+
+    public string Description => PlatformResources.FileArtifactCopyDataConsumerDescription;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        if (value is not TestNodeUpdateMessage message)
+        {
+            return Task.CompletedTask;
+        }
+
+        FileArtifactProperty[] artifacts = message.TestNode.Properties.OfType<FileArtifactProperty>();
+        if (artifacts.Length == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        string resultsDirectory = _configuration.GetTestResultDirectory();
+
+        foreach (FileArtifactProperty artifact in artifacts)
+        {
+            CopyFileToResultsDirectory(artifact.FileInfo, resultsDirectory);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void CopyFileToResultsDirectory(FileInfo file, string resultsDirectory)
+    {
+        // If the file is already under the results directory, skip.
+        string fullResultsDirectory = Path.GetFullPath(resultsDirectory);
+        if (file.FullName.StartsWith(fullResultsDirectory, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(resultsDirectory))
+        {
+            Directory.CreateDirectory(resultsDirectory);
+        }
+
+        string destination = Path.Combine(resultsDirectory, file.Name);
+        for (int nameCounter = 1; File.Exists(destination) && nameCounter <= 10; nameCounter++)
+        {
+            destination = Path.Combine(resultsDirectory, $"{Path.GetFileNameWithoutExtension(file.Name)}_{nameCounter}{Path.GetExtension(file.Name)}");
+        }
+
+        File.Copy(file.FullName, destination, overwrite: false);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -473,11 +473,11 @@ public class TrxTests
         string trxContentsPattern = @"
     <UnitTestResult .* testName=""TestMethod"" .* outcome=""Passed"" .*>
       <ResultFiles>
-        <ResultFile path=.*fileName"" />
+        <ResultFile path=""fileName"" />
       </ResultFiles>
     </UnitTestResult>
  ";
-        Assert.IsTrue(Regex.IsMatch(trxContent, trxContentsPattern));
+        Assert.IsTrue(Regex.IsMatch(trxContent, trxContentsPattern), trxContent);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestHost/FileArtifactCopyDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestHost/FileArtifactCopyDataConsumerTests.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class FileArtifactCopyDataConsumerTests : IDisposable
+{
+    private readonly string _resultsDirectory;
+    private readonly string _sourceDirectory;
+    private readonly FileArtifactCopyDataConsumer _consumer;
+
+    public FileArtifactCopyDataConsumerTests()
+    {
+        _resultsDirectory = Path.Combine(Path.GetTempPath(), $"TestResults_{Guid.NewGuid():N}");
+        _sourceDirectory = Path.Combine(Path.GetTempPath(), $"TestSource_{Guid.NewGuid():N}");
+
+        Directory.CreateDirectory(_resultsDirectory);
+        Directory.CreateDirectory(_sourceDirectory);
+
+        Mock<IConfiguration> configMock = new();
+        configMock.Setup(c => c[PlatformConfigurationConstants.PlatformResultDirectory]).Returns(_resultsDirectory);
+
+        _consumer = new FileArtifactCopyDataConsumer(configMock.Object);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_resultsDirectory))
+        {
+            Directory.Delete(_resultsDirectory, recursive: true);
+        }
+
+        if (Directory.Exists(_sourceDirectory))
+        {
+            Directory.Delete(_sourceDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task IsEnabledAsync_ReturnsTrue()
+    {
+        bool isEnabled = await _consumer.IsEnabledAsync();
+
+        Assert.IsTrue(isEnabled);
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_WithNoFileArtifacts_DoesNotCopyAnything()
+    {
+        TestNodeUpdateMessage message = CreateMessage(new PropertyBag(new PassedTestNodeStateProperty()));
+
+        await _consumer.ConsumeAsync(new DummyProducer(), message, CancellationToken.None);
+
+        Assert.AreEqual(0, Directory.GetFiles(_resultsDirectory).Length);
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_WithFileArtifact_CopiesFileToResultsDirectory()
+    {
+        string sourceFile = CreateSourceFile("TestOutput.txt", "test content");
+        TestNodeUpdateMessage message = CreateMessage(new PropertyBag(
+            new PassedTestNodeStateProperty(),
+            new FileArtifactProperty(new FileInfo(sourceFile), "TestOutput.txt")));
+
+        await _consumer.ConsumeAsync(new DummyProducer(), message, CancellationToken.None);
+
+        string expectedDestination = Path.Combine(_resultsDirectory, "TestOutput.txt");
+        Assert.IsTrue(File.Exists(expectedDestination));
+        Assert.AreEqual("test content", File.ReadAllText(expectedDestination));
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_WithFileAlreadyInResultsDirectory_DoesNotCopyAgain()
+    {
+        string fileInResults = Path.Combine(_resultsDirectory, "AlreadyHere.txt");
+        File.WriteAllText(fileInResults, "already here");
+
+        TestNodeUpdateMessage message = CreateMessage(new PropertyBag(
+            new PassedTestNodeStateProperty(),
+            new FileArtifactProperty(new FileInfo(fileInResults), "AlreadyHere.txt")));
+
+        await _consumer.ConsumeAsync(new DummyProducer(), message, CancellationToken.None);
+
+        Assert.AreEqual(1, Directory.GetFiles(_resultsDirectory).Length);
+        Assert.AreEqual("already here", File.ReadAllText(fileInResults));
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_WithNonTestNodeUpdateMessage_DoesNothing()
+    {
+        Mock<IData> dataMock = new();
+
+        await _consumer.ConsumeAsync(new DummyProducer(), dataMock.Object, CancellationToken.None);
+
+        Assert.AreEqual(0, Directory.GetFiles(_resultsDirectory).Length);
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_WithDuplicateFileName_AppendsCounter()
+    {
+        // Pre-create a file in the results directory with the same name.
+        File.WriteAllText(Path.Combine(_resultsDirectory, "Duplicate.txt"), "original");
+
+        string sourceFile = CreateSourceFile("Duplicate.txt", "new content");
+        TestNodeUpdateMessage message = CreateMessage(new PropertyBag(
+            new PassedTestNodeStateProperty(),
+            new FileArtifactProperty(new FileInfo(sourceFile), "Duplicate.txt")));
+
+        await _consumer.ConsumeAsync(new DummyProducer(), message, CancellationToken.None);
+
+        string expectedDestination = Path.Combine(_resultsDirectory, "Duplicate_1.txt");
+        Assert.IsTrue(File.Exists(expectedDestination));
+        Assert.AreEqual("new content", File.ReadAllText(expectedDestination));
+    }
+
+    private string CreateSourceFile(string name, string content)
+    {
+        string path = Path.Combine(_sourceDirectory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static TestNodeUpdateMessage CreateMessage(PropertyBag properties)
+        => new(
+            default,
+            new TestNode
+            {
+                Uid = new TestNodeUid("test-id"),
+                DisplayName = "TestMethod",
+                Properties = properties,
+            });
+
+    private sealed class DummyProducer : IDataProducer
+    {
+        public Type[] DataTypesProduced => [typeof(TestNodeUpdateMessage)];
+
+        public string Uid => nameof(DummyProducer);
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => string.Empty;
+
+        public string Description => string.Empty;
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    }
+}


### PR DESCRIPTION
Variant of #7449, where the copy is done at the core platform.

When using MTP, files added via TestContext.AddResultFile were not copied to the results directory. The TRX file referenced them with absolute paths, making the results directory non-self-contained and causing warnings in Azure DevOps builds.

Add FileArtifactCopyDataConsumer, a new IDataConsumer in the core platform that subscribes to TestNodeUpdateMessage. When it sees FileArtifactProperty, it copies the file to the results directory. This benefits all downstream consumers.

Update TRX report engine to write just the filename in ResultFile path elements, since the file is now in the results directory.

Also: replace unbounded while(true) with bounded for loop when resolving duplicate file names in TRX artifact copy.

Fixes #6782