### PR TITLE
Convert ExitCodes from static class to enum

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -298,16 +298,16 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 catch (OperationCanceledException) when (processExitedCancellationToken.IsCancellationRequested)
                 {
                     await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestHostProcessExitedBeforeRetryCouldConnect, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
-                    return ExitCodes.GenericFailure;
+                    return (int)ExitCodes.GenericFailure;
                 }
             }
 
             await testHostProcess.WaitForExitAsync().ConfigureAwait(false);
 
             exitCodes.Add(testHostProcess.ExitCode);
-            if (testHostProcess.ExitCode != ExitCodes.Success)
+            if (testHostProcess.ExitCode != (int)ExitCodes.Success)
             {
-                if (testHostProcess.ExitCode != ExitCodes.AtLeastOneTestFailed)
+                if (testHostProcess.ExitCode != (int)ExitCodes.AtLeastOneTestFailed)
                 {
                     await outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedWithWrongExitCode, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
                     retryInterrupted = true;
@@ -370,7 +370,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
 
         if (!thresholdPolicyKickedIn && !retryInterrupted)
         {
-            if (exitCodes[^1] != ExitCodes.Success)
+            if (exitCodes[^1] != (int)ExitCodes.Success)
             {
                 await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedInAllAttempts, userMaxRetryCount + 1)), cancellationToken).ConfigureAwait(false);
             }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -298,16 +298,16 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 catch (OperationCanceledException) when (processExitedCancellationToken.IsCancellationRequested)
                 {
                     await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestHostProcessExitedBeforeRetryCouldConnect, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
-                    return (int)ExitCodes.GenericFailure;
+                    return (int)ExitCode.GenericFailure;
                 }
             }
 
             await testHostProcess.WaitForExitAsync().ConfigureAwait(false);
 
             exitCodes.Add(testHostProcess.ExitCode);
-            if (testHostProcess.ExitCode != (int)ExitCodes.Success)
+            if (testHostProcess.ExitCode != (int)ExitCode.Success)
             {
-                if (testHostProcess.ExitCode != (int)ExitCodes.AtLeastOneTestFailed)
+                if (testHostProcess.ExitCode != (int)ExitCode.AtLeastOneTestFailed)
                 {
                     await outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedWithWrongExitCode, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
                     retryInterrupted = true;
@@ -370,7 +370,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
 
         if (!thresholdPolicyKickedIn && !retryInterrupted)
         {
-            if (exitCodes[^1] != (int)ExitCodes.Success)
+            if (exitCodes[^1] != (int)ExitCode.Success)
             {
                 await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedInAllAttempts, userMaxRetryCount + 1)), cancellationToken).ConfigureAwait(false);
             }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
