### PR TITLE
Delete dead code

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineHandler.cs
@@ -112,7 +112,7 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
             string optionInfoIndent = new(' ', (indentLevel + 1) * 2);
             foreach (CommandLineOption option in options.OrderBy(x => x.Name))
             {
-                string optionName = option.ObsolescenceMessage is not null ? $"{optionNameIndent}--{option.Name} [obsolete]" : $"{optionNameIndent}--{option.Name}";
+                string optionName = $"{optionNameIndent}--{option.Name}";
                 await outputDevice.DisplayAsync(this, new TextOutputDeviceData(optionName), cancellationToken).ConfigureAwait(false);
                 if (option.Arity.Min == option.Arity.Max)
                 {
@@ -126,10 +126,6 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
 
                 await outputDevice.DisplayAsync(this, new TextOutputDeviceData($"{optionInfoIndent}Hidden: {option.IsHidden}"), cancellationToken).ConfigureAwait(false);
                 await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"Description: {option.Description}") { Padding = optionInfoIndent.Length }, cancellationToken).ConfigureAwait(false);
-                if (option.ObsolescenceMessage is not null)
-                {
-                    await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"Obsolete: {option.ObsolescenceMessage}") { Padding = optionInfoIndent.Length }, cancellationToken).ConfigureAwait(false);
-                }
             }
         }
 
@@ -262,14 +258,9 @@ internal sealed class CommandLineHandler : ICommandLineHandler, ICommandLineOpti
 
             foreach (CommandLineOption? option in options)
             {
-                string optionName = option.ObsolescenceMessage is not null ? $"--{option.Name} [obsolete]" : $"--{option.Name}";
+                string optionName = $"--{option.Name}";
                 await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(optionName) { Padding = 4 }, cancellationToken).ConfigureAwait(false);
                 await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(option.Description) { Padding = 8 }, cancellationToken).ConfigureAwait(false);
-                if (option.ObsolescenceMessage is not null)
-                {
-                    await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData($"Obsolete: {option.ObsolescenceMessage}") { Padding = 8 }, cancellationToken).ConfigureAwait(false);
-                }
-
                 await outputDevice.DisplayAsync(this, new TextOutputDeviceData(string.Empty), cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs
@@ -20,8 +20,7 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
     /// <param name="arity">The arity of the command line option.</param>
     /// <param name="isHidden">Indicates whether the command line option is hidden.</param>
     /// <param name="isBuiltIn">Indicates whether the command line option is built-in.</param>
-    /// <param name="obsolescenceMessage">The obsolescence message for the command line option.</param>
-    internal CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden, bool isBuiltIn, string? obsolescenceMessage = null)
+    internal CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden, bool isBuiltIn)
     {
         Ensure.NotNullOrWhiteSpace(name);
         Ensure.NotNullOrWhiteSpace(description);
@@ -38,37 +37,6 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
         Arity = arity;
         IsHidden = isHidden;
         IsBuiltIn = isBuiltIn;
-        ObsolescenceMessage = obsolescenceMessage;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CommandLineOption"/> class.
-    /// </summary>
-    /// <param name="name">The name of the command line option.</param>
-    /// <param name="description">The description of the command line option.</param>
-    /// <param name="arity">The arity of the command line option.</param>
-    /// <param name="isHidden">Indicates whether the command line option is hidden.</param>
-    /// <param name="isBuiltIn">Indicates whether the command line option is built-in.</param>
-    internal CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden, bool isBuiltIn)
-        : this(name, description, arity, isHidden, isBuiltIn, null)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CommandLineOption"/> class.
-    /// </summary>
-    /// <param name="name">The name of the command line option.</param>
-    /// <param name="description">The description of the command line option.</param>
-    /// <param name="arity">The arity of the command line option.</param>
-    /// <param name="isHidden">Indicates whether the command line option is hidden.</param>
-    /// <param name="obsolescenceMessage">The obsolescence message for the command line option.</param>
-    /// <remarks>
-    /// This ctor is public and used by non built-in extension, we need to know if the extension is built-in or not
-    /// to correctly handle the --internal- prefix.
-    /// </remarks>
-    public CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden, string? obsolescenceMessage = null)
-        : this(name, description, arity, isHidden, isBuiltIn: false, obsolescenceMessage)
-    {
     }
 
     /// <summary>
