### PR TITLE
Fix CS8625 nullable warnings in DesktopTestSourceHostTests

### DIFF
--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestSourceHostTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestSourceHostTests.cs
@@ -104,7 +104,7 @@ public class DesktopTestSourceHostTests : TestContainer
         _ = new DummyClass();
 
         string location = typeof(TestSourceHost).Assembly.Location;
-        Mock<TestSourceHost> sourceHost = new(location, null) { CallBase = true };
+        Mock<TestSourceHost> sourceHost = new(location, (IRunSettings?)null) { CallBase = true };
 
         try
         {
@@ -161,7 +161,7 @@ public class DesktopTestSourceHostTests : TestContainer
         DummyClass dummyClass = new();
 
         string location = typeof(TestSourceHost).Assembly.Location;
-        Mock<TestSourceHost> sourceHost = new(location, null) { CallBase = true };
+        Mock<TestSourceHost> sourceHost = new(location, (IRunSettings?)null) { CallBase = true };
 
         try
         {


### PR DESCRIPTION
Fix two CS8625 build errors (`Cannot convert null literal to non-nullable reference type`) in `DesktopTestSourceHostTests.cs` on lines 107 and 164.

The `Mock<TestSourceHost>` constructor receives `null` for the `IRunSettings?` parameter, but the compiler cannot infer the nullable type through the `Mock<T>` constructor's `params object[]`. The fix adds an explicit cast to `(IRunSettings?)null`.