### PR TITLE
[Lean Squad] feat(ci): Task 9 — skip guard + FVSquad scaffold for lean-proofs workflow

### DIFF
--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -1,7 +1,11 @@
 name: Lean Proofs
 
 # 🔬 Lean Squad — CI workflow for formal verification proofs.
-# Runs `lake build` to verify Lean 4 proofs in formal-verification/lean/.
+# Runs `lake build` to verify Lean 4 proofs in formal-verification/lean/FVSquad/.
+#
+# Skip guard: if no .lean source files are present in FVSquad/, the build
+# steps are skipped and the job succeeds immediately. This avoids spurious
+# failures while the FVSquad library is still being bootstrapped.
 
 permissions:
   contents: read
@@ -27,11 +31,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check for Lean source files
+        id: check-lean
+        run: |
+          lean_count=$(find formal-verification/lean/FVSquad -name "*.lean" 2>/dev/null | wc -l)
+          echo "lean_file_count=${lean_count}" >> "$GITHUB_OUTPUT"
+          if [ "${lean_count}" -eq 0 ]; then
+            echo "No .lean source files found in FVSquad/ — lake build will be skipped."
+          else
+            echo "Found ${lean_count} .lean source file(s) — proceeding with lake build."
+          fi
+
       - name: Install elan (Lean version manager)
+        if: steps.check-lean.outputs.lean_file_count != '0'
         run: |
           ELAN_VERSION="v4.2.1"
-          ELAN_TARGET="x86_64-unknown-linux-gnu"
-          ELAN_ARCHIVE="elan-${ELAN_TARGET}.tar.gz"
+          ELAN_ARCHIVE="elan-x86_64-unknown-linux-gnu.tar.gz"
           ELAN_BASE_URL="https://github.com/leanprover/elan/releases/download/${ELAN_VERSION}"
           ELAN_TMP_DIR="$(mktemp -d)"
 
@@ -57,12 +72,15 @@ jobs:
           rm -rf "${ELAN_TMP_DIR}"
 
       - name: Add elan to PATH
+        if: steps.check-lean.outputs.lean_file_count != '0'
         run: echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Show Lean version
+        if: steps.check-lean.outputs.lean_file_count != '0'
         run: lean --version
 
       - name: Cache Lean / Lake build artifacts
+        if: steps.check-lean.outputs.lean_file_count != '0'
         uses: actions/cache@v4
         with:
           path: |
@@ -73,5 +91,6 @@ jobs:
             lean-${{ runner.os }}-
 
       - name: Build Lean proofs
+        if: steps.check-lean.outputs.lean_file_count != '0'
         working-directory: formal-verification/lean
         run: lake build

--- a/formal-verification/lean/FVSquad/README.md
+++ b/formal-verification/lean/FVSquad/README.md
@@ -1,0 +1,17 @@
+# FVSquad — Lean 4 Formal Verification Sources
+
+> 🔬 **Lean Squad** — auto-generated and maintained by the Lean Squad FV agent.
+
+This directory will contain one `.lean` file per FV target as targets advance to Phase 3 (Formal Spec Writing).
+
+## Planned targets
+
+| File | Target | Phase |
+|------|--------|-------|
+| `ArgumentArity.lean` | `ArgumentArity` struct — predefined constants and equality laws | Phase 2 (informal spec done) |
+| `CommandLineParser.lean` | `CommandLineParser.TryUnescape` — string unescaping properties | Phase 2 (informal spec done) |
+
+## Status
+
+No `.lean` source files yet. The CI workflow (`lean-proofs.yml`) skips `lake build`
+until at least one `.lean` file is present in this directory.


### PR DESCRIPTION
Add skip guard to lean-proofs.yml: when no .lean source files exist in
FVSquad/, all build steps (elan install, lake build) are skipped and the
job completes successfully. This prevents spurious CI failures during the
bootstrapping phase before any Lean files are committed.

Also scaffold the FVSquad/ directory with a README documenting the
planned targets and the skip-guard behaviour.

Changes:
- .github/workflows/lean-proofs.yml: add 'Check for Lean source files'
  step (id: check-lean); gate all subsequent steps on lean_file_count != '0'
- formal-verification/lean/FVSquad/README.md: new directory scaffold

🔬 Lean Squad — automated formal verification agent
Run: https://github.com/microsoft/testfx/actions/runs/24971730371

Fixes #7853

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
