### PR TITLE
VSTestBridge: Support TreeNodeFilter

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
@@ -43,6 +43,7 @@ public static class TestApplicationBuilderExtensions
         testApplicationBuilder.AddTestRunParametersService(extension);
         testApplicationBuilder.AddMaximumFailedTestsService(extension);
         testApplicationBuilder.AddRunSettingsEnvironmentVariableProvider(extension);
+        testApplicationBuilder.AddTreeNodeFilterService(extension);
         testApplicationBuilder.RegisterTestFramework(
             serviceProvider => new TestFrameworkCapabilities(
                 new MSTestCapabilities(),

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ContextAdapterBase.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ContextAdapterBase.cs
@@ -13,9 +13,12 @@ namespace Microsoft.Testing.Extensions.VSTestBridge.ObjectModel;
 
 internal abstract class ContextAdapterBase
 {
+    private readonly TreeNodeFilter? _treeNodeFilter;
+
     protected ContextAdapterBase(ICommandLineOptions commandLineOptions, IRunSettings runSettings, ITestExecutionFilter filter)
     {
         RunSettings = runSettings;
+        _treeNodeFilter = filter as TreeNodeFilter;
 
         RoslynDebug.Assert(runSettings.SettingsXml is not null);
 
@@ -43,19 +46,17 @@ internal abstract class ContextAdapterBase
         IEnumerable<string>? supportedProperties,
         Func<string, TestProperty?> propertyProvider)
     {
-        if (FilterExpressionWrapper is null)
+        if (FilterExpressionWrapper is null && _treeNodeFilter is null)
         {
             return null;
         }
 
-        if (!RoslynString.IsNullOrEmpty(FilterExpressionWrapper.ParseError))
+        if (!RoslynString.IsNullOrEmpty(FilterExpressionWrapper?.ParseError))
         {
             throw new TestPlatformFormatException(FilterExpressionWrapper.ParseError, FilterExpressionWrapper.FilterString);
         }
 
-        var adapterSpecificTestCaseFilter = new TestCaseFilterExpression(FilterExpressionWrapper);
-        string[]? invalidProperties = adapterSpecificTestCaseFilter.ValidForProperties(supportedProperties, propertyProvider);
-
+        string[]? invalidProperties = FilterExpressionWrapper?.ValidForProperties(supportedProperties, propertyProvider);
         if (invalidProperties != null)
         {
             string validPropertiesString = supportedProperties == null
@@ -66,7 +67,7 @@ internal abstract class ContextAdapterBase
             EqtTrace.Info($"No tests matched the filter because it contains one or more properties that are not valid ({string.Join(", ", invalidProperties)}). Specify filter expression containing valid properties ({validPropertiesString}).");
         }
 
-        return adapterSpecificTestCaseFilter;
+        return new TestCaseFilterExpression(FilterExpressionWrapper, _treeNodeFilter);
     }
 
     private void HandleFilter(ITestExecutionFilter? filter, string? filterFromRunsettings, string? filterFromCommandLineOption)

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseFilterExpression.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/TestCaseFilterExpression.cs
@@ -3,6 +3,7 @@
 
 // NOTE: This file is copied as-is from VSTest source code.
 using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.Requests;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
@@ -13,43 +14,27 @@ namespace Microsoft.Testing.Extensions.VSTestBridge.ObjectModel;
 /// </summary>
 internal sealed class TestCaseFilterExpression : ITestCaseFilterExpression
 {
-    private readonly FilterExpressionWrapper _filterWrapper;
-
-    /// <summary>
-    /// If filter Expression is valid for performing TestCase matching
-    /// (has only supported properties, syntax etc).
-    /// </summary>
-    private readonly bool _validForMatch;
+    private readonly FilterExpressionWrapper? _filterWrapper;
+    private readonly TreeNodeFilter? _treeNodeFilter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TestCaseFilterExpression"/> class.
     /// Adapter specific filter expression.
     /// </summary>
-    public TestCaseFilterExpression(FilterExpressionWrapper filterWrapper)
+    public TestCaseFilterExpression(FilterExpressionWrapper? filterWrapper, TreeNodeFilter? treeNodeFilter)
     {
-        Ensure.NotNull(filterWrapper);
         _filterWrapper = filterWrapper;
-        _validForMatch = RoslynString.IsNullOrEmpty(filterWrapper.ParseError);
+        _treeNodeFilter = treeNodeFilter;
+        if (RoslynString.IsNullOrEmpty(filterWrapper?.ParseError))
+        {
+            throw new UnreachableException();
+        }
     }
 
     /// <summary>
     /// Gets user specified filter criteria.
     /// </summary>
-    public string TestCaseFilterValue => _filterWrapper.FilterString;
-
-    /// <summary>
-    /// Validate if underlying filter expression is valid for given set of supported properties.
-    /// </summary>
-    public string[]? ValidForProperties(IEnumerable<string>? supportedProperties, Func<string, TestProperty?> propertyProvider)
-    {
-        string[]? invalidProperties = null;
-        if (_validForMatch)
-        {
-            invalidProperties = _filterWrapper.ValidForProperties(supportedProperties, propertyProvider);
-        }
-
-        return invalidProperties;
-    }
+    public string TestCaseFilterValue => _filterWrapper?.FilterString ?? string.Empty;
 
     /// <summary>
     /// Match test case with filter criteria.
@@ -59,6 +44,13 @@ internal sealed class TestCaseFilterExpression : ITestCaseFilterExpression
         Ensure.NotNull(testCase);
         Ensure.NotNull(propertyValueProvider);
 
-        return _validForMatch && _filterWrapper.Evaluate(propertyValueProvider);
+        bool vstestFilterMatch = _filterWrapper is null ||
+            _filterWrapper.Evaluate(propertyValueProvider);
+
+        bool treeNodeFilterMatch = _treeNodeFilter is null ||
+            _treeNodeFilter.MatchesFilter(string.Empty /*TODO*/, new Platform.Extensions.Messages.PropertyBag() /*TODO*/);
+
+        // TODO: To be defined: Use AND or OR.
+        return vstestFilterMatch && treeNodeFilterMatch;
     }
 }


### PR DESCRIPTION
Fixes #4293

For the remaining TODOs, we might make this work by having the test framework itself adding VSTest property representing the TreeNodePath, which the bridge retrieves and pass to `TreeNodeFilter.MatchesFilter`. This is still work not completed.