### PR TITLE
Cleanup TimeoutHelper and increase the timeout to 5 mins

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Helpers/TimeSpanParser.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/TimeSpanParser.cs
@@ -24,7 +24,7 @@ internal static partial class TimeSpanParser
         if (RoslynString.IsNullOrWhiteSpace(time))
         {
             result = TimeSpan.Zero;
-            return true;
+            return false;
         }
 
         Match match = Pattern.Match(time);

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/TimeoutHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/TimeoutHelper.cs
@@ -19,10 +19,10 @@ internal static class TimeoutHelper
             ? customHangTimeout
             : TimeSpan.FromMinutes(5);
 
-        DefaultHangTimeoutSeconds = (int)DefaultHangTimeSpanTimeout.TotalSeconds;
+        DefaultHangTimeoutSeconds = DefaultHangTimeSpanTimeout.TotalSeconds;
     }
 
-    public static int DefaultHangTimeoutSeconds { get; private set; }
+    public static double DefaultHangTimeoutSeconds { get; }
 
     public static TimeSpan DefaultHangTimeSpanTimeout { get; }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/TimeoutHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/TimeoutHelper.cs
@@ -14,26 +14,13 @@ internal static class TimeoutHelper
         string? customAntiHangTimeout = Environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT);
 #pragma warning restore RS0030 // Do not use banned APIs
 
-        // Took from Tpv2 experience, it's the timeout for the testhost.exe start.
-        DefaultHangTimeSpanTimeout = TimeSpan.FromSeconds(90);
-
-        if (customAntiHangTimeout is not null)
-        {
-            if (TimeSpanParser.TryParse(customAntiHangTimeout, out TimeSpan customHangTimeout))
-            {
-                DefaultHangTimeSpanTimeout = customHangTimeout;
-            }
-        }
+        DefaultHangTimeSpanTimeout =
+            TimeSpanParser.TryParse(customAntiHangTimeout, out TimeSpan customHangTimeout)
+            ? customHangTimeout
+            : TimeSpan.FromMinutes(5);
 
         DefaultHangTimeoutSeconds = (int)DefaultHangTimeSpanTimeout.TotalSeconds;
-        DefaultHangTimeoutMilliseconds = (int)DefaultHangTimeSpanTimeout.TotalMilliseconds;
     }
-
-    /// <summary>
-    /// Gets defaultAntiHangTimeout* values are used as timeout for every wait operation in the test platform.
-    /// Are not intended for any timeout logic, but only to avoid infinite waits in case of test platform hangs.
-    /// </summary>
-    public static int DefaultHangTimeoutMilliseconds { get; private set; }
 
     public static int DefaultHangTimeoutSeconds { get; private set; }
 

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -619,7 +619,7 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         string? seconds = configuration[PlatformConfigurationConstants.PlatformTestHostControllersManagerNamedPipeClientConnectTimeoutSeconds];
 
         // Default timeout is 30 seconds
-        int timeoutSeconds = seconds is null ? TimeoutHelper.DefaultHangTimeoutSeconds : int.Parse(seconds, CultureInfo.InvariantCulture);
+        double timeoutSeconds = seconds is null ? TimeoutHelper.DefaultHangTimeoutSeconds : double.Parse(seconds, CultureInfo.InvariantCulture);
         await logger.LogDebugAsync($"Setting PlatformTestHostControllersManagerNamedPipeClientConnectTimeoutSeconds '{timeoutSeconds}'").ConfigureAwait(false);
         using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(timeoutSeconds));
         await client.ConnectAsync(timeout.Token).ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -618,7 +618,6 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         await logger.LogDebugAsync($"Connecting to named pipe '{pipeName}'").ConfigureAwait(false);
         string? seconds = configuration[PlatformConfigurationConstants.PlatformTestHostControllersManagerNamedPipeClientConnectTimeoutSeconds];
 
-        // Default timeout is 30 seconds
         double timeoutSeconds = seconds is null ? TimeoutHelper.DefaultHangTimeoutSeconds : double.Parse(seconds, CultureInfo.InvariantCulture);
         await logger.LogDebugAsync($"Setting PlatformTestHostControllersManagerNamedPipeClientConnectTimeoutSeconds '{timeoutSeconds}'").ConfigureAwait(false);
         using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(timeoutSeconds));

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -269,7 +269,7 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
             else
             {
                 string? seconds = configuration[PlatformConfigurationConstants.PlatformTestHostControllersManagerSingleConnectionNamedPipeServerWaitConnectionTimeoutSeconds];
-                int timeoutSeconds = seconds is null ? TimeoutHelper.DefaultHangTimeoutSeconds : int.Parse(seconds, CultureInfo.InvariantCulture);
+                double timeoutSeconds = seconds is null ? TimeoutHelper.DefaultHangTimeoutSeconds : double.Parse(seconds, CultureInfo.InvariantCulture);
                 await _logger.LogDebugAsync($"Setting PlatformTestHostControllersManagerSingleConnectionNamedPipeServerWaitConnectionTimeoutSeconds '{timeoutSeconds}'").ConfigureAwait(false);
 
                 // Wait for the test host controller to connect

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -30,7 +30,7 @@ public sealed class AsynchronousMessageBusTests
 
         // Fire consume with a good message
         await proxy.PublishAsync(new DummyProducer("DummyProducer", typeof(InvalidTypePublished.ValidDataToProduce)), new InvalidTypePublished.ValidDataToProduce());
-        consumer.Published.WaitOne((int)TimeoutHelper.DefaultHangTimeSpanTimeout.TotalMilliseconds);
+        consumer.Published.WaitOne();
         await Assert.ThrowsAsync<InvalidOperationException>(proxy.DrainDataAsync);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -30,7 +30,7 @@ public sealed class AsynchronousMessageBusTests
 
         // Fire consume with a good message
         await proxy.PublishAsync(new DummyProducer("DummyProducer", typeof(InvalidTypePublished.ValidDataToProduce)), new InvalidTypePublished.ValidDataToProduce());
-        consumer.Published.WaitOne(TimeoutHelper.DefaultHangTimeoutMilliseconds);
+        consumer.Published.WaitOne((int)TimeoutHelper.DefaultHangTimeSpanTimeout.TotalMilliseconds);
         await Assert.ThrowsAsync<InvalidOperationException>(proxy.DrainDataAsync);
     }
 


### PR DESCRIPTION
Especially for Code Coverage, connecting to the pipe may take long. I think it's safe to increase the timeout, or even remove it completely (which I personally would vote for, but I decided to make the more minimal change in this PR).