### PR TITLE
[Lean Squad] ci: improve Lean proofs CI — per-file sorry breakdown and root module checks

### DIFF
--- a/.github/workflows/fv-docs-validation.yml
+++ b/.github/workflows/fv-docs-validation.yml
@@ -147,3 +147,32 @@ jobs:
           if failed:
               sys.exit(1)
           EOF
+
+      - name: Check FVSquad root module consistency
+        run: |
+          LEAN_DIR="formal-verification/lean/FVSquad"
+          ROOT_MODULE="formal-verification/lean/FVSquad.lean"
+
+          LEAN_COUNT=$(find "${LEAN_DIR}" -maxdepth 1 -name "*.lean" 2>/dev/null | wc -l)
+
+          if [ "${LEAN_COUNT}" -eq 0 ]; then
+            echo "ℹ️  No .lean files in FVSquad/ yet — skipping root module check"
+            exit 0
+          fi
+
+          # When .lean source files exist, the root module must be present so lake build works.
+          if [ ! -f "${ROOT_MODULE}" ]; then
+            echo "::error file=${ROOT_MODULE}::FVSquad.lean root module is missing but ${LEAN_COUNT} .lean source file(s) exist in FVSquad/"
+            exit 1
+          fi
+          echo "✅  ${ROOT_MODULE} present"
+
+          # Each source file in FVSquad/ should be imported by the root module.
+          while IFS= read -r lean_file; do
+            MODULE_NAME="FVSquad.$(basename "${lean_file%.lean}")"
+            if grep -qF "import ${MODULE_NAME}" "${ROOT_MODULE}"; then
+              echo "✅  ${MODULE_NAME} imported"
+            else
+              echo "::warning file=${ROOT_MODULE}::Root module does not import ${MODULE_NAME} (from ${lean_file}); lake build may miss this file"
+            fi
+          done < <(find "${LEAN_DIR}" -maxdepth 1 -name "*.lean" 2>/dev/null | sort)

--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -124,7 +124,7 @@ jobs:
           LEAN_DIR="formal-verification/lean/FVSquad"
           # Emit a GitHub Actions warning annotation for each line containing sorry,
           # so reviewers see them inline in the Files Changed tab.
-          grep -rnw 'sorry' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
+          grep -rn '\<sorry\>' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
           | while IFS= read -r match; do
               FILE="${match%%:*}"
               REST="${match#*:}"

--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -124,13 +124,12 @@ jobs:
           LEAN_DIR="formal-verification/lean/FVSquad"
           # Emit a GitHub Actions warning annotation for each line containing sorry,
           # so reviewers see them inline in the Files Changed tab.
-          grep -rn '\<sorry\>' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
-          | while IFS= read -r match; do
+          while IFS= read -r match; do
               FILE="${match%%:*}"
               REST="${match#*:}"
               LINENUM="${REST%%:*}"
               echo "::warning file=${FILE},line=${LINENUM}::sorry — proof stub pending"
-            done
+            done < <(grep -rn '\<sorry\>' "${LEAN_DIR}" --include='*.lean' 2>/dev/null || true)
 
       - name: Proof summary
         if: steps.check-lean-files.outputs.lean_count != '0'
@@ -152,7 +151,7 @@ jobs:
             echo "| Lines containing \`sorry\` (stubs) | ${SORRY_COUNT} |"
             echo "| Proof status | ${SORRY_STATUS} |"
             echo ""
-            echo "### Per-file breakdown"
+            echo "### Per-file breakdown (recursive)"
             echo ""
             echo "| File | Theorems | sorry lines |"
             echo "|------|----------|-------------|"

--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -38,6 +38,16 @@ jobs:
             echo "Found ${LEAN_COUNT} .lean file(s). Proceeding with build."
           fi
 
+          # Check for lake-manifest.json (committed manifest enables reproducible builds
+          # and avoids requiring network access for 'lake update' in CI).
+          if [ -f "formal-verification/lean/lake-manifest.json" ]; then
+            echo "has_manifest=true" >> "$GITHUB_OUTPUT"
+            echo "✅ lake-manifest.json present — reproducible build (no network needed)"
+          else
+            echo "has_manifest=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  lake-manifest.json missing — 'lake update' will run and requires network access"
+          fi
+
       - name: Restore elan + Lake cache
         id: restore-cache
         if: steps.check-lean-files.outputs.lean_count != '0'
@@ -45,8 +55,9 @@ jobs:
         with:
           path: |
             formal-verification/lean/.lake
+            formal-verification/lean/lake-manifest.json
             ~/.elan