@@ -73,12 +73,12 @@ internal sealed class TrxCompareTool : ITool, IOutputDeviceDataProducer
         if (AreMatchingTrxFiles(baseLineResults, comparedResults, outputBuilder))
         {
             await _outputDisplay.DisplayAsync(this, new TextOutputDeviceData(outputBuilder.ToString()), cancellationToken).ConfigureAwait(false);
-            return ExitCodes.Success;
+            return (int)ExitCodes.Success;
         }
         else
         {
             await _outputDisplay.DisplayAsync(this, new TextOutputDeviceData(outputBuilder.ToString()), cancellationToken).ConfigureAwait(false);
-            return ExitCodes.GenericFailure;
+            return (int)ExitCodes.GenericFailure;
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCompareTool.cs
@@ -73,12 +73,12 @@ internal sealed class TrxCompareTool : ITool, IOutputDeviceDataProducer
         if (AreMatchingTrxFiles(baseLineResults, comparedResults, outputBuilder))
         {
             await _outputDisplay.DisplayAsync(this, new TextOutputDeviceData(outputBuilder.ToString()), cancellationToken).ConfigureAwait(false);
-            return (int)ExitCodes.Success;
+            return (int)ExitCode.Success;
         }
         else
         {
             await _outputDisplay.DisplayAsync(this, new TextOutputDeviceData(outputBuilder.ToString()), cancellationToken).ConfigureAwait(false);
-            return (int)ExitCodes.GenericFailure;
+            return (int)ExitCode.GenericFailure;
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
@@ -165,7 +165,7 @@ internal sealed partial class TrxReportEngine
             AddTestLists(testRun);
 
             bool hasFailedTests = summaryCounts.Failed > 0 || summaryCounts.Timedout > 0;
-            string trxOutcome = isTestHostCrashed || _exitCode != (int)ExitCodes.Success || hasFailedTests ? "Failed" : "Completed";
+            string trxOutcome = isTestHostCrashed || _exitCode != (int)ExitCode.Success || hasFailedTests ? "Failed" : "Completed";
 
             AddResultSummary(testRun, trxOutcome, runDeploymentRoot, testHostCrashInfo, _exitCode, summaryCounts, isTestHostCrashed);
 
@@ -333,7 +333,7 @@ internal sealed partial class TrxReportEngine
             runInfo.Add(text);
             runInfos.Add(runInfo);
         }
-        else if (exitCode != (int)ExitCodes.Success)
+        else if (exitCode != (int)ExitCode.Success)
         {
             var runInfos = new XElement(NamespaceUri + "RunInfos");
             resultSummary.Add(runInfos);

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.cs
@@ -165,7 +165,7 @@ internal sealed partial class TrxReportEngine
             AddTestLists(testRun);
 
             bool hasFailedTests = summaryCounts.Failed > 0 || summaryCounts.Timedout > 0;
-            string trxOutcome = isTestHostCrashed || _exitCode != ExitCodes.Success || hasFailedTests ? "Failed" : "Completed";
+            string trxOutcome = isTestHostCrashed || _exitCode != (int)ExitCodes.Success || hasFailedTests ? "Failed" : "Completed";
 
             AddResultSummary(testRun, trxOutcome, runDeploymentRoot, testHostCrashInfo, _exitCode, summaryCounts, isTestHostCrashed);
 
@@ -333,7 +333,7 @@ internal sealed partial class TrxReportEngine
             runInfo.Add(text);
             runInfos.Add(runInfo);
         }
-        else if (exitCode != ExitCodes.Success)
+        else if (exitCode != (int)ExitCodes.Success)
         {
             var runInfos = new XElement(NamespaceUri + "RunInfos");
             resultSummary.Add(runInfos);

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -433,14 +433,14 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     protected override bool HandleTaskExecutionErrors()
     {
         // This is an unexpected situation we simply print to the console the output and return false.
-        if (string.IsNullOrEmpty(_outputFileName) && ExitCode != ExitCodes.InvalidCommandLine)
+        if (string.IsNullOrEmpty(_outputFileName) && ExitCode != (int)ExitCodes.InvalidCommandLine)
         {
             Log.LogError(null, "run failed", null, TargetPath.ItemSpec.Trim(), 0, 0, 0, 0, Resources.MSBuildResources.TestFailedNoDetail, _output);
         }
         else
         {
             // If the output file name is null and the exit code is invalid command line we create a default one.
-            if (_outputFileName is null && ExitCode == ExitCodes.InvalidCommandLine)
+            if (_outputFileName is null && ExitCode == (int)ExitCodes.InvalidCommandLine)
             {
                 _outputFileName = Path.Combine(Path.GetDirectoryName(TargetPath.ItemSpec.Trim())!, "TestResults");
                 _fileSystem.CreateDirectory(_outputFileName);

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -433,14 +433,14 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
     protected override bool HandleTaskExecutionErrors()
     {
         // This is an unexpected situation we simply print to the console the output and return false.
-        if (string.IsNullOrEmpty(_outputFileName) && ExitCode != (int)ExitCodes.InvalidCommandLine)
+        if (string.IsNullOrEmpty(_outputFileName) && ExitCode != (int)Helpers.ExitCode.InvalidCommandLine)
         {
             Log.LogError(null, "run failed", null, TargetPath.ItemSpec.Trim(), 0, 0, 0, 0, Resources.MSBuildResources.TestFailedNoDetail, _output);
         }
         else
         {
             // If the output file name is null and the exit code is invalid command line we create a default one.
-            if (_outputFileName is null && ExitCode == (int)ExitCodes.InvalidCommandLine)
+            if (_outputFileName is null && ExitCode == (int)Helpers.ExitCode.InvalidCommandLine)
             {
                 _outputFileName = Path.Combine(Path.GetDirectoryName(TargetPath.ItemSpec.Trim())!, "TestResults");
                 _fileSystem.CreateDirectory(_outputFileName);

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Testing.Platform.Helpers;
 /// On POSIX systems the standard exit code is 0 for success and any number from 1 to 255 for anything else.
 /// </summary>
 [Embedded]
-internal enum ExitCodes
+internal enum ExitCode
 {
     Success = 0,
     GenericFailure = 1,

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
@@ -9,25 +9,21 @@ namespace Microsoft.Testing.Platform.Helpers;
 /// We use positive exit codes for failure because POSIX/BASH exit codes are unsigned 8-bit integers.
 /// On POSIX systems the standard exit code is 0 for success and any number from 1 to 255 for anything else.
 /// </summary>
-// TODO: Consider changing this to an enum, and rename to 'ExitCode' to follow enum naming convention.
-// Being an enum makes it easier to do 'Enum.IsDefined' checks to validate if an exit code is a known MTP exit code.
-// Note: Changing this to enum would be binary breaking for extensions built against MTP <= 2.1 that still consume this via IVT
-// (those extensions reference the class directly from the MTP assembly, not via source embedding).
 [Embedded]
-internal static class ExitCodes
+internal enum ExitCodes
 {
-    public const int Success = 0;
-    public const int GenericFailure = 1;
-    public const int AtLeastOneTestFailed = 2;
-    public const int TestSessionAborted = 3;
-    public const int InvalidPlatformSetup = 4;
-    public const int InvalidCommandLine = 5;
-    // public const int FeatureNotImplemented = 6;
-    public const int TestHostProcessExitedNonGracefully = 7;
-    public const int ZeroTests = 8;
-    public const int MinimumExpectedTestsPolicyViolation = 9;
-    public const int TestAdapterTestSessionFailure = 10;
-    public const int DependentProcessExited = 11;
-    public const int IncompatibleProtocolVersion = 12;
-    public const int TestExecutionStoppedForMaxFailedTests = 13;
+    Success = 0,
+    GenericFailure = 1,
+    AtLeastOneTestFailed = 2,
+    TestSessionAborted = 3,
+    InvalidPlatformSetup = 4,
+    InvalidCommandLine = 5,
+    // FeatureNotImplemented = 6,
+    TestHostProcessExitedNonGracefully = 7,
+    ZeroTests = 8,
+    MinimumExpectedTestsPolicyViolation = 9,
+    TestAdapterTestSessionFailure = 10,
+    DependentProcessExited = 11,
+    IncompatibleProtocolVersion = 12,
+    TestExecutionStoppedForMaxFailedTests = 13,
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/NonCooperativeParentProcessListener.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/NonCooperativeParentProcessListener.cs
@@ -35,11 +35,11 @@ internal sealed class NonCooperativeParentProcessListener : IDisposable
         {
             // If we fail the process is already gone, so we can just exit.
             // The first check is already done inside the command line parser.
-            _environment.Exit((int)ExitCodes.DependentProcessExited);
+            _environment.Exit((int)ExitCode.DependentProcessExited);
         }
     }
 
-    private void ParentProcess_Exited(object? sender, EventArgs e) => _environment.Exit((int)ExitCodes.DependentProcessExited);
+    private void ParentProcess_Exited(object? sender, EventArgs e) => _environment.Exit((int)ExitCode.DependentProcessExited);
 
     public void Dispose() => _parentProcess?.Dispose();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/NonCooperativeParentProcessListener.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/NonCooperativeParentProcessListener.cs
@@ -35,11 +35,11 @@ internal sealed class NonCooperativeParentProcessListener : IDisposable
         {
             // If we fail the process is already gone, so we can just exit.
             // The first check is already done inside the command line parser.
-            _environment.Exit(ExitCodes.DependentProcessExited);
+            _environment.Exit((int)ExitCodes.DependentProcessExited);
         }
     }
 
-    private void ParentProcess_Exited(object? sender, EventArgs e) => _environment.Exit(ExitCodes.DependentProcessExited);
+    private void ParentProcess_Exited(object? sender, EventArgs e) => _environment.Exit((int)ExitCodes.DependentProcessExited);
 
     public void Dispose() => _parentProcess?.Dispose();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -30,7 +30,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
     {
         CancellationToken testApplicationCancellationToken = ServiceProvider.GetTestApplicationCancellationTokenSource().CancellationToken;
 
-        int exitCode = ExitCodes.GenericFailure;
+        int exitCode = (int)ExitCodes.GenericFailure;
         IPlatformOpenTelemetryService? platformOTelService = null;
         IPlatformActivity? activity = null;
         try
@@ -45,7 +45,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
                 if (testApplicationCancellationToken.IsCancellationRequested)
                 {
-                    exitCode = ExitCodes.TestSessionAborted;
+                    exitCode = (int)ExitCodes.TestSessionAborted;
                 }
 
                 return exitCode;
@@ -59,7 +59,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
                 exitCode = isValidProtocol
                     ? await RunTestAppAsync(platformOTelService, testApplicationCancellationToken).ConfigureAwait(false)
-                    : ExitCodes.IncompatibleProtocolVersion;
+                    : (int)ExitCodes.IncompatibleProtocolVersion;
             }
             finally
             {
@@ -90,7 +90,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
         if (testApplicationCancellationToken.IsCancellationRequested)
         {
-            exitCode = ExitCodes.TestSessionAborted;
+            exitCode = (int)ExitCodes.TestSessionAborted;
         }
 
         return exitCode;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -30,7 +30,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
     {
         CancellationToken testApplicationCancellationToken = ServiceProvider.GetTestApplicationCancellationTokenSource().CancellationToken;
 
-        int exitCode = (int)ExitCodes.GenericFailure;
+        int exitCode = (int)ExitCode.GenericFailure;
         IPlatformOpenTelemetryService? platformOTelService = null;
         IPlatformActivity? activity = null;
         try
@@ -45,7 +45,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
                 if (testApplicationCancellationToken.IsCancellationRequested)
                 {
-                    exitCode = (int)ExitCodes.TestSessionAborted;
+                    exitCode = (int)ExitCode.TestSessionAborted;
                 }
 
                 return exitCode;
@@ -59,7 +59,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
                 exitCode = isValidProtocol
                     ? await RunTestAppAsync(platformOTelService, testApplicationCancellationToken).ConfigureAwait(false)
-                    : (int)ExitCodes.IncompatibleProtocolVersion;
+                    : (int)ExitCode.IncompatibleProtocolVersion;
             }
             finally
             {
@@ -90,7 +90,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
         if (testApplicationCancellationToken.IsCancellationRequested)
         {
-            exitCode = (int)ExitCodes.TestSessionAborted;
+            exitCode = (int)ExitCode.TestSessionAborted;
         }
 
         return exitCode;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
@@ -108,7 +108,7 @@ internal sealed class ConsoleTestHost(
         {
             requestExecuteStop ??= _clock.UtcNow;
 
-            exitCode = ExitCodes.TestSessionAborted;
+            exitCode = (int)ExitCodes.TestSessionAborted;
             await _logger.LogInformationAsync("Test session canceled.").ConfigureAwait(false);
         }
         finally
@@ -128,7 +128,7 @@ internal sealed class ConsoleTestHost(
                 { TelemetryProperties.RequestProperties.AdapterLoadStop, adapterLoadStop },
                 { TelemetryProperties.RequestProperties.RequestExecuteStart, requestExecuteStart },
                 { TelemetryProperties.RequestProperties.RequestExecuteStop, requestExecuteStop },
-                { TelemetryProperties.HostProperties.ExitCodePropertyName, cancellationToken.IsCancellationRequested ? ExitCodes.TestSessionAborted : exitCode.ToString(CultureInfo.InvariantCulture) },
+                { TelemetryProperties.HostProperties.ExitCodePropertyName, cancellationToken.IsCancellationRequested ? (int)ExitCodes.TestSessionAborted : exitCode.ToString(CultureInfo.InvariantCulture) },
             };
 
             if (statistics is not null)

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
@@ -108,7 +108,7 @@ internal sealed class ConsoleTestHost(
         {
             requestExecuteStop ??= _clock.UtcNow;
 
-            exitCode = (int)ExitCodes.TestSessionAborted;
+            exitCode = (int)ExitCode.TestSessionAborted;
             await _logger.LogInformationAsync("Test session canceled.").ConfigureAwait(false);
         }
         finally
@@ -128,7 +128,7 @@ internal sealed class ConsoleTestHost(
                 { TelemetryProperties.RequestProperties.AdapterLoadStop, adapterLoadStop },
                 { TelemetryProperties.RequestProperties.RequestExecuteStart, requestExecuteStart },
                 { TelemetryProperties.RequestProperties.RequestExecuteStop, requestExecuteStop },
-                { TelemetryProperties.HostProperties.ExitCodePropertyName, cancellationToken.IsCancellationRequested ? (int)ExitCodes.TestSessionAborted : exitCode.ToString(CultureInfo.InvariantCulture) },
+                { TelemetryProperties.HostProperties.ExitCodePropertyName, exitCode.ToString(CultureInfo.InvariantCulture) },
             };
 
             if (statistics is not null)

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -170,8 +170,8 @@ internal sealed partial class ServerTestHost : CommonHost, IServerTestHost, IDis
 
         // If the global cancellation is called together with the server closing one the server exited gracefully.
         return !cancellationToken.IsCancellationRequested && _serverClosingTokenSource.IsCancellationRequested
-            ? ExitCodes.Success
-            : ExitCodes.TestSessionAborted;
+            ? (int)ExitCodes.Success
+            : (int)ExitCodes.TestSessionAborted;
     }
 
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -170,8 +170,8 @@ internal sealed partial class ServerTestHost : CommonHost, IServerTestHost, IDis
 
         // If the global cancellation is called together with the server closing one the server exited gracefully.
         return !cancellationToken.IsCancellationRequested && _serverClosingTokenSource.IsCancellationRequested
-            ? (int)ExitCodes.Success
-            : (int)ExitCodes.TestSessionAborted;
+            ? (int)ExitCode.Success
+            : (int)ExitCode.TestSessionAborted;
     }
 
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -261,7 +261,7 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
 
             builderActivity?.SetTag(BuilderHostTypeOTelKey, nameof(InformativeCommandLineHost));
             builderActivity?.Dispose();
-            return new InformativeCommandLineHost((int)ExitCodes.InvalidCommandLine, serviceProvider);
+            return new InformativeCommandLineHost((int)ExitCode.InvalidCommandLine, serviceProvider);
         }
 
         // Register as ICommandLineOptions.

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.cs
@@ -261,7 +261,7 @@ internal sealed class TestHostBuilder(IFileSystem fileSystem, IRuntimeFeature ru
 
             builderActivity?.SetTag(BuilderHostTypeOTelKey, nameof(InformativeCommandLineHost));
             builderActivity?.Dispose();
-            return new InformativeCommandLineHost(ExitCodes.InvalidCommandLine, serviceProvider);
+            return new InformativeCommandLineHost((int)ExitCodes.InvalidCommandLine, serviceProvider);
         }
 
         // Register as ICommandLineOptions.

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -221,7 +221,7 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
 
                     await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(displayErrorMessageBuilder.ToString()), cancellationToken).ConfigureAwait(false);
                     await _logger.LogErrorAsync(logErrorMessageBuilder.ToString()).ConfigureAwait(false);
-                    return (int)ExitCodes.InvalidPlatformSetup;
+                    return (int)ExitCode.InvalidPlatformSetup;
                 }
 
                 foreach (EnvironmentVariable envVar in environmentVariables.GetAll())
@@ -346,17 +346,17 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
 
             // If we have a process in the middle between the test host controller and the test host process we need to keep it into account.
             exitCode = testHostProcess.ExitCode;
-            if (exitCode == (int)ExitCodes.Success && cancellationToken.IsCancellationRequested)
+            if (exitCode == (int)ExitCode.Success && cancellationToken.IsCancellationRequested)
             {
                 // In case of cancellation, only alter exit code if it was success.
                 // If there is another exit code indicating another failure, we prefer it over the cancellation.
-                exitCode = (int)ExitCodes.TestSessionAborted;
+                exitCode = (int)ExitCode.TestSessionAborted;
             }
             else if (!testHostProcessInformation.HasExitedGracefully ||
                 _testHostExitCodeReceived != testHostProcess.ExitCode)
             {
                 await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, PlatformResources.TestProcessDidNotExitGracefullyErrorMessage, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
-                exitCode = (int)ExitCodes.TestHostProcessExitedNonGracefully;
+                exitCode = (int)ExitCode.TestHostProcessExitedNonGracefully;
             }
 
             await _logger.LogInformationAsync($"TestHostControllersTestHost ended with exit code '{exitCode}' (real test host exit code '{testHostProcess.ExitCode}') in '{consoleRunStarted.Elapsed}'").ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -221,7 +221,7 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
 
                     await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(displayErrorMessageBuilder.ToString()), cancellationToken).ConfigureAwait(false);
                     await _logger.LogErrorAsync(logErrorMessageBuilder.ToString()).ConfigureAwait(false);
-                    return ExitCodes.InvalidPlatformSetup;
+                    return (int)ExitCodes.InvalidPlatformSetup;
                 }
 
                 foreach (EnvironmentVariable envVar in environmentVariables.GetAll())
@@ -346,17 +346,17 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
 
             // If we have a process in the middle between the test host controller and the test host process we need to keep it into account.
             exitCode = testHostProcess.ExitCode;
-            if (exitCode == ExitCodes.Success && cancellationToken.IsCancellationRequested)
+            if (exitCode == (int)ExitCodes.Success && cancellationToken.IsCancellationRequested)
             {
                 // In case of cancellation, only alter exit code if it was success.
                 // If there is another exit code indicating another failure, we prefer it over the cancellation.
-                exitCode = ExitCodes.TestSessionAborted;
+                exitCode = (int)ExitCodes.TestSessionAborted;
             }
             else if (!testHostProcessInformation.HasExitedGracefully ||
                 _testHostExitCodeReceived != testHostProcess.ExitCode)
             {
                 await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, PlatformResources.TestProcessDidNotExitGracefullyErrorMessage, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
-                exitCode = ExitCodes.TestHostProcessExitedNonGracefully;
+                exitCode = (int)ExitCodes.TestHostProcessExitedNonGracefully;
             }
 
             await _logger.LogInformationAsync($"TestHostControllersTestHost ended with exit code '{exitCode}' (real test host exit code '{testHostProcess.ExitCode}') in '{consoleRunStarted.Elapsed}'").ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostOchestratorHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostOchestratorHost.cs
@@ -46,7 +46,7 @@ internal sealed class TestHostOrchestratorHost(TestHostOrchestratorConfiguration
         catch (OperationCanceledException) when (applicationCancellationToken.CancellationToken.IsCancellationRequested)
         {
             // We do nothing we're canceling
-            exitCode = (int)ExitCodes.TestSessionAborted;
+            exitCode = (int)ExitCode.TestSessionAborted;
         }
 
         return exitCode;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostOchestratorHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostOchestratorHost.cs
@@ -46,7 +46,7 @@ internal sealed class TestHostOrchestratorHost(TestHostOrchestratorConfiguration
         catch (OperationCanceledException) when (applicationCancellationToken.CancellationToken.IsCancellationRequested)
         {
             // We do nothing we're canceling
-            exitCode = ExitCodes.TestSessionAborted;
+            exitCode = (int)ExitCodes.TestSessionAborted;
         }
 
         return exitCode;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ToolsTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ToolsTestHost.cs
@@ -63,20 +63,20 @@ internal sealed class ToolsHost(
                 {
                     await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(unknownOptionsError), cancellationToken).ConfigureAwait(false);
                     console.WriteLine();
-                    return (int)ExitCodes.InvalidCommandLine;
+                    return (int)ExitCode.InvalidCommandLine;
                 }
 
                 if (ExtensionArgumentArityAreInvalid(out string? arityErrors, tool))
                 {
                     await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(arityErrors), cancellationToken).ConfigureAwait(false);
-                    return (int)ExitCodes.InvalidCommandLine;
+                    return (int)ExitCode.InvalidCommandLine;
                 }
 
                 ValidationResult optionsArgumentsValidationResult = await ValidateOptionsArgumentsAsync(tool).ConfigureAwait(false);
                 if (!optionsArgumentsValidationResult.IsValid)
                 {
                     await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(optionsArgumentsValidationResult.ErrorMessage), cancellationToken).ConfigureAwait(false);
-                    return (int)ExitCodes.InvalidCommandLine;
+                    return (int)ExitCode.InvalidCommandLine;
                 }
 
                 return await tool.RunAsync(cancellationToken).ConfigureAwait(false);
@@ -85,7 +85,7 @@ internal sealed class ToolsHost(
 
         await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData($"Tool '{toolNameToRun}' not found in the list of registered tools."), cancellationToken).ConfigureAwait(false);
         await _commandLineHandler.PrintHelpAsync(_outputDevice, null, cancellationToken).ConfigureAwait(false);
-        return (int)ExitCodes.InvalidCommandLine;
+        return (int)ExitCode.InvalidCommandLine;
     }
 
     private bool UnknownOptions([NotNullWhen(true)] out string? error, ITool tool)

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ToolsTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ToolsTestHost.cs
@@ -63,20 +63,20 @@ internal sealed class ToolsHost(
                 {
                     await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(unknownOptionsError), cancellationToken).ConfigureAwait(false);
                     console.WriteLine();
-                    return ExitCodes.InvalidCommandLine;
+                    return (int)ExitCodes.InvalidCommandLine;
                 }
 
                 if (ExtensionArgumentArityAreInvalid(out string? arityErrors, tool))
                 {
                     await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(arityErrors), cancellationToken).ConfigureAwait(false);
-                    return ExitCodes.InvalidCommandLine;
+                    return (int)ExitCodes.InvalidCommandLine;
                 }
 
                 ValidationResult optionsArgumentsValidationResult = await ValidateOptionsArgumentsAsync(tool).ConfigureAwait(false);
                 if (!optionsArgumentsValidationResult.IsValid)
                 {
                     await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(optionsArgumentsValidationResult.ErrorMessage), cancellationToken).ConfigureAwait(false);
-                    return ExitCodes.InvalidCommandLine;
+                    return (int)ExitCodes.InvalidCommandLine;
                 }
 
                 return await tool.RunAsync(cancellationToken).ConfigureAwait(false);
@@ -85,7 +85,7 @@ internal sealed class ToolsHost(
 
         await _outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData($"Tool '{toolNameToRun}' not found in the list of registered tools."), cancellationToken).ConfigureAwait(false);
         await _commandLineHandler.PrintHelpAsync(_outputDevice, null, cancellationToken).ConfigureAwait(false);
-        return ExitCodes.InvalidCommandLine;
+        return (int)ExitCodes.InvalidCommandLine;
     }
 
     private bool UnknownOptions([NotNullWhen(true)] out string? error, ITool tool)

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -181,7 +181,7 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     // This is especially important for 'dotnet test', where the user can simply kill the dotnet.exe process themselves.
                     // In that case, we want the MTP process to also die.
                     // Exit code 1 indicates abnormal termination due to IPC connection loss.
-                    _environment.Exit((int)ExitCodes.GenericFailure);
+                    _environment.Exit((int)ExitCode.GenericFailure);
                 }
 
                 // Reset the current chunk size

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -181,7 +181,7 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     // This is especially important for 'dotnet test', where the user can simply kill the dotnet.exe process themselves.
                     // In that case, we want the MTP process to also die.
                     // Exit code 1 indicates abnormal termination due to IPC connection loss.
