### PR TITLE
Add net10.0 to SupportedNetFrameworks, drop net9.0 (EOL May 12 2026)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
     <ModernUwpMinimum>net9.0-windows10.0.17763.0</ModernUwpMinimum>
     <WinUiMinimum>net8.0-windows10.0.18362.0</WinUiMinimum>
 
-    <SupportedNetFrameworks>net8.0;net9.0</SupportedNetFrameworks>
+    <SupportedNetFrameworks>net8.0;net10.0</SupportedNetFrameworks>
   </PropertyGroup>
 
   <!-- Build config -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26229.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26230.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>3ed6c23fee67b840de0fb5473ea6a95fc667b0a9</Sha>
+      <Sha>8a7b2d3d39078db20f33067c7929b88fdff4ee63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="11.0.0-beta.26229.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="11.0.0-beta.26230.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>3ed6c23fee67b840de0fb5473ea6a95fc667b0a9</Sha>
+      <Sha>8a7b2d3d39078db20f33067c7929b88fdff4ee63</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.26229.1">
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.26230.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>3ed6c23fee67b840de0fb5473ea6a95fc667b0a9</Sha>
+      <Sha>8a7b2d3d39078db20f33067c7929b88fdff4ee63</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0-preview.26229.1">
       <Uri>https://dev.azure.com/devdiv/DevDiv/_git/vs-code-coverage</Uri>
       <Sha>6b29c14c934bae1e26c21961b7e5ad1a25c4d3c5</Sha>
     </Dependency>
-    <Dependency Name="MSTest" Version="4.3.0-preview.26229.1">
+    <Dependency Name="MSTest" Version="4.3.0-preview.26230.4">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>0da10c24091f1ad35610ac05dd5aa7bd3ea79dd5</Sha>
+      <Sha>e6af9df44f1c17bcae2798b15388641609add3a3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Testing.Platform" Version="2.3.0-preview.26229.1">
+    <Dependency Name="Microsoft.Testing.Platform" Version="2.3.0-preview.26230.4">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>0da10c24091f1ad35610ac05dd5aa7bd3ea79dd5</Sha>
+      <Sha>e6af9df44f1c17bcae2798b15388641609add3a3</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,10 +7,10 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">
-    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26229.1</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
+    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26230.2</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
     <MicrosoftTestingExtensionsCodeCoverageVersion>18.8.0-preview.26229.1</MicrosoftTestingExtensionsCodeCoverageVersion>
     <!-- empty line to avoid merge conflicts for darc PRs to update CC and MSTest+MTP -->
-    <MSTestVersion>4.3.0-preview.26229.1</MSTestVersion>
-    <MicrosoftTestingPlatformVersion>2.3.0-preview.26229.1</MicrosoftTestingPlatformVersion>
+    <MSTestVersion>4.3.0-preview.26230.4</MSTestVersion>
+    <MicrosoftTestingPlatformVersion>2.3.0-preview.26230.4</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/eng/common/AGENTS.md
+++ b/eng/common/AGENTS.md
@@ -1,0 +1,5 @@
+# `eng/common`
+
+Files under `eng/common` come from [Arcade](https://github.com/dotnet/arcade).
+Edits in `eng/common` will be overwritten by automation unless the changes are made directly in the Arcade repository.
+For more information, see the [Arcade documentation](https://github.com/dotnet/arcade/tree/main/Documentation).

--- a/global.json
+++ b/global.json
@@ -37,7 +37,7 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26229.1",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26230.2",
     "MSBuild.Sdk.Extras": "3.0.44"
   }
 }


### PR DESCRIPTION
## Summary

Updates SupportedNetFrameworks in Directory.Build.props from 
et8.0;net9.0 to 
et8.0;net10.0.

.NET 9.0 STS reaches end-of-life on **May 12, 2026**. The repository has already been moving in this direction:
- TargetFrameworks.cs in test infrastructure lists 
et10.0 as primary with 
et8.0 as secondary (no net9.0)
- Previous commit removed net9.0 from test utilities entirely

This single-property change propagates 
et10.0 automatically to all ~30 source and test projects that reference \.

## Changes

- Directory.Build.props: 
et8.0;net9.0 → 
et8.0;net10.0

## Note on closed PR #6762

That PR was opened in October 2025 when net10.0 was still pre-release. Now that net10.0 is GA and net9.0 is at EOL, the timing is right.