### PR TITLE
Cleanup Microsoft.Testing.Platform.MSBuild

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SupportedNetFrameworks);netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);NU5100</NoWarn>
+    <DefineConstants>$(DefineConstants);MTP_MSBUILD_TASKS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -109,16 +110,6 @@ This package provides MSBuild integration of the platform, its extensions and co
 
   <ItemGroup>
     <Using Include="Polyfills" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- NOTE: SDK already adds Linux, macOS, and Windows. -->
-    <!-- See https://github.com/dotnet/sdk/blob/cb459ebc2d9374b2bc5ce944cc633a6e79ed8275/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props -->
-    <SupportedPlatform Include="android" />
-    <SupportedPlatform Include="ios" />
-    <SupportedPlatform Include="browser" />
-    <SupportedPlatform Include="tvos" />
-    <SupportedPlatform Include="wasi" />
   </ItemGroup>
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/DotnetMuxerLocator.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/DotnetMuxerLocator.cs
@@ -6,7 +6,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.Testing.Platform.MSBuild.Tasks;
 
-[UnsupportedOSPlatform("browser")]
 internal sealed class DotnetMuxerLocator
 {
     // Mach-O magic numbers from https://en.wikipedia.org/wiki/Mach-O

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Testing.Platform.MSBuild;
 /// <summary>
 /// Task that invokes the Testing Platform.
 /// </summary>
-[UnsupportedOSPlatform("browser")]
 public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 {
     private const string MonoRunnerName = "mono";

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformAutoRegisteredExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformAutoRegisteredExtensions.cs
@@ -20,6 +20,8 @@ public sealed class TestingPlatformSelfRegisteredExtensions : Build.Utilities.Ta
     private const string FSharpLanguageSymbol = "F#";
     private const string VBLanguageSymbol = "VB";
 
+    private readonly IFileSystem _fileSystem;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TestingPlatformSelfRegisteredExtensions"/> class.
     /// </summary>
@@ -81,8 +83,6 @@ Expected item spec:
 Expected method signature
 static Contoso.BuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.TestApplicationBuilder builder, string[] args)
 """;
-
-    private readonly IFileSystem _fileSystem;
 
     /// <inheritdoc />
     public override bool Execute()

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformEntryPointTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformEntryPointTask.cs
@@ -17,6 +17,8 @@ public sealed class TestingPlatformEntryPointTask : Build.Utilities.Task
     private const string FSharpLanguageSymbol = "F#";
     private const string VBLanguageSymbol = "VB";
 
+    private readonly IFileSystem _fileSystem;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TestingPlatformEntryPointTask"/> class.
     /// </summary>
@@ -57,8 +59,6 @@ public sealed class TestingPlatformEntryPointTask : Build.Utilities.Task
     /// </summary>
     [Output]
     public ITaskItem TestingPlatformEntryPointGeneratedFilePath { get; set; }
-
-    private readonly IFileSystem _fileSystem;
 
     /// <inheritdoc />
     public override bool Execute()

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -13,7 +13,9 @@ using Microsoft.Testing.Platform.Helpers;
 namespace Microsoft.Testing.Platform.IPC;
 
 [Embedded]
+#if !MTP_MSBUILD_TASKS
 [UnsupportedOSPlatform("browser")]
+#endif
 internal sealed class NamedPipeClient : NamedPipeBase, IClient
 {
     private const PipeOptions CurrentUserPipeOptions = PipeOptions.None

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -12,7 +12,9 @@ using Microsoft.Testing.Platform.Resources;
 namespace Microsoft.Testing.Platform.IPC;
 
 [Embedded]
+#if !MTP_MSBUILD_TASKS
 [UnsupportedOSPlatform("browser")]
+#endif
 internal sealed class NamedPipeServer : NamedPipeBase, IServer
 {
     private const PipeOptions AsyncCurrentUserPipeOptions = PipeOptions.Asynchronous


### PR DESCRIPTION
MSBuild tasks never run on Android, iOS, Browser, ...
So the whole assembly is effectively not supported on these platforms and so removing the SupportedPlatform stuff.