### PR TITLE
Avoid BlockingCollection usage in MTP

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
@@ -147,6 +147,11 @@ internal sealed partial class AppInsightsProvider :
             {
                 while (_payloads.TryRead(out (string EventName, IDictionary<string, object> ParamsMap) payload))
                 {
+                    if (_flushTimeoutOrStop.Token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     (string eventName, IDictionary<string, object> paramsMap) = payload;
 #endif
 
@@ -280,6 +285,11 @@ internal sealed partial class AppInsightsProvider :
 #if NETCOREAPP
         await _payloads.Writer.WriteAsync((eventName, paramsMap), cancellationToken).ConfigureAwait(false);
 #else
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
         _payloads.Write((eventName, paramsMap));
         return Task.CompletedTask;
 #endif

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
@@ -9,6 +9,9 @@ using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
+#if !NETCOREAPP
+using Microsoft.Testing.Platform.Messages;
+#endif
 using Microsoft.Testing.Platform.Services;
 using Microsoft.Testing.Platform.Telemetry;
 
@@ -45,7 +48,7 @@ internal sealed partial class AppInsightsProvider :
 #if NETCOREAPP
     private readonly Channel<(string EventName, IDictionary<string, object> ParamsMap)> _payloads;
 #else
-    private readonly BlockingCollection<(string EventName, IDictionary<string, object> ParamsMap)> _payloads;
+    private readonly SingleConsumerUnboundedChannel<(string EventName, IDictionary<string, object> ParamsMap)> _payloads;
 #endif
 #if DEBUG
     // Telemetry properties that are allowed to contain unhashed information.
@@ -101,14 +104,11 @@ internal sealed partial class AppInsightsProvider :
             AllowSynchronousContinuations = false,
         });
 
-        _telemetryTask = task.Run(IngestLoopAsync, _testApplicationCancellationTokenSource.CancellationToken);
 #else
-        // Keep the custom thread to avoid to waste one from thread pool.
-        // We have some await but we should stay on the custom thread if not for special cases like trace log or exception.
-        _payloads = [];
-        _telemetryTask = _task.RunLongRunning(IngestLoopAsync, "Telemetry AppInsightsProvider", _testApplicationCancellationTokenSource.CancellationToken);
+        _payloads = new SingleConsumerUnboundedChannel<(string EventName, IDictionary<string, object> ParamsMap)>();
 #endif
 
+        _telemetryTask = task.Run(IngestLoopAsync, _testApplicationCancellationTokenSource.CancellationToken);
         _logger = loggerFactory.CreateLogger<AppInsightsProvider>();
     }
 
@@ -134,90 +134,96 @@ internal sealed partial class AppInsightsProvider :
 
         DateTimeOffset? lastLoggedError = null;
         _testApplicationCancellationTokenSource.CancellationToken.Register(_flushTimeoutOrStop.Cancel);
