### PR TITLE
[Test Improver] Add unit tests for LoggingManager.BuildAsync

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggingManagerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggingManagerTests.cs
@@ -16,7 +16,7 @@ public sealed class LoggingManagerTests
     private readonly Mock<IServiceProvider> _mockServiceProvider = new();
 
     public LoggingManagerTests()
-        => _mockMonitor.Setup(x => x.Lock(It.IsAny<object>())).Returns(new Mock<IDisposable>().Object);
+        => _mockMonitor.Setup(m => m.Lock(It.IsAny<object>())).Returns(new Mock<IDisposable>().Object);
 
     [TestMethod]
     public void AddProvider_NullFactory_ThrowsArgumentNullException()
@@ -31,10 +31,14 @@ public sealed class LoggingManagerTests
         LoggingManager manager = new();
         ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
         Assert.IsNotNull(factory);
+        factory.CreateLogger("smoke");
     }
 
     [TestMethod]
-    public async Task BuildAsync_PassesCorrectLogLevelAndServiceProviderToFactory()
+    [DataRow(LogLevel.Trace)]
+    [DataRow(LogLevel.Warning)]
+    [DataRow(LogLevel.Critical)]
+    public async Task BuildAsync_PassesCorrectLogLevelAndServiceProviderToFactory(LogLevel level)
     {
         LogLevel capturedLevel = default;
         IServiceProvider? capturedServiceProvider = null;
@@ -50,9 +54,10 @@ public sealed class LoggingManagerTests
             return mockProvider.Object;
         });
 
-        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Warning, _mockMonitor.Object);
+        await manager.BuildAsync(_mockServiceProvider.Object, level, _mockMonitor.Object);
 
-        Assert.AreEqual(LogLevel.Warning, capturedLevel);
+        Assert.AreEqual(level, capturedLevel);
+        Assert.IsNotNull(capturedServiceProvider, "Factory was not invoked");
         Assert.AreSame(_mockServiceProvider.Object, capturedServiceProvider);
     }
 
@@ -109,9 +114,11 @@ public sealed class LoggingManagerTests
         mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
         manager.AddProvider((_, _) => mockProvider.Object);
 
-        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        factory.CreateLogger("test");
 
         mockProvider.Verify(p => p.InitializeAsync(), Times.Once);
+        mockProvider.Verify(p => p.CreateLogger("test"), Times.Once);
     }
 
     [TestMethod]
@@ -136,9 +143,11 @@ public sealed class LoggingManagerTests
         mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
         manager.AddProvider((_, _) => mockProvider.Object);
 
-        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        factory.CreateLogger("test");
 
         mockProvider.Verify(p => p.InitializeAsync(), Times.Once);
+        mockProvider.Verify(p => p.CreateLogger("test"), Times.Once);
     }
 }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggingManagerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggingManagerTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class LoggingManagerTests
