### PR TITLE
Fix typo: 'CompositeExtensonFactory' -> 'CompositeExtensionFactory'

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -124,7 +124,7 @@
     <value>Failed to create a test execution filter</value>
   </data>
   <data name="CompositeServiceFactoryInstanceAlreadyRegistered" xml:space="preserve">
-    <value>The same instance of 'CompositeExtensonFactory' is already registered</value>
+    <value>The same instance of 'CompositeExtensionFactory' is already registered</value>
   </data>
   <data name="ConfigurationManagerCannotFindDefaultJsonConfigurationErrorMessage" xml:space="preserve">
     <value>Could not find the default json configuration</value>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">Už je zaregistrovaná stejná instance CompositeExtensonFactory.</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">Už je zaregistrovaná stejná instance CompositeExtensonFactory.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">Die gleiche Instanz von "CompositeExtensonFactory" ist bereits registriert</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">Die gleiche Instanz von "CompositeExtensonFactory" ist bereits registriert</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">La misma instancia de "CompositeExtensonFactory" ya está registrada</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">La misma instancia de "CompositeExtensonFactory" ya está registrada</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">La même instance de « CompositeExtensonFactory » est déjà inscrite</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">La même instance de « CompositeExtensonFactory » est déjà inscrite</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">La stessa istanza di 'CompositeExtensonFactory' è già registrata</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">La stessa istanza di 'CompositeExtensonFactory' è già registrata</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">'CompositeExtensonFactory' の同じインスタンスが既に登録されています</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">'CompositeExtensonFactory' の同じインスタンスが既に登録されています</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">동일한 'CompositeExtensonFactory' 인스턴스가 이미 등록됨</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">동일한 'CompositeExtensonFactory' 인스턴스가 이미 등록됨</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">To samo wystąpienie elementu „CompositeExtensonFactory” jest już zarejestrowane</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">To samo wystąpienie elementu „CompositeExtensonFactory” jest już zarejestrowane</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">A mesma instância de “CompositeExtensonFactory” já está registrada</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">A mesma instância de “CompositeExtensonFactory” já está registrada</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">Такой же экземпляр CompositeExtensonFactory уже зарегистрирован</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">Такой же экземпляр CompositeExtensonFactory уже зарегистрирован</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">Aynı 'CompositeExtensonFactory' örneği zaten kayıtlı</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">Aynı 'CompositeExtensonFactory' örneği zaten kayıtlı</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">“CompositeExtensonFactory”的同一实例已注册</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">“CompositeExtensonFactory”的同一实例已注册</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -163,8 +163,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompositeServiceFactoryInstanceAlreadyRegistered">
-        <source>The same instance of 'CompositeExtensonFactory' is already registered</source>
-        <target state="translated">已註冊 'CompositeExtensonFactory' 的同一執行個體</target>
+        <source>The same instance of 'CompositeExtensionFactory' is already registered</source>
+        <target state="needs-review-translation">已註冊 'CompositeExtensonFactory' 的同一執行個體</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationFileNotFound">


### PR DESCRIPTION
## Summary

Fix typo in `PlatformResources.resx` where `CompositeExtensonFactory` was missing the `i` — should be `CompositeExtensionFactory`.

Addresses Task 4 of #8065.

## Changes

- Fixed the typo in `PlatformResources.resx` (`CompositeExtensonFactory` → `CompositeExtensionFactory`)
- Rebuilt the project to regenerate all 13 `.xlf` localization files (source strings updated; translations marked as `needs-review-translation`)