### PR TITLE
[Efficiency Improver] perf: eliminate yield-iterator state machine in PropertyBag.OfType(T)()

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
@@ -274,9 +274,38 @@ public sealed partial class PropertyBag
         }
 
         // We don't want to allocate an array if we know that we're looking for a TestNodeStateProperty
-        return typeof(TestNodeStateProperty).IsAssignableFrom(typeof(TProperty))
+        if (typeof(TestNodeStateProperty).IsAssignableFrom(typeof(TProperty)) || _property is null)
+        {
+            return [];
+        }
+
+        // Direct linked-list walk: avoids allocating a yield-iterator state machine
+        // (the original code called _property.OfType<TProperty>() which uses yield return).
+        TProperty? first = default;
+        bool foundAny = false;
+        List<TProperty>? overflow = null;
+        Property? current = _property;
+        while (current is not null)
+        {
+            if (current.Current is TProperty match)
+            {
+                if (!foundAny)
+                {
+                    first = match;
+                    foundAny = true;
+                }
+                else
+                {
+                    (overflow ??= [first!]).Add(match);
+                }
+            }
+
+            current = current.Next;
+        }
+
+        return !foundAny
             ? []
-            : _property is null ? [] : [.. _property.OfType<TProperty>()];
+            : overflow is not null ? [.. overflow] : [first!];
     }
 
     /// <summary>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/PropertyBagTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/PropertyBagTests.cs
@@ -121,6 +121,33 @@ public sealed class PropertyBagTests
 
         Assert.AreEqual(PassedTestNodeStateProperty.CachedInstance, property.OfType<TestNodeStateProperty>().Single());
         Assert.HasCount(2, property.OfType<DummyProperty>());
+
+        // No DummyProperty2 in the bag — exercises the "no match found" path in the while-loop
+        Assert.IsEmpty(property.OfType<DummyProperty2>());
+    }
+
+    [TestMethod]
+    public void OfType_WithSingleMatch_ReturnsSingleItemArray()
+    {
+        PropertyBag bag = new();
+        DummyProperty single = new();
+        bag.Add(single);
+        bag.Add(PassedTestNodeStateProperty.CachedInstance);
+
+        DummyProperty[] result = bag.OfType<DummyProperty>();
+
+        Assert.HasCount(1, result);
+        Assert.AreSame(single, result[0]);
+    }
+
+    [TestMethod]
+    public void OfType_WithOnlyTestNodeStateProperty_ReturnsEmpty()
+    {
+        PropertyBag property = new();
+        property.Add(PassedTestNodeStateProperty.CachedInstance);
+
+        // _property is null; _testNodeStateProperty is set — exercises the new early-return path
+        Assert.IsEmpty(property.OfType<DummyProperty>());
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/PropertyBagTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/PropertyBagTests.cs
@@ -129,15 +129,15 @@ public sealed class PropertyBagTests
     [TestMethod]
     public void OfType_WithSingleMatch_ReturnsSingleItemArray()
     {
-        PropertyBag bag = new();
-        DummyProperty single = new();
-        bag.Add(single);
-        bag.Add(PassedTestNodeStateProperty.CachedInstance);
+        PropertyBag property = new();
+        DummyProperty singleProperty = new();
+        property.Add(singleProperty);
+        property.Add(PassedTestNodeStateProperty.CachedInstance);
 
-        DummyProperty[] result = bag.OfType<DummyProperty>();
+        DummyProperty[] result = property.OfType<DummyProperty>();
 
         Assert.HasCount(1, result);
-        Assert.AreSame(single, result[0]);
+        Assert.AreSame(singleProperty, result[0]);
     }
 
     [TestMethod]


### PR DESCRIPTION
Replace the yield-based iterator from Property.OfType<TProperty>() with a direct linked-list walk inside PropertyBag.OfType<TProperty>().

Before: _property.OfType<TProperty>() (yield return) allocates one state- machine heap object per call, even when no matching property is found.

After: direct while-loop walk; no state-machine allocated; returns [] for the common case (no matching property) with zero heap allocations beyond the empty array constant.

Fixes  #7914