### PR TITLE
[Efficiency Improver] perf: skip PropertyBag construction in BFSTestNodeVisitor when filter has no property expressions

### DIFF
--- a/src/Adapter/MSTest.Engine/Engine/BFSTestNodeVisitor.cs
+++ b/src/Adapter/MSTest.Engine/Engine/BFSTestNodeVisitor.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Testing.Framework;
 internal sealed class BFSTestNodeVisitor
 {
     private static readonly string PathSeparatorString = TreeNodeFilter.PathSeparator.ToString();
+    private static readonly PropertyBag EmptyPropertyBag = new();
 
     private readonly IEnumerable<TestNode> _rootTestNodes;
     private readonly ITestExecutionFilter _testExecutionFilter;
@@ -72,7 +73,10 @@ internal sealed class BFSTestNodeVisitor
             // When we are filtering as tree filter and the current node does not match the filter, we skip the node and its children.
             if (_testExecutionFilter is TreeNodeFilter treeNodeFilter)
             {
-                if (!treeNodeFilter.MatchesFilter(currentNodeFullPath, CreatePropertyBagForFilter(currentNode.Properties)))
+                PropertyBag filterPropertyBag = treeNodeFilter.ContainsPropertyFilters
+                    ? new PropertyBag(currentNode.Properties)
+                    : EmptyPropertyBag;
+                if (!treeNodeFilter.MatchesFilter(currentNodeFullPath, filterPropertyBag))
                 {
                     continue;
                 }
@@ -98,17 +102,6 @@ internal sealed class BFSTestNodeVisitor
         }
 
         DuplicatedNodes = [.. testNodesByUid.Where(x => x.Value.Count > 1)];
-    }
-
-    private static PropertyBag CreatePropertyBagForFilter(IProperty[] properties)
-    {
-        PropertyBag propertyBag = new();
-        foreach (IProperty property in properties)
-        {
-            propertyBag.Add(property);
-        }
-
-        return propertyBag;
     }
 
     private static string EncodeString(string value)

--- a/src/Adapter/MSTest.Engine/Engine/BFSTestNodeVisitor.cs
+++ b/src/Adapter/MSTest.Engine/Engine/BFSTestNodeVisitor.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Testing.Framework;
 internal sealed class BFSTestNodeVisitor
 {
     private static readonly string PathSeparatorString = TreeNodeFilter.PathSeparator.ToString();
+
+    // Read-only; must never be mutated. Shared across all BFS traversals where ContainsPropertyFilters is false.
     private static readonly PropertyBag EmptyPropertyBag = new();
 
     private readonly IEnumerable<TestNode> _rootTestNodes;

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -26,12 +26,20 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
     {
         Filter = filter ?? throw new ArgumentNullException(nameof(filter));
         _filters = ParseFilter(filter);
+        ContainsPropertyFilters = _filters.Any(HasPropertyFilterExpression);
     }
 
     /// <summary>
     /// Gets the filter string.
     /// </summary>
     public string Filter { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether any filter segment contains a property expression (e.g., <c>Method[Trait=Foo]</c>).
+    /// When <see langword="false"/>, the <see cref="PropertyBag"/> argument to <see cref="MatchesFilter"/> is never
+    /// inspected, and callers may safely pass an empty bag to avoid per-node allocation.
+    /// </summary>
+    internal bool ContainsPropertyFilters { get; }
 
     /// <remarks>
     /// The current grammar for the filter looks as follows:
@@ -578,4 +586,8 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
         => prop is TestMetadataProperty testMetadataProperty &&
             propExpr.Regex.IsMatch(testMetadataProperty.Key) &&
             valueExpr.Regex.IsMatch(testMetadataProperty.Value);
+
+    private static bool HasPropertyFilterExpression(FilterExpression expression)
+        => expression is ValueAndPropertyExpression ||
+           (expression is OperatorExpression op && op.SubExpressions.Any(HasPropertyFilterExpression));
 }

--- a/test/UnitTests/MSTest.Engine.UnitTests/BFSTestNodeVisitorTests.cs
+++ b/test/UnitTests/MSTest.Engine.UnitTests/BFSTestNodeVisitorTests.cs
@@ -245,6 +245,39 @@ public sealed class BFSTestNodeVisitorTests : TestBase
         Assert.AreEqual(typeof(InternalUnsafeActionTestNode), includedTestNodes[6].Node.GetType());
     }
 
+    [TestMethod]
+    public async Task Visit_WhenFilterHasPropertyExpression_OnlyIncludesNodesMatchingProperty()
+    {
+        // Arrange — filter with a property expression (ContainsPropertyFilters == true)
+        var nodeWithMatchingTag = new TestNode
+        {
+            StableUid = "ID1",
+            DisplayName = "A",
+            Properties = [new TestMetadataProperty("Tag", "Fast")],
+        };
+        var nodeWithNonMatchingTag = new TestNode
+        {
+            StableUid = "ID2",
+            DisplayName = "A",
+            Properties = [new TestMetadataProperty("Tag", "Slow")],
+        };
+
+        var filter = new TreeNodeFilter("/A[Tag=Fast]");
+        var visitor = new BFSTestNodeVisitor(new[] { nodeWithMatchingTag, nodeWithNonMatchingTag }, filter, null!);
+
+        // Act
+        List<TestNode> includedTestNodes = [];
+        await visitor.VisitAsync((testNode, _) =>
+        {
+            includedTestNodes.Add(testNode);
+            return Task.CompletedTask;
+        });
+
+        // Assert
+        Assert.HasCount(1, includedTestNodes);
+        Assert.AreEqual("ID1", includedTestNodes[0].StableUid);
+    }
+
     private static TestNode CreateParameterizedTestNode(string parameterizedTestNode, bool? expansionPropertyValue)
     {
         TestNode rootNode = parameterizedTestNode switch

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
@@ -328,4 +328,18 @@ public sealed class TreeNodeFilterTests
 
     [TestMethod]
     public void MatchAllFilterWithPropertyExpression_DoNotAllowInMiddleOfFilter() => Assert.ThrowsExactly<ArgumentException>(() => _ = new TreeNodeFilter("/**/Path[A=B]"));
+
+    [DataRow("/**", false)]
+    [DataRow("/A/B", false)]
+    [DataRow("/(A|B)", false)]
+    [DataRow("/(A&B)", false)]
+    [DataRow("/*.UnitTests[Tag=Fast]", true)]
+    [DataRow("/**[A=B]", true)]
+    [DataRow("/(A[Tag=Fast]&B)", true)]
+    [TestMethod]
+    public void ContainsPropertyFilters_ReturnsExpectedValue(string filterExpression, bool expected)
+    {
+        TreeNodeFilter filter = new(filterExpression);
+        Assert.AreEqual(expected, filter.ContainsPropertyFilters);
+    }
 }


### PR DESCRIPTION
Add ContainsPropertyFilters to TreeNodeFilter — computed once at parse time. When false, BFSTestNodeVisitor reuses a static empty PropertyBag instead of allocating a new PropertyBag (+ N Property linked-list nodes) per traversed test node.

Proxy metric: heap allocations per test node during BFS traversal with a TreeNodeFilter that contains no [Trait=Value] property conditions (the common case).
  Before: 1 PropertyBag + N Property nodes per node (N = number of properties)
  After:  0 allocations (static empty bag reused)

Fixes #7883