### PR TITLE
Throw PlatformNotSupportedException in STATestMethodAttribute on non-Windows

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
@@ -73,14 +73,12 @@ public class STATestMethodAttribute : TestMethodAttribute
             return await ExecuteCoreAsync(testMethod).ConfigureAwait(false);
         }
 
-#if NETFRAMEWORK
-        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-#else
+#if !NETFRAMEWORK
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-#endif
         {
             throw new PlatformNotSupportedException(FrameworkMessages.STATestMethodNonWindowsNotSupported);
         }
+#endif
 
         TestResult[]? results = null;
         var t = new Thread(() => results = ExecuteCoreAsync(testMethod).GetAwaiter().GetResult())

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
@@ -76,22 +76,7 @@ public class STATestMethodAttribute : TestMethodAttribute
 #if !NETFRAMEWORK
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            // STA (Single Threaded Apartment) is a Windows-only COM threading concept and is not
-            // supported on non-Windows platforms. The test is executed on the current thread without
-            // STA context, which is acceptable because STA has no meaning outside of Windows.
-            TestResult[] nonWindowsResults = await ExecuteCoreAsync(testMethod).ConfigureAwait(false);
-            string warning = string.Format(
-                CultureInfo.InvariantCulture,
-                FrameworkMessages.STATestMethodNonWindowsWarning,
-                testMethod.TestMethodName);
-            foreach (TestResult result in nonWindowsResults)
-            {
-                result.LogOutput = result.LogOutput is null
-                    ? warning
-                    : result.LogOutput + Environment.NewLine + warning;
-            }
-
-            return nonWindowsResults;
+            throw new PlatformNotSupportedException(FrameworkMessages.STATestMethodNonWindowsNotSupported);
         }
 #endif
 

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
@@ -76,8 +76,22 @@ public class STATestMethodAttribute : TestMethodAttribute
 #if !NETFRAMEWORK
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            // TODO: Throw?
-            return await ExecuteCoreAsync(testMethod).ConfigureAwait(false);
+            // STA (Single Threaded Apartment) is a Windows-only COM threading concept and is not
+            // supported on non-Windows platforms. The test is executed on the current thread without
+            // STA context, which is acceptable because STA has no meaning outside of Windows.
+            TestResult[] nonWindowsResults = await ExecuteCoreAsync(testMethod).ConfigureAwait(false);
+            string warning = string.Format(
+                CultureInfo.InvariantCulture,
+                FrameworkMessages.STATestMethodNonWindowsWarning,
+                testMethod.TestMethodName);
+            foreach (TestResult result in nonWindowsResults)
+            {
+                result.LogOutput = result.LogOutput is null
+                    ? warning
+                    : result.LogOutput + Environment.NewLine + warning;
+            }
+
+            return nonWindowsResults;
         }
 #endif
 

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/STATestMethodAttribute.cs
@@ -73,12 +73,14 @@ public class STATestMethodAttribute : TestMethodAttribute
             return await ExecuteCoreAsync(testMethod).ConfigureAwait(false);
         }
 
-#if !NETFRAMEWORK
+#if NETFRAMEWORK
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+#else
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#endif
         {
             throw new PlatformNotSupportedException(FrameworkMessages.STATestMethodNonWindowsNotSupported);
         }
-#endif
 
         TestResult[]? results = null;
         var t = new Thread(() => results = ExecuteCoreAsync(testMethod).GetAwaiter().GetResult())

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -405,8 +405,7 @@ Actual: {2}</value>
   <data name="AssertScopeNestedNotAllowed" xml:space="preserve">
     <value>Nested assert scopes are not allowed. Dispose the current scope before creating a new one.</value>
   </data>
-  <data name="STATestMethodNonWindowsWarning" xml:space="preserve">
-    <value>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</value>
-    <comment>{0} is the test method name.</comment>
+  <data name="STATestMethodNonWindowsNotSupported" xml:space="preserve">
+    <value>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</value>
   </data>
 </root>

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -405,4 +405,8 @@ Actual: {2}</value>
   <data name="AssertScopeNestedNotAllowed" xml:space="preserve">
     <value>Nested assert scopes are not allowed. Dispose the current scope before creating a new one.</value>
   </data>
