### PR TITLE
Allow blocked domains in Daily QA workflow firewall

### DIFF
--- a/.github/workflows/daily-qa.md
+++ b/.github/workflows/daily-qa.md
@@ -13,7 +13,11 @@ timeout-minutes: 15
 
 permissions: read-all
 
-network: defaults
+network:
+  allowed:
+    - defaults
+    - "dc.services.visualstudio.com"
+    - "pkgs.dev.azure.com"
 
 imports:
   - shared/repo-build-setup.md


### PR DESCRIPTION
Add `dc.services.visualstudio.com` and `pkgs.dev.azure.com` to the network allowed list in the Daily QA workflow frontmatter.

These domains were being blocked by the firewall, as reported in https://github.com/microsoft/testfx/discussions/7786, causing NuGet restore failures (`403`) during sandbox test runs.