### PR TITLE
Remove PSM from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,12 +5,6 @@
   </solution>
   <packageSources>
     <clear />
-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <!--  Begin: Package sources from microsoft-testfx -->
-    <!--  End: Package sources from microsoft-testfx -->
-    <!--  Begin: Package sources from vs-code-coverage -->
-    <!--  End: Package sources from vs-code-coverage -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
@@ -19,37 +13,7 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
   </packageSources>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
   <disabledPackageSources>
     <clear />
-    <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
-    <!--  Begin: Package sources from vs-code-coverage -->
-    <!--  End: Package sources from vs-code-coverage -->
-    <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>
-  <packageSourceMapping>
-    <packageSource key="test-tools">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet-public">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet-tools">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet-eng">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet9">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet10">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet11">
-      <package pattern="*" />
-    </packageSource>
-  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/52863 broke us. Darc in official pipeline is installed with `--add-source` but this doesn't work when PSM is used.

SDK PR breaking us https://github.com/dotnet/sdk/pull/52863

See also https://github.com/dotnet/arcade/pull/16628

https://github.com/dotnet/arcade/pull/16642/ might fix the failure differently - but I think this might still be good cleanup anyways :)