### PR TITLE
Remove redundant dotnet restore calls in MSTest tests

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -101,11 +101,6 @@ public class UnitTest1
             .PatchCodeWithReplace("$MSTestEngineVersion$", MSTestEngineVersion),
             addPublicFeeds: true);
 
-        await DotnetCli.RunAsync(
-            $"restore {generator.TargetAssetPath} -r {RID}",
-            AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
-            retryCount: 0,
-            cancellationToken: TestContext.CancellationToken);
         DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
             $"publish {generator.TargetAssetPath} -r {RID} -f {tfm}",
             AcceptanceFixture.NuGetGlobalPackagesFolder.Path,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
@@ -27,10 +27,8 @@ public class RunnerTests : AcceptanceTestBase<NopAssetFixture>
                 .PatchCodeWithReplace("$EnableMSTestRunner$", "<EnableMSTestRunner>true</EnableMSTestRunner>")
                 .PatchCodeWithReplace("$OutputType$", "<OutputType>Exe</OutputType>")
                 .PatchCodeWithReplace("$Extra$", string.Empty));
+
         DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
-            $"restore {generator.TargetAssetPath} -r {RID}",
-            AcceptanceFixture.NuGetGlobalPackagesFolder.Path, cancellationToken: TestContext.CancellationToken);
-        compilationResult = await DotnetCli.RunAsync(
             $"{verb} {generator.TargetAssetPath} -c {buildConfiguration} -r {RID}",
             AcceptanceFixture.NuGetGlobalPackagesFolder.Path, cancellationToken: TestContext.CancellationToken);
 
@@ -68,7 +66,7 @@ return await app.RunAsync();
 <GenerateTestingPlatformEntryPoint>False</GenerateTestingPlatformEntryPoint>
 <LangVersion>preview</LangVersion>
 """));
-        await DotnetCli.RunAsync($"restore {generator.TargetAssetPath} -r {RID}", AcceptanceFixture.NuGetGlobalPackagesFolder.Path, cancellationToken: TestContext.CancellationToken);
+
         await DotnetCli.RunAsync(
             $"{verb} {generator.TargetAssetPath} -c {buildConfiguration} -r {RID}",
             AcceptanceFixture.NuGetGlobalPackagesFolder.Path, cancellationToken: TestContext.CancellationToken);
@@ -90,7 +88,6 @@ return await app.RunAsync();
                 .PatchCodeWithReplace("$EnableMSTestRunner$", "<EnableMSTestRunner>false</EnableMSTestRunner>")
                 .PatchCodeWithReplace("$OutputType$", "<OutputType>Exe</OutputType>")
                 .PatchCodeWithReplace("$Extra$", string.Empty));
-        await DotnetCli.RunAsync($"restore {generator.TargetAssetPath} -r {RID}", AcceptanceFixture.NuGetGlobalPackagesFolder.Path, cancellationToken: TestContext.CancellationToken);
 
         if (TargetFrameworks.NetFramework.Any(x => x == tfm))
         {

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrimTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrimTests.cs
@@ -57,11 +57,6 @@ System.Console.WriteLine("This project validates trim/AOT compatibility via dotn
             addPublicFeeds: true);
 
         await DotnetCli.RunAsync(
-            $"restore {generator.TargetAssetPath} -r {RID}",
-            AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
-            retryCount: 0,
-            cancellationToken: TestContext.CancellationToken);
-        await DotnetCli.RunAsync(
             $"publish {generator.TargetAssetPath} -r {RID} -f {tfm}",
             AcceptanceFixture.NuGetGlobalPackagesFolder.Path,
             retryCount: 0,


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->