-                    _environment.Exit(ExitCodes.GenericFailure);
+                    _environment.Exit((int)ExitCodes.GenericFailure);
                 }
 
                 // Reset the current chunk size

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -129,16 +129,16 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
 
     public int GetProcessExitCode()
     {
-        int exitCode = (int)ExitCodes.Success;
-        exitCode = exitCode == (int)ExitCodes.Success && _policiesService.IsMaxFailedTestsTriggered ? (int)ExitCodes.TestExecutionStoppedForMaxFailedTests : exitCode;
-        exitCode = exitCode == (int)ExitCodes.Success && _testAdapterTestSessionFailure ? (int)ExitCodes.TestAdapterTestSessionFailure : exitCode;
-        exitCode = exitCode == (int)ExitCodes.Success && _failedTestsCount > 0 ? (int)ExitCodes.AtLeastOneTestFailed : exitCode;
-        exitCode = exitCode == (int)ExitCodes.Success && _policiesService.IsAbortTriggered ? (int)ExitCodes.TestSessionAborted : exitCode;
-        exitCode = exitCode == (int)ExitCodes.Success && _totalRanTests == 0 ? (int)ExitCodes.ZeroTests : exitCode;
+        ExitCode exitCode = ExitCode.Success;
+        exitCode = exitCode == ExitCode.Success && _policiesService.IsMaxFailedTestsTriggered ? ExitCode.TestExecutionStoppedForMaxFailedTests : exitCode;
+        exitCode = exitCode == ExitCode.Success && _testAdapterTestSessionFailure ? ExitCode.TestAdapterTestSessionFailure : exitCode;
+        exitCode = exitCode == ExitCode.Success && _failedTestsCount > 0 ? ExitCode.AtLeastOneTestFailed : exitCode;
+        exitCode = exitCode == ExitCode.Success && _policiesService.IsAbortTriggered ? ExitCode.TestSessionAborted : exitCode;
+        exitCode = exitCode == ExitCode.Success && _totalRanTests == 0 ? ExitCode.ZeroTests : exitCode;
 
         if (_commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.MinimumExpectedTestsOptionKey, out string[]? argumentList))
         {
-            exitCode = exitCode == (int)ExitCodes.Success && _totalRanTests < int.Parse(argumentList[0], CultureInfo.InvariantCulture) ? (int)ExitCodes.MinimumExpectedTestsPolicyViolation : exitCode;
+            exitCode = exitCode == ExitCode.Success && _totalRanTests < int.Parse(argumentList[0], CultureInfo.InvariantCulture) ? ExitCode.MinimumExpectedTestsPolicyViolation : exitCode;
         }
 
         // If the user has specified the IgnoreExitCode, then we don't want to return a non-zero exit code if the exit code matches the one specified.
@@ -153,13 +153,13 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
 
         if (exitCodeToIgnore is not null)
         {
-            if (exitCodeToIgnore.Split(';').Any(code => int.TryParse(code, out int parsedExitCode) && parsedExitCode == exitCode))
+            if (exitCodeToIgnore.Split(';').Any(code => int.TryParse(code, out int parsedExitCode) && parsedExitCode == (int)exitCode))
             {
-                exitCode = (int)ExitCodes.Success;
+                exitCode = ExitCode.Success;
             }
         }
 
-        return exitCode;
+        return (int)exitCode;
     }
 
     public async Task SetTestAdapterTestSessionFailureAsync(string errorMessage, CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -129,16 +129,16 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
 
     public int GetProcessExitCode()
     {
-        int exitCode = ExitCodes.Success;
-        exitCode = exitCode == ExitCodes.Success && _policiesService.IsMaxFailedTestsTriggered ? ExitCodes.TestExecutionStoppedForMaxFailedTests : exitCode;
-        exitCode = exitCode == ExitCodes.Success && _testAdapterTestSessionFailure ? ExitCodes.TestAdapterTestSessionFailure : exitCode;
-        exitCode = exitCode == ExitCodes.Success && _failedTestsCount > 0 ? ExitCodes.AtLeastOneTestFailed : exitCode;
-        exitCode = exitCode == ExitCodes.Success && _policiesService.IsAbortTriggered ? ExitCodes.TestSessionAborted : exitCode;
-        exitCode = exitCode == ExitCodes.Success && _totalRanTests == 0 ? ExitCodes.ZeroTests : exitCode;
+        int exitCode = (int)ExitCodes.Success;
+        exitCode = exitCode == (int)ExitCodes.Success && _policiesService.IsMaxFailedTestsTriggered ? (int)ExitCodes.TestExecutionStoppedForMaxFailedTests : exitCode;
+        exitCode = exitCode == (int)ExitCodes.Success && _testAdapterTestSessionFailure ? (int)ExitCodes.TestAdapterTestSessionFailure : exitCode;
+        exitCode = exitCode == (int)ExitCodes.Success && _failedTestsCount > 0 ? (int)ExitCodes.AtLeastOneTestFailed : exitCode;
+        exitCode = exitCode == (int)ExitCodes.Success && _policiesService.IsAbortTriggered ? (int)ExitCodes.TestSessionAborted : exitCode;
+        exitCode = exitCode == (int)ExitCodes.Success && _totalRanTests == 0 ? (int)ExitCodes.ZeroTests : exitCode;
 
         if (_commandLineOptions.TryGetOptionArgumentList(PlatformCommandLineProvider.MinimumExpectedTestsOptionKey, out string[]? argumentList))
         {
-            exitCode = exitCode == ExitCodes.Success && _totalRanTests < int.Parse(argumentList[0], CultureInfo.InvariantCulture) ? ExitCodes.MinimumExpectedTestsPolicyViolation : exitCode;
+            exitCode = exitCode == (int)ExitCodes.Success && _totalRanTests < int.Parse(argumentList[0], CultureInfo.InvariantCulture) ? (int)ExitCodes.MinimumExpectedTestsPolicyViolation : exitCode;
         }
 
         // If the user has specified the IgnoreExitCode, then we don't want to return a non-zero exit code if the exit code matches the one specified.
@@ -155,7 +155,7 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
         {
             if (exitCodeToIgnore.Split(';').Any(code => int.TryParse(code, out int parsedExitCode) && parsedExitCode == exitCode))
             {
-                exitCode = ExitCodes.Success;
+                exitCode = (int)ExitCodes.Success;
             }
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AbortionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AbortionTests.cs
@@ -31,7 +31,7 @@ public sealed class AbortionTests : AcceptanceTestBase<AbortionTests.TestAssetFi
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestSessionAborted);
+        testHostResult.AssertExitCodeIs(ExitCode.TestSessionAborted);
 
         testHostResult.AssertOutputMatchesRegex("Canceling the test session.*");
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyCleanupTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyCleanupTests.cs
@@ -16,7 +16,7 @@ public sealed class AssemblyCleanupTests : AcceptanceTestBase<AssemblyCleanupTes
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 2, skipped: 0);
         testHostResult.AssertOutputContains("""
             TestClass1.Test1.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyResolverTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyResolverTests.cs
@@ -21,7 +21,7 @@ public class AssemblyResolverTests : AcceptanceTestBase<AssemblyResolverTests.Te
 
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationMSTestSettingsTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationMSTestSettingsTests.cs
@@ -20,7 +20,7 @@ public sealed class ConfigurationMSTestSettingsTests : AcceptanceTestBase<Config
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertStandardErrorContains("Both '.runsettings' and '.testconfig.json' files have been detected. Please select only one of these test configuration files.");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationMSTestV2SettingsTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationMSTestV2SettingsTests.cs
@@ -20,7 +20,7 @@ public sealed class ConfigurationMSTestV2SettingsTests : AcceptanceTestBase<Conf
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertStandardErrorContains("Both '.runsettings' and '.testconfig.json' files have been detected. Please select only one of these test configuration files.");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationSettingsTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationSettingsTests.cs
@@ -18,7 +18,7 @@ public sealed class ConfigurationSettingsTests : AcceptanceTestBase<Configuratio
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     [TestMethod]
@@ -29,7 +29,7 @@ public sealed class ConfigurationSettingsTests : AcceptanceTestBase<Configuratio
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     [TestMethod]
@@ -44,7 +44,7 @@ public sealed class ConfigurationSettingsTests : AcceptanceTestBase<Configuratio
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContainsSummary(failed: 1, passed: 1, skipped: 0);
     }
 
@@ -60,7 +60,7 @@ public sealed class ConfigurationSettingsTests : AcceptanceTestBase<Configuratio
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 1);
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CustomAttributesTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CustomAttributesTests.cs
@@ -19,7 +19,7 @@ public sealed class CustomAttributesTests : AcceptanceTestBase<CustomAttributesT
         var testHost = TestHost.LocateFrom(AssetFixture.DuplicateTestMethodProjectPath, TestAssetFixture.DuplicateTestMethodProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContainsSummary(failed: 1, passed: 1, skipped: 0);
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DataSourceTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DataSourceTests.cs
@@ -101,7 +101,7 @@ num1,num2,expectedSum
         var testHost = TestHost.LocateFrom(generator.TargetAssetPath, "DataSourceTests", "net472");
 
         TestHostResult result = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        result.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        result.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         result.AssertOutputContainsSummary(failed: 1, passed: 4, skipped: 0);
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DeploymentItemTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DeploymentItemTests.cs
@@ -21,7 +21,7 @@ public class DeploymentItemTests : AcceptanceTestBase<DeploymentItemTests.TestAs
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetFramework[0]);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runsettings}", cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DuplicateTestClassAttributeTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DuplicateTestClassAttributeTests.cs
@@ -19,7 +19,7 @@ public sealed class DuplicateTestClassAttributeTests : AcceptanceTestBase<Duplic
         var testHost = TestHost.LocateFrom(AssetFixture.DuplicateTestClassProjectPath, TestAssetFixture.DuplicateTestClassProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertStandardErrorContains("Only one attribute of type 'Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute' is allowed, but multiple were found.");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DynamicDataMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DynamicDataMethodTests.cs
@@ -17,7 +17,7 @@ public sealed class DynamicDataMethodTests : AcceptanceTestBase<DynamicDataMetho
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContainsSummary(failed: 3, passed: 9, skipped: 0);
 
         // failed TestMethodSingleParameterIntCountMismatchSmaller (0ms)

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/FrameworkOnlyTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/FrameworkOnlyTests.cs
@@ -25,7 +25,7 @@ public class FrameworkOnlyTests : AcceptanceTestBase<FrameworkOnlyTests.TestAsse
             3,4
             """);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/GenericTestMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/GenericTestMethodTests.cs
@@ -17,7 +17,7 @@ public class GenericTestMethodTests : AcceptanceTestBase<GenericTestMethodTests.
 
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
             """
             failed AMethodWithBadConstraints \(0\) \((\d+s )?\d+ms\)

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -19,7 +19,7 @@ public class HelpInfoTests : AcceptanceTestBase<HelpInfoTests.TestAssetFixture>
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--help", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string wildcardMatchPattern = $"""
 MSTest v{MSTestVersion} (UTC *) [* - *]
@@ -101,7 +101,7 @@ Extension options:
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--info", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string output = $"""
   MSTestExtension

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/IgnoreTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/IgnoreTests.cs
@@ -17,7 +17,7 @@ public sealed class IgnoreTests : AcceptanceTestBase<IgnoreTests.TestAssetFixtur
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --filter ClassName!~TestClassWithAssemblyInitialize", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 11, skipped: 8);
 
         testHostResult.AssertOutputContains("SubClass.Method");
@@ -32,7 +32,7 @@ public sealed class IgnoreTests : AcceptanceTestBase<IgnoreTests.TestAssetFixtur
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --filter TestClassWithAssemblyInitialize", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 0, skipped: 1);
         testHostResult.AssertOutputDoesNotContain("AssemblyInitialize");
         testHostResult.AssertOutputDoesNotContain("AssemblyCleanup");
@@ -45,7 +45,7 @@ public sealed class IgnoreTests : AcceptanceTestBase<IgnoreTests.TestAssetFixtur
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --filter TestClassWithDataSourcesUsingIgnoreMessage", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("TestInitialize: TestMethod1 (0)");
         testHostResult.AssertOutputContains("TestCleanup: TestMethod1 (0)");
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
@@ -44,12 +44,12 @@ public sealed class InconclusiveTests : AcceptanceTestBase<InconclusiveTests.Tes
 
         if (inconclusiveStep >= Lifecycle.ClassCleanup)
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+            testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
             testHostResult.AssertOutputContainsSummary(failed: 1, passed: 1, skipped: 0);
         }
         else
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+            testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
             testHostResult.AssertOutputContainsSummary(failed: 0, passed: 0, skipped: 1);
         }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/LifecycleTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/LifecycleTests.cs
