### PR TITLE
Exclude backported skills and agents from markdownlint

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -151,6 +151,8 @@
     "tools/**/*.md",
     ".dotnet/**/*.md",
     ".github/ISSUE_TEMPLATE/**/*.md",
+    ".github/skills/**/*.md",
+    ".github/agents/**/*.md",
     "**/AnalyzerReleases.*.md"
   ]
 }


### PR DESCRIPTION
Add `.github/skills/**/*.md` and `.github/agents/**/*.md` to the markdownlint ignore list, since these files are backported from external sources and we don't control their formatting.

Related to #7733