### PR TITLE
Add 'Needs: Triage' label for issues opened by github-actions[bot]

### DIFF
--- a/.github/policies/LabelManagement.IssueOpened.yml
+++ b/.github/policies/LabelManagement.IssueOpened.yml
@@ -13,13 +13,16 @@ configuration:
           - payloadType: Issues
           - isAction:
               action: Opened
-          - and:
-            - not:
-                activitySenderHasPermission:
-                  permission: Admin
-            - not:
-                activitySenderHasPermission:
-                  permission: Write
+          - or:
+            - and:
+              - not:
+                  activitySenderHasPermission:
+                    permission: Admin
+              - not:
+                  activitySenderHasPermission:
+                    permission: Write
+            - isActivitySender:
+                user: github-actions[bot]
         then:
           - addLabel:
               label: 'Needs: Triage :mag:'


### PR DESCRIPTION
The `LabelManagement.IssueOpened` policy skips the "Needs: Triage 🔎" label for users with Write or Admin permission. Since `github-actions[bot]` has Write permission, issues it opens (e.g. #7793) never get triaged.

This adds an `or` condition so the label is applied when:
1. The author lacks Write/Admin permission (existing behavior), **or**
2. The author is `github-actions[bot]`