### PR TITLE
[code-simplifier] Remove redundant `.ToString()` in `TimingInfo.ToString()`

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -46,6 +46,10 @@ An MTP extension (`Microsoft.Testing.Extensions.HangDump`) that captures a proce
 
 ## I
 
+### Informal Spec (FV)
+
+An intermediate artifact in the [Formal Verification (FV)](#formal-verification-fv) workflow that documents the behavioural properties of an [FV Target](#fv-target) in plain English (or structured natural language), before writing formal [Lean 4](#lean-4) proofs. An informal spec lists preconditions, postconditions, edge-case expectations, and any confirmed bugs discovered during analysis. It corresponds to Phase 2 of the FV target lifecycle and lives in the `formal-verification/specs/` directory.
+
 ### IsTestingPlatformApplication
 
 An MSBuild property (`<IsTestingPlatformApplication>true</IsTestingPlatformApplication>`) that marks a project as an MTP test application. When set, the project builds into a self-contained test runner executable rather than a class library consumed by a separate test host.

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TimingProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TimingProperties.cs
@@ -46,7 +46,7 @@ public readonly struct TimingInfo : IEquatable<TimingInfo>
         builder.Append($", {nameof(EndTime)} = ");
         builder.Append(EndTime);
         builder.Append($", {nameof(Duration)} = ");
-        builder.Append(Duration.ToString());
+        builder.Append(Duration);
         builder.Append(" }");
         return builder.ToString();
     }


### PR DESCRIPTION
- **docs: add Informal Spec (FV) to glossary**
- **Remove redundant .ToString() in TimingInfo.Append call**

Fixes #7955