### PR TITLE
Simplify TerminalOutputDevice

### DIFF
--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <PackageReference Include="StreamJsonRpc" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.CrashDump\Microsoft.Testing.Extensions.CrashDump.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.OpenTelemetry\Microsoft.Testing.Extensions.OpenTelemetry.csproj" />
   </ItemGroup>

--- a/samples/Playground/Program.cs
+++ b/samples/Playground/Program.cs
@@ -50,7 +50,7 @@ public class Program
             // testApplicationBuilder.TestHostControllers.AddProcessLifetimeHandler(s => new OutOfProc(s.GetMessageBus()));
 
             // Enable Trx
-            // testApplicationBuilder.AddTrxReportProvider();
+            testApplicationBuilder.AddTrxReportProvider();
 
             // Enable Telemetry
             // testApplicationBuilder.AddAppInsightsTelemetryProvider();

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -5,7 +5,6 @@ using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
-using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.OutputDevice.Terminal;
@@ -22,7 +21,6 @@ namespace Microsoft.Testing.Platform.OutputDevice;
 internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDevice,
     IDataConsumer,
     IOutputDeviceDataProducer,
-    ITestSessionLifetimeHandler,
     IDisposable,
     IAsyncInitializableExtension
 {
@@ -55,11 +53,11 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
     private readonly string _assemblyName;
 
     private TerminalTestReporter? _terminalTestReporter;
-    private bool _firstCallTo_OnSessionStartingAsync = true;
     private bool _bannerDisplayed;
     private bool _isListTests;
     private bool _isServerMode;
     private ILogger? _logger;
+    private TestProcessRole? _processRole;
 
     public TerminalOutputDevice(
         IConsole console,
@@ -325,34 +323,12 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
         using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
         {
-            if (!_firstCallTo_OnSessionStartingAsync)
+            if (_processRole == TestProcessRole.TestHost)
             {
                 _terminalTestReporter.AssemblyRunCompleted();
                 _terminalTestReporter.TestExecutionCompleted(_clock.UtcNow);
             }
         }
-    }
-
-    public Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext) => Task.CompletedTask;
-
-    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
-    {
-        CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        cancellationToken.ThrowIfCancellationRequested();
-        if (_isServerMode)
-        {
-            return Task.CompletedTask;
-        }
-
-        // We implement IDataConsumerService and IOutputDisplayService.
-        // So the engine is calling us before as IDataConsumerService and after as IOutputDisplayService.
-        // The engine look for the ITestSessionLifetimeHandler in both case and call it.
-        if (_firstCallTo_OnSessionStartingAsync)
-        {
-            _firstCallTo_OnSessionStartingAsync = false;
-        }
-
-        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -416,9 +392,8 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
                 foreach (FileArtifactProperty artifact in testNodeStateChanged.TestNode.Properties.OfType<FileArtifactProperty>())
                 {
-                    bool isOutOfProcessArtifact = _firstCallTo_OnSessionStartingAsync;
                     _terminalTestReporter.ArtifactAdded(
-                        isOutOfProcessArtifact,
+                        outOfProcess: _processRole != TestProcessRole.TestHost,
                         testNodeStateChanged.TestNode.DisplayName,
                         artifact.FileInfo.FullName);
                 }
@@ -532,9 +507,8 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
             case SessionFileArtifact artifact:
                 {
-                    bool isOutOfProcessArtifact = _firstCallTo_OnSessionStartingAsync;
                     _terminalTestReporter.ArtifactAdded(
-                        isOutOfProcessArtifact,
+                        outOfProcess: _processRole != TestProcessRole.TestHost,
                         testName: null,
                         artifact.FileInfo.FullName);
                 }
@@ -542,9 +516,8 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
                 break;
             case FileArtifact artifact:
                 {
-                    bool isOutOfProcessArtifact = _firstCallTo_OnSessionStartingAsync;
                     _terminalTestReporter.ArtifactAdded(
-                        isOutOfProcessArtifact,
+                        outOfProcess: _processRole != TestProcessRole.TestHost,
                         testName: null,
                         artifact.FileInfo.FullName);
                 }
@@ -560,6 +533,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
     public async Task HandleProcessRoleAsync(TestProcessRole processRole, CancellationToken cancellationToken)
     {
+        _processRole = processRole;
         if (processRole == TestProcessRole.TestHost)
         {
             await _policiesService.RegisterOnMaxFailedTestsCallbackAsync(


### PR DESCRIPTION
The `_firstCallTo_OnSessionStartingAsync` field is not very trivial to understand at a first glance. So refactoring this out. How it used to work is:

- It defaults to true.
- It's set to false in `OnTestSessionStartingAsync` (this called ONLY in the testhost).
- End result is
    - in testhost: the value of this field is false
    - in testhost controller: the value of this field is true.
    - So the variable is semantically "is out of process"

Now that we have already HandleProcessRole, I'm using that to directly store the role of the current process.

This also means we no longer need any logic in `OnTestSessionStartingAsync` and we don't need to implement `ITestSessionLifetimeHandler`.