### PR TITLE
Fix Hash input in _GenerateVersionSourceFileCache target

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -30,7 +30,7 @@
       <_TemplatePropertiesCacheFile>$(IntermediateOutputPath)$(MSBuildProjectFile).GenerateVersionSourceFile.cache</_TemplatePropertiesCacheFile>
     </PropertyGroup>
 
-    <Hash ItemsToHash="@(_TemplateProperties)">
+    <Hash ItemsToHash="$(_TemplateProperties)">
       <Output TaskParameter="HashResult" PropertyName="_TemplatePropertiesHash" />
     </Hash>
 


### PR DESCRIPTION
## Summary

Fix incorrect MSBuild syntax in the `_GenerateVersionSourceFileCache` target in `Directory.Build.targets`.

## Problem

`_TemplateProperties` is defined as a **property** (`<PropertyGroup>`), but the `Hash` task referenced it with **item-group** syntax `@(_TemplateProperties)`. Since no item group with that name exists, `@(_TemplateProperties)` always evaluates to empty — producing a constant hash regardless of the actual version value.

This means the cache file never reflects version changes, so the `GenerateVersionSourceFile` target's incremental build check (`Inputs`/`Outputs`) never detects that the version changed, and `BuildInfo.cs` doesn't get regenerated on incremental builds.

## Fix

Changed `@(_TemplateProperties)` → `$(_TemplateProperties)` so the `Hash` task receives the actual `Version=X.Y.Z` string.

## Impact

Affects all projects with `GenerateBuildInfo=true`:
- Microsoft.Testing.Extensions.CrashDump
- Microsoft.Testing.Extensions.HangDump
- Microsoft.Testing.Extensions.TrxReport
- Microsoft.Testing.Extensions.Retry
- Microsoft.Testing.Extensions.MSBuild
- Microsoft.Testing.Extensions.VSTestBridge
- Microsoft.Testing.Extensions.OpenTelemetry
- MSTest.TestAdapter
- MSTest.Engine
- Microsoft.Testing.TestInfrastructure

Fixes #8034