### PR TITLE
[Lean Squad] feat(ci): Task 9 — FV docs validation workflow + updated REPORT.md

### DIFF
--- a/.github/workflows/fv-docs-validation.yml
+++ b/.github/workflows/fv-docs-validation.yml
@@ -59,9 +59,19 @@ jobs:
 
       - name: Verify lean-toolchain is non-empty and well-formed
         run: |
-          TOOLCHAIN="$(cat formal-verification/lean/lean-toolchain | tr -d '\r\n')"
+          TOOLCHAIN="$(tr -d '\r\n' < formal-verification/lean/lean-toolchain)"
           if [ -z "$TOOLCHAIN" ]; then
             echo "::error file=formal-verification/lean/lean-toolchain::lean-toolchain file is empty"
+            exit 1
+          fi
+
+          if [[ "$TOOLCHAIN" =~ [[:space:]] ]]; then
+            echo "::error file=formal-verification/lean/lean-toolchain::lean-toolchain must not contain whitespace"
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$TOOLCHAIN" | grep -Eq '^[^[:space:]/]+/[^[:space:]/]+:[^[:space:]]+$'; then
+            echo "::error file=formal-verification/lean/lean-toolchain::lean-toolchain must match <org>/<repo>:<tag>"
             exit 1
           fi
           echo "✅  lean-toolchain: ${TOOLCHAIN}"
@@ -71,11 +81,15 @@ jobs:
           FAILED=0
           for doc in RESEARCH.md TARGETS.md CORRESPONDENCE.md CRITIQUE.md REPORT.md; do
             if ! grep -q "🔬" "formal-verification/${doc}"; then
-              echo "::warning file=formal-verification/${doc}::FV document missing 🔬 Lean Squad disclosure: ${doc}"
+              echo "::error file=formal-verification/${doc}::FV document missing 🔬 Lean Squad disclosure: ${doc}"
+              FAILED=1
             else
               echo "✅  formal-verification/${doc} has 🔬 disclosure"
             fi
           done
