### PR TITLE
Fix triage label being applied to github-actions bot issues

### DIFF
--- a/.github/policies/LabelManagement.IssueOpened.yml
+++ b/.github/policies/LabelManagement.IssueOpened.yml
@@ -13,15 +13,14 @@ configuration:
           - payloadType: Issues
           - isAction:
               action: Opened
-          - or:
-            - and:
-              - not:
-                  activitySenderHasPermission:
-                    permission: Admin
-              - not:
-                  activitySenderHasPermission:
-                    permission: Write
-            - isActivitySender:
+          - not:
+              activitySenderHasPermission:
+                permission: Admin
+          - not:
+              activitySenderHasPermission:
+                permission: Write
+          - not:
+              isActivitySender:
                 user: github-actions[bot]
         then:
           - addLabel:


### PR DESCRIPTION
## Problem

The `LabelManagement.IssueOpened` policy had `github-actions[bot]` inside an `or` branch:

```yaml
- or:
  - and:
    - not: Admin
    - not: Write
  - isActivitySender: github-actions[bot]
```

This meant bot-created issues **always** received the "Needs: Triage 🔍" label, regardless of permissions. Every automated issue from agentic workflows (e.g. Perf Improver, QA, etc.) was incorrectly flagged for triage.

See https://github.com/microsoft/testfx/issues/7815 for an example.

## Fix

Change the condition so "Needs: Triage" is added only when **all** of:
- Sender lacks Admin permission
- Sender lacks Write permission  
- Sender is **not** `github-actions[bot]`

This ensures external/community issues still get triaged, while bot-created issues from our own workflows do not.