### PR TITLE
[Lean Squad] feat(fv): Task 1 — expand TARGETS.md to 17 targets; add LLMEnvironmentDetector research

### DIFF
--- a/formal-verification/RESEARCH.md
+++ b/formal-verification/RESEARCH.md
@@ -193,6 +193,41 @@ A pure recursive function that evaluates whether a test-node path and property b
 
 ---
 
+### Target 17 — `LLMEnvironmentDetector` rule composition ★★★☆☆
+
+**File**: `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs`
+**Type**: Internal rule-based DSL for AI coding-tool detection
+
+This recently-added helper detects whether the process is running inside an LLM-powered coding agent (Claude Code, GitHub Copilot, Cursor, Gemini, Codex, etc.). It models detection as a composition of four rule types over environment variables.
+
+**Rule types**:
+- `BooleanEnvironmentRule(vars)`: any var in `vars` parses as `true` via `ParseBool`
+- `AnyPresentEnvironmentRule(vars)`: any var in `vars` is non-null/non-empty
+- `EnvironmentVariableValueRule(var, expected)`: `var` == `expected` (case-insensitive)
+- `AnyMatchEnvironmentRule(rules)`: logical OR over a list of sub-rules
+
+**Why interesting for FV**:
+- Pure algebraic structure: `Rule → (String → Option String) → Bool`
+- `AnyMatchEnvironmentRule []` → always `false` (empty OR = false identity)
+- `AnyMatchEnvironmentRule [r]` is extensionally equal to `r.IsMatch()` (singleton identity)
+- Monotonicity: adding a rule can only increase detection (inductive)
+- `EnvironmentVariableParser.ParseBool` inside this file is the same logic as target id=8 — the Lean model can be reused
+- All detection rules are closed (finite known environment var names) → decidable for any given env snapshot
+
+**Properties to verify**:
+1. `AnyMatchEnvironmentRule []` never matches (∀ env, false) — decidable
+2. `AnyMatchEnvironmentRule [r]` same as `r.IsMatch()` — provable by unfolding
+3. Monotonicity: `rules₁ ⊆ rules₂ → (rules₁.any match → rules₂.any match)` — inductive
+4. `ParseBool null default = default` — decidable
+5. `ParseBool "1" _ = true`, `ParseBool "0" _ = false` — decidable
+6. `ParseBool` range: result ∈ {true, false} — trivially true
+
+**Approximations**: Environment modelled as `String → Option String`. `RoslynString.IsNullOrEmpty` approximated as `Option.isNone ∨ (Option.get = "")`.
+
+**Priority**: Medium (phase 1 → candidate for Task 2 next run).
+
+---
+
 ## Approach Notes
 
 - We use Lean 4 with Mathlib for all proofs.

--- a/formal-verification/TARGETS.md
+++ b/formal-verification/TARGETS.md
@@ -14,32 +14,90 @@
 
 ## Target List
 
