### PR TITLE
Fix log accumulation across DynamicData test invocations

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
@@ -458,9 +458,9 @@ internal sealed class TestClassInfo
             {
                 // Assembly initialize and class initialize logs are pre-pended to the first result.
                 var testContextImpl = testContext as TestContextImplementation;
-                result.LogOutput = initializationLogs + testContextImpl?.GetOut();
-                result.LogError = initializationErrorLogs + testContextImpl?.GetErr();
-                result.DebugTrace = initializationTrace + testContextImpl?.GetTrace();
+                result.LogOutput = initializationLogs + testContextImpl?.GetAndClearOutput();
+                result.LogError = initializationErrorLogs + testContextImpl?.GetAndClearError();
+                result.DebugTrace = initializationTrace + testContextImpl?.GetAndClearTrace();
                 result.TestContextMessages = initializationTestContextMessages + testContext.GetAndClearDiagnosticMessages();
             }
 
@@ -680,9 +680,9 @@ internal sealed class TestClassInfo
                     Outcome = UnitTestOutcome.Failed,
                     DisplayName = $"[{ClassType.FullName} ClassCleanup]",
                     TestFailureException = ex,
-                    LogOutput = testContextImpl?.GetOut(),
-                    LogError = testContextImpl?.GetErr(),
-                    DebugTrace = testContextImpl?.GetTrace(),
+                    LogOutput = testContextImpl?.GetAndClearOutput(),
+                    LogError = testContextImpl?.GetAndClearError(),
+                    DebugTrace = testContextImpl?.GetAndClearTrace(),
                     TestContextMessages = testContext.GetAndClearDiagnosticMessages(),
                 };
             }
@@ -690,9 +690,9 @@ internal sealed class TestClassInfo
             if (results.Length > 0)
             {
                 TestResult lastResult = results[results.Length - 1];
-                lastResult.LogOutput += testContextImpl?.GetOut();
-                lastResult.LogError += testContextImpl?.GetErr();
-                lastResult.DebugTrace += testContextImpl?.GetTrace();
+                lastResult.LogOutput += testContextImpl?.GetAndClearOutput();
+                lastResult.LogError += testContextImpl?.GetAndClearError();
+                lastResult.DebugTrace += testContextImpl?.GetAndClearTrace();
                 lastResult.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
             }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -148,9 +148,9 @@ internal class TestMethodInfo : ITestMethod
             if (result != null)
             {
                 var testContextImpl = TestContext as TestContextImplementation;
-                result.LogOutput = testContextImpl?.GetOut();
-                result.LogError = testContextImpl?.GetErr();
-                result.DebugTrace = testContextImpl?.GetTrace();
+                result.LogOutput = testContextImpl?.GetAndClearOutput();
+                result.LogError = testContextImpl?.GetAndClearError();
+                result.DebugTrace = testContextImpl?.GetAndClearTrace();
                 result.TestContextMessages = TestContext?.GetAndClearDiagnosticMessages();
                 result.ResultFiles = TestContext?.GetResultFiles();
                 result.Duration = watch.Elapsed;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -265,9 +265,9 @@ internal sealed class UnitTestRunner : MarshalByRefObject
         finally
         {
             var testContextImpl = testContext.Context as TestContextImplementation;
-            result!.LogOutput = testContextImpl?.GetOut();
-            result.LogError = testContextImpl?.GetErr();
-            result.DebugTrace = testContextImpl?.GetTrace();
+            result!.LogOutput = testContextImpl?.GetAndClearOutput();
+            result.LogError = testContextImpl?.GetAndClearError();
+            result.DebugTrace = testContextImpl?.GetAndClearTrace();
             result.TestContextMessages = testContext.GetAndClearDiagnosticMessages();
         }
 
@@ -288,9 +288,9 @@ internal sealed class UnitTestRunner : MarshalByRefObject
                 {
                     Outcome = UnitTestOutcome.Failed,
                     TestFailureException = ex,
-                    LogOutput = testContextImpl?.GetOut(),
-                    LogError = testContextImpl?.GetErr(),
-                    DebugTrace = testContextImpl?.GetTrace(),
+                    LogOutput = testContextImpl?.GetAndClearOutput(),
+                    LogError = testContextImpl?.GetAndClearError(),
+                    DebugTrace = testContextImpl?.GetAndClearTrace(),
                     TestContextMessages = testContext.GetAndClearDiagnosticMessages(),
                 };
             }
@@ -298,9 +298,9 @@ internal sealed class UnitTestRunner : MarshalByRefObject
             if (results.Length > 0)
             {
                 TestResult lastResult = results[results.Length - 1];
-                lastResult.LogOutput += testContextImpl?.GetOut();
-                lastResult.LogError += testContextImpl?.GetErr();
-                lastResult.DebugTrace += testContextImpl?.GetTrace();
+                lastResult.LogOutput += testContextImpl?.GetAndClearOutput();
+                lastResult.LogError += testContextImpl?.GetAndClearError();
+                lastResult.DebugTrace += testContextImpl?.GetAndClearTrace();
                 lastResult.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
             }
         }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -380,12 +380,27 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
         return _testContextMessageStringBuilder;
     }
 