+          if [ "$FAILED" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Check specs/ directory exists
         run: |

--- a/.github/workflows/fv-docs-validation.yml
+++ b/.github/workflows/fv-docs-validation.yml
@@ -1,0 +1,128 @@
+name: FV Documentation Validation
+
+# 🔬 Lean Squad — CI workflow for formal-verification documentation consistency.
+# Checks that required FV artifacts exist and are structurally sound.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "formal-verification/**"
+      - ".github/workflows/fv-docs-validation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "formal-verification/**"
+  workflow_dispatch:
+
+jobs:
+  validate-fv-docs:
+    name: Validate FV Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check required top-level FV documents
+        run: |
+          MISSING=0
+          for doc in RESEARCH.md TARGETS.md CORRESPONDENCE.md CRITIQUE.md REPORT.md; do
+            if [ ! -f "formal-verification/${doc}" ]; then
+              echo "::error file=formal-verification/${doc}::Required FV document missing: ${doc}"
+              MISSING=1
+            else
+              echo "✅  formal-verification/${doc} present"
+            fi
+          done
+          if [ "$MISSING" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Check Lean project files
+        run: |
+          MISSING=0
+          for f in lean/lakefile.toml lean/lean-toolchain lean/README.md; do
+            if [ ! -f "formal-verification/${f}" ]; then
+              echo "::error file=formal-verification/${f}::Required Lean project file missing: ${f}"
+              MISSING=1
+            else
+              echo "✅  formal-verification/${f} present"
+            fi
+          done
+          if [ "$MISSING" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Verify lean-toolchain is non-empty and well-formed
+        run: |
+          TOOLCHAIN="$(cat formal-verification/lean/lean-toolchain | tr -d '\r\n')"
+          if [ -z "$TOOLCHAIN" ]; then
+            echo "::error file=formal-verification/lean/lean-toolchain::lean-toolchain file is empty"
+            exit 1
+          fi
+          echo "✅  lean-toolchain: ${TOOLCHAIN}"
+
+      - name: Check FV 🔬 disclosure in top-level docs
+        run: |
+          FAILED=0
+          for doc in RESEARCH.md TARGETS.md CORRESPONDENCE.md CRITIQUE.md REPORT.md; do
+            if ! grep -q "🔬" "formal-verification/${doc}"; then
+              echo "::warning file=formal-verification/${doc}::FV document missing 🔬 Lean Squad disclosure: ${doc}"
+            else
+              echo "✅  formal-verification/${doc} has 🔬 disclosure"
+            fi
+          done
+
+      - name: Check specs/ directory exists
+        run: |
+          if [ ! -d "formal-verification/specs" ]; then
+            echo "::error::formal-verification/specs/ directory is missing"
+            exit 1
+          fi
+          SPEC_COUNT="$(find formal-verification/specs -name '*_informal.md' | wc -l)"
+          echo "✅  formal-verification/specs/ present with ${SPEC_COUNT} informal spec(s)"
+
+      - name: Verify TARGETS.md phase-2+ targets have informal specs
+        run: |
+          python3 - <<'EOF'
+          import re, sys, os, glob
+
+          targets_path = "formal-verification/TARGETS.md"
+          specs_dir    = "formal-verification/specs"
+
+          with open(targets_path) as f:
+              content = f.read()
+
+          row_re = re.compile(
+              r'\|\s*\d+\s*\|\s*`([^`]+)`\s*\|[^|]+\|\s*(\d+)\s*\|'
+          )
+
+          def name_to_keywords(name):
+              # Split on CamelCase, dots, underscores, spaces
+              parts = re.sub(r'([a-z])([A-Z])', r'\1_\2', name)
+              return [w.lower() for w in re.split(r'[._\s]+', parts) if len(w) >= 3]
+
+          all_specs = [os.path.basename(p) for p in glob.glob(os.path.join(specs_dir, "*.md"))]
+
+          for m in row_re.finditer(content):
+              name  = m.group(1)
+              phase = int(m.group(2))
+              if phase < 2:
+                  continue
+              keywords = name_to_keywords(name)
+              # A spec matches if it contains ALL keywords derived from the name
+              matched = [s for s in all_specs if all(kw in s for kw in keywords)]
+              if matched:
+                  print(f"✅  Phase-{phase} target '{name}' — spec: {matched}")
+              else:
+                  # Partial: at least the first keyword
+                  partial = [s for s in all_specs if keywords and keywords[0] in s]
+                  if partial:
+                      print(f"✅  Phase-{phase} target '{name}' — spec found (partial): {partial}")
+                  else:
+                      print(f"::warning::Phase-{phase} target '{name}' has no informal spec in specs/ (keywords: {keywords})")
+          EOF

--- a/.github/workflows/fv-docs-validation.yml
+++ b/.github/workflows/fv-docs-validation.yml
@@ -120,23 +120,30 @@ jobs:
               parts = re.sub(r'([a-z])([A-Z])', r'\1_\2', name)
               return [w.lower() for w in re.split(r'[._\s]+', parts) if len(w) >= 3]
 
-          all_specs = [os.path.basename(p) for p in glob.glob(os.path.join(specs_dir, "*.md"))]
+          all_specs = [os.path.basename(p) for p in glob.glob(os.path.join(specs_dir, "*_informal.md"))]
 
+          failed = False
           for m in row_re.finditer(content):
               name  = m.group(1)
               phase = int(m.group(2))
               if phase < 2:
                   continue
               keywords = name_to_keywords(name)
+              if not keywords:
+                  print(f"::warning::Phase-{phase} target '{name}' produced no keywords — cannot validate spec")
+                  continue
               # A spec matches if it contains ALL keywords derived from the name
               matched = [s for s in all_specs if all(kw in s for kw in keywords)]
               if matched:
                   print(f"✅  Phase-{phase} target '{name}' — spec: {matched}")
               else:
                   # Partial: at least the first keyword
-                  partial = [s for s in all_specs if keywords and keywords[0] in s]
+                  partial = [s for s in all_specs if keywords[0] in s]
                   if partial:
                       print(f"✅  Phase-{phase} target '{name}' — spec found (partial): {partial}")
                   else:
-                      print(f"::warning::Phase-{phase} target '{name}' has no informal spec in specs/ (keywords: {keywords})")
+                      print(f"::error::Phase-{phase} target '{name}' has no informal spec in specs/ (keywords: {keywords})")
+                      failed = True
+          if failed:
+              sys.exit(1)
           EOF

--- a/formal-verification/REPORT.md
+++ b/formal-verification/REPORT.md
@@ -4,16 +4,20 @@
 
 ## Status
 
-**Phase**: Early — Research expanded to 7 targets; informal specs extracted for `ArgumentArity` (merged) and `CommandLineParser.TryUnescape` (PR open). Lean toolchain unavailable in runner (network firewall), blocking Task 3+.
+**Phase**: Early — Research expanded to 7 targets; informal specs extracted for `ArgumentArity` (merged) and `CommandLineParser.TryUnescape` (PR open). CI automation maturing. Lean toolchain blocked in CI runner; Task 3+ deferred.
 
 ## Summary
 
-The Lean Squad has surveyed the `microsoft/testfx` codebase and identified **seven** high-quality FV targets. Two informal specifications have been extracted. The Lean toolchain cannot currently be installed in the runner environment due to network restrictions.
+The Lean Squad has surveyed the `microsoft/testfx` codebase and identified **seven** high-quality FV targets in the command-line infrastructure and filter logic of Microsoft.Testing.Platform. All targets are pure or near-pure functions with clear algebraic properties, making them suitable for Lean 4 formal verification.
 
 Key findings:
-- **`ArgumentArity`**: informal spec extracted (14 properties, 4 groups). Constructor does not enforce `Min ≤ Max`; `CommandLineOption` enforces this on construction, acting as the real guard.
+- **`ArgumentArity`**: informal spec extracted (14 properties, 4 groups). Constructor does not enforce `Min ≤ Max`; `CommandLineOption` enforces this on construction, acting as the real guard. Correspondence documented.
 - **`CommandLineParser.TryUnescape`**: informal spec extracted (24 properties, 5 groups, 2 confirmed bugs for single-char quote inputs). PR open.
 - **New targets identified**: `ResponseFileHelper.SplitCommandLine` (pure tokeniser) and `TreeNodeFilter.MatchFilterPattern` (Boolean algebra — ideal for structural induction proofs of De Morgan, double negation, idempotence).
+
+The CI infrastructure has been progressively improved: the `lean-proofs.yml` workflow and an FV docs validation workflow (`fv-docs-validation.yml`) are in place.
+
+**Blocker**: Lean toolchain (elan) cannot be executed in the GitHub Actions sandbox environment used by this agent. All `.lean` file tasks (Tasks 3–5) are deferred until elan execution is unblocked.
 
 Next steps (once Lean toolchain available):
 1. Write Lean 4 formal spec for `ArgumentArity` (Task 3).
@@ -35,6 +39,8 @@ Next steps (once Lean toolchain available):
 
 | Date | Tasks | Outcome |
 |------|-------|---------|
+| 2026-04-27 | Task 3 (blocked), Task 9 (CI Automation) | Task 3 blocked by Lean toolchain; added `fv-docs-validation.yml` CI workflow validating FV artifact structure |
+| 2026-04-27 | Task 9 (CI improvements), Task 6 (Correspondence review) | Skip guard for lean-proofs.yml; FVSquad/ scaffold; CORRESPONDENCE.md extended |
 | 2026-04-26 | Task 1 (Research expansion), Task 3 (blocked — Lean unavailable) | Added 2 new targets: SplitCommandLine and TreeNodeFilter.MatchFilterPattern; updated priority order; Lean toolchain still blocked by runner network |
 | 2026-04-25 | Task 2 (Informal Spec — TryUnescape) | Extracted 24-property informal spec; discovered 2 confirmed bugs for single-char quote inputs |
 | 2026-04-24 | Task 1 (Research), Task 2 (Informal Spec), Task 9 (CI Automation) | Identified 5 targets; extracted informal spec for ArgumentArity (14 properties, open question on ill-formed arity); set up CI workflow |


### PR DESCRIPTION
Add .github/workflows/fv-docs-validation.yml: a CI workflow that validates
the structural integrity of formal-verification/ artifacts on every PR or
push that touches formal-verification/**.

Checks performed:
- Required top-level FV docs present (RESEARCH.md, TARGETS.md,
  CORRESPONDENCE.md, CRITIQUE.md, REPORT.md)
- Lean project files present (lakefile.toml, lean-toolchain, README.md)
- lean-toolchain is non-empty and well-formed
- 🔬 Lean Squad disclosure present in top-level docs
- specs/ directory exists
- Phase-2+ targets in TARGETS.md each have an informal spec in specs/
  (keyword-based matching handles CamelCase name decomposition)

Also update formal-verification/REPORT.md: add run history for the
2026-04-27 runs, expand target table with new targets, and document the
Lean toolchain blocker.

�� Lean Squad — automated formal verification agent
Run: https://github.com/microsoft/testfx/actions/runs/24986088168

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #7861