-| # | Name | File | Phase | Status | PR/Issue |
-|---|------|------|-------|--------|----------|
-| 1 | `ArgumentArity` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ArgumentArity.cs` | 2 | Informal spec extracted | [PR #7799](https://github.com/microsoft/testfx/pull/7799) |
-| 2 | `CommandLineParser.TryUnescape` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec extracted | — |
-| 3 | `CommandLineParser.ParseOptionAndSeparators` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec extracted | — |
-| 4 | `CommandLineOptionsValidator` arity validation | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs` | 2 | Informal spec extracted | — |
-| 5 | `CommandLineParseResult.Equals` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs` | 2 | Informal spec extracted | — |
-| 6 | `ResponseFileHelper.SplitCommandLine` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs` | 2 | Informal spec extracted | [PR #7899](https://github.com/microsoft/testfx/pull/7899) |
-| 7 | `TreeNodeFilter.MatchFilterPattern` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 2 | Informal spec extracted | — |
-| 8 | `EnvironmentVariableParser.ParseBool` | `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs` | 2 | Informal spec extracted | — |
+| # | Name | File | Phase | Status | PR/Issue | Notes |
+|---|------|------|-------|--------|----------|-------|
+| 1 | `ArgumentArity` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ArgumentArity.cs` | 2 | Informal spec extracted | [PR #7799](https://github.com/microsoft/testfx/pull/7799) | Top priority for Task 3 |
+| 2 | `CommandLineParser.TryUnescape` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec extracted | — | BUG-1, BUG-2 documented |
+| 3 | `CommandLineParser.ParseOptionAndSeparators` | `src/Platform/Microsoft.Testing.Platform/CommandLine/Parser.cs` | 2 | Informal spec extracted | — | BUG-5 documented |
+| 4 | `CommandLineOptionsValidator.ValidateOptionsArgumentArity` | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs` | 2 | Informal spec extracted | — | OQ-1..OQ-4 documented |
+| 5 | `CommandLineParseResult.Equals` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs` | 2 | Informal spec extracted | — | Equivalence-relation laws |
+| 6 | `ResponseFileHelper.SplitCommandLine` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs` | 2 | Informal spec extracted | [PR #7899](https://github.com/microsoft/testfx/pull/7899) | BUG-3, BUG-4 documented |
+| 7 | `TreeNodeFilter.MatchFilterPattern` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 2 | Informal spec extracted | — | Boolean algebra laws |
+| 8 | `EnvironmentVariableParser.ParseBool` | `src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableParser.cs` | 2 | Informal spec extracted | — | All 8 theorems decidable |
+| 9 | `PasteArguments.ContainsNoWhitespaceOrQuotes` | `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs` | 2 | Informal spec extracted | — | 14 theorems; char whitespace approx |
+| 10 | `CommandLineOptionsValidator.ValidateOptionsAreNotDuplicated` | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs` | 1 | Identified | — | Next: Task 2 |
+| 11 | `ValidationResult` | `src/Platform/Microsoft.Testing.Platform/Extensions/ValidationResult.cs` | 1 | Identified | — | Discriminated union invariant |
+| 12 | `PasteArguments.AppendArgument` | `src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs` | 1 | Identified | — | Deferred until target 9 proved |
+| 13 | `TreeNodeFilter.TokenizeFilter` | `src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs` | 1 | Identified | — | Lexer; deferred |
+| 14 | `TimeSpanParser.TryParse` | `src/Platform/Microsoft.Testing.Platform/Helpers/TimeSpanParser.cs` | 1 | Identified | — | Regex-driven; harder to model |
+| 15 | `CommandLineOption` name validation | `src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOption.cs` | 1 | Identified | — | Character predicate |
+| 16 | `DotnetTestConnection.IsVersionCompatible` | `src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs` | 1 | Identified | — | One-liner; ideal smallest target |
+| 17 | `LLMEnvironmentDetector` rule composition | `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs` | 1 | **NEW** — Identified this run | — | Rule-based DSL; composition laws |
 
 ## Priority Order
 
-1. **`ArgumentArity`** — highest priority. Smallest self-contained target; decidable properties; good warm-up for setting up the Lean environment. Informal spec done. **Next: Task 3 (blocked by Lean toolchain).**
-2. **`CommandLineParser.TryUnescape`** — second priority. Pure function with clear specification; security-relevant string processing. Informal spec extracted. **Next: Task 3 (blocked by Lean toolchain).**
-3. **`TreeNodeFilter.MatchFilterPattern`** — **elevated third priority**. Pure recursive Boolean algebra; structural induction proofs; De Morgan and double negation provable by `simp`. Informal spec extracted. **Next: Task 3 (blocked by Lean toolchain).**
-4. **`ResponseFileHelper.SplitCommandLine`** — fourth priority. Pure tokeniser with state machine; clear grammar-based properties. Informal spec extracted (PR open). **Next: Task 3 (blocked by Lean toolchain).**
-5. **`CommandLineParser.ParseOptionAndSeparators`** — fifth priority. Small pure function; useful for verifying parser correctness. Informal spec extracted this run. **Next: Task 3 (blocked by Lean toolchain).**
-6. **`CommandLineOptionsValidator` arity validation** — sixth priority. Validation logic with clear input/output contract. Informal spec extracted. **Next: Task 3.**
-7. **`CommandLineParseResult.Equals`** — seventh priority. Structural equality; good for verifying equivalence-relation laws.
-8. **`EnvironmentVariableParser.ParseBool`** — eighth priority. Pure total function; all 8 theorems of interest provable by `decide`. Informal spec extracted this run. **Next: Task 3 (blocked by Lean toolchain).**
+1. **`ArgumentArity`** (id=1) — highest priority. Smallest self-contained target; decidable properties; warm-up for Lean setup. Informal spec done. **Next: Task 3 (blocked by Lean toolchain).**
+2. **`CommandLineParser.TryUnescape`** (id=2) — second priority. Pure function; security-relevant; 2 confirmed bugs. **Next: Task 3 (blocked by Lean toolchain).**
+3. **`TreeNodeFilter.MatchFilterPattern`** (id=7) — third priority. Boolean algebra; De Morgan and double negation provable by `simp`. **Next: Task 3 (blocked by Lean toolchain).**
+4. **`ResponseFileHelper.SplitCommandLine`** (id=6) — fourth priority. Pure tokeniser; state machine; 2 confirmed bugs. **Next: Task 3 (blocked by Lean toolchain).**
+5. **`CommandLineParser.ParseOptionAndSeparators`** (id=3) — fifth priority. Small pure function; BUG-5 documented. **Next: Task 3.**
+6. **`DotnetTestConnection.IsVersionCompatible`** (id=16) — sixth priority for Task 2. One-liner pure function; trivially provable. **Next: Task 2.**
+7. **`EnvironmentVariableParser.ParseBool`** (id=8) — seventh. All theorems decidable by `decide`. **Next: Task 3.**
+8. **`PasteArguments.ContainsNoWhitespaceOrQuotes`** (id=9) — eighth. Concatenation split via `List.all_append`. **Next: Task 3.**
+
+## Findings
+
+| ID | Description | Target |
+|----|-------------|--------|
+| BUG-1 | `TryUnescape`: single-char quote → `IndexOf(char,1,-1)` throws | id=2 |
+| BUG-2 | `TryUnescape`: single-char double-quote → `input[1..^1]` range exception | id=2 |
+| BUG-3 | `SplitCommandLine`: unclosed quote discards all input | id=6 |
+| BUG-4 | `SplitCommandLine`: adjacent quoted strings emit 2 tokens not 1 | id=6 |
+| BUG-5 | `ParseOptionAndSeparators`: empty option name not rejected | id=3 |
+| OQ-1 | `ValidateOptionsArgumentArity`: absent required options not caught | id=4 |
+| OQ-2 | `ValidateOptionsArgumentArity`: `KeyNotFoundException` if called before ValidateNoUnknownOptions | id=4 |
+| OQ-3 | `ValidateOptionsArgumentArity`: Max==0 message asymmetry | id=4 |
+| OQ-4 | `ValidateOptionsArgumentArity`: grammar defect ("at least 1 arguments") | id=4 |
+| GAP-1 | `UnitTestOutcomeHelper`: Aborted and Unknown have no unit tests | — |
+| GAP-2 | `UnitTestOutcomeHelper`: NotRunnable with MapNotRunnableToFailed=false has no unit test | — |
+
+## New Target Research — Run 14 (2026-05-11)
+
+### Target 17 — `LLMEnvironmentDetector` rule composition ★★★☆☆
+
+**File**: `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs`
+**Type**: Internal rule-based DSL for AI-tool environment detection
+
+This recently-added helper detects whether the current process is running inside an LLM-powered coding agent (Claude Code, Copilot, Cursor, Gemini, etc.). It models detection as a composition of three primitive rule types:
+
+- `BooleanEnvironmentRule`: any env var ∈ list parses as `true` (via `ParseBool`)
+- `AnyPresentEnvironmentRule`: any env var ∈ list is non-null/non-empty
+- `AnyPresentEnvironmentRule`: env var has a specific value (case-insensitive)
+- `AnyMatchEnvironmentRule`: logical OR over a list of sub-rules
+
+**Why good for FV**:
+- The rule types form a small, pure algebraic structure: `Rule → Env → Bool`
+- `AnyMatchEnvironmentRule` with an empty list always returns `false` → **provable by `decide`**
+- `AnyMatchEnvironmentRule [r]` is extensionally equal to `r.IsMatch()` → provable
+- Monotonicity: adding a rule to `AnyMatchEnvironmentRule` can only increase detection → provable by structural induction
+- The private `EnvironmentVariableParser.ParseBool` is the same logic as target id=8 — reuse the same Lean model
+
+**Properties to verify**:
+1. Empty rule list → `AnyMatchEnvironmentRule` never matches (trivially decidable)
+2. Singleton rule list → same as that rule (extensional equality)
+3. `AnyMatchEnvironmentRule` is monotone in rule count (inductive)
+4. `ParseBool(null, default)` = `default` (decidable)
+5. `ParseBool("1", _)` = `true`, `ParseBool("0", _)` = `false` (decidable)
+6. `ParseBool` result ∈ {`true`, `false`} for any input (trivially true)
+
+**Approximations**: Model environment as a `HashMap String (Option String)`. The `AnyMatchEnvironmentRule` list is modelled as a `List Rule`.
+
+**Priority**: Medium. Rich composition properties, but requires modelling env as a function parameter.
 
 ## Notes
 
-- Six of the seven targets are in the command-line infrastructure of Microsoft.Testing.Platform; one target is in the tree-node filter subsystem.
-- `TreeNodeFilter.MatchFilterPattern` (Target 7) is the highest-complexity target but also the most mathematically rich: proofs of Boolean-algebra laws give immediate, meaningful results.
-- `ResponseFileHelper.SplitCommandLine` (Target 6) is derived from `dotnet/command-line-api` — the upstream source is noted in comments; cross-referencing it may reveal documented invariants.
-- MSTest assertion APIs (e.g., `Assert.AreEqual`, `Assert.IsTrue`) remain interesting but harder to model formally due to generic type constraints and exception-based control flow.
-- Future targets may include the server-mode protocol state machine and the test-filter tokeniser (`TreeNodeFilter.TokenizeFilter`).
+- Lean 4 toolchain installation has been blocked in the agent sandbox for 14 consecutive runs (elan binary execution denied by security policy). All Tasks 3–5 are deferred until this is resolved.
+- Fourteen targets are in Microsoft.Testing.Platform (command-line infrastructure, server mode, helpers). One target (`UnitTestOutcomeHelper` gaps) is in the MSTest adapter.
+- `TreeNodeFilter.MatchFilterPattern` (id=7) is the mathematically richest target: Boolean algebra proofs.
+- `DotnetTestConnection.IsVersionCompatible` (id=16) is the smallest remaining Task-2 target: a single expression.
+- `LLMEnvironmentDetector` (id=17) is newly identified this run from recently-added code; interesting for rule-composition properties.


### PR DESCRIPTION
- Updated TARGETS.md from 7 to 17 entries (reflects 14 runs of accumulated memory)
- Added all previously-tracked targets (ids 1-16) in a consolidated clean table
- Added new target 17: LLMEnvironmentDetector rule composition
  - Rule-based DSL for AI coding-tool detection (pure, algebraic)
  - Composition laws: empty OR=false, singleton identity, monotonicity
  - ParseBool logic reuses same Lean model as target id=8
- Updated findings table (BUG-1..BUG-5, OQ-1..OQ-4, GAP-1..GAP-2)
- Added new target section to RESEARCH.md with full rationale
- Task 3 remains blocked: Lean toolchain (elan) execution denied by
  agent security policy (confirmed 14 consecutive runs)

🔬 Lean Squad automated FV agent — run 25645127282

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #8084
