### PR TITLE
[Efficiency Improver] perf: avoid iterator allocation in GetRetryAttribute()

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -183,20 +183,22 @@ internal partial class TestMethodInfo : ITestMethod
     /// </returns>
     private RetryBaseAttribute? GetRetryAttribute()
     {
-        IEnumerable<RetryBaseAttribute> attributes = ReflectHelper.Instance.GetAttributes<RetryBaseAttribute>(MethodInfo);
-        using IEnumerator<RetryBaseAttribute> enumerator = attributes.GetEnumerator();
-        if (!enumerator.MoveNext())
+        // Iterate the cached attribute array directly to avoid allocating the yield-return
+        // state machine that GetAttributes<T>() would create.
+        RetryBaseAttribute? found = null;
+        foreach (Attribute attribute in ReflectHelper.Instance.GetCustomAttributesCached(MethodInfo))
         {
-            return null;
+            if (attribute is RetryBaseAttribute retryAttribute)
+            {
+                if (found is not null)
+                {
+                    ThrowMultipleAttributesException(nameof(RetryBaseAttribute));
+                }
+
+                found = retryAttribute;
+            }
         }
 
-        RetryBaseAttribute attribute = enumerator.Current;
-
-        if (enumerator.MoveNext())
-        {
-            ThrowMultipleAttributesException(nameof(RetryBaseAttribute));
-        }
-
-        return attribute;
+        return found;
     }
 }


### PR DESCRIPTION
Replace GetAttributes<RetryBaseAttribute>() yield-return iterator with
direct iteration over GetCustomAttributesCached() to eliminate one heap
allocation per test execution.

GetAttributes<T>() is a yield-return method: every call allocates a
compiler-generated state machine object (~48 bytes). GetRetryAttribute()
is called from the TestMethodInfo constructor, which is created fresh
for every test execution. For a 10,000-test suite this avoids ~480 KB
of iterator state machine allocations, reducing GC pressure on the
common path where RetryAttribute is absent.

The new pattern is identical to GetFirstAttributeOrDefault<T>() and
GetSingleAttributeOrDefault<T>() in ReflectHelper, which already use
direct array iteration for the same reason.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #8040