### PR TITLE
Refactor to simplify RunConfigurationSettings

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
@@ -258,7 +258,7 @@ internal sealed class MSTestSettings
 
         // This will contain default adapter settings
         var settings = new MSTestSettings();
-        var runConfigurationSettings = RunConfigurationSettings.PopulateSettings(context?.RunSettings?.SettingsXml);
+        var runConfigurationSettings = RunConfigurationSettings.GetSettings(context?.RunSettings?.SettingsXml);
 
         // We have runsettings, but we don't have testconfig.
         // Just use runsettings.

--- a/src/Adapter/MSTestAdapter.PlatformServices/RunConfigurationSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/RunConfigurationSettings.cs
@@ -25,7 +25,12 @@ internal sealed class RunConfigurationSettings
     /// </summary>
     internal ApartmentState? ExecutionApartmentState { get; private set; }
 
-    public static RunConfigurationSettings PopulateSettings([StringSyntax(StringSyntaxAttribute.Xml, nameof(runSettingsXml))] string? runSettingsXml)
+    /// <summary>
+    /// Gets the configuration settings from the xml.
+    /// </summary>
+    /// <param name="runSettingsXml"> The xml with the settings passed from the test platform. </param>
+    public static RunConfigurationSettings GetSettings(
+        [StringSyntax(StringSyntaxAttribute.Xml, nameof(runSettingsXml))] string? runSettingsXml)
     {
         if (StringEx.IsNullOrEmpty(runSettingsXml))
         {
@@ -33,21 +38,6 @@ internal sealed class RunConfigurationSettings
             return new RunConfigurationSettings();
         }
 
-        RunConfigurationSettings? settings = GetSettings(runSettingsXml, SettingsName);
-
-        return settings ?? new RunConfigurationSettings();
-    }
-
-    /// <summary>
-    /// Gets the configuration settings from the xml.
-    /// </summary>
-    /// <param name="runSettingsXml"> The xml with the settings passed from the test platform. </param>
-    /// <param name="settingName"> The name of the settings to fetch.</param>
-    /// <returns> The settings if found. Null otherwise. </returns>
-    internal static RunConfigurationSettings? GetSettings(
-        [StringSyntax(StringSyntaxAttribute.Xml, nameof(runSettingsXml))] string runSettingsXml,
-        string settingName)
-    {
         using var stringReader = new StringReader(runSettingsXml);
         var reader = XmlReader.Create(stringReader, new() { IgnoreComments = true, IgnoreWhitespace = true, DtdProcessing = DtdProcessing.Prohibit });
 
@@ -56,7 +46,7 @@ internal sealed class RunConfigurationSettings
         ReadToNextElement(reader);
 
         // Read till we reach nodeName element or reach EOF
-        while (!string.Equals(reader.Name, settingName, StringComparison.OrdinalIgnoreCase)
+        while (!string.Equals(reader.Name, SettingsName, StringComparison.OrdinalIgnoreCase)
                 && !reader.EOF)
         {
             SkipToNextElement(reader);
@@ -68,7 +58,7 @@ internal sealed class RunConfigurationSettings
             return ToSettings(reader.ReadSubtree());
         }
 
-        return null;
+        return new RunConfigurationSettings();
     }
 
     /// <summary>


### PR DESCRIPTION
Combined PopulateSettings and `GetSettings` together, and used the name `GetSettings`.