+
         try
         {
 #if NETCOREAPP
             while (await _payloads.Reader.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
             {
-                (string eventName, IDictionary<string, object> paramsMap) = await _payloads.Reader.ReadAsync().ConfigureAwait(false);
+                {
+                    (string eventName, IDictionary<string, object> paramsMap) = await _payloads.Reader.ReadAsync().ConfigureAwait(false);
 #else
-            foreach ((string eventName, IDictionary<string, object> paramsMap) in _payloads.GetConsumingEnumerable(_flushTimeoutOrStop.Token))
+            while (await _payloads.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
             {
+                while (_payloads.TryRead(out (string EventName, IDictionary<string, object> ParamsMap) payload))
+                {
+                    (string eventName, IDictionary<string, object> paramsMap) = payload;
 #endif
 
-                // Add common properties.
-                paramsMap.Add(TelemetryProperties.VersionPropertyName, _telemetryInformation.Version);
-                paramsMap.Add(TelemetryProperties.SessionId, _currentSessionId);
-                paramsMap.Add(TelemetryProperties.ReporterIdPropertyName, CurrentReporterId);
-                paramsMap.Add(TelemetryProperties.IsCIPropertyName, _isCi.AsTelemetryBool());
+                    // Add common properties.
+                    paramsMap.Add(TelemetryProperties.VersionPropertyName, _telemetryInformation.Version);
+                    paramsMap.Add(TelemetryProperties.SessionId, _currentSessionId);
+                    paramsMap.Add(TelemetryProperties.ReporterIdPropertyName, CurrentReporterId);
+                    paramsMap.Add(TelemetryProperties.IsCIPropertyName, _isCi.AsTelemetryBool());
 
-                if (_isDevelopmentRepository)
-                {
-                    paramsMap.Add(TelemetryProperties.HostProperties.IsDevelopmentRepositoryPropertyName, TelemetryProperties.True);
-                }
-
-                var metrics = new Dictionary<string, double>();
-                var properties = new Dictionary<string, string>();
-
-                foreach (KeyValuePair<string, object> pair in paramsMap)
-                {
-                    switch (pair.Value)
+                    if (_isDevelopmentRepository)
                     {
-                        // Metrics:
-                        case double value:
-                            metrics.Add(pair.Key, value);
-                            break;
-                        case DateTimeOffset value:
-                            metrics.Add(pair.Key, ToUnixTimeNanoseconds(value));
-                            break;
+                        paramsMap.Add(TelemetryProperties.HostProperties.IsDevelopmentRepositoryPropertyName, TelemetryProperties.True);
+                    }
 
-                        // Properties:
+                    var metrics = new Dictionary<string, double>();
+                    var properties = new Dictionary<string, string>();
+
+                    foreach (KeyValuePair<string, object> pair in paramsMap)
+                    {
+                        switch (pair.Value)
+                        {
+                            // Metrics:
+                            case double value:
+                                metrics.Add(pair.Key, value);
+                                break;
+                            case DateTimeOffset value:
+                                metrics.Add(pair.Key, ToUnixTimeNanoseconds(value));
+                                break;
+
+                            // Properties:
 #if DEBUG
-                        case string value:
-                            AssertHashed(pair.Key, value);
-                            properties.Add(pair.Key, value);
-                            break;
+                            case string value:
+                                AssertHashed(pair.Key, value);
+                                properties.Add(pair.Key, value);
+                                break;
 #endif
-                        case bool value:
-                            RoslynDebug.Assert(false, $"Telemetry entry '{pair.Key}' contains a boolean value, boolean values should always be converted to string using: .{nameof(TelemetryExtensions.AsTelemetryBool)}()");
-                            properties.Add(pair.Key, value.AsTelemetryBool());
-                            break;
-                        default:
-                            properties.Add(pair.Key, pair.Value?.ToString() ?? string.Empty);
-                            break;
-                    }
-                }
-
-                if (_logger.IsEnabled(LogLevel.Trace))
-                {
-                    StringBuilder builder = new();
-                    builder.AppendLine(CultureInfo.InvariantCulture, $"Send telemetry event: {eventName}");
-                    foreach (KeyValuePair<string, string> kvp in properties)
-                    {
-                        builder.AppendLine(CultureInfo.InvariantCulture, $"    {kvp.Key}: {kvp.Value}");
+                            case bool value:
+                                RoslynDebug.Assert(false, $"Telemetry entry '{pair.Key}' contains a boolean value, boolean values should always be converted to string using: .{nameof(TelemetryExtensions.AsTelemetryBool)}()");
+                                properties.Add(pair.Key, value.AsTelemetryBool());
+                                break;
+                            default:
+                                properties.Add(pair.Key, pair.Value?.ToString() ?? string.Empty);
+                                break;
+                        }
                     }
 
-                    foreach (KeyValuePair<string, double> kvp in metrics)
+                    if (_logger.IsEnabled(LogLevel.Trace))
                     {
-                        builder.AppendLine(CultureInfo.InvariantCulture, $"    {kvp.Key}: {kvp.Value.ToString("f", CultureInfo.InvariantCulture)}");
+                        StringBuilder builder = new();
+                        builder.AppendLine(CultureInfo.InvariantCulture, $"Send telemetry event: {eventName}");
+                        foreach (KeyValuePair<string, string> kvp in properties)
+                        {
+                            builder.AppendLine(CultureInfo.InvariantCulture, $"    {kvp.Key}: {kvp.Value}");
+                        }
+
+                        foreach (KeyValuePair<string, double> kvp in metrics)
+                        {
+                            builder.AppendLine(CultureInfo.InvariantCulture, $"    {kvp.Key}: {kvp.Value.ToString("f", CultureInfo.InvariantCulture)}");
+                        }
+
+                        await _logger.LogTraceAsync(builder.ToString()).ConfigureAwait(false);
                     }
 
-                    await _logger.LogTraceAsync(builder.ToString()).ConfigureAwait(false);
-                }
-
-                try
-                {
-                    _client.TrackEvent(eventName, properties, metrics);
-                }
-                catch (Exception ex)
-                {
-                    // If we have a lot of issues with the network we could have a lot of logs here.
-                    // We log one error every 3 seconds.
-                    // We could do better back-pressure.
-                    if (_logger.IsEnabled(LogLevel.Error) && (!lastLoggedError.HasValue || (lastLoggedError.Value - _clock.UtcNow).TotalSeconds > 3))
+                    try
                     {
-                        await _logger.LogErrorAsync("Error during telemetry report.", ex).ConfigureAwait(false);
-                        lastLoggedError = _clock.UtcNow;
+                        _client.TrackEvent(eventName, properties, metrics);
+                    }
+                    catch (Exception ex)
+                    {
+                        // If we have a lot of issues with the network we could have a lot of logs here.
+                        // We log one error every 3 seconds.
+                        // We could do better back-pressure.
+                        if (_logger.IsEnabled(LogLevel.Error) && (!lastLoggedError.HasValue || (lastLoggedError.Value - _clock.UtcNow).TotalSeconds > 3))
+                        {
+                            await _logger.LogErrorAsync("Error during telemetry report.", ex).ConfigureAwait(false);
+                            lastLoggedError = _clock.UtcNow;
+                        }
                     }
                 }
             }
@@ -274,7 +280,7 @@ internal sealed partial class AppInsightsProvider :
 #if NETCOREAPP
         await _payloads.Writer.WriteAsync((eventName, paramsMap), cancellationToken).ConfigureAwait(false);
 #else
-        _payloads.Add((eventName, paramsMap), cancellationToken);
+        _payloads.Write((eventName, paramsMap));
         return Task.CompletedTask;
 #endif
     }
@@ -285,7 +291,7 @@ internal sealed partial class AppInsightsProvider :
 #if NETCOREAPP
         _payloads.Writer.Complete();
 #else
-        _payloads.CompleteAdding();
+        _payloads.Complete();
 #endif
         if (!_isDisposed)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <!-- Embedded helpers from Microsoft.Testing.Platform -->
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Messages\SingleConsumerUnboundedChannel.cs" Link="Helpers\SingleConsumerUnboundedChannel.cs" />
   </ItemGroup>
 
   <!-- NuGet properties -->

--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
@@ -6,6 +6,9 @@ using System.Threading.Channels;
 #endif
 
 using Microsoft.Testing.Platform.Helpers;
+#if !NETCOREAPP
+using Microsoft.Testing.Platform.Messages;
+#endif
 using Microsoft.Testing.Platform.Resources;
 
 namespace Microsoft.Testing.Platform.Logging;
@@ -29,7 +32,7 @@ internal sealed class FileLogger : IDisposable
 #if NETCOREAPP
     private readonly Channel<string>? _channel;
 #else
-    private readonly BlockingCollection<string>? _asyncLogs;
+    private readonly SingleConsumerUnboundedChannel<string>? _channel;
 #endif
     private bool _disposed;
 
@@ -69,7 +72,7 @@ internal sealed class FileLogger : IDisposable
                 AllowSynchronousContinuations = false,
             });
 #else
-            _asyncLogs = [];
+            _channel = new SingleConsumerUnboundedChannel<string>();
 #endif
 
             _logLoop = task.Run(WriteLogToFileAsync, CancellationToken.None);
@@ -222,7 +225,7 @@ internal sealed class FileLogger : IDisposable
             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.FailedToWriteLogToChannelErrorMessage, log));
         }
 #else
