### PR TITLE
[Lean Squad] feat(ci): Task 9 — fix elan SHA256, cache ordering, conditional lake update, proof summary

### DIFF
--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -38,8 +38,20 @@ jobs:
             echo "Found ${LEAN_COUNT} .lean file(s). Proceeding with build."
           fi
 
-      - name: Install elan (Lean version manager)
+      - name: Restore elan + Lake cache
+        id: restore-cache
         if: steps.check-lean-files.outputs.lean_count != '0'
+        uses: actions/cache@v4
+        with:
+          path: |
+            formal-verification/lean/.lake
+            ~/.elan
+          key: lean-${{ runner.os }}-${{ hashFiles('formal-verification/lean/lean-toolchain', 'formal-verification/lean/lakefile.toml', 'formal-verification/lean/lake-manifest.json') }}
+          restore-keys: |
+            lean-${{ runner.os }}-
+
+      - name: Install elan (Lean version manager)
+        if: steps.check-lean-files.outputs.lean_count != '0' && steps.restore-cache.outputs.cache-hit != 'true'
         run: |
           ELAN_VERSION="v4.2.1"
           ELAN_TARGET="x86_64-unknown-linux-gnu"
@@ -61,9 +73,13 @@ jobs:
             exit 1
           fi
 
+          # Download elan archive and its SHA-256 checksum from GitHub Releases.
+          # The checksum is fetched from the same release to avoid hardcoding a
+          # version-specific hash that would silently mismatch on elan upgrades.
           curl -sSfL "${ELAN_BASE_URL}/${ELAN_ARCHIVE}" -o "${ELAN_TMP_DIR}/${ELAN_ARCHIVE}"
+          curl -sSfL "${ELAN_BASE_URL}/${ELAN_ARCHIVE}.sha256" -o "${ELAN_TMP_DIR}/${ELAN_ARCHIVE}.sha256"
           cd "${ELAN_TMP_DIR}"
-          echo "4e717523217af592fa2d7b9c479410a31816c065d66ccbf0c2149337cfec0f5c  ${ELAN_ARCHIVE}" | sha256sum -c -
+          sha256sum -c "${ELAN_ARCHIVE}.sha256"
           tar -xzf "${ELAN_ARCHIVE}"
           ./elan-init -y --default-toolchain "${LEAN_TOOLCHAIN}"
           rm -rf "${ELAN_TMP_DIR}"
@@ -76,19 +92,8 @@ jobs:
         if: steps.check-lean-files.outputs.lean_count != '0'
         run: lean --version
 
-      - name: Cache Lean / Lake build artifacts
-        if: steps.check-lean-files.outputs.lean_count != '0'
-        uses: actions/cache@v4
-        with:
-          path: |
-            formal-verification/lean/.lake
-            ~/.elan
-          key: lean-${{ runner.os }}-${{ hashFiles('formal-verification/lean/lean-toolchain', 'formal-verification/lean/lakefile.toml', 'formal-verification/lean/lake-manifest.json') }}
-          restore-keys: |
-            lean-${{ runner.os }}-
-
       - name: Resolve Lean dependencies
-        if: steps.check-lean-files.outputs.lean_count != '0'
+        if: steps.check-lean-files.outputs.lean_count != '0' && steps.restore-cache.outputs.cache-hit != 'true'
         working-directory: formal-verification/lean
         run: lake update
 
@@ -96,3 +101,19 @@ jobs:
         if: steps.check-lean-files.outputs.lean_count != '0'
         working-directory: formal-verification/lean
         run: lake build
+
+      - name: Proof summary
+        if: steps.check-lean-files.outputs.lean_count != '0'
+        run: |
+          LEAN_DIR="formal-verification/lean/FVSquad"
+          THEOREM_COUNT=$(grep -rEc '^(theorem|lemma) ' "${LEAN_DIR}" --include='*.lean' 2>/dev/null || echo 0)
+          SORRY_COUNT=$(grep -rc '\bsorry\b' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
+            | awk -F: '{sum += $2} END {print sum+0}')
+          {
+            echo "## 🔬 Lean Proof Summary"
+            echo ""
+            echo "| Metric | Count |"
+            echo "|--------|-------|"
+            echo "| Theorems / Lemmas declared | ${THEOREM_COUNT} |"
+            echo "| Lines containing \`sorry\` (stubs) | ${SORRY_COUNT} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -46,7 +46,7 @@ jobs:
           path: |
             formal-verification/lean/.lake
             ~/.elan
-          key: lean-${{ runner.os }}-${{ hashFiles('formal-verification/lean/lean-toolchain', 'formal-verification/lean/lakefile.toml', 'formal-verification/lean/lake-manifest.json') }}
+          key: lean-${{ runner.os }}-${{ hashFiles('formal-verification/lean/lean-toolchain', 'formal-verification/lean/lakefile.toml') }}
           restore-keys: |
             lean-${{ runner.os }}-
 
@@ -107,7 +107,7 @@ jobs:
         run: |
           LEAN_DIR="formal-verification/lean/FVSquad"
           THEOREM_COUNT=$(grep -rEc '^(theorem|lemma) ' "${LEAN_DIR}" --include='*.lean' 2>/dev/null || echo 0)
-          SORRY_COUNT=$(grep -rc '\bsorry\b' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
+          SORRY_COUNT=$(grep -rc '\<sorry\>' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
             | awk -F: '{sum += $2} END {print sum+0}')
           {
             echo "## 🔬 Lean Proof Summary"


### PR DESCRIPTION
Improvements to lean-proofs.yml:

1. Fix SHA256 verification bug: the previous workflow hardcoded the SHA256
   hash from elan v3.1.0 but was downloading v4.2.1. The verification step
   would always fail once .lean files are committed. Now the SHA256 checksum
   file is downloaded from the same GitHub release and used for verification,
   so upgrading elan requires only a version bump.

2. Cache-before-install ordering: move the cache restore step to before the
   elan install step. Both elan install and lake update are now gated on
   cache-hit != 'true', so cold builds install/resolve while warm builds skip
   straight to lake build.

3. Conditional lake update: previously lake update ran unconditionally on
   every CI run, potentially drifting the pinned lake-manifest.json. Now it
   only runs on cache miss (i.e. the first run per toolchain/lakefile hash).

4. Proof summary step: after a successful build, post a markdown summary to
   the GitHub Actions step summary showing theorem/lemma count and the number
   of lines using sorry (stub markers).

🔬 Lean Squad — automated formal verification agent
Run: https://github.com/microsoft/testfx/actions/runs/25043800787

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #7902