@@ -83,7 +51,7 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
     /// to correctly handle the --internal- prefix.
     /// </remarks>
     public CommandLineOption(string name, string description, ArgumentArity arity, bool isHidden)
-        : this(name, description, arity, isHidden, isBuiltIn: false, null)
+        : this(name, description, arity, isHidden, isBuiltIn: false)
     {
     }
 
@@ -109,11 +77,6 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
 
     internal bool IsBuiltIn { get; }
 
-    /// <summary>
-    /// Gets the obsolescence message for the command line option.
-    /// </summary>
-    public string? ObsolescenceMessage { get; }
-
     /// <inheritdoc />
     public override bool Equals(object? obj) => Equals(obj as CommandLineOption);
 
@@ -123,8 +86,7 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
             Name == other.Name &&
             Description == other.Description &&
             Arity == other.Arity &&
-            IsHidden == other.IsHidden &&
-            ObsolescenceMessage == other.ObsolescenceMessage;
+            IsHidden == other.IsHidden;
 
     /// <inheritdoc />
     public override int GetHashCode()
@@ -134,7 +96,6 @@ public sealed class CommandLineOption : IEquatable<CommandLineOption>
         hc.Add(Description);
         hc.Add(Arity.GetHashCode());
         hc.Add(IsHidden);
-        hc.Add(ObsolescenceMessage);
         return hc.ToHashCode();
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
@@ -3,9 +3,7 @@
 
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
-using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.OutputDevice;
 using Microsoft.Testing.Platform.Resources;
 
 namespace Microsoft.Testing.Platform.CommandLine;
@@ -68,30 +66,6 @@ internal static class CommandLineOptionsValidator
 
         // Last validation step
         return await ValidateConfigurationAsync(extensionOptionsByProvider.Keys, systemOptionsByProvider.Keys, commandLineOptions).ConfigureAwait(false);