-        _asyncLogs.Add(log);
+        _channel.Write(log);
 #endif
     }
 
@@ -232,27 +235,23 @@ internal sealed class FileLogger : IDisposable
     private async Task WriteLogToFileAsync()
     {
         // We do this check out of the try because we want to crash the process if the _channel/_asyncLogs is null.
-#if NETCOREAPP
         ApplicationStateGuard.Ensure(_channel is not null);
-#else
-        // We do this check out of the try because we want to crash the process if the _asyncLogs is null.
-        ApplicationStateGuard.Ensure(_asyncLogs is not null);
-#endif
 
         try
         {
-#if NETCOREAPP
             // We don't need cancellation token because the task will be stopped when the Channel is completed thanks to the call to Complete() inside the Dispose method.
+#if NETCOREAPP
             while (await _channel.Reader.WaitToReadAsync().ConfigureAwait(false))
             {
                 await _writer.WriteLineAsync(await _channel.Reader.ReadAsync().ConfigureAwait(false)).ConfigureAwait(false);
             }
 #else
-            // We don't need cancellation token because the task will be stopped when the BlockingCollection is completed thanks to the call to CompleteAdding()
-            // inside the Dispose method.
-            foreach (string message in _asyncLogs.GetConsumingEnumerable())
+            while (await _channel.WaitToReadAsync(CancellationToken.None).ConfigureAwait(false))
             {
-                await _writer.WriteLineAsync(message).ConfigureAwait(false);
+                while (_channel.TryRead(out string message))
+                {
+                    await _writer.WriteLineAsync(message).ConfigureAwait(false);
+                }
             }
 #endif
         }
@@ -262,18 +261,10 @@ internal sealed class FileLogger : IDisposable
         }
     }
 