@@ -17,7 +17,7 @@ public sealed class LifecycleTests : AcceptanceTestBase<LifecycleTests.TestAsset
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 4, skipped: 0);
         // Order is:
         // - Assembly initialize

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MaxFailedTestsExtensionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MaxFailedTestsExtensionTests.cs
@@ -19,7 +19,7 @@ public sealed class MaxFailedTestsExtensionTests : AcceptanceTestBase<MaxFailedT
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--maximum-failed-tests 3", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestExecutionStoppedForMaxFailedTests);
+        testHostResult.AssertExitCodeIs(ExitCode.TestExecutionStoppedForMaxFailedTests);
 
         int total = int.Parse(Regex.Match(testHostResult.StandardOutput, @"total: (\d+)").Groups[1].Value, CultureInfo.InvariantCulture);
 
@@ -30,7 +30,7 @@ public sealed class MaxFailedTestsExtensionTests : AcceptanceTestBase<MaxFailedT
         Assert.IsGreaterThanOrEqualTo(5, total);
 
         testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
 
         total = int.Parse(Regex.Match(testHostResult.StandardOutput, @"total: (\d+)").Groups[1].Value, CultureInfo.InvariantCulture);
         Assert.AreEqual(12, total);

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedDataRowTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedDataRowTests.cs
@@ -28,7 +28,7 @@ public sealed class ParameterizedDataRowTests : AcceptanceTestBase<Parameterized
 
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettings}.runsettings --filter ClassName=ParameterizedTestSerializationIssue2390");
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 3, skipped: 0);
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedDataSourceTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedDataSourceTests.cs
@@ -35,7 +35,7 @@ public sealed class ParameterizedDataSourceTests : AcceptanceTestBase<Parameteri
 
         bool isSuccess = isEmptyDataInconclusive.HasValue && isEmptyDataInconclusive.Value;
 
-        testHostResult.AssertExitCodeIs(isSuccess ? ExitCodes.Success : ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(isSuccess ? ExitCode.Success : ExitCode.AtLeastOneTestFailed);
 
         testHostResult.AssertOutputContains(isSuccess ? "skipped Test" : "failed Test");
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedTestTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParameterizedTestTests.cs
@@ -58,7 +58,7 @@ public class ParameterizedTestTests : AcceptanceTestBase<ParameterizedTestTests.
         // progress causes flakiness. See https://github.com/microsoft/testfx/pull/4930#issuecomment-2648506466
         testHostResult = await testHost.ExecuteAsync("--filter ClassName=TestDataRowTests --no-progress", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 9, skipped: 15);
         // If this assert fails with difference showing only missing double quotes, then we are using the wrong value
         // of DynamicDataAttribute.TestIdGenerationStrategy.
@@ -107,7 +107,7 @@ public class ParameterizedTestTests : AcceptanceTestBase<ParameterizedTestTests.
 
         bool isSuccess = isEmptyDataInconclusive.HasValue && isEmptyDataInconclusive.Value;
 
-        testHostResult.AssertExitCodeIs(isSuccess ? ExitCodes.Success : ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(isSuccess ? ExitCode.Success : ExitCode.AtLeastOneTestFailed);
 
         testHostResult.AssertOutputContains(isSuccess ? "skipped Test" : "failed Test");
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RetryTests.cs
@@ -16,7 +16,7 @@ public sealed class RetryTests : AcceptanceTestBase<RetryTests.TestAssetFixture>
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("""
             TestMethod1 executed 1 time.
             TestMethod2 executed 2 times.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -226,7 +226,7 @@ namespace MSTestSdkTest
             testHostResult.AssertOutputContainsSummary(0, 1, 0);
 
             testHostResult = await testHost.ExecuteAsync(command: invalidCommandLineArg, cancellationToken: TestContext.CancellationToken);
-            Assert.AreEqual((int)ExitCodes.InvalidCommandLine, testHostResult.ExitCode);
+            testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         }
     }
 
@@ -283,7 +283,7 @@ namespace MSTestSdkTest
             }
             else
             {
-                Assert.AreEqual((int)ExitCodes.InvalidCommandLine, testHostResult.ExitCode);
+                testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
             }
         }
     }
@@ -329,7 +329,7 @@ namespace MSTestSdkTest
         var testHost = TestHost.LocateFrom(testAsset.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent, verb: Verb.publish);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(0, 1, 0);
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -226,7 +226,7 @@ namespace MSTestSdkTest
             testHostResult.AssertOutputContainsSummary(0, 1, 0);
 
             testHostResult = await testHost.ExecuteAsync(command: invalidCommandLineArg, cancellationToken: TestContext.CancellationToken);
-            Assert.AreEqual(ExitCodes.InvalidCommandLine, testHostResult.ExitCode);
+            Assert.AreEqual((int)ExitCodes.InvalidCommandLine, testHostResult.ExitCode);
         }
     }
 
@@ -283,7 +283,7 @@ namespace MSTestSdkTest
             }
             else
             {
-                Assert.AreEqual(ExitCodes.InvalidCommandLine, testHostResult.ExitCode);
+                Assert.AreEqual((int)ExitCodes.InvalidCommandLine, testHostResult.ExitCode);
             }
         }
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ShowOutputOptionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ShowOutputOptionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -72,7 +72,7 @@ public sealed class ShowOutputOptionTests : AcceptanceTestBase<ShowOutputOptionT
             "--show-stdout invalid",
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertOutputContains("--show-stdout and --show-stderr expect a single parameter with value 'All', 'Failed', or 'None'.");
     }
 
@@ -138,7 +138,7 @@ public sealed class ShowOutputOptionTests : AcceptanceTestBase<ShowOutputOptionT
             "--show-stderr invalid",
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertOutputContains("--show-stdout and --show-stderr expect a single parameter with value 'All', 'Failed', or 'None'.");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SoftAssertionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SoftAssertionTests.cs
@@ -16,7 +16,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ScopeWithNoFailures", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
     }
 
@@ -26,7 +26,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ScopeWithSingleFailure", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
             """failed ScopeWithSingleFailure \(\d+ms\)[\s\S]+Assert\.AreEqual failed\. Expected:<1>\. Actual:<2>\.[\s\S]+at UnitTest1\.ScopeWithSingleFailure\(\)""");
     }
@@ -37,7 +37,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ScopeWithMultipleFailures", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         // Validate the output includes the aggregate message and that inner exception stack traces
         // point to the test method (assertion call site).
         testHostResult.AssertOutputMatchesRegex(
@@ -50,7 +50,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter AssertFailIsHardFailure", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         // Assert.Fail is a hard assertion — it throws immediately, even within a scope.
         // The second Assert.Fail should not be reached.
         testHostResult.AssertOutputMatchesRegex(
@@ -64,7 +64,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter SoftFailureFollowedByException", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
             """failed SoftFailureFollowedByException \(\d+ms\)[\s\S]+at UnitTest1\.SoftFailureFollowedByException\(\)""");
     }
@@ -75,7 +75,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ScopeWithIsNotNullSoftFailure", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
             """failed ScopeWithIsNotNullSoftFailure \(\d+ms\)[\s\S]+Assert\.IsNotNull failed\.[\s\S]+at UnitTest1\.ScopeWithIsNotNullSoftFailure\(\)""");
     }
@@ -86,7 +86,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter IndependentTest", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestDiscoveryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestDiscoveryTests.cs
@@ -20,7 +20,7 @@ public class TestDiscoveryTests : AcceptanceTestBase<TestDiscoveryTests.TestAsse
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("Test1");
         testHostResult.AssertOutputContains("Test2");
         testHostResult.AssertOutputContains("Display name: 1, one");
@@ -35,7 +35,7 @@ public class TestDiscoveryTests : AcceptanceTestBase<TestDiscoveryTests.TestAsse
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests --filter Name=Test1", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("Test1");
         testHostResult.AssertOutputDoesNotContain("Test2");
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestDiscoveryWarningsTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestDiscoveryWarningsTests.cs
@@ -27,7 +27,7 @@ public class TestDiscoveryWarningsTests : AcceptanceTestBase<TestDiscoveryWarnin
             // We check for appdomain directly in the test, so if tests fail we did not run in appdomain.
             TestHostResult testHostSuccessResult = await testHost.ExecuteAsync("--settings AppDomainEnabled.runsettings", cancellationToken: TestContext.CancellationToken);
 
-            testHostSuccessResult.AssertExitCodeIs(ExitCodes.Success);
+            testHostSuccessResult.AssertExitCodeIs(ExitCode.Success);
         }
 
         // Delete the TestDiscoveryWarningsBaseClass.dll from the test bin folder on purpose, to break discovering
@@ -36,7 +36,7 @@ public class TestDiscoveryWarningsTests : AcceptanceTestBase<TestDiscoveryWarnin
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         if (isNetFx)
         {
             testHostResult.AssertStandardErrorContains("Could not load file or assembly 'TestDiscoveryWarningsBaseClass, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.");

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestFilterTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestFilterTests.cs
@@ -20,7 +20,7 @@ public class TestFilterTests : AcceptanceTestBase<TestFilterTests.TestAssetFixtu
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter tree=one", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
     }
 
@@ -32,7 +32,7 @@ public class TestFilterTests : AcceptanceTestBase<TestFilterTests.TestAssetFixtu
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter tree=one --list-tests", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputMatchesRegex("""
   Test2
 Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
@@ -62,25 +62,25 @@ Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         testHostResult.AssertOutputContains("Running test: CategoryAOnly");
         testHostResult.AssertOutputDoesNotContain("Running test: CategoryBOnly");
         testHostResult.AssertOutputContains("Running test: CategoryAAndB");
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult = await testHost.ExecuteAsync("--settings NoFilter.runsettings", cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertOutputContains("Running test: CategoryAOnly");
         testHostResult.AssertOutputContains("Running test: CategoryBOnly");
         testHostResult.AssertOutputContains("Running test: CategoryAAndB");
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult = await testHost.ExecuteAsync("--settings CategoryA.runsettings --filter TestCategory~CategoryA", cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertOutputContains("Running test: CategoryAOnly");
         testHostResult.AssertOutputDoesNotContain("Running test: CategoryBOnly");
         testHostResult.AssertOutputContains("Running test: CategoryAAndB");
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult = await testHost.ExecuteAsync("--settings CategoryA.runsettings --filter TestCategory~CategoryB", cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertOutputDoesNotContain("Running test: CategoryAOnly");
         testHostResult.AssertOutputDoesNotContain("Running test: CategoryBOnly");
         testHostResult.AssertOutputContains("Running test: CategoryAAndB");
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutCooperativeTestMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutCooperativeTestMethodTests.cs
@@ -22,7 +22,7 @@ public sealed class TimeoutCooperativeTestMethodTests : AcceptanceTestBase<Timeo
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test 'TestMethod' timed out after 1000ms");
     }
 
@@ -38,7 +38,7 @@ public sealed class TimeoutCooperativeTestMethodTests : AcceptanceTestBase<Timeo
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test initialize method 'TimeoutTest.UnitTest1.TestInit' timed out after 1000ms");
     }
 
@@ -54,7 +54,7 @@ public sealed class TimeoutCooperativeTestMethodTests : AcceptanceTestBase<Timeo
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test cleanup method 'TimeoutTest.UnitTest1.TestCleanup' timed out after 1000ms");
     }
 
@@ -70,7 +70,7 @@ public sealed class TimeoutCooperativeTestMethodTests : AcceptanceTestBase<Timeo
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test 'TestMethod' timed out after 1000ms");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutTestMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutTestMethodTests.cs
@@ -22,7 +22,7 @@ public sealed class TimeoutTestMethodTests : AcceptanceTestBase<TimeoutTestMetho
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test 'TestMethod' timed out after 1000ms");
     }
 
@@ -38,7 +38,7 @@ public sealed class TimeoutTestMethodTests : AcceptanceTestBase<TimeoutTestMetho
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test 'TestMethod' timed out after 1000ms");
     }
 
@@ -54,7 +54,7 @@ public sealed class TimeoutTestMethodTests : AcceptanceTestBase<TimeoutTestMetho
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test 'TestMethod' timed out after 1000ms");
     }
 