-    }
-
-    public static async Task CheckForObsoleteOptionsAsync(
-        CommandLineParseResult commandLineParseResult,
-        IEnumerable<ICommandLineOptionsProvider> systemCommandLineOptionsProviders,
-        IEnumerable<ICommandLineOptionsProvider> extensionCommandLineOptionsProviders,
-        IOutputDevice outputDevice,
-        IOutputDeviceDataProducer outputDeviceDataProducer,
-        CancellationToken cancellationToken)
-    {
-        var allOptions = systemCommandLineOptionsProviders
-            .Union(extensionCommandLineOptionsProviders)
-            .SelectMany(provider => provider.GetCommandLineOptions())
-            .Where(option => option.ObsolescenceMessage is not null)
-            .ToDictionary(option => option.Name);
-
-        foreach (CommandLineParseOption optionRecord in commandLineParseResult.Options)
-        {
-            if (allOptions.TryGetValue(optionRecord.Name, out CommandLineOption? option))
-            {
-                string warningMessage = string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionObsoleteWarning, optionRecord.Name, option.ObsolescenceMessage);
-                await outputDevice.DisplayAsync(outputDeviceDataProducer, new WarningMessageOutputDeviceData(warningMessage), cancellationToken).ConfigureAwait(false);
-            }
-        }
     }
 
     private static ValidationResult ValidateExtensionOptionsDoNotContainReservedPrefix(

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -305,15 +305,6 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
         // to file disc also the banner, so at this point we need to have all services and configuration(result directory) built.
         await DisplayBannerIfEnabledAsync(loggingState, proxyOutputDevice, testFrameworkCapabilities, testApplicationCancellationTokenSource.CancellationToken).ConfigureAwait(false);
 
-        // Check for obsolete options and display warnings
-        await CommandLineOptionsValidator.CheckForObsoleteOptionsAsync(
-            loggingState.CommandLineParseResult,
-            commandLineHandler.SystemCommandLineOptionsProviders,
-            commandLineHandler.ExtensionsCommandLineOptionsProviders,
-            proxyOutputDevice,
-            commandLineHandler,
-            testApplicationCancellationTokenSource.CancellationToken).ConfigureAwait(false);
-
         // Add global telemetry service.
         // Add at this point or the telemetry banner appearance order will be wrong, we want the testing app banner before the telemetry banner.
         ITelemetryCollector telemetryService = await ((TelemetryManager)Telemetry).BuildTelemetryAsync(serviceProvider, loggerFactory, testApplicationOptions).ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Shipped.txt
@@ -117,13 +117,11 @@ Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity.Max.get -> int
 Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity.Min.get -> int
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.Arity.get -> Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity
-Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.CommandLineOption(string! name, string! description, Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity arity, bool isHidden, string? obsolescenceMessage = null) -> void
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.CommandLineOption(string! name, string! description, Microsoft.Testing.Platform.Extensions.CommandLine.ArgumentArity arity, bool isHidden) -> void
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.Description.get -> string!
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.Equals(Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption? other) -> bool
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.IsHidden.get -> bool
 Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.Name.get -> string!
-Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption.ObsolescenceMessage.get -> string?
 Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider
 Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider.GetCommandLineOptions() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>!
 Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider.ValidateCommandLineOptionsAsync(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -319,9 +319,6 @@
   <data name="CommandLineOptionIsReserved" xml:space="preserve">
     <value>Option '--{0}' is reserved and cannot be used by providers: '{0}'</value>
   </data>
-  <data name="CommandLineOptionObsoleteWarning" xml:space="preserve">
-    <value>Warning: Option '--{0}' is obsolete. {1}</value>
-  </data>
   <data name="CommandLineParserUnexpectedArgument" xml:space="preserve">
     <value>Unexpected argument {0}</value>
   </data>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Možnost --{0} je vyhrazená a nelze ji použít zprostředkovateli: {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Upozornění: Možnost --{0} je zastaralá. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">Možnost --{0} od zprostředkovatele {1} (UID: {2}) používá vyhrazenou předponu --internal.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Die Option "--{0}" ist reserviert und kann nicht von Anbietern verwendet werden: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Warnung: Die Option „--{0}“ ist veraltet. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">Die Option "--{0}" vom Anbieter "{1}" (UID: {2}) verwendet das reservierte Präfix "--internal".</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -122,11 +122,6 @@
         <target state="translated">La opción “--{0}” está reservada y los proveedores no la pueden usar: “{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Advertencia: La opción "--{0}" está obsoleta. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">La opción “--{0}” del proveedor “{1}” (UID: {2}) usa el prefijo reservado “--internal”</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -122,11 +122,6 @@
         <target state="translated">L’option « --{0} » est réservée et ne peut pas être utilisée par les fournisseurs : « {0} »</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Avertissement : l’option « --{0} » est obsolète. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">L’option « --{0} » du fournisseur « {1} » (UID : {2}) utilise le préfixe réservé « --internal »</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -122,11 +122,6 @@
         <target state="translated">L'opzione '--{0}' è riservata e non può essere usata dai provider: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Avviso: l'opzione '--{0}' è obsoleta. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">L'opzione '--{0}' del provider '{1}' (UID: {2}) usa il prefisso riservato '--internal'</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -122,11 +122,6 @@
         <target state="translated">オプション '--{0}' は予約されており、プロバイダーでは使用できません: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">警告: オプション '--{0}' は廃止されています。{1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">プロバイダー '{1}' のオプション '--{0}' (UID:{2}) は予約済みプレフィックス '--internal' を 使用しています</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -122,11 +122,6 @@
         <target state="translated">'--{0}' 옵션은 예약되어 있으므로 공급자 '{0}'이(가) 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">경고: 옵션 '--{0}'이(가) 사용되지 않습니다. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">공급자 '{1}'(UID: {2})의 옵션 '-- {0}'이 예약된 접두사 '--internal'을 사용하고 있습니다.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Opcja „--{0}” jest zastrzeżona i nie może być używana przez dostawców: „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Ostrzeżenie: opcja „--{0}” jest przestarzała. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">Opcja „--{0}” od dostawcy „{1}” (UID: {2}) używa zastrzeżonego prefiksu „--internal”</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -122,11 +122,6 @@
         <target state="translated">A opção '--{0}' está reservada e não pode ser usada pelos provedores: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Aviso: a opção '--{0}' está obsoleta. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">A opção '--{0}' do provedor '{1}' (UID: {2}) está usando o prefixo reservado '--internal'</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Параметр "--{0}" зарезервирован и не может использоваться поставщиками: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Предупреждение: параметр "--{0}" устарел. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">Параметр "--{0}" от поставщика "{1}" (UID: {2}) использует зарезервированный префикс "--internal"</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -122,11 +122,6 @@
         <target state="translated">'--{0}' seçeneği ayrılmıştır ve şu sağlayıcılar tarafından kullanılamaz: '{0}'</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">Uyarı: '--{0}' seçeneği artık kullanılmamaktadır. {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">'{1}' sağlayıcısındaki (UID: {2}) `--{0}` seçeneği ayrılmış '--internal' önekini kullanıyor</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -122,11 +122,6 @@
         <target state="translated">选项“--{0}”是保留的，提供程序不能使用:“{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">警告: 选项“--{0}”已过时。 {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">来自提供程序“{1}” (UID: {2}) 的选项“--{0}”正在使用保留前缀“--internal”</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -122,11 +122,6 @@
         <target state="translated">選項 '--{0}' 已保留，無法供提供者 '{0}' 使用</target>
         <note />
       </trans-unit>
-      <trans-unit id="CommandLineOptionObsoleteWarning">
-        <source>Warning: Option '--{0}' is obsolete. {1}</source>
-        <target state="translated">警告: 選項 '--{0}' 已過時。{1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandLineOptionIsUsingReservedPrefix">
         <source>Option `--{0}` from provider '{1}' (UID: {2}) is using the reserved prefix '--internal'</source>
         <target state="translated">提供者 '{1}' (UID: {2}) 中的選項 '--{0}' 使用保留的前置詞 '--internal'</target>

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -78,8 +78,7 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
                     commandLineOption.Name,
                     commandLineOption.Description,
                     commandLineOption.IsHidden,
-                    commandLineOption.IsBuiltIn,
-                    commandLineOption.ObsolescenceMessage));
+                    commandLineOption.IsBuiltIn));
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/CommandLineOptionMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/CommandLineOptionMessages.cs
@@ -3,6 +3,6 @@
 
 namespace Microsoft.Testing.Platform.IPC.Models;
 
-internal sealed record CommandLineOptionMessage(string? Name, string? Description, bool? IsHidden, bool? IsBuiltIn, string? ObsolescenceMessage);
+internal sealed record CommandLineOptionMessage(string? Name, string? Description, bool? IsHidden, bool? IsBuiltIn);
 
 internal sealed record CommandLineOptionMessages(string? ModulePath, CommandLineOptionMessage[]? CommandLineOptionMessageList) : IRequest;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
@@ -36,7 +36,7 @@ internal static class CommandLineOptionMessageFieldsId
     public const ushort Description = 2;
     public const ushort IsHidden = 3;
     public const ushort IsBuiltIn = 4;
-    // public const ushort ObsolescenceMessage = 5;
+    // Reserved: field ID 5 was ObsolescenceMessage, removed as unused.
 }
 
 internal static class DiscoveredTestMessagesFieldsId

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
@@ -36,7 +36,7 @@ internal static class CommandLineOptionMessageFieldsId
     public const ushort Description = 2;
     public const ushort IsHidden = 3;
     public const ushort IsBuiltIn = 4;
-    public const ushort ObsolescenceMessage = 5;
+    // public const ushort ObsolescenceMessage = 5;
 }
 
 internal static class DiscoveredTestMessagesFieldsId

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -34,10 +34,6 @@ namespace Microsoft.Testing.Platform.IPC.Serializers;
        |---CommandLineOptionMessageList[0].IsBuiltIn Id---| (2 bytes)
        |---CommandLineOptionMessageList[0].IsBuiltIn Size---| (4 bytes)
        |---CommandLineOptionMessageList[0].IsBuiltIn Value---| (1 byte)
