### PR TITLE
Remove unused product-to-product IVTs from TestFramework projects

### DIFF
--- a/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
+++ b/src/TestFramework/TestFramework.Extensions/TestFramework.Extensions.csproj
@@ -90,7 +90,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="MSTest.TestAdapter" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTestAdapter.PlatformServices" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTestAdapter.PlatformServices.UnitTests" Key="$(VsPublicKey)" />
   </ItemGroup>

--- a/src/TestFramework/TestFramework/TestFramework.csproj
+++ b/src/TestFramework/TestFramework/TestFramework.csproj
@@ -39,7 +39,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
-    <InternalsVisibleTo Include="MSTest.TestAdapter" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTestAdapter.PlatformServices" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTest.TestFramework.Extensions" Key="$(VsPublicKey)" />


### PR DESCRIPTION
## Summary

Remove unused `InternalsVisibleTo` entries from `TestFramework.csproj` and `TestFramework.Extensions.csproj` that target `MSTest.TestAdapter`.

## Analysis

`MSTest.TestAdapter` does not directly reference either `TestFramework` or `TestFramework.Extensions` in its project references. It only accesses these assemblies transitively through `MSTestAdapter.PlatformServices`:

```
MSTest.TestAdapter
  └─→ MSTestAdapter.PlatformServices
       └─→ TestFramework.Extensions
            └─→ TestFramework
```

A thorough search of the `MSTest.TestAdapter` source confirmed it does **not** use any internal types from either project:
- No references to `StringEx`, `DebugEx`, `ITestDataRow`, `DebuggerLaunchMode`, `AppModel`, `RuntimeTypeHelper`, or any other internal type from these assemblies.
- All internal type access happens in `MSTestAdapter.PlatformServices`, which has its own (still valid) IVT entries.

## Changes

| Project | Removed IVT | Reason |
|---------|-------------|--------|
| `TestFramework.csproj` | `MSTest.TestAdapter` | No internal types consumed |
| `TestFramework.Extensions.csproj` | `MSTest.TestAdapter` | No internal types consumed |

## Context

This is the first in a series of PRs to reduce unnecessary IVT coupling between product projects. Future PRs will address harder cases that require code changes (making types public, using file linking with `[Embedded]`, etc.).