### PR TITLE
Prefer setting TrxFullyQualifiedTypeNameProperty per TestMethodIdentifierProperty

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -147,11 +147,23 @@ internal static class ObjectModelConverters
 
             testNode.Properties.Add(new TrxTestDefinitionName(testResult.TestCase.DisplayName ?? testResult.TestCase.FullyQualifiedName));
 
-            // TODO: Consider retrieving TestMethodIdentifierProperty first (which could have been added through addAdditionalProperties.
-            // VSTest's TestCase.FQN is very non-standard.
-            // We should avoid using it if we can.
-            if (TryParseFullyQualifiedType(testResult.TestCase.FullyQualifiedName, out string? fullyQualifiedType))
+            TestMethodIdentifierProperty? testMethodIdentifierProperty = testNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+            if (testMethodIdentifierProperty is not null)
             {
+                // TODO: Should TRX className have arity for generic classes?
+                if (RoslynString.IsNullOrEmpty(testMethodIdentifierProperty.Namespace))
+                {
+                    testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(testMethodIdentifierProperty.TypeName));
+                }
+                else
+                {
+                    testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty($"{testMethodIdentifierProperty.Namespace}.{testMethodIdentifierProperty.TypeName}"));
+                }
+            }
+            else if (TryParseFullyQualifiedType(testResult.TestCase.FullyQualifiedName, out string? fullyQualifiedType))
+            {
+                // VSTest's TestCase.FQN is very non-standard.
+                // We should avoid using it if we can, and so we prefer TestMethodIdentifierProperty first.
                 testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(fullyQualifiedType));
             }
             else


### PR DESCRIPTION
Related to https://github.com/nunit/nunit3-vs-adapter/issues/1351

Once NUnit adds TestMethodIdentifierProperty, we want that to be used for `TrxFullyQualifiedTypeNameProperty`.

The alternative for this would be updating TRX extension to consider `TestMethodIdentifierProperty` before it considers TrxFullyQualifiedTypeNameProperty altogether. Eventually, maybe we should deprecate `TrxFullyQualifiedTypeNameProperty`.