-
-       |---CommandLineOptionMessageList[0].ObsolescenceMessage Id---| (2 bytes)
-       |---CommandLineOptionMessageList[0].ObsolescenceMessage Size---| (4 bytes)
-       |---CommandLineOptionMessageList[0].ObsolescenceMessage Value---| (n bytes)
    */
 
 internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INamedPipeSerializer
@@ -83,7 +79,7 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
         int length = ReadInt(stream);
         for (int i = 0; i < length; i++)
         {
-            string? name = null, description = null, obsolescenceMessage = null;
+            string? name = null, description = null;
             bool? isHidden = null, isBuiltIn = null;
 
             int fieldCount = ReadUShort(stream);
@@ -111,17 +107,13 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
                         isBuiltIn = ReadBool(stream);
                         break;
 
-                    case CommandLineOptionMessageFieldsId.ObsolescenceMessage:
-                        obsolescenceMessage = ReadStringValue(stream, fieldSize);
-                        break;
-
                     default:
                         SetPosition(stream, stream.Position + fieldSize);
                         break;
                 }
             }
 
-            commandLineOptionMessages.Add(new CommandLineOptionMessage(name, description, isHidden, isBuiltIn, obsolescenceMessage));
+            commandLineOptionMessages.Add(new CommandLineOptionMessage(name, description, isHidden, isBuiltIn));
         }
 
         return commandLineOptionMessages;
