### PR TITLE
Re-enable signing validation

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -254,6 +254,3 @@ extends:
             LclPackageId: 'LCL-JUNO-PROD-TESTFX'
 
     - template: eng/common/templates-official/post-build/post-build.yml@self
-      parameters:
-        # Temporarily disable signing validation until infra issues are resolved, based on advice from Arcade.
-        enableSigningValidation: False


### PR DESCRIPTION
Probably fixed with https://github.com/dotnet/arcade/pull/16634. Let's see.