### PR TITLE
Create GitHub Action to sync dotnet-test plugin from dotnet/skills

### DIFF
--- a/.github/workflows/mirror-dotnet-test-plugin.yml
+++ b/.github/workflows/mirror-dotnet-test-plugin.yml
@@ -1,0 +1,56 @@
+name: Mirror dotnet-test plugin
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repository
+        uses: actions/checkout@v4
+
+      - name: Checkout dotnet/skills repository
+        uses: actions/checkout@v4
+        with:
+          repository: dotnet/skills
+          path: dotnet-skills-clone
+          sparse-checkout: plugins/dotnet-test
+
+      - name: Sync dotnet-test skills to .github
+        run: |
+          mkdir -p .github/skills
+          cp -r dotnet-skills-clone/plugins/dotnet-test/skills/. .github/skills
+
+      - name: Sync dotnet-test agents to .github
+        run: |
+          mkdir -p .github/agents
+          cp -r dotnet-skills-clone/plugins/dotnet-test/agents/. .github/agents
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add .github
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Mirror dotnet-test plugin from dotnet/skills"
+          title: "Mirror dotnet-test plugin from dotnet/skills"
+          body: |
+            Automated sync of the `dotnet-test` plugin from [dotnet/skills](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test).
+          branch: mirror/dotnet-test-plugin
+          delete-branch: true
+          add-paths: .github


### PR DESCRIPTION
NOTE: If a skill/agent got deleted, this automated isn't going to delete it. What we will need in future is:

1. Create a txt file with all skills/agents that are mirrored.
1. At the beginning of the workflow, the txt file is read, and all agents/skills in it are deleted.
1. Then delete the txt file itself.
1. Then re-create the txt file based on what exists in dotnet/skills, and copy the stuff.