@@ -70,7 +70,7 @@ public sealed class TimeoutTestMethodTests : AcceptanceTestBase<TimeoutTestMetho
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputContains("Test 'TestMethod' timed out after 1000ms");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutTests.cs
@@ -17,7 +17,7 @@ public sealed class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixt
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 5", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'timeout' option should have one argument as string in the format <value>[h|m|s] where 'value' is float");
     }
 
@@ -28,7 +28,7 @@ public sealed class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixt
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 5y", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'timeout' option should have one argument as string in the format <value>[h|m|s] where 'value' is float");
     }
 
@@ -39,7 +39,7 @@ public sealed class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixt
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 5h6m", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'timeout' option should have one argument as string in the format <value>[h|m|s] where 'value' is float");
     }
 
@@ -50,7 +50,7 @@ public sealed class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixt
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 1s", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertOutputContains("Canceling the test session");
     }
 
@@ -61,7 +61,7 @@ public sealed class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixt
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 30s", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult.AssertOutputDoesNotContain("Canceling the test session");
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrxReportTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrxReportTests.cs
@@ -18,7 +18,7 @@ public sealed class TrxReportTests : AcceptanceTestBase<TrxReportTests.TestAsset
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {fileName}.trx", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
 
         string trxFile = Directory.GetFiles(testHost.DirectoryName, $"{fileName}.trx", SearchOption.AllDirectories).Single();
         string trxContent = File.ReadAllText(trxFile);

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TupleDynamicDataTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TupleDynamicDataTests.cs
@@ -18,7 +18,7 @@ public sealed class TupleDynamicDataTests : AcceptanceTestBase<TupleDynamicDataT
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ClassName=CanUseLongTuplesAndValueTuplesForAllFrameworks --settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("""
             1, 2, 3, 4, 5, 6, 7, 8
             9, 10, 11, 12, 13, 14, 15, 16
@@ -44,7 +44,7 @@ public sealed class TupleDynamicDataTests : AcceptanceTestBase<TupleDynamicDataT
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter ClassName=TupleSupportDoesNotBreakObjectArraySupport --settings my.runsettings", cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("""
             Length: 1
             (Hello, World)

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WinUITests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WinUITests.cs
@@ -20,7 +20,7 @@ public sealed class WinUITests : AcceptanceTestBase<WinUITests.TestAssetFixture>
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
         // Assert
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/AbortionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/AbortionTests.cs
@@ -19,7 +19,7 @@ public class AbortionTests : AcceptanceTestBase<AbortionTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestSessionAborted);
+        testHostResult.AssertExitCodeIs(ExitCode.TestSessionAborted);
 
         // We don't assert "Canceling the test session" message.
         // Cancellation could happen very first that we didn't have the opportunity to write this message.

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ConsoleTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ConsoleTests.cs
@@ -49,7 +49,7 @@ public class ConsoleTests : AcceptanceTestBase<ConsoleTests.TestAssetFixture>
             $"\"{testHost.FullName}\" --ignore-exit-code 8",
             cancellationToken: TestContext.CancellationToken);
 
-        Assert.AreEqual(ExitCodes.Success, exitCode);
+        Assert.AreEqual((int)ExitCodes.Success, exitCode);
         Assert.Contains("Slowest 10 tests", commandLine.StandardOutput);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ConsoleTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ConsoleTests.cs
@@ -49,7 +49,7 @@ public class ConsoleTests : AcceptanceTestBase<ConsoleTests.TestAssetFixture>
             $"\"{testHost.FullName}\" --ignore-exit-code 8",
             cancellationToken: TestContext.CancellationToken);
 
-        Assert.AreEqual((int)ExitCodes.Success, exitCode);
+        Assert.AreEqual((int)ExitCode.Success, exitCode);
         Assert.Contains("Slowest 10 tests", commandLine.StandardOutput);
     }
 
@@ -68,7 +68,7 @@ public class ConsoleTests : AcceptanceTestBase<ConsoleTests.TestAssetFixture>
         }
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--ignore-exit-code 8", environmentVariables, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("ABCDEF123");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CrashDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CrashDumpTests.cs
@@ -13,7 +13,7 @@ public sealed class CrashDumpTests : AcceptanceTestBase<CrashDumpTests.TestAsset
         string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "CrashDump", tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--crashdump --results-directory {resultDirectory}", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string? dumpFile = Directory.GetFiles(resultDirectory, "CrashDump_*.dmp", SearchOption.AllDirectories).SingleOrDefault();
         Assert.IsNotNull(dumpFile, $"Dump file not found '{tfm}'\n{testHostResult}'");
     }
@@ -24,7 +24,7 @@ public sealed class CrashDumpTests : AcceptanceTestBase<CrashDumpTests.TestAsset
         string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "CrashDump", TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--crashdump --crashdump-filename customdumpname.dmp --results-directory {resultDirectory}", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         Assert.ContainsSingle(Directory.GetFiles(resultDirectory, "customdumpname.dmp", SearchOption.AllDirectories), $"Dump file not found\n{testHostResult}");
     }
 
@@ -38,7 +38,7 @@ public sealed class CrashDumpTests : AcceptanceTestBase<CrashDumpTests.TestAsset
         string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "CrashDump", TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--crashdump --crashdump-type {format} --results-directory {resultDirectory}", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         string dumpFile = Assert.ContainsSingle(Directory.GetFiles(resultDirectory, "CrashDump_*.dmp", SearchOption.AllDirectories), $"Dump file not found '{format}'\n{testHostResult}");
         File.Delete(dumpFile);
@@ -50,7 +50,7 @@ public sealed class CrashDumpTests : AcceptanceTestBase<CrashDumpTests.TestAsset
         string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "CrashDump", TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--crashdump  --crashdump-type invalid --results-directory {resultDirectory}", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("Option '--crashdump-type' has invalid arguments: 'invalid' is not a valid dump type. Valid options are 'Mini', 'Heap', 'Triage' and 'Full'");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CrashPlusHangDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CrashPlusHangDumpTests.cs
@@ -22,7 +22,7 @@ public sealed class CrashPlusHangDumpTests : AcceptanceTestBase<CrashPlusHangDum
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         testHostResult.AssertOutputMatchesRegex(@"Test host process with PID \'.+\' crashed, a dump file was generated");
         testHostResult.AssertOutputDoesNotContain(@"Hang dump timeout '00:00:08' expired");
 
@@ -46,7 +46,7 @@ public sealed class CrashPlusHangDumpTests : AcceptanceTestBase<CrashPlusHangDum
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         testHostResult.AssertOutputDoesNotMatchRegex(@"Test host process with PID '.+' crashed, a dump file was generated");
         testHostResult.AssertOutputContains(@"Hang dump timeout of '00:00:08' expired");
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CustomBannerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CustomBannerTests.cs
@@ -15,7 +15,7 @@ public class CustomBannerTests : AcceptanceTestBase<CustomBannerTests.TestAssetF
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--no-banner", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain(TestAssetFixture.CustomBannerPrefix);
     }
 
@@ -32,7 +32,7 @@ public class CustomBannerTests : AcceptanceTestBase<CustomBannerTests.TestAssetF
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain(TestAssetFixture.CustomBannerPrefix);
     }
 
@@ -49,7 +49,7 @@ public class CustomBannerTests : AcceptanceTestBase<CustomBannerTests.TestAssetF
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain(TestAssetFixture.CustomBannerPrefix);
     }
 
@@ -60,7 +60,7 @@ public class CustomBannerTests : AcceptanceTestBase<CustomBannerTests.TestAssetF
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputMatchesRegex($"{TestAssetFixture.CustomBannerPrefix} Platform info: Name: Microsoft.Testing.Platform, Version: .+?, Hash: .*?, Date: .+?");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DataConsumerThroughputTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DataConsumerThroughputTests.cs
@@ -18,7 +18,7 @@ public class DataConsumerThroughputTests : AcceptanceTestBase<DataConsumerThroug
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
         stopwatch.Stop();
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
 
         Assert.IsLessThan(7, stopwatch.Elapsed.TotalSeconds, testHostResult.ToString());

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DiagnosticTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DiagnosticTests.cs
@@ -73,7 +73,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic-file-prefix cccc", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'--diagnostic-file-prefix' requires '--diagnostic' to be provided");
     }
 
@@ -84,7 +84,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic-output-directory cccc", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'--diagnostic-output-directory' requires '--diagnostic' to be provided");
     }
 
@@ -95,7 +95,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic-file-prefix aaaa --diagnostic-output-directory cccc", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'--diagnostic-output-directory' requires '--diagnostic' to be provided");
     }
 
