### PR TITLE
[Perf Improver] perf: eliminate LINQ iterator allocations in GetTestCategories and GetTestFromMethod

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
@@ -169,6 +169,7 @@ internal class TypeEnumerator
 
         if (workItemIds is not null)
         {
+            workItemIds.Reverse();
             testElement.WorkItemIds = [.. workItemIds];
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/TypeEnumerator.cs
@@ -125,7 +125,9 @@ internal class TypeEnumerator
         DebugEx.Assert(_type.AssemblyQualifiedName != null, "AssemblyQualifiedName for method is null.");
 
         ManagedNameHelper.GetManagedNameAndHierarchy(method, out string managedType, out string managedMethod, out string?[] hierarchyValues);
-        var testMethod = new TestMethod(managedType, managedMethod, hierarchyValues, method.Name, _type.FullName!, _assemblyFilePath, null, string.Join(",", method.GetParameters().Select(p => p.ParameterType.ToString())))
+        ParameterInfo[] parameters = method.GetParameters();
+        var testMethod = new TestMethod(managedType, managedMethod, hierarchyValues, method.Name, _type.FullName!, _assemblyFilePath, null,
+            parameters.Length == 0 ? string.Empty : string.Join(",", Array.ConvertAll(parameters, static p => p.ParameterType.ToString())))
         {
             MethodInfo = method,
         };
@@ -144,9 +146,11 @@ internal class TypeEnumerator
 
         Attribute[] attributes = _reflectHelper.GetCustomAttributesCached(method);
         TestMethodAttribute? testMethodAttribute = null;
+        List<string>? workItemIds = null;
 
         // Backward looping for backcompat. This used to be calls to _reflectHelper.GetFirstAttributeOrDefault
         // So, to make sure the first attribute always wins, we loop from end to start.
+        // WorkItemAttribute is also collected here to avoid a second pass with OfType + Any + Select.
         for (int i = attributes.Length - 1; i >= 0; i--)
         {
             if (attributes[i] is TestMethodAttribute tma)
@@ -157,12 +161,15 @@ internal class TypeEnumerator
             {
                 testElement.Priority = priorityAttribute.Priority;
             }
+            else if (attributes[i] is WorkItemAttribute workItem)
+            {
+                (workItemIds ??= []).Add(workItem.Id.ToString(CultureInfo.InvariantCulture));
+            }
         }
 
-        IEnumerable<WorkItemAttribute> workItemAttributes = attributes.OfType<WorkItemAttribute>();
-        if (workItemAttributes.Any())
+        if (workItemIds is not null)
         {
-            testElement.WorkItemIds = [.. workItemAttributes.Select(x => x.Id.ToString(CultureInfo.InvariantCulture))];
+            testElement.WorkItemIds = [.. workItemIds];
         }
 
         // In production, we always have a TestMethod attribute because GetTestFromMethod is called under IsValidTestMethod

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -143,11 +143,39 @@ internal class ReflectHelper : MarshalByRefObject
     /// <returns>Categories defined.</returns>
     internal string[] GetTestCategories(MemberInfo categoryAttributeProvider, Type owningType)
     {
-        IEnumerable<TestCategoryBaseAttribute> methodCategories = GetAttributes<TestCategoryBaseAttribute>(categoryAttributeProvider);
-        IEnumerable<TestCategoryBaseAttribute> typeCategories = GetAttributes<TestCategoryBaseAttribute>(owningType);
-        IEnumerable<TestCategoryBaseAttribute> assemblyCategories = GetAttributes<TestCategoryBaseAttribute>(owningType.Assembly);
+        Attribute[] methodAttributes = GetCustomAttributesCached(categoryAttributeProvider);
+        Attribute[] typeAttributes = GetCustomAttributesCached(owningType);
+        Attribute[] assemblyAttributes = GetCustomAttributesCached(owningType.Assembly);
 
-        return [.. methodCategories.Concat(typeCategories).Concat(assemblyCategories).SelectMany(c => c.TestCategories)];
+        // Avoid LINQ iterator allocations by iterating the cached attribute arrays directly.
+        // This follows the same allocation-free pattern used by GetTestPropertiesAsTraits.
+        List<string>? categories = null;
+
+        foreach (Attribute attribute in methodAttributes)
+        {
+            if (attribute is TestCategoryBaseAttribute categoryAttr)
+            {
+                (categories ??= []).AddRange(categoryAttr.TestCategories);
+            }
+        }
+
+        foreach (Attribute attribute in typeAttributes)
+        {
+            if (attribute is TestCategoryBaseAttribute categoryAttr)
+            {
+                (categories ??= []).AddRange(categoryAttr.TestCategories);
+            }
+        }
+
+        foreach (Attribute attribute in assemblyAttributes)
+        {
+            if (attribute is TestCategoryBaseAttribute categoryAttr)
+            {
+                (categories ??= []).AddRange(categoryAttr.TestCategories);
+            }
+        }
+
+        return categories is null ? [] : [.. categories];
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request optimizes the way test categories and work item IDs are collected during test discovery in the MSTest adapter. The changes focus on reducing memory allocations by replacing LINQ-based code with direct iteration, improving performance and efficiency.

Fixes #7868