-    internal string? GetOut()
-        => _stdOutStringBuilder?.ToString();
+    internal string? GetAndClearOutput()
+    {
+        string? output = _stdOutStringBuilder?.ToString();
+        _stdOutStringBuilder?.Clear();
 
-    internal string? GetErr()
-        => _stdErrStringBuilder?.ToString();
+        return output;
+    }
 
-    internal string? GetTrace()
-        => _traceStringBuilder?.ToString();
+    internal string? GetAndClearError()
+    {
+        string? error = _stdErrStringBuilder?.ToString();
+        _stdErrStringBuilder?.Clear();
+
+        return error;
+    }
+
+    internal string? GetAndClearTrace()
+    {
+        string? trace = _traceStringBuilder?.ToString();
+        _traceStringBuilder?.Clear();
+
+        return trace;
+    }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -47,6 +47,15 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
             => _builder.Clear();
 
         [MethodImpl(MethodImplOptions.Synchronized)]
+        internal string GetAndClear()
+        {
+            string result = _builder.ToString();
+            _builder.Clear();
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public override string ToString()
             => _builder.ToString();
     }
@@ -381,26 +390,11 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     }
 
     internal string? GetAndClearOutput()
-    {
-        string? output = _stdOutStringBuilder?.ToString();
-        _stdOutStringBuilder?.Clear();
-
-        return output;
-    }
+        => _stdOutStringBuilder?.GetAndClear();
 
     internal string? GetAndClearError()
-    {
-        string? error = _stdErrStringBuilder?.ToString();
-        _stdErrStringBuilder?.Clear();
-
-        return error;
-    }
+        => _stdErrStringBuilder?.GetAndClear();
 
     internal string? GetAndClearTrace()
-    {
-        string? trace = _traceStringBuilder?.ToString();
-        _traceStringBuilder?.Clear();
-
-        return trace;
-    }
+        => _traceStringBuilder?.GetAndClear();
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -1501,11 +1501,14 @@ public class TestMethodInfoTests : TestContainer
         ((string[])expectedArguments[1]).SequenceEqual((string[])resolvedArguments[1]!).Should().BeTrue();
     }
 
+    // Regression tests for https://github.com/microsoft/testfx/issues/7846
+    // Verify that log output buffers are cleared between invocations to prevent
+    // exponential memory growth with DynamicData tests.
+    // NOTE: The TestClassInfo (class init/cleanup) and UnitTestRunner (assembly init/cleanup)
+    // call sites use the same GetAndClear* methods tested in isolation in
+    // TestContextImplementationTests.GetAndClear{Output,Error,Trace}_ShouldReturnContentThenClearBuffer.
     public async Task InvokeAsync_ShouldNotAccumulateLogOutputAcrossMultipleInvocations()
     {
-        // Regression test for https://github.com/microsoft/testfx/issues/7846
-        // Verify that log output buffers are cleared between invocations to prevent
-        // exponential memory growth with DynamicData tests.
         DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteConsoleOut("invocation_output");
 
         TestResult result1 = await _testMethodInfo.InvokeAsync(null);
@@ -1517,7 +1520,6 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task InvokeAsync_ShouldNotAccumulateLogErrorAcrossMultipleInvocations()
     {
-        // Regression test for https://github.com/microsoft/testfx/issues/7846
         DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteConsoleErr("error_output");
 
         TestResult result1 = await _testMethodInfo.InvokeAsync(null);
@@ -1529,7 +1531,6 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task InvokeAsync_ShouldNotAccumulateDebugTraceAcrossMultipleInvocations()
     {
-        // Regression test for https://github.com/microsoft/testfx/issues/7846
         DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteTrace("trace_output");
 
         TestResult result1 = await _testMethodInfo.InvokeAsync(null);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -1501,6 +1501,44 @@ public class TestMethodInfoTests : TestContainer
         ((string[])expectedArguments[1]).SequenceEqual((string[])resolvedArguments[1]!).Should().BeTrue();
     }
 
+    public async Task InvokeAsync_ShouldNotAccumulateLogOutputAcrossMultipleInvocations()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/7846
+        // Verify that log output buffers are cleared between invocations to prevent
+        // exponential memory growth with DynamicData tests.
+        DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteConsoleOut("invocation_output");
+
+        TestResult result1 = await _testMethodInfo.InvokeAsync(null);
+        TestResult result2 = await _testMethodInfo.InvokeAsync(null);
+
+        result1.LogOutput.Should().Be("invocation_output");
+        result2.LogOutput.Should().Be("invocation_output");
+    }
+
+    public async Task InvokeAsync_ShouldNotAccumulateLogErrorAcrossMultipleInvocations()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/7846
+        DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteConsoleErr("error_output");
+
+        TestResult result1 = await _testMethodInfo.InvokeAsync(null);
+        TestResult result2 = await _testMethodInfo.InvokeAsync(null);
+
+        result1.LogError.Should().Be("error_output");
+        result2.LogError.Should().Be("error_output");
+    }
+
+    public async Task InvokeAsync_ShouldNotAccumulateDebugTraceAcrossMultipleInvocations()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/7846
+        DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteTrace("trace_output");
+
+        TestResult result1 = await _testMethodInfo.InvokeAsync(null);
+        TestResult result2 = await _testMethodInfo.InvokeAsync(null);
+
+        result1.DebugTrace.Should().Be("trace_output");
+        result2.DebugTrace.Should().Be("trace_output");
+    }
+
     #region helper methods
 
     private static async Task RunWithTestablePlatformService(TestablePlatformServiceProvider testablePlatformServiceProvider, Func<Task> action)

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -360,8 +360,8 @@ public class TestContextImplementationTests : TestContainer
         });
 
         t.Start();
