### PR TITLE
Revert "Enable UsingToolNuGetRepack for exact version dependencies on all inter-package references"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,6 @@
     <!-- Testing Platform version -->
     <TestingPlatformVersionPrefix>2.2.0</TestingPlatformVersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <!-- Repack NuGet packages to use exact version dependencies (see https://github.com/NuGet/Home/issues/7213) -->
-    <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26173.2</MicrosoftDotNetBuildTasksTemplatingPackageVersion>


### PR DESCRIPTION
Reverts microsoft/testfx#7569

This is breaking official pipeline. We can look later into getting this back.