### PR TITLE
Use MoveFile and remove CopyFile/DeleteFile

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -323,12 +323,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 fileSystem.CreateDirectory(Path.GetDirectoryName(finalFileLocation)!);
 
                 await outputDevice.DisplayAsync(this, new TextOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.MovingFileToLocation, file, finalFileLocation)), cancellationToken).ConfigureAwait(false);
-#if NETCOREAPP
                 fileSystem.MoveFile(file, finalFileLocation, overwrite: true);
-#else
-                fileSystem.CopyFile(file, finalFileLocation, overwrite: true);
-                fileSystem.DeleteFile(file);
-#endif
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs
@@ -21,9 +21,5 @@ internal interface IFileSystem
 
     Task<string> ReadAllTextAsync(string path);
 
-    void CopyFile(string sourceFileName, string destFileName, bool overwrite = false);
-
-    void DeleteFile(string path);
-
     string[] GetFiles(string path, string searchPattern, SearchOption searchOption);
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
@@ -19,10 +19,6 @@ internal sealed class SystemFileSystem : IFileSystem
 
     public Task<string> ReadAllTextAsync(string path) => File.ReadAllTextAsync(path);
 
-    public void CopyFile(string sourceFileName, string destFileName, bool overwrite = false) => File.Copy(sourceFileName, destFileName, overwrite);
-
-    public void DeleteFile(string path) => File.Delete(path);
-
     public bool ExistDirectory(string? path) => Directory.Exists(path);
 
     public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => Directory.GetFiles(path, searchPattern, searchOption);


### PR DESCRIPTION
Unify file-moving logic by removing the NETCOREAPP conditional and calling IFileSystem.MoveFile unconditionally in RetryOrchestrator. Remove CopyFile and DeleteFile members from IFileSystem and their implementations in SystemFileSystem, simplifying the file system abstraction.