+  <data name="STATestMethodNonWindowsWarning" xml:space="preserve">
+    <value>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</value>
+    <comment>{0} is the test method name.</comment>
+  </data>
 </root>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -358,10 +358,10 @@ Skutečnost: {2}</target>
         <target state="translated">Elementy &lt;{0}&gt; se v kolekci nenachází.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -358,6 +358,11 @@ Skutečnost: {2}</target>
         <target state="translated">Elementy &lt;{0}&gt; se v kolekci nenachází.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">Řetězec „{0}“ nezačíná řetězcem „{1}“. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -358,6 +358,11 @@ Tatsächlich: {2}</target>
         <target state="translated">Element(e) &lt;{0}&gt; ist/sind in der Auflistung nicht vorhanden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">Die Zeichenfolge „{0}“ beginnt nicht mit der Zeichenfolge „{1}“. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -358,10 +358,10 @@ Tatsächlich: {2}</target>
         <target state="translated">Element(e) &lt;{0}&gt; ist/sind in der Auflistung nicht vorhanden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -358,10 +358,10 @@ Real: {2}</target>
         <target state="translated">Los elementos &lt;{0}&gt; no están presentes en la colección.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -358,6 +358,11 @@ Real: {2}</target>
         <target state="translated">Los elementos &lt;{0}&gt; no están presentes en la colección.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">La cadena "{0}" no empieza con la cadena "{1}". {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -358,6 +358,11 @@ Réel : {2}</target>
         <target state="translated">L’élément ou les éléments &lt;{0}&gt; n’est ou ne sont pas présent(s) dans la collection.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">La chaîne '{0}' ne commence pas par la chaîne '{1}'. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -358,10 +358,10 @@ Réel : {2}</target>
         <target state="translated">L’élément ou les éléments &lt;{0}&gt; n’est ou ne sont pas présent(s) dans la collection.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -358,10 +358,10 @@ Effettivo: {2}</target>
         <target state="translated">Gli elementi &lt;{0}&gt; non sono presenti nella raccolta.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -358,6 +358,11 @@ Effettivo: {2}</target>
         <target state="translated">Gli elementi &lt;{0}&gt; non sono presenti nella raccolta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">La stringa '{0}' non inizia con la stringa '{1}'. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -358,10 +358,10 @@ Actual: {2}</source>
         <target state="translated">要素 &lt;{0}&gt; がコレクション内に存在しません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -358,6 +358,11 @@ Actual: {2}</source>
         <target state="translated">要素 &lt;{0}&gt; がコレクション内に存在しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">文字列 '{0}' は文字列 '{1}' で始まりません。{2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -358,6 +358,11 @@ Actual: {2}</source>
         <target state="translated">컬렉션에 &lt;{0}&gt; 요소가 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">'{0}' 문자열이 '{1}' 문자열로 시작되지 않습니다. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -358,10 +358,10 @@ Actual: {2}</source>
         <target state="translated">컬렉션에 &lt;{0}&gt; 요소가 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -358,6 +358,11 @@ Rzeczywiste: {2}</target>
         <target state="translated">Elementy &lt;{0}&gt; nie występują w kolekcji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">Ciąg „{0}” nie rozpoczyna się od ciągu „{1}”. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -358,10 +358,10 @@ Rzeczywiste: {2}</target>
         <target state="translated">Elementy &lt;{0}&gt; nie występują w kolekcji.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -358,6 +358,11 @@ Real: {2}</target>
         <target state="translated">O(s) elemento(s) &lt;{0}&gt; não está/estão presente(s) na coleção.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">A cadeia de caracteres “{0}” não começa com a cadeia de caracteres “{1}”. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -358,10 +358,10 @@ Real: {2}</target>
         <target state="translated">O(s) elemento(s) &lt;{0}&gt; não está/estão presente(s) na coleção.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -358,10 +358,10 @@ Actual: {2}</source>
         <target state="translated">Элементы &lt;{0}&gt; отсутствуют в коллекции.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -358,6 +358,11 @@ Actual: {2}</source>
         <target state="translated">Элементы &lt;{0}&gt; отсутствуют в коллекции.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">Строка "{0}" не начинается со строки "{1}". {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -358,6 +358,11 @@ Gerçekte olan: {2}</target>
         <target state="translated">Öğe(ler) &lt;{0}&gt; koleksiyonda mevcut değildir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">'{0}' dizesi, '{1}' dizesi ile başlamıyor. {2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -358,10 +358,10 @@ Gerçekte olan: {2}</target>
         <target state="translated">Öğe(ler) &lt;{0}&gt; koleksiyonda mevcut değildir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -358,6 +358,11 @@ Actual: {2}</source>
         <target state="translated">集合中不存在元素 &lt;{0}&gt;。</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">字符串 '{0}' 不以字符串 '{1}' 开头。{2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -358,10 +358,10 @@ Actual: {2}</source>
         <target state="translated">集合中不存在元素 &lt;{0}&gt;。</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -358,6 +358,11 @@ Actual: {2}</source>
         <target state="translated">集合中不存在元素 &lt;{0}&gt;。</target>
         <note />
       </trans-unit>
+      <trans-unit id="STATestMethodNonWindowsWarning">
+        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
+        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
+        <note>{0} is the test method name.</note>
+      </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>
         <target state="translated">字串 '{0}' 不是以字串 '{1}' 開頭。{2}</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -358,10 +358,10 @@ Actual: {2}</source>
         <target state="translated">集合中不存在元素 &lt;{0}&gt;。</target>
         <note />
       </trans-unit>
-      <trans-unit id="STATestMethodNonWindowsWarning">
-        <source>Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</source>
-        <target state="new">Test method '{0}' is marked with [STATestMethod] but STA is a Windows-only COM threading concept. The test was executed without STA context on the current (non-Windows) platform.</target>
-        <note>{0} is the test method name.</note>
+      <trans-unit id="STATestMethodNonWindowsNotSupported">
+        <source>[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</source>
+        <target state="new">[STATestMethod] is not supported on non-Windows platforms. STA (Single Threaded Apartment) is a Windows-only COM threading concept. Use [OSCondition(OperatingSystems.Windows)] to skip this test on non-Windows platforms.</target>
+        <note />
       </trans-unit>
       <trans-unit id="StartsWithFail">
         <source>String '{0}' does not start with string '{1}'. {2}</source>


### PR DESCRIPTION
## Summary

`STATestMethodAttribute.ExecuteAsync` had an ambiguous `// TODO: Throw?` comment on the non-Windows code path (line 79). The test would silently run without STA context on non-Windows, with no indication to the user.

## Change

Replace the `// TODO: Throw?` with a `PlatformNotSupportedException`. STA (Single Threaded Apartment) is a Windows-only COM threading concept — silently running without it is misleading. Failing explicitly makes the contract clear.

The error message guides users to use `[OSCondition(OperatingSystems.Windows)]` to skip the test on non-Windows platforms.

## Changes

- **`STATestMethodAttribute.cs`**: Throw `PlatformNotSupportedException` on non-Windows instead of silently executing without STA.
- **`FrameworkMessages.resx`**: Added `STATestMethodNonWindowsNotSupported` resource string.
- **`xlf/` files**: Auto-generated by build.