### PR TITLE
Delete dead code in TestHostControllersManager

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
@@ -17,7 +17,6 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
 
     private readonly List<Func<IServiceProvider, ITestHostEnvironmentVariableProvider>> _environmentVariableProviderFactories = [];
     private readonly List<Func<IServiceProvider, ITestHostProcessLifetimeHandler>> _lifetimeHandlerFactories = [];
-    private readonly List<Func<IServiceProvider, IDataConsumer>> _dataConsumerFactories = [];
     private readonly List<ICompositeExtensionFactory> _environmentVariableProviderCompositeFactories = [];
     private readonly List<ICompositeExtensionFactory> _lifetimeHandlerCompositeFactories = [];
     private readonly List<ICompositeExtensionFactory> _alreadyBuiltServices = [];
@@ -229,22 +228,6 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
         }
 
         List<(IDataConsumer Consumer, int RegistrationOrder)> dataConsumers = [];
-        foreach (Func<IServiceProvider, IDataConsumer> dataConsumerFactory in _dataConsumerFactories)
-        {
-            IDataConsumer service = dataConsumerFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            dataConsumers.ValidateUniqueExtension(service, x => x.Consumer);
-
-            // We initialize only if enabled
-            if (await service.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await service.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                dataConsumers.Add((service, _factoryOrdering.IndexOf(dataConsumerFactory)));
-            }
-        }
 
         foreach (ICompositeExtensionFactory compositeServiceFactory in _dataConsumersCompositeServiceFactories)
         {


### PR DESCRIPTION
I think generally we don't have data consumers running in test host controller, except for few internal exceptions.

Our only **public** APIs to register data consumers are the two overloads of `ITestHostManager.AddDataConsumer`.

Other than that, everything else is internal. And even for internal usages, none of the usages need `_dataConsumerFactories`.