-#if NETCOREAPP
     [MemberNotNull(nameof(_channel), nameof(_logLoop))]
-#else
-    [MemberNotNull(nameof(_asyncLogs), nameof(_logLoop))]
-#endif
     private void EnsureAsyncLogObjectsAreNotNull()
     {
-#if NETCOREAPP
         ApplicationStateGuard.Ensure(_channel is not null);
-#else
-        ApplicationStateGuard.Ensure(_asyncLogs is not null);
-#endif
         ApplicationStateGuard.Ensure(_logLoop is not null);
     }
 
@@ -288,12 +279,11 @@ internal sealed class FileLogger : IDisposable
         {
             EnsureAsyncLogObjectsAreNotNull();
 
-#if NETCOREAPP
             // Wait for all logs to be written
+#if NETCOREAPP
             _channel.Writer.TryComplete();
 #else
-            // Wait for all logs to be written
-            _asyncLogs.CompleteAdding();
+            _channel.Complete();
 #endif
 
             if (!_logLoop.Wait(TimeoutHelper.DefaultHangTimeSpanTimeout))

--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
@@ -234,7 +234,7 @@ internal sealed class FileLogger : IDisposable
 
     private async Task WriteLogToFileAsync()
     {
-        // We do this check out of the try because we want to crash the process if the _channel/_asyncLogs is null.
+        // We do this check out of the try because we want to crash the process if the _channel is null.
         ApplicationStateGuard.Ensure(_channel is not null);
 
         try

--- a/src/Platform/Microsoft.Testing.Platform/Messages/SingleConsumerUnboundedChannel.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/SingleConsumerUnboundedChannel.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !NETCOREAPP
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.Testing.Platform.Messages;
 
+[Embedded]
 internal sealed class SingleConsumerUnboundedChannel<T>
 {
     // On .NET Framework, these are not cached internally.


### PR DESCRIPTION
This better ensures we don't end up in long blocks while running in the thread pool, and is more performant.

Our custom channel implementation has been used by MTP MessageBus for a while already, which is a very core component in MTP, and no issues were noticed.