@@ -190,17 +190,17 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
                 { EnvironmentVariableConstants.TESTINGPLATFORM_DIAGNOSTIC, "0" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain("Diagnostic file");
 
         testHostResult = await testHost.ExecuteAsync("--diagnostic", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputContains("Diagnostic file");
     }
 
     private static async Task<string> AssertDiagnosticReportWasGeneratedAsync(TestHostResult testHostResult, string diagPathPattern, string level = "Trace", string flushType = "async")
     {
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string outputPattern = $"""
 Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/EnvironmentVariablesConfigurationProviderTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/EnvironmentVariablesConfigurationProviderTests.cs
@@ -14,7 +14,7 @@ public sealed class EnvironmentVariablesConfigurationProviderTests : AcceptanceT
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
     }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -28,14 +28,14 @@ public sealed class EnvironmentVariablesConfigurationProviderTests : AcceptanceT
             {
                 ["MESS_UP_TESTHOST_EXIT_CODE"] = "1",
             }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         testHostResult = await testHost.ExecuteAsync(
             environmentVariables: new()
             {
                 ["MESS_UP_TESTHOST_EXIT_CODE"] = "100",
             }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         testHostResult = await testHost.ExecuteAsync(
             environmentVariables: new()
@@ -43,7 +43,7 @@ public sealed class EnvironmentVariablesConfigurationProviderTests : AcceptanceT
                 ["MESS_UP_TESTHOST_EXIT_CODE"] = "1",
                 ["ZERO_TESTS"] = "1",
             }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         testHostResult = await testHost.ExecuteAsync(
             environmentVariables: new()
@@ -51,7 +51,7 @@ public sealed class EnvironmentVariablesConfigurationProviderTests : AcceptanceT
                 ["MESS_UP_TESTHOST_EXIT_CODE"] = "100",
                 ["ZERO_TESTS"] = "1",
             }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         testHostResult = await testHost.ExecuteAsync(
             environmentVariables: new()
@@ -59,7 +59,7 @@ public sealed class EnvironmentVariablesConfigurationProviderTests : AcceptanceT
                 ["MESS_UP_TESTHOST_EXIT_CODE"] = "8",
                 ["ZERO_TESTS"] = "1",
             }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionRequestCompleteTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionRequestCompleteTests.cs
@@ -16,7 +16,7 @@ public sealed class ExecutionRequestCompleteTests : AcceptanceTestBase<Execution
         var stopwatch = Stopwatch.StartNew();
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
         stopwatch.Stop();
-        Assert.AreEqual((int)ExitCodes.Success, testHostResult.ExitCode);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         Assert.IsGreaterThan(3, stopwatch.Elapsed.TotalSeconds);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionRequestCompleteTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionRequestCompleteTests.cs
@@ -16,7 +16,7 @@ public sealed class ExecutionRequestCompleteTests : AcceptanceTestBase<Execution
         var stopwatch = Stopwatch.StartNew();
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
         stopwatch.Stop();
-        Assert.AreEqual(ExitCodes.Success, testHostResult.ExitCode);
+        Assert.AreEqual((int)ExitCodes.Success, testHostResult.ExitCode);
         Assert.IsGreaterThan(3, stopwatch.Elapsed.TotalSeconds);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -15,7 +15,7 @@ public class ExecutionTests : AcceptanceTestBase<ExecutionTests.TestAssetFixture
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         const string OutputPattern = """
   Test1
@@ -33,7 +33,7 @@ Test discovery summary: found 2 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 2, skipped: 0);
         testHostResult.AssertOutputMatchesRegex($"Passed! - .*\\.(dll|exe) \\(net.+\\|.+\\)");
@@ -46,18 +46,18 @@ Test discovery summary: found 2 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--filter-uid NonExistingUid", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         testHostResult = await testHost.ExecuteAsync("--filter-uid 0", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
 
         testHostResult = await testHost.ExecuteAsync("--filter-uid 1", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
 
         testHostResult = await testHost.ExecuteAsync("--filter-uid 0 --filter-uid 1", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 2, skipped: 0);
     }
 
@@ -68,24 +68,24 @@ Test discovery summary: found 2 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests --filter-uid NonExistingUid", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         testHostResult = await testHost.ExecuteAsync("--list-tests --filter-uid 0", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputMatchesRegex("""
               Test1
             Test discovery summary: found 1 test\(s\)
             """);
 
         testHostResult = await testHost.ExecuteAsync("--list-tests --filter-uid 1", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputMatchesRegex("""
               Test2
             Test discovery summary: found 1 test\(s\)
             """);
 
         testHostResult = await testHost.ExecuteAsync("--list-tests --filter-uid 0 --filter-uid 1", cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputMatchesRegex("""
               Test1
               Test2
@@ -100,7 +100,7 @@ Test discovery summary: found 2 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests --treenode-filter \"<whatever>\"", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         const string OutputPattern = """
   Test1
@@ -117,7 +117,7 @@ Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--treenode-filter \"<whatever>\"", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
         testHostResult.AssertOutputMatchesRegex($"Passed! - .*\\.(dll|exe) \\(net.+\\|.+\\)");
@@ -130,7 +130,7 @@ Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--minimum-expected-tests 2", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 2, skipped: 0);
         testHostResult.AssertOutputMatchesRegex($"Passed! - .*\\.(dll|exe) \\(net.+\\|.+\\)");
@@ -143,7 +143,7 @@ Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--minimum-expected-tests 3", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.MinimumExpectedTestsPolicyViolation);
+        testHostResult.AssertExitCodeIs(ExitCode.MinimumExpectedTestsPolicyViolation);
 
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 2, skipped: 0, minimumNumberOfTests: 3);
         testHostResult.AssertOutputMatchesRegex($" - .*\\.(dll|exe) \\(net.+\\|.+\\)");
@@ -156,7 +156,7 @@ Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--list-tests --minimum-expected-tests 2", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("Error: '--list-tests' and '--minimum-expected-tests' are incompatible options");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ForwardCompatibilityTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ForwardCompatibilityTests.cs
@@ -14,7 +14,7 @@ public class ForwardCompatibilityTests : AcceptanceTestBase<ForwardCompatibility
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--crashdump --hangdump --report-trx --retry-failed-tests 3", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(0, 1, 0);
 
         string testResultsPath = Path.Combine(testHost.DirectoryName, "TestResults");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpOutputTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpOutputTests.cs
@@ -25,7 +25,7 @@ public sealed class HangDumpOutputTests : AcceptanceTestBase<HangDumpOutputTests
                 { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         testHostResult.AssertOutputContains("Test1");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpProcessTreeTests.cs
@@ -20,7 +20,7 @@ public sealed class HangDumpProcessTreeTests : AcceptanceTestBase<HangDumpProces
                 { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
         Assert.HasCount(4, dumpFiles, $"There should be 4 dumps, one for each process in the tree. {testHostResult}");
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
@@ -20,7 +20,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                         { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
         Assert.ContainsSingle(dumpFiles, $"Expected single dump file. Found: {Environment.NewLine}{string.Join(Environment.NewLine, dumpFiles)}{Environment.NewLine}{testHostResult}");
     }
@@ -41,7 +41,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
 
-        testResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
         Assert.ContainsSingle(dumpFiles, $"Expected single dump file. Found: {Environment.NewLine}{string.Join(Environment.NewLine, dumpFiles)}{Environment.NewLine}{testResult}");
     }
@@ -62,7 +62,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
 
-        testResult.AssertExitCodeIs(ExitCodes.Success);
+        testResult.AssertExitCodeIs(ExitCode.Success);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
         Assert.IsEmpty(dumpFiles);
     }
@@ -79,7 +79,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 { "SLEEPTIMEMS1", "4000" },
                 { "SLEEPTIMEMS2", "600000" },
             }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string? dumpFile = Directory.GetFiles(resultDirectory, "myhungdumpfile_*.dmp", SearchOption.AllDirectories).SingleOrDefault();
         Assert.IsNotNull(dumpFile, $"Dump file not found '{TargetFrameworks.NetCurrent}'\n{testHostResult}'");
     }
@@ -99,7 +99,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string? dumpFile = Directory.GetFiles(resultDirectory, "myhungdumpfile_*.dmp", SearchOption.AllDirectories).SingleOrDefault();
         Assert.IsNotNull(dumpFile, $"Dump file not found '{TargetFrameworks.NetCurrent}'\n{testHostResult}'");
     }
@@ -122,7 +122,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         string? dumpFile = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories).SingleOrDefault();
         if (format != "None")
@@ -148,7 +148,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 { "SLEEPTIMEMS2", "600000" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("""
             Option '--hangdump-type' has invalid arguments: 'invalid' is not a valid dump type.
             Valid options are 'Mini', 'Heap', 'Triage', 'None' (only available in .NET 6+) and 'Full'
@@ -169,7 +169,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 { "SPAWN_FOREGROUND_THREAD", "true" },
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "HangDump*.dmp", SearchOption.AllDirectories);
         Assert.ContainsSingle(dumpFiles, $"Expected single dump file. Found: {Environment.NewLine}{string.Join(Environment.NewLine, dumpFiles)}{Environment.NewLine}{testHostResult}");
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -13,7 +13,7 @@ public sealed class HelpInfoAllExtensionsTests : AcceptanceTestBase<HelpInfoAllE
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.AllExtensionsTargetAssetPath, TestAssetFixture.AllExtensionsAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--help", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string wildcardPattern = $"""
 Microsoft.Testing.Platform v*