+{
+    private readonly Mock<IMonitor> _mockMonitor = new();
+    private readonly Mock<IServiceProvider> _mockServiceProvider = new();
+
+    public LoggingManagerTests()
+        => _mockMonitor.Setup(x => x.Lock(It.IsAny<object>())).Returns(new Mock<IDisposable>().Object);
+
+    [TestMethod]
+    public void AddProvider_NullFactory_ThrowsArgumentNullException()
+    {
+        LoggingManager manager = new();
+        Assert.ThrowsExactly<ArgumentNullException>(() => manager.AddProvider(null!));
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NoProviders_ReturnsNonNullFactory()
+    {
+        LoggingManager manager = new();
+        ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        Assert.IsNotNull(factory);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_PassesCorrectLogLevelAndServiceProviderToFactory()
+    {
+        LogLevel capturedLevel = default;
+        IServiceProvider? capturedServiceProvider = null;
+
+        LoggingManager manager = new();
+        Mock<ILoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+
+        manager.AddProvider((level, sp) =>
+        {
+            capturedLevel = level;
+            capturedServiceProvider = sp;
+            return mockProvider.Object;
+        });
+
+        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Warning, _mockMonitor.Object);
+
+        Assert.AreEqual(LogLevel.Warning, capturedLevel);
+        Assert.AreSame(_mockServiceProvider.Object, capturedServiceProvider);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NonExtensionProvider_IsAlwaysIncluded()
+    {
+        LoggingManager manager = new();
+        Mock<ILoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+        manager.AddProvider((_, _) => mockProvider.Object);
+
+        ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        factory.CreateLogger("test");
+
+        mockProvider.Verify(p => p.CreateLogger("test"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_EnabledExtensionProvider_IsIncluded()
+    {
+        LoggingManager manager = new();
+        Mock<IExtensionLoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.IsEnabledAsync()).ReturnsAsync(true);
+        mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+        manager.AddProvider((_, _) => mockProvider.Object);
+
+        ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        factory.CreateLogger("test");
+
+        mockProvider.Verify(p => p.CreateLogger("test"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_DisabledExtensionProvider_IsExcluded()
+    {
+        LoggingManager manager = new();
+        Mock<IExtensionLoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.IsEnabledAsync()).ReturnsAsync(false);
+        manager.AddProvider((_, _) => mockProvider.Object);
+
+        ILoggerFactory factory = await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+        factory.CreateLogger("test");
+
+        mockProvider.Verify(p => p.CreateLogger(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_InitializableExtensionProvider_WhenEnabled_CallsInitializeAsync()
+    {
+        LoggingManager manager = new();
+        Mock<IInitializableExtensionLoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.IsEnabledAsync()).ReturnsAsync(true);
+        mockProvider.Setup(p => p.InitializeAsync()).Returns(Task.CompletedTask);
+        mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+        manager.AddProvider((_, _) => mockProvider.Object);
+
+        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+
+        mockProvider.Verify(p => p.InitializeAsync(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_InitializableExtensionProvider_WhenDisabled_DoesNotCallInitializeAsync()
+    {
+        LoggingManager manager = new();
+        Mock<IInitializableExtensionLoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.IsEnabledAsync()).ReturnsAsync(false);
+        manager.AddProvider((_, _) => mockProvider.Object);
+
+        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+
+        mockProvider.Verify(p => p.InitializeAsync(), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task BuildAsync_NonExtensionInitializableProvider_CallsInitializeAsync()
+    {
+        LoggingManager manager = new();
+        Mock<IInitializableLoggerProvider> mockProvider = new();
+        mockProvider.Setup(p => p.InitializeAsync()).Returns(Task.CompletedTask);
+        mockProvider.Setup(p => p.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+        manager.AddProvider((_, _) => mockProvider.Object);
+
+        await manager.BuildAsync(_mockServiceProvider.Object, LogLevel.Information, _mockMonitor.Object);
+
+        mockProvider.Verify(p => p.InitializeAsync(), Times.Once);
+    }
+}
+
+internal interface IExtensionLoggerProvider : ILoggerProvider, IExtension;
+
+internal interface IInitializableLoggerProvider : ILoggerProvider, IAsyncInitializableExtension;
+
+internal interface IInitializableExtensionLoggerProvider : ILoggerProvider, IExtension, IAsyncInitializableExtension;


### PR DESCRIPTION
Cover all key behaviors of LoggingManager:
- AddProvider with null throws ArgumentNullException
- BuildAsync with no providers returns a non-null factory
- BuildAsync with no providers returns a functional factory that can create a logger
- Factory delegate receives the correct LogLevel and IServiceProvider (validated across Trace, Warning, and Critical)
- Non-IExtension provider is always included
- IExtension provider enabled -> included; disabled -> excluded
- IAsyncInitializableExtension + enabled -> InitializeAsync called and provider included
- IAsyncInitializableExtension + disabled -> InitializeAsync not called
- Non-extension IAsyncInitializableExtension -> InitializeAsync called and provider included

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;