### PR TITLE
Use `trigger: none` instead of explicit branch triggers in public pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,4 @@
-trigger:
-  branches:
-    include:
-    - main
-    - rel/*
-  paths:
-    exclude:
-      - .github/**
-      - .gitignore
+trigger: none
 
 # Branch(es) that trigger(s) build(s) on PR
 pr:


### PR DESCRIPTION
Relates to #6156

The public pipeline (`azure-pipelines.yml`) is intended to run only on PRs, not on branch pushes. PR #6159 added explicit branch triggers for `main` and `rel/*` to work around the dnceng requirement (dotnet/dnceng#6014) of having an explicit trigger section. However, this causes every non-fork PR to trigger the pipeline twice (once for the push, once for the PR).

Replace the explicit branch trigger with `trigger: none` which:
- Explicitly disables CI (push) triggers — satisfying the dnceng requirement
- Prevents duplicate builds for non-fork PRs
- Keeps PR triggers working as defined by the `pr:` section