### PR TITLE
[Perf Improver] perf: reduce allocations in test discovery and data-driven test execution

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -321,10 +321,19 @@ internal sealed class TestMethodRunner
             data = tupleExpandedToArray;
         }
 
-        displayName = displayNameFromTestDataRow
-            ?? testDataSource?.GetDisplayName(new ReflectionTestMethodInfo(_testMethodInfo.MethodInfo, _test.DisplayName), data)
-            ?? (testDataSource is null ? displayName : TestDataSourceUtilities.ComputeDefaultDisplayName(new ReflectionTestMethodInfo(_testMethodInfo.MethodInfo, _test.DisplayName), data))
-            ?? displayName;
+        // PERF: Extract ReflectionTestMethodInfo to avoid allocating it twice when testDataSource is not null
+        // and both GetDisplayName and ComputeDefaultDisplayName need to be consulted.
+        if (displayNameFromTestDataRow is null && testDataSource is not null)
+        {
+            var reflectionMethodInfo = new ReflectionTestMethodInfo(_testMethodInfo.MethodInfo, _test.DisplayName);
+            displayName = testDataSource.GetDisplayName(reflectionMethodInfo, data)
+                ?? TestDataSourceUtilities.ComputeDefaultDisplayName(reflectionMethodInfo, data)
+                ?? displayName;
+        }
+        else
+        {
+            displayName = displayNameFromTestDataRow ?? displayName;
+        }
 
         var stopwatch = Stopwatch.StartNew();
         _testMethodInfo.SetArguments(data);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
@@ -52,19 +52,22 @@ internal sealed class TestSourceHandler : ITestSourceHandler
         ];
 #endif
 
+    // PERF: Cached to avoid allocating a new list on every property access.
+    private static readonly IEnumerable<string> CachedValidSourceExtensions =
+        [
+            EngineConstants.DllExtension,
+#if NETFRAMEWORK
+            EngineConstants.PhoneAppxPackageExtension,
+#elif WINDOWS_UWP || WIN_UI
+            EngineConstants.AppxPackageExtension,
+#endif
+            EngineConstants.ExeExtension,
+        ];
+
     /// <summary>
     /// Gets the set of valid extensions for sources targeting this platform.
     /// </summary>
-    public IEnumerable<string> ValidSourceExtensions => new List<string>
-            {
-                EngineConstants.DllExtension,
-#if NETFRAMEWORK
-                EngineConstants.PhoneAppxPackageExtension,
-#elif WINDOWS_UWP || WIN_UI
-                EngineConstants.AppxPackageExtension,
-#endif
-                EngineConstants.ExeExtension,
-            };
+    public IEnumerable<string> ValidSourceExtensions => CachedValidSourceExtensions;
 
     /// <summary>
     /// Verifies if the assembly provided is referenced by the source.


### PR DESCRIPTION
…tion

- ValidSourceExtensions in TestSourceHandler now returns a cached static readonly collection instead of allocating a new List<string> on every property access. This eliminates unnecessary heap allocations during test source validation.

- ExecuteTestWithDataSourceAsync in TestMethodRunner no longer creates two ReflectionTestMethodInfo instances when testDataSource is not null and GetDisplayName returns null (requiring fallback to ComputeDefaultDisplayName). The instance is now created once and reused, halving the allocations for this code path in data-driven tests.