### PR TITLE
Fix command line parser splitting quoted paths with spaces

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs
@@ -78,6 +78,10 @@ internal static class CommandLineParser
 
             if (currentArg is not null)
             {
+                // When a quoted value is split across multiple args (e.g. a path with spaces),
+                // reassemble the fragments into a single argument.
+                currentArg = TryMergeQuotedArguments(args, ref i, currentArg);
+
                 if (currentOption is null)
                 {
                     errors.Add(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineParserUnexpectedArgument, args[i]));
@@ -114,6 +118,71 @@ internal static class CommandLineParser
             currentOption = currentOption.TrimStart('-');
         }
 
+        // When a quoted argument value is split across multiple args[] entries (e.g. a path
+        // containing spaces like "/path/my dir/log"), reassemble the fragments into a single
+        // string. Handles double-quote, single-quote, and escaped-quote (\") wrapping.
+        static string TryMergeQuotedArguments(List<string> args, ref int i, string currentArg)
+        {
+            string trimmed = currentArg.Trim();
+            if (trimmed.Length == 0)
+            {
+                return currentArg;
+            }
+
+            // Determine the opening quote style and whether it's already closed.
+            string? closingSuffix;
+            if (trimmed.StartsWith("\\\"", StringComparison.Ordinal))
+            {
+                // Escaped double-quote: \"...\"
+                if (trimmed.Length > 4 && trimmed.EndsWith("\\\"", StringComparison.Ordinal))
+                {
+                    return currentArg;
+                }
+
+                closingSuffix = "\\\"";
+            }
+            else if (trimmed[0] == '"')
+            {
+                if (trimmed.Length > 1 && trimmed[trimmed.Length - 1] == '"')
+                {
+                    return currentArg;
+                }
+
+                closingSuffix = "\"";
+            }
+            else if (trimmed[0] == '\'')
+            {
+                if (trimmed.Length > 1 && trimmed[trimmed.Length - 1] == '\'')
+                {
+                    return currentArg;
+                }
+
+                closingSuffix = "'";
+            }
+            else
+            {
+                return currentArg;
+            }
+
+            // Merge subsequent args until the closing quote is found.
+            StringBuilder merged = new(currentArg);
+            while (i + 1 < args.Count)
+            {
+                string nextArg = args[i + 1];
+                i++;
+                merged.Append(' ').Append(nextArg);
+
+                if (nextArg.TrimEnd().EndsWith(closingSuffix, StringComparison.Ordinal))
+                {
+                    return merged.ToString();
+                }
+            }
+
+            // Closing quote was never found — return what we assembled.
+            // TryUnescape / arity validation will report appropriate errors downstream.
+            return merged.ToString();
+        }
+
         static bool TryUnescape(string input, string? option, IEnvironment environment, [NotNullWhen(true)] out string? unescapedArg, [NotNullWhen(false)] out string? error)
         {
             unescapedArg = input;
@@ -132,6 +201,15 @@ internal static class CommandLineParser
                 }
 
                 unescapedArg = input[1..^1];
+                return true;
+            }
+
+            // Handle escaped double-quotes: \"...\"
+            // Some process launchers (e.g. VS Code on Linux) emit escaped quotes that arrive
+            // as literal backslash-quote characters in the args array.
+            if (input.StartsWith("\\\"", StringComparison.Ordinal) && input.EndsWith("\\\"", StringComparison.Ordinal) && input.Length > 4)
+            {
+                unescapedArg = input[2..^2];
                 return true;
             }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineTests.cs
@@ -198,6 +198,31 @@ public sealed class CommandLineTests
             new("option3", ["c"]),
             new("option4", ["d"]),
         }.ToArray(), []));
+
+        // Quoted path with spaces split across multiple args (double-quotes)
+        yield return (31, ["--option1", "\"path/with", "spaces/log\""], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption> { new("option1", ["path/with spaces/log"]) }.ToArray(), []));
+
+        // Quoted path with spaces split across three args (double-quotes)
+        yield return (32, ["--option1", "\"/home/user/Example", "Solution/artifacts/build", "bin/Log\""], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption> { new("option1", ["/home/user/Example Solution/artifacts/build bin/Log"]) }.ToArray(), []));
+
+        // Escaped double-quote path with spaces split across multiple args
+        yield return (33, ["--option1", "\\\"/path/with", "spaces/log\\\""], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption> { new("option1", ["/path/with spaces/log"]) }.ToArray(), []));
+
+        // Single-quoted path with spaces split across multiple args
+        yield return (34, ["--option1", "'path/with", "spaces/log'"], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption> { new("option1", ["path/with spaces/log"]) }.ToArray(), []));
+
+        // Quoted path with spaces using = delimiter
+        yield return (35, ["--option1=\"path/with", "spaces/log\""], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption> { new("option1", ["path/with spaces/log"]) }.ToArray(), []));
+
+        // Quoted path with spaces using : delimiter
+        yield return (36, ["--option1:\"path/with", "spaces/log\""], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption> { new("option1", ["path/with spaces/log"]) }.ToArray(), []));
+
+        // Quoted path with spaces followed by another option
+        yield return (37, ["--option1", "\"path/with", "spaces\"", "--option2", "value"], null, new CommandLineParseResultWrapper(null, new List<CommandLineParseOption>
+        {
+            new("option1", ["path/with spaces"]),
+            new("option2", ["value"]),
+        }.ToArray(), []));
     }
 
     [TestMethod]


### PR DESCRIPTION
When a path with spaces is passed to `--diagnostic-output-directory` (or any option expecting a single argument), the OS can split it across multiple `args[]` entries. The parser then sees each fragment as a separate argument, fails arity validation, and the test host exits immediately.

This happens in practice when VS Code C# Dev Kit launches MTP on Linux/WSL with paths like `/home/user/repro folder/bin/Debug/net10.0/Log`.

The fix teaches the parser to reassemble quoted argument fragments: when an arg starts with an unmatched `\"`, `'`, or `\\\"` it merges subsequent args until the closing quote. Also extends `TryUnescape` to strip escaped double-quotes (`\\"...\\"`).

Fixes https://github.com/microsoft/vscode-dotnettools/issues/2891