### PR TITLE
[main] Update version to 4.2.1/2.2.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <!-- MSTest version -->
-    <VersionPrefix>4.2.0</VersionPrefix>
+    <VersionPrefix>4.2.1</VersionPrefix>
     <!-- Testing Platform version -->
-    <TestingPlatformVersionPrefix>2.2.0</TestingPlatformVersionPrefix>
+    <TestingPlatformVersionPrefix>2.2.1</TestingPlatformVersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">


### PR DESCRIPTION
We accidentally published 4.2.0 stable to test-tools and we cannot take that back (likely happened with https://github.com/microsoft/testfx/pull/7569). Publicly we will have to publish 4.2.1.