@@ -120,7 +120,7 @@ Extension options:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.AllExtensionsTargetAssetPath, TestAssetFixture.AllExtensionsAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("-?", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string wildcardPattern = $"""
 Microsoft.Testing.Platform v*
@@ -139,7 +139,7 @@ Options:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.AllExtensionsTargetAssetPath, TestAssetFixture.AllExtensionsAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--info", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string wildcardPattern = $"""
 Microsoft.Testing.Platform v* [*]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -13,7 +13,7 @@ public class HelpInfoTests : AcceptanceTestBase<HelpInfoTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.NoExtensionAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--help", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         const string wildcardMatchPattern = $"""
 Microsoft.Testing.Platform v*
@@ -87,7 +87,7 @@ Extension options:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.NoExtensionAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--?", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         const string wildcardMatchPattern = $"""
 Microsoft.Testing.Platform v*
@@ -108,7 +108,7 @@ Options:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.NoExtensionAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"-{UnknownOption}", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
 
         const string wildcardMatchPattern = $"""
 Microsoft.Testing.Platform v*
@@ -128,7 +128,7 @@ Options:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.NoExtensionAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--info", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string regexMatchPattern = $"""
 Microsoft.Testing.Platform v.+ \[.+\]
@@ -301,7 +301,7 @@ Registered tools:
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--help", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // Verify that TestResults folder was not created
         Assert.IsFalse(Directory.Exists(testResultsPath), "TestResults folder should not be created for help command");
@@ -323,7 +323,7 @@ Registered tools:
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--?", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // Verify that TestResults folder was not created
         Assert.IsFalse(Directory.Exists(testResultsPath), "TestResults folder should not be created for help short name command");
@@ -345,7 +345,7 @@ Registered tools:
 
         TestHostResult testHostResult = await testHost.ExecuteAsync("--info", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // Verify that TestResults folder was not created
         Assert.IsFalse(Directory.Exists(testResultsPath), "TestResults folder should not be created for info command");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
@@ -10,13 +10,13 @@ internal static class AcceptanceAssert
     public static void AssertExitCodeIs(this TestHostResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
-    public static void AssertExitCodeIs(this TestHostResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+    public static void AssertExitCodeIs(this TestHostResult testHostResult, ExitCode exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => AssertExitCodeIs(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
 
     public static void AssertExitCodeIsNot(this TestHostResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreNotEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
-    public static void AssertExitCodeIsNot(this TestHostResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+    public static void AssertExitCodeIsNot(this TestHostResult testHostResult, ExitCode exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => AssertExitCodeIsNot(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
 
     /// <summary>
@@ -98,13 +98,13 @@ internal static class AcceptanceAssert
     public static void AssertExitCodeIs(this DotnetMuxerResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
-    public static void AssertExitCodeIs(this DotnetMuxerResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+    public static void AssertExitCodeIs(this DotnetMuxerResult testHostResult, ExitCode exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => AssertExitCodeIs(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
 
     public static void AssertExitCodeIsNot(this DotnetMuxerResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreNotEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
-    public static void AssertExitCodeIsNot(this DotnetMuxerResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+    public static void AssertExitCodeIsNot(this DotnetMuxerResult testHostResult, ExitCode exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => AssertExitCodeIsNot(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
 
     public static void AssertOutputContains(this DotnetMuxerResult dotnetMuxerResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.Helpers;
+
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 
 internal static class AcceptanceAssert
@@ -8,8 +10,14 @@ internal static class AcceptanceAssert
     public static void AssertExitCodeIs(this TestHostResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
+    public static void AssertExitCodeIs(this TestHostResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+        => AssertExitCodeIs(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
+
     public static void AssertExitCodeIsNot(this TestHostResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreNotEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
+
+    public static void AssertExitCodeIsNot(this TestHostResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+        => AssertExitCodeIsNot(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
 
     /// <summary>
     /// Ensure that the output matches the given pattern. The pattern can use `*` to mean any character, it is internally replaced by `.*` and matched as regex.
@@ -90,8 +98,14 @@ internal static class AcceptanceAssert
     public static void AssertExitCodeIs(this DotnetMuxerResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
+    public static void AssertExitCodeIs(this DotnetMuxerResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+        => AssertExitCodeIs(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
+
     public static void AssertExitCodeIsNot(this DotnetMuxerResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreNotEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
+
+    public static void AssertExitCodeIsNot(this DotnetMuxerResult testHostResult, ExitCodes exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+        => AssertExitCodeIsNot(testHostResult, (int)exitCode, callerMemberName, callerFilePath, callerLineNumber);
 
     public static void AssertOutputContains(this DotnetMuxerResult dotnetMuxerResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.Contains(value, dotnetMuxerResult.StandardOutput, StringComparison.Ordinal, GenerateFailedAssertionMessage(dotnetMuxerResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
@@ -36,7 +36,7 @@ public sealed class LocalizationFailingTests : AcceptanceTestBase<LocalizationFa
             environmentVariables: new() { ["DOTNET_CLI_UI_LANGUAGE"] = "fr" },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
 
         // Verify failure summary is in French ("Résumé de série de tests : Échec!")
         AssertOutputContainsNormalized(testHostResult, "Résumé de série de tests : Échec!");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
@@ -45,7 +45,7 @@ public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetF
             environmentVariables: new() { ["DOTNET_CLI_UI_LANGUAGE"] = "fr" },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // Verify the summary line is in French ("Résumé de série de tests : Réussite!")
         AssertOutputContainsNormalized(testHostResult, "Résumé de série de tests : Réussite!");
@@ -70,7 +70,7 @@ public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetF
             environmentVariables: new() { ["DOTNET_CLI_UI_LANGUAGE"] = "es" },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // Verify the summary line is in Spanish ("Resumen de la serie de pruebas: Correcta!")
         testHostResult.AssertOutputContains("Resumen de la serie de pruebas: Correcta!");
@@ -99,7 +99,7 @@ public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetF
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // French should win because TESTINGPLATFORM_UI_LANGUAGE has higher precedence
         AssertOutputContainsNormalized(testHostResult, "Résumé de série de tests : Réussite!");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
@@ -145,7 +145,7 @@ module MicrosoftTestingPlatformEntryPoint =
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(testAsset.TargetAssetPath, AssetName, tfm, rid: RID, verb: verb, buildConfiguration: compilationMode);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         Assert.Contains("Passed!", testHostResult.StandardOutput);
 
         SL.Target[] coreCompileTargets = binLog.FindChildrenRecursive<SL.Target>().Where(t => t.Name == "CoreCompile" && t.Children.Count > 0).ToArray();
@@ -171,7 +171,7 @@ module MicrosoftTestingPlatformEntryPoint =
 
         testHost = TestInfrastructure.TestHost.LocateFrom(testAsset.TargetAssetPath, AssetName, tfm, rid: RID, verb: verb, buildConfiguration: compilationMode);
         testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        Assert.AreEqual((int)ExitCodes.Success, testHostResult.ExitCode);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         Assert.Contains("Passed!", testHostResult.StandardOutput);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
@@ -171,7 +171,7 @@ module MicrosoftTestingPlatformEntryPoint =
 
         testHost = TestInfrastructure.TestHost.LocateFrom(testAsset.TargetAssetPath, AssetName, tfm, rid: RID, verb: verb, buildConfiguration: compilationMode);
         testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        Assert.AreEqual(ExitCodes.Success, testHostResult.ExitCode);
+        Assert.AreEqual((int)ExitCodes.Success, testHostResult.ExitCode);
         Assert.Contains("Passed!", testHostResult.StandardOutput);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MaxFailedTestsExtensionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MaxFailedTestsExtensionTests.cs
@@ -14,7 +14,7 @@ public class MaxFailedTestsExtensionTests : AcceptanceTestBase<MaxFailedTestsExt
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--maximum-failed-tests 2", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestExecutionStoppedForMaxFailedTests);
+        testHostResult.AssertExitCodeIs(ExitCode.TestExecutionStoppedForMaxFailedTests);
 
         testHostResult.AssertOutputContains("Test session is aborting due to reaching failures ('2') specified by the '--maximum-failed-tests' option.");
         testHostResult.AssertOutputContainsSummary(failed: 3, passed: 3, skipped: 0);
@@ -32,7 +32,7 @@ public class MaxFailedTestsExtensionTests : AcceptanceTestBase<MaxFailedTestsExt
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("The current test framework does not implement 'IGracefulStopTestExecutionCapability' which is required for '--maximum-failed-tests' feature.");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/NoBannerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/NoBannerTests.cs
@@ -16,7 +16,7 @@ public class NoBannerTests : AcceptanceTestBase<NoBannerTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--no-banner", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotMatchRegex(_bannerRegexMatchPattern);
     }
 
@@ -33,7 +33,7 @@ public class NoBannerTests : AcceptanceTestBase<NoBannerTests.TestAssetFixture>
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotMatchRegex(_bannerRegexMatchPattern);
     }
 
@@ -50,7 +50,7 @@ public class NoBannerTests : AcceptanceTestBase<NoBannerTests.TestAssetFixture>
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotMatchRegex(_bannerRegexMatchPattern);
     }
 
@@ -61,7 +61,7 @@ public class NoBannerTests : AcceptanceTestBase<NoBannerTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputMatchesRegex(_bannerRegexMatchPattern);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -40,7 +40,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
 
         if (!failOnly)
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.Success);
+            testHostResult.AssertExitCodeIs(ExitCode.Success);
             testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
@@ -56,7 +56,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         }
         else
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+            testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
             testHostResult.AssertOutputContains("Tests suite failed in all 4 attempts");
             testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 1/4");
             testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 2/4");
@@ -96,14 +96,14 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
 
         if (fail)
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+            testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
             testHostResult.AssertOutputContains("Failure threshold policy is enabled, failed tests will not be restarted.");
             testHostResult.AssertOutputContains("Percentage failed threshold is 50% and 66.67% tests failed (2/3)");
             testHostResult.AssertOutputContains("Failed! -");
         }
         else
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.Success);
+            testHostResult.AssertExitCodeIs(ExitCode.Success);
             testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
@@ -128,14 +128,14 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
 
         if (fail)
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+            testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
             testHostResult.AssertOutputContains("Failure threshold policy is enabled, failed tests will not be restarted.");
             testHostResult.AssertOutputContains("Maximum failed tests threshold is 1 and 2 tests failed");
             testHostResult.AssertOutputContains("Failed! -");
         }
         else
         {
-            testHostResult.AssertExitCodeIs(ExitCodes.Success);
+            testHostResult.AssertExitCodeIs(ExitCode.Success);
             testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
@@ -159,7 +159,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         string[] entries = [.. Directory.GetFiles(resultDirectory, "*.*", SearchOption.AllDirectories).Where(x => !x.Contains("Retries", StringComparison.OrdinalIgnoreCase))];
 
@@ -189,7 +189,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             $"build \"{AssetFixture.TargetAssetPath}\" -c Release -t:DispatchToInnerBuildsWithMTPTestTarget -p:TestingPlatformCommandLineArguments=\"--retry-failed-tests 1 --results-directory %22{resultDirectory}%22\"",
             workingDirectory: AssetFixture.TargetAssetPath, cancellationToken: TestContext.CancellationToken);
 
-        result.AssertExitCodeIs(ExitCodes.Success);
+        result.AssertExitCodeIs(ExitCode.Success);
 
         // File names are on the form: RetryFailedTests_tfm_architecture.log
         string[] logFilesFromInvokeTestingPlatformTask = Directory.GetFiles(resultDirectory, "RetryFailedTests_*_*.log");
@@ -223,7 +223,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             },
             cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
         testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 1/4");
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
@@ -20,7 +20,7 @@ public sealed class TelemetryDisabledTests : AcceptanceTestBase<TelemetryDisable
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string diagContentsPattern =
 """
@@ -34,7 +34,7 @@ public sealed class TelemetryDisabledTests : AcceptanceTestBase<TelemetryDisable
 
     private static async Task<string> AssertDiagnosticReportAsync(TestHostResult testHostResult, string diagPathPattern, string diagContentsPattern, string level = "Trace", string flushType = "async")
     {
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string outputPattern = $"""
 Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -20,7 +20,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string diagContentsPattern =
 """
@@ -48,7 +48,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
             },
             disableTelemetry: false, TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string diagContentsPattern =
 """
@@ -76,7 +76,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
             },
             disableTelemetry: false, TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string diagContentsPattern =
 """
@@ -90,7 +90,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
 
     private static async Task<string> AssertDiagnosticReportAsync(TestHostResult testHostResult, string diagPathPattern, string diagContentsPattern, string level = "Trace", string flushType = "async")
     {
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string outputPattern = $"""
 Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -14,7 +14,7 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         Assert.AreEqual("TestHostProcessLifetimeHandler.BeforeTestHostProcessStartAsync", File.ReadAllText(Path.Combine(testHost.DirectoryName, "BeforeTestHostProcessStartAsync.txt")));
         Assert.AreEqual("TestHostProcessLifetimeHandler.OnTestHostProcessStartedAsync", File.ReadAllText(Path.Combine(testHost.DirectoryName, "OnTestHostProcessStartedAsync.txt")));
         Assert.AreEqual("TestHostProcessLifetimeHandler.OnTestHostProcessExitedAsync", File.ReadAllText(Path.Combine(testHost.DirectoryName, "OnTestHostProcessExitedAsync.txt")));

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TimeoutTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TimeoutTests.cs
@@ -13,7 +13,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 5", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'timeout' option should have one argument as string in the format <value>[h|m|s] where 'value' is float");
     }
 
@@ -24,7 +24,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 5y", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'timeout' option should have one argument as string in the format <value>[h|m|s] where 'value' is float");
     }
 
@@ -35,7 +35,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 5h6m", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("'timeout' option should have one argument as string in the format <value>[h|m|s] where 'value' is float");
     }
 
@@ -46,7 +46,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 1s", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+        testHostResult.AssertExitCodeIsNot(ExitCode.Success);
         testHostResult.AssertOutputContains("Canceling the test session");
     }
 
@@ -57,7 +57,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 12.5s", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain("Canceling the test session");
     }
 
@@ -68,7 +68,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 1m", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain("Canceling the test session");
     }
 
@@ -79,7 +79,7 @@ public class TimeoutTests : AcceptanceTestBase<TimeoutTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.NoExtensionTargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--timeout 1h", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
         testHostResult.AssertOutputDoesNotContain("Canceling the test session");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxDataRowTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxDataRowTests.cs
@@ -22,7 +22,7 @@ public sealed class TrxDataRowTests : AcceptanceTestBase<TrxDataRowTests.TestAss
 
     private async Task AssertTrxReportWasGeneratedAsync(TestHostResult testHostResult, string trxPathPattern, int numberOfTests)
     {
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string outputPattern = $"""
   In process file artifacts produced:

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxFailingTestTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxFailingTestTests.cs
@@ -14,7 +14,7 @@ public sealed class TrxFailingTestTests : AcceptanceTestBase<TrxFailingTestTests
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {fileName}.trx", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.AtLeastOneTestFailed);
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
 
         string[] trxFiles = Directory.GetFiles(testHost.DirectoryName, $"{fileName}.trx", SearchOption.AllDirectories);
         Assert.HasCount(1, trxFiles, $"Expected exactly one trx file but found {trxFiles.Length}: {string.Join(", ", trxFiles)}");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxSkippedTestTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxSkippedTestTests.cs
@@ -14,7 +14,7 @@ public sealed class TrxSkippedTestTests : AcceptanceTestBase<TrxSkippedTestTests
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetNameUsingMSTest, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {fileName}.trx", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string[] trxFiles = Directory.GetFiles(testHost.DirectoryName, $"{fileName}.trx", SearchOption.AllDirectories);
         Assert.HasCount(1, trxFiles, $"Expected exactly one trx file but found {trxFiles.Length}: {string.Join(", ", trxFiles)}");
@@ -37,7 +37,7 @@ public sealed class TrxSkippedTestTests : AcceptanceTestBase<TrxSkippedTestTests
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetNameUsingMSTest, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {fileName}.trx", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.ZeroTests);
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
 
         string[] trxFiles = Directory.GetFiles(testHost.DirectoryName, $"{fileName}.trx", SearchOption.AllDirectories);
         Assert.HasCount(1, trxFiles, $"Expected exactly one trx file but found {trxFiles.Length}: {string.Join(", ", trxFiles)}");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
@@ -13,7 +13,7 @@ public class TrxTests : AcceptanceTestBase<TrxTests.TestAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string outputPattern = """
 Out of process file artifacts produced:
@@ -46,7 +46,7 @@ Out of process file artifacts produced:
             $"--crashdump --report-trx --report-trx-filename {fileName}.trx",
             new() { { "CRASHPROCESS", "1" } }, cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         string[] trxFiles = Directory.GetFiles(testHost.DirectoryName, $"{fileName}.trx", SearchOption.AllDirectories);
         Assert.HasCount(1, trxFiles, $"Expected exactly one trx file but found {trxFiles.Length}: {string.Join(", ", trxFiles)}");
@@ -70,7 +70,7 @@ Out of process file artifacts produced:
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
 
-        result.AssertExitCodeIs(ExitCodes.TestHostProcessExitedNonGracefully);
+        result.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
         string[] trxFiles = Directory.GetFiles(testResultsPath, $"{fileName}.trx", SearchOption.AllDirectories);
         Assert.HasCount(1, trxFiles, $"Expected exactly one trx file but found {trxFiles.Length}: {string.Join(", ", trxFiles)}");
@@ -90,7 +90,7 @@ Out of process file artifacts produced:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {Path.Combine(testResultsPath, "report.trx")}", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("Option '--report-trx-filename' has invalid arguments: file name argument must not contain path (e.g. --report-trx-filename myreport.trx)");
     }
 
@@ -101,7 +101,7 @@ Out of process file artifacts produced:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {Path.Combine("aaa", "report.trx")}", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("Option '--report-trx-filename' has invalid arguments: file name argument must not contain path (e.g. --report-trx-filename myreport.trx)");
     }
 
@@ -112,7 +112,7 @@ Out of process file artifacts produced:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--report-trx-filename report.trx", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("Error: '--report-trx-filename' requires '--report-trx' to be enabled");
     }
 
@@ -124,13 +124,13 @@ Out of process file artifacts produced:
         string reportFileName = $"report-{tfm}.trx";
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {reportFileName}", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         string warningMessage = $"Warning: Trx file '{Path.Combine(testHost.DirectoryName, "TestResults", reportFileName)}' already exists and will be overwritten.";
         testHostResult.AssertOutputDoesNotContain(warningMessage);
 
         testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {reportFileName}", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains(warningMessage);
     }
 
@@ -141,13 +141,13 @@ Out of process file artifacts produced:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--report-trx --list-tests", cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.InvalidCommandLine);
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
         testHostResult.AssertOutputContains("Error: '--report-trx' cannot be enabled when using '--list-tests'");
     }
 
     private async Task AssertTrxReportWasGeneratedAsync(TestHostResult testHostResult, string trxPathPattern, int numberOfTests)
     {
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         string outputPattern = $"""
   In process file artifacts produced:

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TypeForwardingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TypeForwardingTests.cs
@@ -73,7 +73,7 @@ public class TypeForwardingTests : AcceptanceTestBase<NopAssetFixture>
         var testHost = TestInfrastructure.TestHost.LocateFrom($"{testAsset.TargetAssetPath}/ConsoleApp", "ConsoleApp", TargetFrameworks.NetCurrent);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
-        testHostResult.AssertExitCodeIs(ExitCodes.Success);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContains("MyDisplayName");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/UnhandledExceptionPolicyTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/UnhandledExceptionPolicyTests.cs
@@ -46,19 +46,19 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
             case Mode.Enabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": true"));
                 testHostResult = await testHost.ExecuteAsync(null, new() { { "UNOBSERVEDTASKEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException(testhost controller workflow)]");
                 break;
             case Mode.Disabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": false"));
                 testHostResult = await testHost.ExecuteAsync(null, new() { { "UNOBSERVEDTASKEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
-                testHostResult.AssertExitCodeIs(ExitCodes.Success);
+                testHostResult.AssertExitCodeIs(ExitCode.Success);
                 testHostResult.AssertOutputDoesNotContain("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException]");
                 break;
             case Mode.Default:
                 File.Delete(configFileName);
                 testHostResult = await testHost.ExecuteAsync(null, new() { { "UNOBSERVEDTASKEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
-                testHostResult.AssertExitCodeIs(ExitCodes.Success);
+                testHostResult.AssertExitCodeIs(ExitCode.Success);
                 testHostResult.AssertOutputDoesNotContain("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException]");
                 break;
             case Mode.DisabledByEnvironmentVariable:
@@ -71,7 +71,7 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                         { EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION, "0" },
                     },
                     cancellationToken: TestContext.CancellationToken);
-                testHostResult.AssertExitCodeIs(ExitCodes.Success);
+                testHostResult.AssertExitCodeIs(ExitCode.Success);
                 testHostResult.AssertOutputDoesNotContain("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException]");
                 break;
             case Mode.EnabledByEnvironmentVariable:
@@ -84,7 +84,7 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                         { EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION, "1" },
                     },
                     cancellationToken: TestContext.CancellationToken);
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException(testhost controller workflow)]");
                 break;
             default:
@@ -111,18 +111,18 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                 testHostResult = await testHost.ExecuteAsync(null, new() { { "UNHANDLEDEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnCurrentDomainUnhandledException(testhost controller workflow)]");
                 testHostResult.AssertOutputContains("IsTerminating: True");
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.Disabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": false"));
                 testHostResult = await testHost.ExecuteAsync(null, new() { { "UNHANDLEDEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
                 Assert.IsTrue(testHostResult.StandardError.Contains("Unhandled exception", StringComparison.OrdinalIgnoreCase), testHostResult.ToString());
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.Default:
                 File.Delete(configFileName);
                 testHostResult = await testHost.ExecuteAsync(null, new() { { "UNHANDLEDEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.DisabledByEnvironmentVariable:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": true"));
@@ -136,7 +136,7 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                     cancellationToken: TestContext.CancellationToken);
                 Assert.IsTrue(testHostResult.StandardError.Contains("Unhandled exception", StringComparison.OrdinalIgnoreCase), testHostResult.ToString());
                 testHostResult.AssertOutputDoesNotContain("IsTerminating: True");
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.EnabledByEnvironmentVariable:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": false"));
@@ -150,7 +150,7 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                     cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnCurrentDomainUnhandledException(testhost controller workflow)]");
                 testHostResult.AssertOutputContains("IsTerminating: True");
-                testHostResult.AssertExitCodeIsNot(ExitCodes.Success);
+                testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             default:
                 throw new NotImplementedException($"Mode not found '{mode}'");

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
@@ -48,7 +48,7 @@ public sealed class ServerTests
         ITestApplicationCancellationTokenSource stopService = testApplication.ServiceProvider.GetTestApplicationCancellationTokenSource();
 
         stopService.Cancel();
-        Assert.AreEqual((int)ExitCodes.TestSessionAborted, await serverTask);
+        Assert.AreEqual((int)ExitCode.TestSessionAborted, await serverTask);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
@@ -48,7 +48,7 @@ public sealed class ServerTests
         ITestApplicationCancellationTokenSource stopService = testApplication.ServiceProvider.GetTestApplicationCancellationTokenSource();
 
         stopService.Cancel();
-        Assert.AreEqual(ExitCodes.TestSessionAborted, await serverTask);
+        Assert.AreEqual((int)ExitCodes.TestSessionAborted, await serverTask);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
@@ -31,7 +31,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(SkippedTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -46,7 +46,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -62,7 +62,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(testNodeStateProperty),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.AtLeastOneTestFailed, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.AtLeastOneTestFailed, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -91,7 +91,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.TestSessionAborted, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.TestSessionAborted, testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -107,7 +107,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(PassedTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.TestAdapterTestSessionFailure, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.TestAdapterTestSessionFailure, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -139,7 +139,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(InProgressTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.MinimumExpectedTestsPolicyViolation, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.MinimumExpectedTestsPolicyViolation, testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -159,7 +159,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 DisplayName = "DisplayName",
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.ZeroTests, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.ZeroTests, testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -180,20 +180,20 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(DiscoveredTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual(ExitCodes.Success, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCodes.Success, testApplicationResult.GetProcessExitCode());
     }
 
-    [DataRow("8", ExitCodes.Success)]
-    [DataRow("8;2", ExitCodes.Success)]
-    [DataRow("8;", ExitCodes.Success)]
-    [DataRow("8;2;", ExitCodes.Success)]
-    [DataRow("5", ExitCodes.ZeroTests)]
-    [DataRow("5;7", ExitCodes.ZeroTests)]
-    [DataRow("5;", ExitCodes.ZeroTests)]
-    [DataRow("5;7;", ExitCodes.ZeroTests)]
-    [DataRow(";", ExitCodes.ZeroTests)]
-    [DataRow(null, ExitCodes.ZeroTests)]
-    [DataRow("", ExitCodes.ZeroTests)]
+    [DataRow("8", (int)ExitCodes.Success)]
+    [DataRow("8;2", (int)ExitCodes.Success)]
+    [DataRow("8;", (int)ExitCodes.Success)]
+    [DataRow("8;2;", (int)ExitCodes.Success)]
+    [DataRow("5", (int)ExitCodes.ZeroTests)]
+    [DataRow("5;7", (int)ExitCodes.ZeroTests)]
+    [DataRow("5;", (int)ExitCodes.ZeroTests)]
+    [DataRow("5;7;", (int)ExitCodes.ZeroTests)]
+    [DataRow(";", (int)ExitCodes.ZeroTests)]
+    [DataRow(null, (int)ExitCodes.ZeroTests)]
+    [DataRow("", (int)ExitCodes.ZeroTests)]
     [TestMethod]
     public void GetProcessExitCodeAsync_IgnoreExitCodes(string? argument, int expectedExitCode)
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/TestApplicationResultTests.cs
@@ -31,7 +31,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(SkippedTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.ZeroTests, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -46,7 +46,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.ZeroTests, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.ZeroTests, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -62,7 +62,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(testNodeStateProperty),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.AtLeastOneTestFailed, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.AtLeastOneTestFailed, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -91,7 +91,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.TestSessionAborted, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.TestSessionAborted, testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -107,7 +107,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(PassedTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.TestAdapterTestSessionFailure, _testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.TestAdapterTestSessionFailure, _testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -139,7 +139,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(InProgressTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.MinimumExpectedTestsPolicyViolation, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.MinimumExpectedTestsPolicyViolation, testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -159,7 +159,7 @@ public sealed class TestApplicationResultTests : IDisposable
                 DisplayName = "DisplayName",
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.ZeroTests, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.ZeroTests, testApplicationResult.GetProcessExitCode());
     }
 
     [TestMethod]
@@ -180,20 +180,20 @@ public sealed class TestApplicationResultTests : IDisposable
                 Properties = new PropertyBag(DiscoveredTestNodeStateProperty.CachedInstance),
             }), CancellationToken.None);
 
-        Assert.AreEqual((int)ExitCodes.Success, testApplicationResult.GetProcessExitCode());
+        Assert.AreEqual((int)ExitCode.Success, testApplicationResult.GetProcessExitCode());
     }
 
-    [DataRow("8", (int)ExitCodes.Success)]
-    [DataRow("8;2", (int)ExitCodes.Success)]
-    [DataRow("8;", (int)ExitCodes.Success)]
-    [DataRow("8;2;", (int)ExitCodes.Success)]
-    [DataRow("5", (int)ExitCodes.ZeroTests)]
-    [DataRow("5;7", (int)ExitCodes.ZeroTests)]
-    [DataRow("5;", (int)ExitCodes.ZeroTests)]
-    [DataRow("5;7;", (int)ExitCodes.ZeroTests)]
-    [DataRow(";", (int)ExitCodes.ZeroTests)]
-    [DataRow(null, (int)ExitCodes.ZeroTests)]
-    [DataRow("", (int)ExitCodes.ZeroTests)]
+    [DataRow("8", (int)ExitCode.Success)]
+    [DataRow("8;2", (int)ExitCode.Success)]
+    [DataRow("8;", (int)ExitCode.Success)]
+    [DataRow("8;2;", (int)ExitCode.Success)]
+    [DataRow("5", (int)ExitCode.ZeroTests)]
+    [DataRow("5;7", (int)ExitCode.ZeroTests)]
+    [DataRow("5;", (int)ExitCode.ZeroTests)]
+    [DataRow("5;7;", (int)ExitCode.ZeroTests)]
+    [DataRow(";", (int)ExitCode.ZeroTests)]
+    [DataRow(null, (int)ExitCode.ZeroTests)]
+    [DataRow("", (int)ExitCode.ZeroTests)]
     [TestMethod]
     public void GetProcessExitCodeAsync_IgnoreExitCodes(string? argument, int expectedExitCode)
     {


### PR DESCRIPTION
## Summary

Converts the internal `ExitCodes` static class with `public const int` fields to an `internal enum`. This improves type safety, discoverability, and enables `Enum.IsDefined` checks for validating known MTP exit codes.

## Breaking change analysis

**No breaking change**, because:

1. **`const int` values are inlined at compile time** — extensions compiled against the old `static class ExitCodes` have the literal integer values baked into their IL. The consumer assembly has zero runtime reference to the `ExitCodes` type. Verified by disassembling a Consumer.dll — the string "ExitCodes" does not appear.

2. **Runtime verified** — built an old consumer against `static class ExitCodes`, then swapped the library to `enum ExitCodes` without recompiling the consumer. It runs correctly.

3. **Out-of-repo IVT consumers don't use ExitCodes** — checked `MSTest.Engine`, `OpenTelemetry`, `AzureFoundry`, `Platform.AI`, `HotReload`, `CrashDump`, `Telemetry`, `VSTestBridge` — none reference `ExitCodes`.

4. **Source-embedded consumers always recompile** — extensions that DO use `ExitCodes` (Retry, TrxReport, HangDump, MSBuild) embed `ExitCodes.cs` via `<Compile Include>` and compile their own internal copy.

5. **Not in any `PublicAPI.txt`** — `ExitCodes` is `internal`, so no public API surface change.

## Changes

- Converted `ExitCodes` from `internal static class` to `internal enum` (same numeric values)
- Added `(int)` casts at all usage sites in source code
- Added `ExitCodes` enum overloads to `AcceptanceAssert.AssertExitCodeIs`/`AssertExitCodeIsNot` for both `TestHostResult` and `DotnetMuxerResult`
- Added explicit `using Microsoft.Testing.Platform.Helpers` to `AcceptanceAssert.cs` (shared across projects with different global usings)

Fixes #7807