### PR TITLE
Print out-of-process artifacts

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -149,6 +149,30 @@ internal sealed partial class TerminalTestReporter : IDisposable
         }
     }
 
+    public void PrintOutOfProcessArtifacts()
+    {
+        if (_artifacts.Count == 0)
+        {
+            return;
+        }
+
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.Append(SingleIndentation);
+            terminal.AppendLine(PlatformResources.OutOfProcessArtifactsProduced);
+
+            foreach (TestRunArtifact artifact in _artifacts)
+            {
+                terminal.Append(DoubleIndentation);
+                terminal.Append("- ");
+                terminal.AppendLink(artifact.Path, lineNumber: null);
+                terminal.AppendLine();
+            }
+
+            terminal.AppendLine();
+        });
+    }
+
     public void TestExecutionCompleted(DateTimeOffset endTime)
     {
         _testExecutionEndTime = endTime;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -328,6 +328,10 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
                 _terminalTestReporter.AssemblyRunCompleted();
                 _terminalTestReporter.TestExecutionCompleted(_clock.UtcNow);
             }
+            else
+            {
+                _terminalTestReporter.PrintOutOfProcessArtifacts();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #7471

<img width="1735" height="580" alt="image" src="https://github.com/user-attachments/assets/9eb7fd46-9854-4620-8bc2-fe1918afda78" />

It's a little bit ugly because Out of process artifacts are printed at the very end, but it's better than not showing the info at all.