### PR TITLE
Enable PR Nitpick Reviewer on all opened PRs

### DIFF
--- a/.github/workflows/pr-nitpick-reviewer.lock.yml
+++ b/.github/workflows/pr-nitpick-reviewer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"61f67eaba4abfc0270c38dcd1f968731c8f2cb03c038a2713bebd79c611c69a3","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c7aeb0ff49749532de284f0c637e70db20f94b66870f01f531d3f9aa82a8c067","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Provides detailed nitpicky code review focusing on style, best practices, and minor improvements when invoked with the /nit command
+# Provides detailed nitpicky code review focusing on style, best practices, and minor improvements. Runs automatically on all opened PRs and can also be invoked on-demand with the /nit command.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -53,28 +53,10 @@
 
 name: "PR Nitpick Reviewer 🔍"
 "on":
-  discussion:
-    types:
-    - created
-    - edited
-  discussion_comment:
-    types:
-    - created
-    - edited
   issue_comment:
     types:
     - created
     - edited
-  issues:
-    types:
-    - opened
-    - edited
-    - reopened
-  pull_request:
-    types:
-    - opened
-    - edited
-    - reopened
   pull_request_review_comment:
     types:
     - created
@@ -90,7 +72,7 @@ run-name: "PR Nitpick Reviewer 🔍"
 jobs:
   activation:
     needs: pre_activation
-    if: "needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/nit ') || startsWith(github.event.issue.body, '/nit\n') || github.event.issue.body == '/nit') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') && github.event.issue.pull_request == null || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') && github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') || github.event_name == 'pull_request' && (startsWith(github.event.pull_request.body, '/nit ') || startsWith(github.event.pull_request.body, '/nit\n') || github.event.pull_request.body == '/nit') || github.event_name == 'discussion' && (startsWith(github.event.discussion.body, '/nit ') || startsWith(github.event.discussion.body, '/nit\n') || github.event.discussion.body == '/nit') || github.event_name == 'discussion_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit'))"
+    if: "needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') && github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit'))"
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -234,15 +216,15 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_34d40200773a6369_EOF'
+          cat << 'GH_AW_PROMPT_ca9cbbd39a00d4b8_EOF'
           <system>
-          GH_AW_PROMPT_34d40200773a6369_EOF
+          GH_AW_PROMPT_ca9cbbd39a00d4b8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_34d40200773a6369_EOF'
+          cat << 'GH_AW_PROMPT_ca9cbbd39a00d4b8_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:10), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -274,16 +256,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_34d40200773a6369_EOF
+          GH_AW_PROMPT_ca9cbbd39a00d4b8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_34d40200773a6369_EOF'
+          cat << 'GH_AW_PROMPT_ca9cbbd39a00d4b8_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/pr-nitpick-reviewer.md}}
-          GH_AW_PROMPT_34d40200773a6369_EOF
+          GH_AW_PROMPT_ca9cbbd39a00d4b8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -482,9 +464,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c43b5789b48a63bd_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_48b659154f4f5c15_EOF'
           {"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c43b5789b48a63bd_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_48b659154f4f5c15_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -700,7 +682,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3a551ea5000fd983_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_fc6f71015fe039c2_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -744,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3a551ea5000fd983_EOF
+          GH_AW_MCP_CONFIG_fc6f71015fe039c2_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1188,7 +1170,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           WORKFLOW_NAME: "PR Nitpick Reviewer 🔍"
-          WORKFLOW_DESCRIPTION: "Provides detailed nitpicky code review focusing on style, best practices, and minor improvements when invoked with the /nit command"
+          WORKFLOW_DESCRIPTION: "Provides detailed nitpicky code review focusing on style, best practices, and minor improvements. Runs automatically on all opened PRs and can also be invoked on-demand with the /nit command."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1260,7 +1242,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: "github.event_name == 'issues' && (startsWith(github.event.issue.body, '/nit ') || startsWith(github.event.issue.body, '/nit\n') || github.event.issue.body == '/nit') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') && github.event.issue.pull_request == null || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') && github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') || github.event_name == 'pull_request' && (startsWith(github.event.pull_request.body, '/nit ') || startsWith(github.event.pull_request.body, '/nit\n') || github.event.pull_request.body == '/nit') || github.event_name == 'discussion' && (startsWith(github.event.discussion.body, '/nit ') || startsWith(github.event.discussion.body, '/nit\n') || github.event.discussion.body == '/nit') || github.event_name == 'discussion_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit')"
+    if: "github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit') && github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/nit ') || startsWith(github.event.comment.body, '/nit\n') || github.event.comment.body == '/nit')"
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}

--- a/.github/workflows/pr-nitpick-reviewer.md
+++ b/.github/workflows/pr-nitpick-reviewer.md
@@ -8,8 +8,6 @@ on:
   slash_command:
     name: nit
     events: [pull_request_comment, pull_request_review_comment]
-  pull_request:
-    types: [opened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-nitpick-reviewer.md
+++ b/.github/workflows/pr-nitpick-reviewer.md
@@ -1,8 +1,15 @@
 ---
-description: Provides detailed nitpicky code review focusing on style, best practices, and minor improvements when invoked with the /nit command
+description: >
+  Provides detailed nitpicky code review focusing on style, best practices,
+  and minor improvements. Runs automatically on all opened PRs and can also
+  be invoked on-demand with the /nit command.
 
 on:
-  slash_command: "nit"
+  slash_command:
+    name: nit
+    events: [pull_request_comment, pull_request_review_comment]
+  pull_request:
+    types: [opened]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Enable the PR Nitpick Reviewer to run automatically on all opened PRs, in addition to keeping on-demand `/nit` slash command support.

### What changed

The frontmatter `on:` section was updated from:

```yaml
on:
  slash_command: "nit"
```

to:

```yaml
on:
  slash_command:
    name: nit
    events: [pull_request_comment, pull_request_review_comment]
  pull_request:
    types: [opened]
```

### Why

- PRs were merging with zero agentic reviews — the nitpicker only ran when someone manually typed `/nit`
- Auto-triggering on `pull_request: opened` ensures every PR gets a style/convention pass
- Particularly useful for Copilot-authored PRs that currently get no automated style review
- The `/nit` command is preserved for re-running the reviewer on demand

### Before merging

**`gh aw compile` must be run** to regenerate `pr-nitpick-reviewer.lock.yml` from the updated `.md` source. The `.lock.yml` is what GitHub Actions actually executes — the `.md` change alone won't take effect.