@@ -162,7 +154,6 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
             WriteField(stream, CommandLineOptionMessageFieldsId.Description, commandLineOptionMessage.Description);
             WriteField(stream, CommandLineOptionMessageFieldsId.IsHidden, commandLineOptionMessage.IsHidden);
             WriteField(stream, CommandLineOptionMessageFieldsId.IsBuiltIn, commandLineOptionMessage.IsBuiltIn);
-            WriteField(stream, CommandLineOptionMessageFieldsId.ObsolescenceMessage, commandLineOptionMessage.ObsolescenceMessage);
         }
 
         // NOTE: We are able to seek only if we are using a MemoryStream
@@ -178,6 +169,5 @@ internal sealed class CommandLineOptionMessagesSerializer : BaseSerializer, INam
         (ushort)((commandLineOptionMessage.Name is null ? 0 : 1) +
         (commandLineOptionMessage.Description is null ? 0 : 1) +
         (commandLineOptionMessage.IsHidden is null ? 0 : 1) +
-        (commandLineOptionMessage.IsBuiltIn is null ? 0 : 1) +
-        (commandLineOptionMessage.ObsolescenceMessage is null ? 0 : 1));
+        (commandLineOptionMessage.IsBuiltIn is null ? 0 : 1));
 }


### PR DESCRIPTION
We should have never introduced this as a public non-experimental API. It was introduced in 2.1.0 and wasn't used and also was never implemented fully with dotnet test. While it's binary breaking change, our users of such API will be test framework authors which is a very limited audience and no one is using it today. So it's a safe breaking change.