### PR TITLE
Remove unused InternalsVisibleTo for HangDump from CrashDump and TrxReport

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Microsoft.Testing.Extensions.CrashDump.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Microsoft.Testing.Extensions.CrashDump.csproj
@@ -52,7 +52,6 @@ This package extends Microsoft Testing Platform to provide a crash dump function
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge" Key="$(VsPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.HangDump" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
@@ -70,7 +70,6 @@ This package extends Microsoft Testing Platform to provide TRX test reports.]]>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge" Key="$(VsPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
@@ -70,7 +70,6 @@ This package extends Microsoft Testing Platform to provide TRX test reports.]]>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge" Key="$(VsPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.HangDump" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Removes two unnecessary `InternalsVisibleTo` attributes that grant HangDump access to internals of CrashDump and TrxReport.

## Details

Investigation of all 4 IVT relationships involving CrashDump/HangDump:

| IVT | Status | Action |
|-----|--------|--------|
| **Platform → CrashDump** | Active (`AppVersion.DefaultSemVer`) | Keep |
| **Platform → HangDump** | Active (11 internal IPC types) | Keep |
| **CrashDump → HangDump** | **Unused** | **Removed** |
| **TrxReport → HangDump** | **Unused** | **Removed** |

**CrashDump → HangDump**: HangDump has no `ProjectReference` to CrashDump. Cross-extension communication happens via `AppDomain.SetData`, not direct type references. The IVT has no effect.

**TrxReport → HangDump**: HangDump has no `ProjectReference` to TrxReport and uses no TrxReport types. The IVT has no effect.

## Validation

All three affected projects (`CrashDump`, `HangDump`, `TrxReport`) build successfully across all target frameworks (`netstandard2.0`, `net8.0`, `net9.0`).