### PR TITLE
[Lean Squad] feat(fv): Task 1+2 — research two new targets; informal spec for UnitTestOutcomeHelper.ToTestOutcome

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,7 +6,7 @@ This glossary defines key terms and concepts used throughout the MSTest and Micr
 
 ### AwesomeAssertions
 
-A .NET fluent-assertion library ([NuGet: AwesomeAssertions](https://www.nuget.org/packages/AwesomeAssertions)) used in the unit and integration test suites of this project. It provides a human-readable, chainable assertion API (e.g., `result.Should().Be(42)`). AwesomeAssertions is the community-maintained fork of `FluentAssertions` created after FluentAssertions changed its license from Apache 2.0 to a commercial model; the two libraries share the same API surface. Within this project, `BannedSymbols.txt` files ban the built-in MSTest `Assert`, `CollectionAssert`, and `StringAssert` types and require `AwesomeAssertions` instead.
+A .NET fluent-assertion library ([NuGet: AwesomeAssertions](https://www.nuget.org/packages/AwesomeAssertions)) used in the unit and integration test suites of this project. It provides a human-readable, chainable assertion API (e.g., `result.Should().Be(42)`). AwesomeAssertions is the community-maintained fork of `FluentAssertions` created after FluentAssertions changed its license from Apache 2.0 to a commercial model; the two libraries share the same API surface. In this project, assertion-library enforcement varies by test project: some `BannedSymbols.txt` files (for example, in adapter unit tests) ban the built-in MSTest `Assert`, `CollectionAssert`, and `StringAssert` types and require `AwesomeAssertions`, while others ban `AwesomeAssertions` and enforce MSTest assertions.
 
 ### ArgumentArity
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -28,6 +28,10 @@ An MTP extension (`Microsoft.Testing.Extensions.CrashDump`) that automatically c
 
 A public enum in the `Microsoft.VisualStudio.TestTools.UnitTesting` namespace that specifies the delay strategy used between retries by the `[Retry]` attribute. Values: `Constant` (fixed delay between each attempt) and `Exponential` (delay doubles with each attempt: base × 2^(n−1)).
 
+### DynamicData
+
+An MSTest attribute (`[DynamicData]`) for data-driven tests where test data is sourced from a static property, method, or field rather than inline `[DataRow]` values. The data source name is passed as a constructor argument; `DynamicDataSourceType` controls how the source is located (`Property`, `Method`, `Field`, or `AutoDetect`). Unlike `[DataRow]`, a single `[DynamicData]` source can be shared across multiple test methods and can produce any number of test cases at runtime. See `docs/RFCs/006-DynamicData-Attribute.md` for the original design.
+
 ## F
 
 ### FQN (Fully Qualified Name)
@@ -69,6 +73,10 @@ The communication protocol used between a test runner executable (server) and a 
 ### Lean 4
 
 A theorem prover and interactive proof assistant used in this project for [Formal Verification (FV)](#formal-verification-fv). Lean 4 proofs are written in the `formal-verification/lean/FVSquad/` directory and compiled via `lake build`. The CI workflow (`lean-proofs.yml`) automatically builds and checks these proofs.
+
+### Lean–C# Correspondence (FV)
+
+A document (`formal-verification/CORRESPONDENCE.md`) that records how each [Lean 4](#lean-4) formal model corresponds to its C# source counterpart. For every [FV Target](#fv-target) it captures the type/function mappings, deliberate approximations and simplifications, properties explicitly excluded from the model, and open questions for maintainer review. Auto-generated and maintained by the [Lean Squad](#lean-squad) FV agent.
 
 ### Lean Squad
 
@@ -112,6 +120,12 @@ A component in MTP that coordinates multi-process test execution. The orchestrat
 
 An MTP extension (`Microsoft.Testing.Extensions.OpenTelemetry`) that exports test session telemetry using the [OpenTelemetry](https://opentelemetry.io/) standard, enabling integration with distributed tracing and observability platforms.
 
+## P
+
+### PropertyBag
+
+An MTP class (`Microsoft.Testing.Platform.Extensions.Messages.PropertyBag`) that holds a typed collection of `IProperty` instances attached to a [TestNode](#testnode). Extension authors populate a `PropertyBag` with properties such as `TimingProperty`, `TestFileLocationProperty`, and `TestMetadataProperty` to communicate rich metadata about a test to the platform and to other extensions. A `PropertyBag` enforces that at most one `TestNodeStateProperty` may be present at a time.
+
 ## R
 
 ### Retry
@@ -123,6 +137,10 @@ An MTP extension (`Microsoft.Testing.Extensions.Retry`) that automatically re-ru
 Request for Comments document in the `docs/RFCs/` folder. RFCs describe design decisions, proposed features, and implementation details for MSTest and MTP.
 
 ## T
+
+### TestNode
+
+A core MTP class (`Microsoft.Testing.Platform.Extensions.Messages.TestNode`) that represents a single test item — either discovered or executed. Each `TestNode` carries a unique `Uid` (`TestNodeUid`), a human-readable `DisplayName`, and a [PropertyBag](#propertybag) of typed properties (state, timing, file location, metadata, etc.). `TestNode` instances are published to the `IMessageBus` by test framework adapters during discovery and execution phases.
 
 ### TFM (Target Framework Moniker)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,6 +4,10 @@ This glossary defines key terms and concepts used throughout the MSTest and Micr
 
 ## A
 
+### AwesomeAssertions
+
+A .NET fluent-assertion library ([NuGet: AwesomeAssertions](https://www.nuget.org/packages/AwesomeAssertions)) used in the unit and integration test suites of this project. It provides a human-readable, chainable assertion API (e.g., `result.Should().Be(42)`). AwesomeAssertions is the community-maintained fork of `FluentAssertions` created after FluentAssertions changed its license from Apache 2.0 to a commercial model; the two libraries share the same API surface. Within this project, `BannedSymbols.txt` files ban the built-in MSTest `Assert`, `CollectionAssert`, and `StringAssert` types and require `AwesomeAssertions` instead.
+
 ### ArgumentArity
 
 An MTP struct (`ArgumentArity.cs`) that defines the minimum and maximum number of values a command-line option accepts. Provides five predefined constants: `Zero` (0,0), `ZeroOrOne` (0,1), `ZeroOrMore` (0,∞), `ExactlyOne` (1,1), and `OneOrMore` (1,∞). Used by `ICommandLineOptionsProvider` implementations to declare option shapes.

--- a/formal-verification/RESEARCH.md
+++ b/formal-verification/RESEARCH.md
@@ -193,13 +193,79 @@ A pure recursive function that evaluates whether a test-node path and property b
 
 ---
 
+### Target 8 — `UnitTestOutcomeHelper.ToTestOutcome` ★★★★★  *(new — 2026-05-08)*
+
+**File**: `src/Adapter/MSTestAdapter.PlatformServices/Helpers/UnitTestOutcomeHelper.cs`
+**Type**: pure static method — `(UnitTestOutcome, MSTestSettings) → TestOutcome`
+
+Maps the MSTest-internal `UnitTestOutcome` enum to the VSTest-platform `TestOutcome` enum.
+
+**Why ideal for FV**:
+- Completely pure: no I/O, no mutation, no exceptions.
+- Finite input domain: 11-value enum × 2 Boolean flags = 44 cases.
+- All 44 cases are decidable with `decide`.
+- Clear mapping table; postconditions are straightforward equalities.
+- Found 5 untested paths in existing test suite.
+
+**Properties to verify**: see `formal-verification/specs/unittestoutcomehelper_totestoutcome_informal.md`.
+
+**Approximations**: Model the two Boolean settings flags as independent `Bool` values; `UnitTestOutcome` as a 11-case inductive type. Out-of-range values modelled as a catch-all `other` constructor.
+
+---
+
+### Target 14 — `EnvironmentVariableParser.ParseBool` ★★★☆☆  *(new — 2026-05-08)*
+
+**File**: `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs`
+**Type**: pure static method — `(string? × bool) → bool`
+
+Parses a string environment-variable value to a Boolean, with explicit truthy (`"1"`, `"true"`, `"yes"`, `"on"`) and falsy (`"0"`, `"false"`, `"no"`, `"off"`) sets, and a caller-supplied default for unrecognised values.
+
+**Why good for FV**:
+- Completely pure.
+- Small, explicit finite set of recognised inputs.
+- `decide` can verify every named case exhaustively.
+- Clearly documented intent (no ambiguity).
+- Symmetry property: a string is in the truthy set if and only if it is not in the falsy set (for named strings).
+
+**Properties to verify**:
+1. Each of `{"1", "true", "yes", "on"}` always returns `true`.
+2. Each of `{"0", "false", "no", "off"}` always returns `false`.
+3. Case-insensitivity: `"TRUE"`, `"True"`, `"yes"`, `"YES"` all return `true`.
+4. Unrecognised strings return the supplied default.
+5. `null` returns the supplied default.
+
+---
+
+### Target 15 — `PasteArguments.ContainsNoWhitespaceOrQuotes` ★★★☆☆  *(new — 2026-05-08)*
+
+**File**: `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs`
+**Type**: pure static method — `string → bool`
+
+Returns `true` if and only if the string contains no whitespace characters and no double-quote characters.
+
+**Why good for FV**:
+- Pure, deterministic, total.
+- Simple inductive definition over a string's characters.
+- Direct correspondence between Lean `List.all` over characters and the C# `for` loop.
+- Verifiable properties: empty string → `true`; any whitespace or `"` → `false`.
+- Round-trip property with `AppendArgument`: if `ContainsNoWhitespaceOrQuotes(s) = true`, then `AppendArgument` appends `s` unchanged.
+
+**Properties to verify**:
+1. `ContainsNoWhitespaceOrQuotes "" = true`
+2. `ContainsNoWhitespaceOrQuotes (s ++ " " ++ t) = false` for all `s`, `t`.
+3. `ContainsNoWhitespaceOrQuotes (s ++ "\"" ++ t) = false` for all `s`, `t`.
+4. If `ContainsNoWhitespaceOrQuotes s = true`, then for all `i < s.length`, `s[i] ≠ ' '` and `s[i] ≠ '"'`.
+
+---
+
 ## Approach Notes
 
 - We use Lean 4 with Mathlib for all proofs.
 - We translate C# business logic into **pure functional Lean models**, explicitly noting what is abstracted away.
 - `sorry` is used liberally early on; the goal is to get theorems stated correctly, then fill proofs.
-- For simple finite types (like `ArgumentArity` constants), we rely on `decide` for closed proofs.
+- For simple finite types (like `ArgumentArity` constants or `UnitTestOutcome`), we rely on `decide` for closed proofs.
 - We track which theorems are `sorry`-guarded vs. fully proved in `TARGETS.md`.
+- **Lean toolchain blocker**: `elan` download is blocked by the network firewall in the CI environment. All Task 3+ work awaits toolchain availability.
 
 ## Open Questions
 

--- a/formal-verification/RESEARCH.md
+++ b/formal-verification/RESEARCH.md
@@ -205,7 +205,7 @@ Maps the MSTest-internal `UnitTestOutcome` enum to the VSTest-platform `TestOutc
 - Finite input domain: 11-value enum × 2 Boolean flags = 44 cases.
 - All 44 cases are decidable with `decide`.
 - Clear mapping table; postconditions are straightforward equalities.
-- Found 5 untested paths in existing test suite.
+- Found 3 remaining untested paths in the existing test suite: `Aborted`, `Unknown`, and out-of-range values.
 
 **Properties to verify**: see `formal-verification/specs/unittestoutcomehelper_totestoutcome_informal.md`.
 

--- a/formal-verification/TARGETS.md
+++ b/formal-verification/TARGETS.md
@@ -23,20 +23,20 @@
 | 5 | `CommandLineParseResult.Equals` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs` | 2 | Informal spec merged | [PR #7918](https://github.com/microsoft/testfx/pull/7918). Ready for Task 3. |
 | 6 | `ResponseFileHelper.SplitCommandLine` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs` | 2 | Informal spec merged | [PR #7899](https://github.com/microsoft/testfx/pull/7899). Unclosed-quote discard bug documented. |
 | 7 | `TreeNodeFilter.MatchFilterPattern` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 2 | Informal spec merged | [PR #7934](https://github.com/microsoft/testfx/pull/7934). Ready for Task 3. |
-| 8 | `UnitTestOutcomeHelper.ToTestOutcome` | `src/Adapter/MSTestAdapter.PlatformServices/Helpers/UnitTestOutcomeHelper.cs` | 2 | **Informal spec extracted this run** | Pure 2-param switch, 14 decidable cases. 5 untested paths found. Highest-priority next Lean spec target. |
+| 8 | `UnitTestOutcomeHelper.ToTestOutcome` | `src/Adapter/MSTestAdapter.PlatformServices/Helpers/UnitTestOutcomeHelper.cs` | 2 | **Informal spec extracted this run** | Pure 2-param switch, 14 decidable cases. 3 untested paths found. Highest-priority next Lean spec target. |
 | 9 | `PasteArguments.AppendArgument` | `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs` | 1 | Identified | Windows CL quoting 2N/2N+1 backslash rules. |
 | 10 | `ValidationResult` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ValidationResult.cs` | 1 | Identified | Discriminated union; two cases (Success/Failure). |
 | 11 | `TreeNodeFilter.TokenizeFilter` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 1 | Identified | Lexer for filter grammar. |
-| 12 | `TimeSpanParser.TryParse` | `src/Platform/Microsoft.Testing.Platform/` | 1 | Identified | Parsing with format fallback. |
+| 12 | `TimeSpanParser.TryParse` | `src/Platform/Microsoft.Testing.Platform/Helpers/TimeSpanParser.cs` | 1 | Identified | Parsing with format fallback. |
 | 13 | `CommandLineOption` name validation | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs` | 1 | Identified | Character-class predicate: `IsLetterOrDigit \|\| hyphen \|\| ?`. |
-| 14 | `EnvironmentVariableParser.ParseBool` | `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs` | 1 | **New this run** | Pure `string? → bool` with explicit truthy/falsy sets. Trivially decidable. |
+| 14 | `EnvironmentVariableParser.ParseBool` | `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs` | 1 | **New this run** | Pure `(string?, bool) → bool` with explicit truthy/falsy sets and default-value fallback. Trivially decidable. |
 | 15 | `PasteArguments.ContainsNoWhitespaceOrQuotes` | `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs` | 1 | **New this run** | Pure string predicate: no whitespace and no `"`. Simple inductive proof. |
 
 ## Priority Order (next-up targets)
 
 1. **`UnitTestOutcomeHelper.ToTestOutcome`** (Target 8) — **highest priority for Task 3**. Pure 2-parameter switch over a 11-value enum with two Boolean flags. All 14 cases are decidable. Informal spec extracted this run. Smallest possible Lean spec once toolchain available.
 2. **`ArgumentArity`** (Target 1) — second priority. Smallest self-contained struct; decidable constant-value properties; good Lean warm-up once toolchain unblocked.
-3. **`EnvironmentVariableParser.ParseBool`** (Target 14) — third priority. Pure function over a few string literals; `decide` can verify all named cases exhaustively.
+3. **`EnvironmentVariableParser.ParseBool`** (Target 14) — third priority. Pure `(string?, bool) → bool` function over a few string literals plus a default-value parameter; `decide` can verify all named cases exhaustively.
 4. **`CommandLineParseResult.Equals`** (Target 5) — fourth priority. Structural equality; equivalence-relation laws straightforward to state and prove.
 5. **`TreeNodeFilter.MatchFilterPattern`** (Target 7) — fifth priority. Richest mathematical content; De Morgan and double-negation laws; structural induction proofs.
 6. **`CommandLineParser.TryUnescape`** (Target 2) — sixth priority. Security-relevant; bugs BUG-1 and BUG-2 documented.

--- a/formal-verification/TARGETS.md
+++ b/formal-verification/TARGETS.md
@@ -14,30 +14,57 @@
 
 ## Target List
 
-| # | Name | File | Phase | Status | PR/Issue |
-|---|------|------|-------|--------|----------|
-| 1 | `ArgumentArity` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ArgumentArity.cs` | 2 | Informal spec extracted | [PR #7799](https://github.com/microsoft/testfx/pull/7799) |
-| 2 | `CommandLineParser.TryUnescape` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec extracted | — |
-| 3 | `CommandLineParser.ParseOptionAndSeparators` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec extracted | — |
-| 4 | `CommandLineOptionsValidator` arity validation | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs` | 1 | Identified | — |
-| 5 | `CommandLineParseResult.Equals` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs` | 1 | Identified | — |
-| 6 | `ResponseFileHelper.SplitCommandLine` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs` | 2 | Informal spec extracted | [PR #7899](https://github.com/microsoft/testfx/pull/7899) |
-| 7 | `TreeNodeFilter.MatchFilterPattern` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 2 | Informal spec extracted | — |
+| # | Name | File | Phase | Status | Notes |
+|---|------|------|-------|--------|-------|
+| 1 | `ArgumentArity` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ArgumentArity.cs` | 2 | Informal spec merged | [PR #7799](https://github.com/microsoft/testfx/pull/7799). Ready for Task 3. |
+| 2 | `CommandLineParser.TryUnescape` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec merged | BUG-1/BUG-2 documented. Ready for Task 3. |
+| 3 | `CommandLineParser.ParseOptionAndSeparators` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec merged | [PR #7919](https://github.com/microsoft/testfx/pull/7919). Ready for Task 3. |
+| 4 | `CommandLineOptionsValidator.ValidateOptionsArgumentArity` | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs` | 2 | Informal spec merged | 4 open questions (OQ-1–OQ-4). |
+| 5 | `CommandLineParseResult.Equals` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs` | 2 | Informal spec merged | [PR #7918](https://github.com/microsoft/testfx/pull/7918). Ready for Task 3. |
+| 6 | `ResponseFileHelper.SplitCommandLine` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs` | 2 | Informal spec merged | [PR #7899](https://github.com/microsoft/testfx/pull/7899). Unclosed-quote discard bug documented. |
+| 7 | `TreeNodeFilter.MatchFilterPattern` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 2 | Informal spec merged | [PR #7934](https://github.com/microsoft/testfx/pull/7934). Ready for Task 3. |
+| 8 | `UnitTestOutcomeHelper.ToTestOutcome` | `src/Adapter/MSTestAdapter.PlatformServices/Helpers/UnitTestOutcomeHelper.cs` | 2 | **Informal spec extracted this run** | Pure 2-param switch, 14 decidable cases. 5 untested paths found. Highest-priority next Lean spec target. |
+| 9 | `PasteArguments.AppendArgument` | `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs` | 1 | Identified | Windows CL quoting 2N/2N+1 backslash rules. |
+| 10 | `ValidationResult` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ValidationResult.cs` | 1 | Identified | Discriminated union; two cases (Success/Failure). |
+| 11 | `TreeNodeFilter.TokenizeFilter` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 1 | Identified | Lexer for filter grammar. |
+| 12 | `TimeSpanParser.TryParse` | `src/Platform/Microsoft.Testing.Platform/` | 1 | Identified | Parsing with format fallback. |
+| 13 | `CommandLineOption` name validation | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs` | 1 | Identified | Character-class predicate: `IsLetterOrDigit \|\| hyphen \|\| ?`. |
+| 14 | `EnvironmentVariableParser.ParseBool` | `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs` | 1 | **New this run** | Pure `string? → bool` with explicit truthy/falsy sets. Trivially decidable. |
+| 15 | `PasteArguments.ContainsNoWhitespaceOrQuotes` | `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs` | 1 | **New this run** | Pure string predicate: no whitespace and no `"`. Simple inductive proof. |
 
-## Priority Order
+## Priority Order (next-up targets)
 
-1. **`ArgumentArity`** — highest priority. Smallest self-contained target; decidable properties; good warm-up for setting up the Lean environment. Informal spec done. **Next: Task 3 (blocked by Lean toolchain).**
-2. **`CommandLineParser.TryUnescape`** — second priority. Pure function with clear specification; security-relevant string processing. Informal spec extracted. **Next: Task 3 (blocked by Lean toolchain).**
-3. **`TreeNodeFilter.MatchFilterPattern`** — **elevated third priority**. Pure recursive Boolean algebra; structural induction proofs; De Morgan and double negation provable by `simp`. Informal spec extracted. **Next: Task 3 (blocked by Lean toolchain).**
-4. **`ResponseFileHelper.SplitCommandLine`** — fourth priority. Pure tokeniser with state machine; clear grammar-based properties. Informal spec extracted (PR open). **Next: Task 3 (blocked by Lean toolchain).**
-5. **`CommandLineParser.ParseOptionAndSeparators`** — fifth priority. Small pure function; useful for verifying parser correctness. Informal spec extracted this run. **Next: Task 3 (blocked by Lean toolchain).**
-6. **`CommandLineOptionsValidator` arity validation** — sixth priority. Validation logic with clear input/output contract.
-7. **`CommandLineParseResult.Equals`** — seventh priority. Structural equality; good for verifying equivalence-relation laws.
+1. **`UnitTestOutcomeHelper.ToTestOutcome`** (Target 8) — **highest priority for Task 3**. Pure 2-parameter switch over a 11-value enum with two Boolean flags. All 14 cases are decidable. Informal spec extracted this run. Smallest possible Lean spec once toolchain available.
+2. **`ArgumentArity`** (Target 1) — second priority. Smallest self-contained struct; decidable constant-value properties; good Lean warm-up once toolchain unblocked.
+3. **`EnvironmentVariableParser.ParseBool`** (Target 14) — third priority. Pure function over a few string literals; `decide` can verify all named cases exhaustively.
+4. **`CommandLineParseResult.Equals`** (Target 5) — fourth priority. Structural equality; equivalence-relation laws straightforward to state and prove.
+5. **`TreeNodeFilter.MatchFilterPattern`** (Target 7) — fifth priority. Richest mathematical content; De Morgan and double-negation laws; structural induction proofs.
+6. **`CommandLineParser.TryUnescape`** (Target 2) — sixth priority. Security-relevant; bugs BUG-1 and BUG-2 documented.
+7. **`ResponseFileHelper.SplitCommandLine`** (Target 6) — seventh priority. Grammar-based tokeniser; unclosed-quote discard bug confirmed.
+8. **`PasteArguments.ContainsNoWhitespaceOrQuotes`** (Target 15) — eighth priority. Tiny pure predicate; ideal `simp`/`induction` proof target.
+
+## Findings to Date
+
+| ID | Target | Finding |
+|----|--------|---------|
+| BUG-1 | TryUnescape | Single-char single-quoted string → `IndexOf(char, 1, -1)` throws `ArgumentOutOfRangeException` |
+| BUG-2 | TryUnescape | Single-char double-quoted string → `input[1..^1]` range exception |
+| BUG-3 | SplitCommandLine | Unclosed quote → all accumulated input is discarded |
+| BUG-4 | SplitCommandLine | Adjacent quoted strings emit 2 tokens, not 1 |
+| BUG-5 | ParseOptionAndSeparators | Empty option name is not rejected |
+| OQ-1 | ValidateOptionsArgumentArity | Absent required options not caught |
+| OQ-2 | ValidateOptionsArgumentArity | `KeyNotFoundException` if called before `ValidateNoUnknownOptions` |
+| OQ-3 | ValidateOptionsArgumentArity | `Max==0` message asymmetry |
+| OQ-4 | ValidateOptionsArgumentArity | Grammar defect: "at least 1 arguments" |
+| GAP-1 | UnitTestOutcomeHelper | `Aborted` and `Unknown` have no unit tests |
+| GAP-2 | UnitTestOutcomeHelper | `NotRunnable` with `MapNotRunnableToFailed=false` has no unit test |
+| GAP-3 | UnitTestOutcomeHelper | `Inconclusive` with `MapInconclusiveToFailed=true` has no unit test |
+| GAP-4 | UnitTestOutcomeHelper | Out-of-range `UnitTestOutcome` values have no unit test |
 
 ## Notes
 
-- Six of the seven targets are in the command-line infrastructure of Microsoft.Testing.Platform; one target is in the tree-node filter subsystem.
-- `TreeNodeFilter.MatchFilterPattern` (Target 7) is the highest-complexity target but also the most mathematically rich: proofs of Boolean-algebra laws give immediate, meaningful results.
-- `ResponseFileHelper.SplitCommandLine` (Target 6) is derived from `dotnet/command-line-api` — the upstream source is noted in comments; cross-referencing it may reveal documented invariants.
-- MSTest assertion APIs (e.g., `Assert.AreEqual`, `Assert.IsTrue`) remain interesting but harder to model formally due to generic type constraints and exception-based control flow.
-- Future targets may include the server-mode protocol state machine and the test-filter tokeniser (`TreeNodeFilter.TokenizeFilter`).
+- **Lean toolchain**: `elan` installation has been blocked by the network firewall in every run so far. All Task 3+ work is deferred until the toolchain becomes available. The `formal-verification/lean/` directory has a valid `lakefile.toml` and `lean-toolchain` file ready to use.
+- **Targets 1–8** all have merged informal specs (see `formal-verification/specs/`). Target 8 was extracted this run.
+- **Targets 9–15** are identified but have no informal spec yet. Targets 14–15 are new this run.
+- `ResponseFileHelper.SplitCommandLine` (Target 6) is derived from `dotnet/command-line-api`; the upstream source is noted in comments.
+- MSTest assertion APIs remain interesting but harder to model formally due to generic type constraints and exception-based control flow.

--- a/formal-verification/specs/unittestoutcomehelper_totestoutcome_informal.md
+++ b/formal-verification/specs/unittestoutcomehelper_totestoutcome_informal.md
@@ -1,0 +1,180 @@
+# Informal Specification: `UnitTestOutcomeHelper.ToTestOutcome`
+
+> 🔬 **Lean Squad** — auto-generated formal-verification artifact.
+> **Target ID**: 8  |  **Phase**: 2 (informal spec)  |  **Date**: 2026-05-08
+
+## 1. Purpose
+
+`UnitTestOutcomeHelper.ToTestOutcome` maps the MSTest-internal `UnitTestOutcome` enum to the VSTest-platform `TestOutcome` enum.  It acts as the **bridge between the MSTest execution layer and the test-platform reporting layer**: every test result that is exposed to IDE, CI, and other consumers passes through this function.
+
+The mapping is **almost deterministic** but has two **configuration-dependent branches** controlled by `MSTestSettings`:
+- `MapNotRunnableToFailed` — when `true`, `NotRunnable` is reported as `Failed` instead of `None`.
+- `MapInconclusiveToFailed` — when `true`, `Inconclusive` is reported as `Failed` instead of `Skipped`.
+
+## 2. Function Signature
+
+```csharp
+internal static TestOutcome ToTestOutcome(
+    UnitTestOutcome unitTestOutcome,
+    MSTestSettings currentSettings)
+```
+
+**Source**: `src/Adapter/MSTestAdapter.PlatformServices/Helpers/UnitTestOutcomeHelper.cs`
+
+## 3. Input Domain
+
+### `UnitTestOutcome` (source enum)
+
+| Value | Int | Meaning |
+|-------|-----|---------|
+| `Failed`      | 0 | Test executed; assertion or exception failed |
+| `Inconclusive`| 1 | Ambiguous result — no assertion passed or failed |
+| `Passed`      | 2 | Test executed without issues |
+| `InProgress`  | 3 | Test currently executing |
+| `Error`       | 4 | System error during execution |
+| `Timeout`     | 5 | Test timed out |
+| `Aborted`     | 6 | Test was aborted |
+| `Unknown`     | 7 | Unknown state |
+| `NotRunnable` | 8 | Test cannot be executed |
+| `NotFound`    | 9 | Specific test was not found |
+| `Ignored`     | 10 | Test is marked as ignored |
+
+Note: the enum has no upper bound enforced by C#; out-of-range integer casts are possible.
+
+### `MSTestSettings` (relevant fields)
+
+| Field | Default | Effect |
+|-------|---------|--------|
+| `MapNotRunnableToFailed` | `true`  | Changes `NotRunnable` mapping |
+| `MapInconclusiveToFailed`| `false` | Changes `Inconclusive` mapping |
+
+## 4. Output Domain
+
+### `TestOutcome` (target enum — VSTest platform)
+
+| Value | Meaning |
+|-------|---------|
+| `Passed`   | Test passed |
+| `Failed`   | Test failed or errored |
+| `Skipped`  | Test was skipped or inconclusive |
+| `None`     | No outcome (not run, not applicable) |
+| `NotFound` | Test was not found |
+
+## 5. Complete Mapping Table
+
+| `unitTestOutcome` | `MapNotRunnableToFailed` | `MapInconclusiveToFailed` | → `TestOutcome` |
+|-------------------|--------------------------|---------------------------|-----------------|
+| `Passed`          | any                      | any                       | `Passed`        |
+| `Failed`          | any                      | any                       | `Failed`        |
+| `Error`           | any                      | any                       | `Failed`        |
+| `Timeout`         | any                      | any                       | `Failed`        |
+| `Aborted`         | any                      | any                       | `Failed`        |
+| `Unknown`         | any                      | any                       | `Failed`        |
+| `Ignored`         | any                      | any                       | `Skipped`       |
+| `NotFound`        | any                      | any                       | `NotFound`      |
+| `NotRunnable`     | `true`                   | any                       | `Failed`        |
+| `NotRunnable`     | `false`                  | any                       | `None`          |
+| `Inconclusive`    | any                      | `true`                    | `Failed`        |
+| `Inconclusive`    | any                      | `false`                   | `Skipped`       |
+| `InProgress`      | any                      | any                       | `None`          |
+| _out-of-range_    | any                      | any                       | `None`          |
+
+## 6. Preconditions
+
+- `unitTestOutcome` is any value of type `UnitTestOutcome` (including out-of-range integer casts).
+- `currentSettings` is a non-null `MSTestSettings` instance.
+- `MapNotRunnableToFailed` and `MapInconclusiveToFailed` are independently set Booleans.
+
+## 7. Postconditions
+
+1. **Passed → Passed**: `unitTestOutcome = Passed` ⟹ result = `TestOutcome.Passed`.
+2. **Failure group → Failed**: `unitTestOutcome ∈ {Failed, Error, Timeout, Aborted, Unknown}` ⟹ result = `TestOutcome.Failed`.
+3. **Ignored → Skipped**: `unitTestOutcome = Ignored` ⟹ result = `TestOutcome.Skipped`.
+4. **NotFound → NotFound**: `unitTestOutcome = NotFound` ⟹ result = `TestOutcome.NotFound`.
+5. **NotRunnable/MapTrue → Failed**: `unitTestOutcome = NotRunnable ∧ currentSettings.MapNotRunnableToFailed = true` ⟹ result = `TestOutcome.Failed`.
+6. **NotRunnable/MapFalse → None**: `unitTestOutcome = NotRunnable ∧ currentSettings.MapNotRunnableToFailed = false` ⟹ result = `TestOutcome.None`.
+7. **Inconclusive/MapTrue → Failed**: `unitTestOutcome = Inconclusive ∧ currentSettings.MapInconclusiveToFailed = true` ⟹ result = `TestOutcome.Failed`.
+8. **Inconclusive/MapFalse → Skipped**: `unitTestOutcome = Inconclusive ∧ currentSettings.MapInconclusiveToFailed = false` ⟹ result = `TestOutcome.Skipped`.
+9. **InProgress → None**: `unitTestOutcome = InProgress` ⟹ result = `TestOutcome.None`.
+10. **Out-of-range → None**: `unitTestOutcome ∉ {Passed, Failed, Inconclusive, InProgress, Error, Timeout, Aborted, Unknown, NotRunnable, NotFound, Ignored}` ⟹ result = `TestOutcome.None`.
+11. **Total coverage**: every input produces exactly one of `{Passed, Failed, Skipped, None, NotFound}`.
+12. **Passed is never demoted**: the output is `Passed` if and only if the input is `Passed`.
+
+## 8. Invariants
+
+- The function is **pure** given a fixed `currentSettings`: same inputs always produce the same output.
+- The function is **total**: it returns a value for every possible `(UnitTestOutcome, bool, bool)` triple.
+- The set `{Passed, Failed, Skipped, NotFound}` is only reached by specific named inputs; only `None` is reachable by out-of-range values.
+- **Monotonicity (informal)**: enabling `MapNotRunnableToFailed` or `MapInconclusiveToFailed` can only change the output from `{None, Skipped}` to `Failed`, never the other direction.
+
+## 9. Edge Cases
+
+| Scenario | Expected | Notes |
+|----------|----------|-------|
+| `InProgress` | `None` | Not handled by named branch; falls to default `_ => TestOutcome.None` |
+| Out-of-range int cast | `None` | Also falls to default |
+| `NotRunnable` with `MapNotRunnableToFailed=false` | `None` | Default setting changed from `true` to `false` in config |
+| `Inconclusive` with `MapInconclusiveToFailed=false` | `Skipped` | Default — not a test failure |
+| `Aborted` | `Failed` | Grouped with `Failed/Error/Timeout/Unknown` |
+| `Unknown` | `Failed` | Same group |
+
+## 10. Formal Properties for Lean (Preview)
+
+The following properties are suitable for `decide`-based proofs in Lean 4:
+
+```
+-- P1: Passed maps to Passed (both configurations)
+∀ s : Settings, ToTestOutcome Passed s = TestOutcome.Passed
+
+-- P2: Failure group all map to Failed
+∀ s, ToTestOutcome Failed s = Failed
+∀ s, ToTestOutcome Error s = Failed
+∀ s, ToTestOutcome Timeout s = Failed
+∀ s, ToTestOutcome Aborted s = Failed
+∀ s, ToTestOutcome Unknown s = Failed
+
+-- P3: NotRunnable respects the flag
+ToTestOutcome NotRunnable {mapNotRunnableToFailed := true, ..} = Failed
+ToTestOutcome NotRunnable {mapNotRunnableToFailed := false, ..} = None
+
+-- P4: Inconclusive respects the flag
+ToTestOutcome Inconclusive {mapInconclusiveToFailed := true, ..} = Failed
+ToTestOutcome Inconclusive {mapInconclusiveToFailed := false, ..} = Skipped
+
+-- P5: Output range is contained in {Passed, Failed, Skipped, None, NotFound}
+∀ uo s, ToTestOutcome uo s ∈ {Passed, Failed, Skipped, None, NotFound}
+
+-- P6: Passed is the unique pre-image of TestOutcome.Passed
+∀ uo s, ToTestOutcome uo s = TestOutcome.Passed ↔ uo = UnitTestOutcome.Passed
+```
+
+All six properties are decidable given finite enumerations and Boolean flags.
+
+## 11. Open Questions
+
+- **OQ-1**: Why is `InProgress` mapped to `None` rather than `Skipped`? Is this intentional? A test still executing should arguably not have a final outcome.
+- **OQ-2**: Can `NotRunnable` and `Inconclusive` be meaningfully round-tripped (i.e., can the original `UnitTestOutcome` be recovered from a `TestOutcome`)? If so, the mapping is lossy and the two flag-dependent cases create aliasing.
+- **OQ-3**: Out-of-range integer casts are silently mapped to `None`. Is there a diagnostic or telemetry hook that should fire in this case?
+
+## 12. Existing Test Coverage
+
+The file `test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/UnitTestOutcomeHelperTests.cs` covers:
+
+| Input | Covered? |
+|-------|----------|
+| `Passed` | ✅ |
+| `Failed` | ✅ |
+| `Error` | ✅ |
+| `Timeout` | ✅ |
+| `NotRunnable` (default `MapNotRunnableToFailed=true`) | ✅ |
+| `Ignored` | ✅ |
+| `Inconclusive` (default `MapInconclusiveToFailed=false`) | ✅ |
+| `NotFound` | ✅ |
+| `InProgress` | ✅ |
+| `Aborted` | ❌ (not tested) |
+| `Unknown` | ❌ (not tested) |
+| `NotRunnable` with `MapNotRunnableToFailed=false` | ❌ (not tested) |
+| `Inconclusive` with `MapInconclusiveToFailed=true` | ❌ (not tested) |
+| Out-of-range | ❌ (not tested) |
+
+Five cases are not covered by existing tests.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -289,21 +289,23 @@ internal class TestMethodInfo : ITestMethod
     /// </returns>
     private RetryBaseAttribute? GetRetryAttribute()
     {
-        IEnumerable<RetryBaseAttribute> attributes = ReflectHelper.Instance.GetAttributes<RetryBaseAttribute>(MethodInfo);
-        using IEnumerator<RetryBaseAttribute> enumerator = attributes.GetEnumerator();
-        if (!enumerator.MoveNext())
+        // Direct iteration avoids allocating a yield iterator state machine via GetAttributes<RetryBaseAttribute>().
+        Attribute[] cachedAttributes = ReflectHelper.Instance.GetCustomAttributesCached(MethodInfo);
+        RetryBaseAttribute? found = null;
+        foreach (Attribute attr in cachedAttributes)
         {
-            return null;
+            if (attr is RetryBaseAttribute retryAttr)
+            {
+                if (found is not null)
+                {
+                    ThrowMultipleAttributesException(nameof(RetryBaseAttribute));
+                }
+
+                found = retryAttr;
+            }
         }
 
-        RetryBaseAttribute attribute = enumerator.Current;
-
-        if (enumerator.MoveNext())
-        {
-            ThrowMultipleAttributesException(nameof(RetryBaseAttribute));
-        }
-
-        return attribute;
+        return found;
     }
 
     [DoesNotReturn]

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -178,14 +178,15 @@ internal sealed class TestMethodRunner
 
     private async Task<bool> TryExecuteDataSourceBasedTestsAsync(List<TestResult> results)
     {
-        DataSourceAttribute[] dataSourceAttribute = _testMethodInfo.GetAttributes<DataSourceAttribute>();
-        if (dataSourceAttribute is { Length: 1 })
+        // IsAttributeDefined avoids the array allocation of GetAttributes<DataSourceAttribute>().
+        // DataSourceAttribute is sealed and does not allow multiple, so presence == exactly one.
+        if (!ReflectHelper.Instance.IsAttributeDefined<DataSourceAttribute>(_testMethodInfo.MethodInfo))
         {
-            await ExecuteTestFromDataSourceAttributeAsync(results).ConfigureAwait(false);
-            return true;
+            return false;
         }
 
-        return false;
+        await ExecuteTestFromDataSourceAttributeAsync(results).ConfigureAwait(false);
+        return true;
     }
 
     private async Task<bool> TryExecuteFoldedDataDrivenTestsAsync(List<TestResult> results)


### PR DESCRIPTION
- **docs: add AwesomeAssertions to glossary**
- **docs: update glossary - weekly full scan 2026-05-04**
- **perf: eliminate yield-iterator allocations in test execution hot path**
- **feat(fv): Task 1+2 — research two new targets; informal spec for UnitTestOutcomeHelper.ToTestOutcome**

Fixes #8068