-          key: lean-${{ runner.os }}-${{ hashFiles('formal-verification/lean/lean-toolchain', 'formal-verification/lean/lakefile.toml') }}
+          key: lean-${{ runner.os }}-${{ hashFiles('formal-verification/lean/lean-toolchain', 'formal-verification/lean/lakefile.toml', 'formal-verification/lean/lake-manifest.json') }}
           restore-keys: |
             lean-${{ runner.os }}-
 
@@ -93,7 +104,7 @@ jobs:
         run: lean --version
 
       - name: Resolve Lean dependencies
-        if: steps.check-lean-files.outputs.lean_count != '0' && steps.restore-cache.outputs.cache-hit != 'true'
+        if: steps.check-lean-files.outputs.lean_count != '0' && steps.restore-cache.outputs.cache-hit != 'true' && steps.check-lean-files.outputs.has_manifest != 'true'
         working-directory: formal-verification/lean
         run: lake update
 
@@ -101,6 +112,20 @@ jobs:
         if: steps.check-lean-files.outputs.lean_count != '0'
         working-directory: formal-verification/lean
         run: lake build
+
+      - name: Annotate sorry occurrences
+        if: steps.check-lean-files.outputs.lean_count != '0'
+        run: |
+          LEAN_DIR="formal-verification/lean/FVSquad"
+          # Emit a GitHub Actions warning annotation for each line containing sorry,
+          # so reviewers see them inline in the Files Changed tab.
+          grep -rn '\bsorry\b' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
+          | while IFS= read -r match; do
+              FILE="${match%%:*}"
+              REST="${match#*:}"
+              LINENUM="${REST%%:*}"
+              echo "::warning file=${FILE},line=${LINENUM}::sorry — proof stub pending"
+            done || true
 
       - name: Proof summary
         if: steps.check-lean-files.outputs.lean_count != '0'
@@ -116,4 +141,15 @@ jobs:
             echo "|--------|-------|"
             echo "| Theorems / Lemmas declared | ${THEOREM_COUNT} |"
             echo "| Lines containing \`sorry\` (stubs) | ${SORRY_COUNT} |"
+            echo ""
+            echo "### Per-file breakdown"
+            echo ""
+            echo "| File | Theorems | sorry lines |"
+            echo "|------|----------|-------------|"
+            while IFS= read -r f; do
+              FNAME="$(basename "$f")"
+              FTHEOREMS=$(grep -Ec '^(theorem|lemma) ' "$f" 2>/dev/null || echo 0)
+              FSORRY=$(grep -c '\bsorry\b' "$f" 2>/dev/null || echo 0)
+              echo "| \`${FNAME}\` | ${FTHEOREMS} | ${FSORRY} |"
+            done < <(find "${LEAN_DIR}" -maxdepth 1 -name "*.lean" 2>/dev/null | sort)
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -124,12 +124,15 @@ jobs:
           LEAN_DIR="formal-verification/lean/FVSquad"
           # Emit a GitHub Actions warning annotation for each line containing sorry,
           # so reviewers see them inline in the Files Changed tab.
+          MATCHES_FILE="$(mktemp)"
+          grep -rn '\<sorry\>' "${LEAN_DIR}" --include='*.lean' > "${MATCHES_FILE}" 2>/dev/null || true
           while IFS= read -r match; do
               FILE="${match%%:*}"
               REST="${match#*:}"
               LINENUM="${REST%%:*}"
               echo "::warning file=${FILE},line=${LINENUM}::sorry — proof stub pending"
-            done < <(grep -rn '\<sorry\>' "${LEAN_DIR}" --include='*.lean' 2>/dev/null || true)
+            done < "${MATCHES_FILE}"
+          rm -f "${MATCHES_FILE}"
 
       - name: Proof summary
         if: steps.check-lean-files.outputs.lean_count != '0'

--- a/.github/workflows/lean-proofs.yml
+++ b/.github/workflows/lean-proofs.yml
@@ -38,14 +38,13 @@ jobs:
             echo "Found ${LEAN_COUNT} .lean file(s). Proceeding with build."
           fi
 
-          # Check for lake-manifest.json (committed manifest enables reproducible builds
-          # and avoids requiring network access for 'lake update' in CI).
+          # Check for lake-manifest.json (committed manifest pins Lean dependencies).
           if [ -f "formal-verification/lean/lake-manifest.json" ]; then
             echo "has_manifest=true" >> "$GITHUB_OUTPUT"
