### PR TITLE
Add .lscache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,11 @@ project.fragment.lock.json
 .fake/
 .ionide/
 
+# ===========================
+# Language Server cache
+# ===========================
+.lscache/
+
 # Arcade files
 .dotnet/
 .packages/


### PR DESCRIPTION
Add `.lscache/` (Language Server cache) directory to `.gitignore` to prevent these files from being tracked.