### PR TITLE
Update changelogs for v4.2.2 release

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## <a name="2.2.2" />[2.2.2] - 2026-04-30
+
+See full log [of v4.2.1...v4.2.2](https://github.com/microsoft/testfx/compare/v4.2.1...v4.2.2)
+
+### Artifacts
+
+* Microsoft.Testing.Platform: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Platform/2.2.2)
+* Microsoft.Testing.Platform.MSBuild: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild/2.2.2)
+* Microsoft.Testing.Extensions.CrashDump: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CrashDump/2.2.2)
+* Microsoft.Testing.Extensions.HangDump: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HangDump/2.2.2)
+* Microsoft.Testing.Extensions.HotReload: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload/2.2.2)
+* Microsoft.Testing.Extensions.Retry: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/2.2.2)
+* Microsoft.Testing.Extensions.Telemetry: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Telemetry/2.2.2)
+* Microsoft.Testing.Extensions.TrxReport: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/2.2.2)
+* Microsoft.Testing.Extensions.TrxReport.Abstractions: [2.2.2](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport.Abstractions/2.2.2)
+
 ## <a name="2.2.1" />[2.2.1] - 2026-04-07
 
 See full log [of v4.1.0...v4.2.1](https://github.com/microsoft/testfx/compare/v4.1.0...v4.2.1)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## <a name="4.2.2" />[4.2.2] - 2026-04-30
+
+See full log [of v4.2.1...v4.2.2](https://github.com/microsoft/testfx/compare/v4.2.1...v4.2.2)
+
+### Fixed
+
+* Fix log accumulation across DynamicData test invocations by @Evangelink in [#7925](https://github.com/microsoft/testfx/pull/7925)
+* Fix WinUI TestContext.Current being null by @Youssef1313 in [#7749](https://github.com/microsoft/testfx/pull/7749)
+
+### Artifacts
+
+* MSTest: [4.2.2](https://www.nuget.org/packages/MSTest/4.2.2)
+* MSTest.TestFramework: [4.2.2](https://www.nuget.org/packages/MSTest.TestFramework/4.2.2)
+* MSTest.TestAdapter: [4.2.2](https://www.nuget.org/packages/MSTest.TestAdapter/4.2.2)
+* MSTest.Analyzers: [4.2.2](https://www.nuget.org/packages/MSTest.Analyzers/4.2.2)
+* MSTest.Sdk: [4.2.2](https://www.nuget.org/packages/MSTest.Sdk/4.2.2)
+* MSTest.SourceGeneration: [2.0.0-alpha.26228.3](https://www.nuget.org/packages/MSTest.SourceGeneration/2.0.0-alpha.26228.3)
+* MSTest.Engine: [2.0.0-alpha.26228.3](https://www.nuget.org/packages/MSTest.Engine/2.0.0-alpha.26228.3)
+
 ## <a name="4.2.1" />[4.2.1] - 2026-04-07
 
 See full log [of v4.1.0...v4.2.1](https://github.com/microsoft/testfx/compare/v4.1.0...v4.2.1)


### PR DESCRIPTION
## Summary

Add release notes for MSTest 4.2.2 / Microsoft.Testing.Platform 2.2.2.

### MSTest 4.2.2 fixes
- Fix log accumulation across DynamicData test invocations (#7925)
- Fix WinUI TestContext.Current being null (#7749)

### Microsoft.Testing.Platform 2.2.2
- No platform-specific changes (artifacts only)