-            echo "✅ lake-manifest.json present — reproducible build (no network needed)"
+            echo "✅ lake-manifest.json present — dependencies are pinned"
           else
             echo "has_manifest=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️  lake-manifest.json missing — 'lake update' will run and requires network access"
+            echo "⚠️ lake-manifest.json missing — 'lake update' will run and requires network access"
           fi
 
       - name: Restore elan + Lake cache
@@ -109,7 +108,8 @@ jobs:
         run: lean --version
 
       - name: Resolve Lean dependencies
-        if: steps.check-lean-files.outputs.lean_count != '0' && steps.restore-cache.outputs.cache-hit != 'true' && steps.check-lean-files.outputs.has_manifest != 'true'
+        # Run on cache miss; a committed lake-manifest.json still keeps dependency versions pinned.
+        if: steps.check-lean-files.outputs.lean_count != '0' && steps.restore-cache.outputs.cache-hit != 'true'
         working-directory: formal-verification/lean
         run: lake update
 
@@ -124,20 +124,20 @@ jobs:
           LEAN_DIR="formal-verification/lean/FVSquad"
           # Emit a GitHub Actions warning annotation for each line containing sorry,
           # so reviewers see them inline in the Files Changed tab.
-          grep -rn '\bsorry\b' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
+          grep -rnw 'sorry' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
           | while IFS= read -r match; do
               FILE="${match%%:*}"
               REST="${match#*:}"
               LINENUM="${REST%%:*}"
               echo "::warning file=${FILE},line=${LINENUM}::sorry — proof stub pending"
-            done || true
+            done
 
       - name: Proof summary
         if: steps.check-lean-files.outputs.lean_count != '0'
         run: |
           LEAN_DIR="formal-verification/lean/FVSquad"
           THEOREM_COUNT=$(grep -rEc '^(theorem|lemma) ' "${LEAN_DIR}" --include='*.lean' 2>/dev/null || echo 0)
-          SORRY_COUNT=$(grep -rc '\bsorry\b' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
+          SORRY_COUNT=$(grep -rEc '\<sorry\>' "${LEAN_DIR}" --include='*.lean' 2>/dev/null \
             | awk -F: '{sum += $2} END {print sum+0}')
           SORRY_STATUS="✅ All proofs complete"
           if [ "${SORRY_COUNT}" -gt 0 ]; then
@@ -150,6 +150,7 @@ jobs:
             echo "|--------|-------|"
             echo "| Theorems / Lemmas declared | ${THEOREM_COUNT} |"
             echo "| Lines containing \`sorry\` (stubs) | ${SORRY_COUNT} |"
+            echo "| Proof status | ${SORRY_STATUS} |"
             echo ""
             echo "### Per-file breakdown"
             echo ""
@@ -158,8 +159,7 @@ jobs:
             while IFS= read -r f; do
               FNAME="$(basename "$f")"
               FTHEOREMS=$(grep -Ec '^(theorem|lemma) ' "$f" 2>/dev/null || echo 0)
-              FSORRY=$(grep -c '\bsorry\b' "$f" 2>/dev/null || echo 0)
+              FSORRY=$(grep -Ec '\<sorry\>' "$f" 2>/dev/null || echo 0)
               echo "| \`${FNAME}\` | ${FTHEOREMS} | ${FSORRY} |"
-            done < <(find "${LEAN_DIR}" -maxdepth 1 -name "*.lean" 2>/dev/null | sort)
-            echo "| Proof status | ${SORRY_STATUS} |"
+            done < <(find "${LEAN_DIR}" -name "*.lean" 2>/dev/null | sort)
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Task 9 (CI Automation) — 🔬 Lean Squad run 2026-05-08

lean-proofs.yml improvements:
- Check for lake-manifest.json presence and surface clear status messaging
  (dependencies pinned when manifest is committed)
- Include lake-manifest.json in cache paths and hash key for accurate
  cache invalidation when dependencies change
- Make 'lake update' conditional on cache miss (runs when Lean files exist and
  cache is not restored), with inline documentation of intent
- Add 'Annotate sorry occurrences' step: emits ::warning:: annotations for
  each sorry line so reviewers see stubs inline in the Files Changed tab
- Use portable/consistent sorry matching (`\<sorry\>`) across annotation and
  summary counting logic
- Expand 'Proof summary' to include per-file breakdown table
  (file name, theorem count, sorry line count), including recursive coverage
  of `.lean` files under `FVSquad/`

fv-docs-validation.yml improvements:
- Add 'Check FVSquad root module consistency' step: when .lean source files
  exist in FVSquad/, verifies FVSquad.lean root module exists and that it
  imports every source file (warns if any import is missing)

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;