### PR TITLE
Add dotnet/skills marketplace and enable plugins

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,23 @@
+{
+  "extraKnownMarketplaces": {
+    "dotnet-arcade-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/arcade-skills"
+      }
+    },
+    "dotnet-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotnet-dnceng@dotnet-arcade-skills": true,
+    "dotnet@dotnet-skills": true,
+    "dotnet-msbuild@dotnet-skills": true,
+    "dotnet-nuget@dotnet-skills": true,
+    "dotnet-test@dotnet-skills": true
+  }
+}


### PR DESCRIPTION
Add `.github/copilot/settings.json` to configure extra known marketplaces (`dotnet/arcade-skills`, `dotnet/skills`) and enable the following Copilot plugins:

- `dotnet-dnceng` (from dotnet-arcade-skills)
- `dotnet`, `dotnet-msbuild`, `dotnet-nuget`, `dotnet-test` (from dotnet-skills)