### PR TITLE
Downgrade .NET SDK in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.3.26170.106",
+    "dotnet": "11.0.100-preview.3.26161.119",
     "runtimes": {
       "dotnet": [
         "8.0.25",
@@ -24,7 +24,7 @@
     }
   },
   "sdk": {
-    "version": "11.0.100-preview.3.26170.106",
+    "version": "11.0.100-preview.3.26161.119",
     "paths": [
       ".dotnet",
       "$host$"


### PR DESCRIPTION
https://github.com/microsoft/testfx/pull/7628 didn't work to fix the failures we have in official pipeline.

This is a workaround until https://github.com/dotnet/arcade/pull/16642/ gets merged and flows.