-        _ = testContextImplementation.GetOut();
-        _ = testContextImplementation.GetErr();
+        _ = testContextImplementation.GetAndClearOutput();
+        _ = testContextImplementation.GetAndClearError();
         t.Join();
     }
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -347,6 +347,42 @@ public class TestContextImplementationTests : TestContainer
         messageLoggerMock.Verify(x => x.SendMessage(TestMessageLevel.Error, "ErrorMessage"), Times.Once);
     }
 
+    public void GetAndClearOutput_ShouldReturnContentThenClearBuffer()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.WriteConsoleOut("hello");
+
+        string? first = _testContextImplementation.GetAndClearOutput();
+        string? second = _testContextImplementation.GetAndClearOutput();
+
+        first.Should().Be("hello");
+        second.Should().BeEmpty();
+    }
+
+    public void GetAndClearError_ShouldReturnContentThenClearBuffer()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.WriteConsoleErr("hello");
+
+        string? first = _testContextImplementation.GetAndClearError();
+        string? second = _testContextImplementation.GetAndClearError();
+
+        first.Should().Be("hello");
+        second.Should().BeEmpty();
+    }
+
+    public void GetAndClearTrace_ShouldReturnContentThenClearBuffer()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.WriteTrace("hello");
+
+        string? first = _testContextImplementation.GetAndClearTrace();
+        string? second = _testContextImplementation.GetAndClearTrace();
+
+        first.Should().Be("hello");
+        second.Should().BeEmpty();
+    }
+
     public void WritesFromBackgroundThreadShouldNotThrow()
     {
         TestContextImplementation testContextImplementation = CreateTestContextImplementation(new Mock<IMessageLogger>().Object);
@@ -362,6 +398,7 @@ public class TestContextImplementationTests : TestContainer
         t.Start();
         _ = testContextImplementation.GetAndClearOutput();
         _ = testContextImplementation.GetAndClearError();
+        _ = testContextImplementation.GetAndClearTrace();
         t.Join();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #7846

When running `DynamicData` tests with multiple invocations, the `TestContextImplementation` output buffers (`_stdOutStringBuilder`, `_stdErrStringBuilder`, `_traceStringBuilder`) were never cleared between invocations. Since DynamicData tests reuse the same `TestContext` instance across all invocations, logs accumulated exponentially:

- Test 1 result: logs from test 1
- Test 2 result: logs from test 1 + test 2
- Test 3 result: logs from test 1 + test 2 + test 3
- ...

This caused >20 GB RAM usage for simple projects and truncated/broken log output in test summaries.

## Root Cause

`GetOut()`, `GetErr()`, and `GetTrace()` on `TestContextImplementation` returned the `StringBuilder` contents via `ToString()` but never cleared them. In contrast, `GetAndClearDiagnosticMessages()` and `GetResultFiles()` already followed a get-then-clear pattern.

## Fix

Replace `GetOut()`, `GetErr()`, `GetTrace()` with `GetAndClearOutput()`, `GetAndClearError()`, `GetAndClearTrace()` that clear the `StringBuilder` after extracting the value — matching the existing `GetAndClearDiagnosticMessages()` pattern.

## Changes

- **`TestContextImplementation.cs`** — Replace non-clearing getters with `GetAndClearOutput/Error/Trace` methods
- **`TestMethodInfo.cs`** — Update call site in `InvokeAsync` finally block
- **`UnitTestRunner.cs`** — Update call sites in assembly init/cleanup
- **`TestClassInfo.cs`** — Update call sites in class init/cleanup
- **`TestMethodInfoTests.cs`** — Add 3 regression tests verifying buffers don't accumulate across invocations
- **`TestContextImplementationTests.cs`** — Update existing thread-safety test to use renamed methods