### PR TITLE
Keep TestInfrastructure project only for acceptance tests

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -33,8 +33,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(EnableMSTestRunner)' == 'true' OR '$(UseInternalTestFramework)' == 'true' ">
-    <ProjectReference Include="$(RepoRoot)test\Utilities\Microsoft.Testing.TestInfrastructure\Microsoft.Testing.TestInfrastructure.csproj"
-                      Condition="'$(UseInternalTestFramework)' != 'true'" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.CrashDump\Microsoft.Testing.Extensions.CrashDump.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.HangDump\Microsoft.Testing.Extensions.HangDump.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Retry\Microsoft.Testing.Extensions.Retry.csproj" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -30,6 +30,10 @@
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)test\Utilities\Microsoft.Testing.TestInfrastructure\Microsoft.Testing.TestInfrastructure.csproj" />
+  </ItemGroup>
+
   <!-- Packages needed for the test assets but that we don't want to reference -->
   <ItemGroup>
     <PackageDownload Include="Aspire.Hosting.Testing" Version="[$(AspireHostingTestingVersion)]" />

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)test\Utilities\Microsoft.Testing.TestInfrastructure\Microsoft.Testing.TestInfrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(RepoRoot)\test\Utilities\Microsoft.Testing.TestInfrastructure\RootFinder.cs" Link="RootFinder.cs" />
   </ItemGroup>
 

--- a/test/Performance/MSTest.Performance.Runner/MSTest.Performance.Runner.csproj
+++ b/test/Performance/MSTest.Performance.Runner/MSTest.Performance.Runner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/Program.cs
@@ -19,9 +19,5 @@ builder.AddHangDumpProvider();
 builder.AddTrxReportProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/MSTest.Engine.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.Engine.UnitTests/Program.cs
@@ -19,11 +19,5 @@ builder.AddTrxReportProvider();
 builder.AddAppInsightsTelemetryProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
-    = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
-
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/Program.cs
@@ -19,11 +19,5 @@ builder.AddTrxReportProvider();
 builder.AddAppInsightsTelemetryProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
-    = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
-
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Program.cs
@@ -19,10 +19,5 @@ builder.AddTrxReportProvider();
 builder.AddAppInsightsTelemetryProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
-    = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Program.cs
@@ -30,10 +30,5 @@ builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
-    = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Program.cs
@@ -16,10 +16,5 @@ builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory
-    = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
@@ -48,16 +48,35 @@ public sealed class FileLoggerTests : IDisposable
     [TestMethod]
     public void Write_IfMalformedUTF8_ShouldNotCrash()
     {
-        using TempDirectory tempDirectory = new(nameof(Write_IfMalformedUTF8_ShouldNotCrash));
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+        var fileStreamFactory = new Mock<IFileStreamFactory>(MockBehavior.Strict);
+        var fileStream = new Mock<IFileStream>(MockBehavior.Strict);
+        var memoryStream = new MemoryStream();
+        fileStream.Setup(f => f.Stream).Returns(memoryStream);
+        fileStream.Setup(f => f.Dispose()).Callback(() => { });
+
+        fileStreamFactory
+            .Setup(f => f.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            .Returns(fileStream.Object)
+            .Callback((string fileName, FileMode _1, FileAccess _2, FileShare _3) => fileStream.Setup(f => f.Name).Returns(fileName));
+
         using FileLogger fileLogger = new(
-            new FileLoggerOptions(tempDirectory.Path, "Test", fileName: null),
+            new FileLoggerOptions(nameof(Write_IfMalformedUTF8_ShouldNotCrash), "Test", fileName: null),
             LogLevel.Trace,
             new SystemClock(),
             new SystemTask(),
             new SystemConsole(),
-            new SystemFileSystem(),
-            new SystemFileStreamFactory());
+            fileSystem.Object,
+            fileStreamFactory.Object);
+
         fileLogger.Log(LogLevel.Trace, "\uD886", null, LoggingExtensions.Formatter, "Category");
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        string logWritten = new StreamReader(memoryStream).ReadToEnd();
+
+        // logWritten looks like this: "[15:01:57.130 Category - Trace] �\r\n"
+        Assert.StartsWith("[", logWritten);
+        Assert.EndsWith($" Category - Trace] \uFFFD{Environment.NewLine}", logWritten);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
@@ -30,9 +30,5 @@ if (!OperatingSystem.IsBrowser())
 builder.AddTrxReportProvider();
 builder.AddAzureDevOpsProvider();
 
-// Custom suite tools
-CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory = new(_ => new SlowestTestsConsumer());
-builder.TestHost.AddDataConsumer(slowestTestCompositeServiceFactory);
-builder.TestHost.AddTestSessionLifetimeHandler(slowestTestCompositeServiceFactory);
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(SupportedNetFrameworks);netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <DefineConstants Condition=" '$(FastAcceptanceTest)' == 'true'">$(DefineConstants);SKIP_INTERMEDIATE_TARGET_FRAMEWORKS</DefineConstants>
   </PropertyGroup>

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/ProcessHandle.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/ProcessHandle.cs
@@ -91,11 +91,7 @@ public sealed class ProcessHandle : IProcessHandle, IDisposable
     {
         try
         {
-#if NETCOREAPP
             process.Kill(true);
-#else
-            process.Kill();
-#endif
         }
         catch (InvalidOperationException)
         {

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -34,7 +34,6 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
 
     public async Task InitializeAsync(CancellationToken cancellationToken) =>
         // Generate all projects into the same temporary base folder, but separate subdirectories, so we can reference one from other.
-#if NET
         await Parallel.ForEachAsync(GetAssetsToGenerate(), async (asset, _) =>
         {
             TestAsset testAsset = await TestAsset.GenerateAssetAsync(asset.ID, asset.Code, _tempDirectory);
@@ -42,15 +41,6 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
             testAsset.DotnetResult = result;
             _testAssets.TryAdd(asset.ID, testAsset);
         });
-#else
-        await Task.WhenAll(GetAssetsToGenerate().Select(async asset =>
-        {
-            TestAsset testAsset = await TestAsset.GenerateAssetAsync(asset.Name, asset.Code, _tempDirectory);
-            DotnetMuxerResult result = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -c Release", _nugetGlobalPackagesDirectory.Path, callerMemberName: asset.Name, cancellationToken: cancellationToken);
-            testAsset.DotnetResult = result;
-            _testAssets.TryAdd(asset.ID, testAsset);
-        }));
-#endif
 
     /// <summary>
     /// Returns a list test assets to generate. A test asset has an id, name and code. A test asset is typically a project and all its files. Like MyTests.csproj, Program.cs, runsettings.runsettings etc.


### PR DESCRIPTION
We should need to build TestInfrastructure only for NetCurrent and avoid building it for other TFMs.

Only piece that is used by non-AcceptanceTest projects is the slowest tests data consumer which we are not using that much.