### PR TITLE
Use indexer syntax for dictionary initializers

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromRunSettingsTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromRunSettingsTests.cs
@@ -80,7 +80,7 @@ public sealed class TimeoutFromRunSettingsTests : AcceptanceTestBase<TimeoutFrom
         string runSettingsFilePath = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.runsettings");
         File.WriteAllText(runSettingsFilePath, runSettings);
 
-        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath}", environmentVariables: new() { { $"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}", "1" } });
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath}", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" });
         testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' timed out after {timeoutValue}ms");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenCanceledTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenCanceledTests.cs
@@ -34,7 +34,7 @@ public sealed class TimeoutWhenCanceledTests : AcceptanceTestBase<TimeoutWhenCan
     private static async Task RunAndAssertTestWasCanceledAsync(string tfm, string envVarPrefix, string entryKind)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
-        TestHostResult testHostResult = await testHost.ExecuteAsync(environmentVariables: new() { { envVarPrefix + InfoByKind[entryKind].EnvVarSuffix, "1" } });
+        TestHostResult testHostResult = await testHost.ExecuteAsync(environmentVariables: new() { [envVarPrefix + InfoByKind[entryKind].EnvVarSuffix] = "1" });
         testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' was canceled");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
@@ -119,7 +119,7 @@ public sealed class TimeoutWhenExpiresTests : AcceptanceTestBase<TimeoutWhenExpi
     private static async Task RunAndAssertTestTimedOutAsync(string tfm, string envVarPrefix, string entryKind)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
-        TestHostResult testHostResult = await testHost.ExecuteAsync(environmentVariables: new() { { envVarPrefix + InfoByKind[entryKind].EnvVarSuffix, "1" } });
+        TestHostResult testHostResult = await testHost.ExecuteAsync(environmentVariables: new() { [envVarPrefix + InfoByKind[entryKind].EnvVarSuffix] = "1" });
         testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' timed out after 1000ms");
     }
 
@@ -142,7 +142,7 @@ public sealed class TimeoutWhenExpiresTests : AcceptanceTestBase<TimeoutWhenExpi
         File.WriteAllText(runSettingsFilePath, runSettings);
 
         var stopwatch = Stopwatch.StartNew();
-        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath}", environmentVariables: new() { { $"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}", "1" } });
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath}", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" });
         stopwatch.Stop();
 
         Assert.IsLessThan(25, stopwatch.Elapsed.TotalSeconds);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExitOnProcessExitTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExitOnProcessExitTests.cs
@@ -16,7 +16,7 @@ public class ExitOnProcessExitTests : AcceptanceTestBase<ExitOnProcessExitTests.
 
         // Create the mutex name used to wait for the PID file created by the test host.
         string waitPid = Guid.NewGuid().ToString("N");
-        _ = testHost.ExecuteAsync(environmentVariables: new Dictionary<string, string?> { { "WaitPid", waitPid } }, cancellationToken: TestContext.CancellationToken);
+        _ = testHost.ExecuteAsync(environmentVariables: new Dictionary<string, string?> { ["WaitPid"] = waitPid }, cancellationToken: TestContext.CancellationToken);
 
         Process? process;
         var startTime = Stopwatch.StartNew();

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
@@ -44,7 +44,7 @@ Out of process file artifacts produced:
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
             $"--crashdump --report-trx --report-trx-filename {fileName}.trx",
-            new() { { "CRASHPROCESS", "1" } }, cancellationToken: TestContext.CancellationToken);
+            new() { ["CRASHPROCESS"] = "1" }, cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
 
@@ -66,7 +66,7 @@ Out of process file artifacts produced:
         DotnetMuxerResult result = await DotnetCli.RunAsync(
             $"test --project \"{AssetFixture.TargetAssetPath}\" --no-build -c Release -f {tfm} --crashdump --report-trx --report-trx-filename {fileName}.trx --results-directory \"{testResultsPath}\"",
             workingDirectory: AssetFixture.TargetAssetPath,
-            environmentVariables: new() { { "CRASHPROCESS", "1" } },
+            environmentVariables: new() { ["CRASHPROCESS"] = "1" },
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/UnhandledExceptionPolicyTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/UnhandledExceptionPolicyTests.cs
@@ -45,19 +45,19 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
         {
             case Mode.Enabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": true"));
-                testHostResult = await testHost.ExecuteAsync(null, new() { { "UNOBSERVEDTASKEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
+                testHostResult = await testHost.ExecuteAsync(null, new() { ["UNOBSERVEDTASKEXCEPTION"] = "1" }, cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException(testhost controller workflow)]");
                 break;
             case Mode.Disabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": false"));
-                testHostResult = await testHost.ExecuteAsync(null, new() { { "UNOBSERVEDTASKEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
+                testHostResult = await testHost.ExecuteAsync(null, new() { ["UNOBSERVEDTASKEXCEPTION"] = "1" }, cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertExitCodeIs(ExitCode.Success);
                 testHostResult.AssertOutputDoesNotContain("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException]");
                 break;
             case Mode.Default:
                 File.Delete(configFileName);
-                testHostResult = await testHost.ExecuteAsync(null, new() { { "UNOBSERVEDTASKEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
+                testHostResult = await testHost.ExecuteAsync(null, new() { ["UNOBSERVEDTASKEXCEPTION"] = "1" }, cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertExitCodeIs(ExitCode.Success);
                 testHostResult.AssertOutputDoesNotContain("[UnhandledExceptionHandler.OnTaskSchedulerUnobservedTaskException]");
                 break;
@@ -67,8 +67,8 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                     null,
                     new()
                     {
-                        { "UNOBSERVEDTASKEXCEPTION", "1" },
-                        { EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION, "0" },
+                        ["UNOBSERVEDTASKEXCEPTION"] = "1",
+                        [EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION] = "0",
                     },
                     cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertExitCodeIs(ExitCode.Success);
@@ -80,8 +80,8 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                     null,
                     new()
                     {
-                        { "UNOBSERVEDTASKEXCEPTION", "1" },
-                        { EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION, "1" },
+                        ["UNOBSERVEDTASKEXCEPTION"] = "1",
+                        [EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION] = "1",
                     },
                     cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertExitCodeIsNot(ExitCode.Success);
@@ -108,20 +108,20 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
         {
             case Mode.Enabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": true"));
-                testHostResult = await testHost.ExecuteAsync(null, new() { { "UNHANDLEDEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
+                testHostResult = await testHost.ExecuteAsync(null, new() { ["UNHANDLEDEXCEPTION"] = "1" }, cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnCurrentDomainUnhandledException(testhost controller workflow)]");
                 testHostResult.AssertOutputContains("IsTerminating: True");
                 testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.Disabled:
                 File.WriteAllText(configFileName, contentFile.Replace("\"exitProcessOnUnhandledException\": false", "\"exitProcessOnUnhandledException\": false"));
-                testHostResult = await testHost.ExecuteAsync(null, new() { { "UNHANDLEDEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
+                testHostResult = await testHost.ExecuteAsync(null, new() { ["UNHANDLEDEXCEPTION"] = "1" }, cancellationToken: TestContext.CancellationToken);
                 Assert.IsTrue(testHostResult.StandardError.Contains("Unhandled exception", StringComparison.OrdinalIgnoreCase), testHostResult.ToString());
                 testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.Default:
                 File.Delete(configFileName);
-                testHostResult = await testHost.ExecuteAsync(null, new() { { "UNHANDLEDEXCEPTION", "1" } }, cancellationToken: TestContext.CancellationToken);
+                testHostResult = await testHost.ExecuteAsync(null, new() { ["UNHANDLEDEXCEPTION"] = "1" }, cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertExitCodeIsNot(ExitCode.Success);
                 break;
             case Mode.DisabledByEnvironmentVariable:
@@ -130,8 +130,8 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                     null,
                     new()
                     {
-                        { "UNHANDLEDEXCEPTION", "1" },
-                        { EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION, "0" },
+                        ["UNHANDLEDEXCEPTION"] = "1",
+                        [EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION] = "0",
                     },
                     cancellationToken: TestContext.CancellationToken);
                 Assert.IsTrue(testHostResult.StandardError.Contains("Unhandled exception", StringComparison.OrdinalIgnoreCase), testHostResult.ToString());
@@ -144,8 +144,8 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
                     null,
                     new()
                     {
-                        { "UNHANDLEDEXCEPTION", "1" },
-                        { EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION, "1" },
+                        ["UNHANDLEDEXCEPTION"] = "1",
+                        [EnvironmentVariableConstants.TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION] = "1",
                     },
                     cancellationToken: TestContext.CancellationToken);
                 testHostResult.AssertOutputContains("[UnhandledExceptionHandler.OnCurrentDomainUnhandledException(testhost controller workflow)]");

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -1141,7 +1141,7 @@ public class MSTestSettingsTests : TestContainer
     public void ConfigJson_WithValidValues_MethodScope()
     {
         // Arrange - setting up valid configuration values
-        var configDictionary = new Dictionary<string, string> { { "mstest:parallelism:scope", "method" } };
+        var configDictionary = new Dictionary<string, string> { ["mstest:parallelism:scope"] = "method" };
 
         var mockConfig = new Mock<IConfiguration>();
         mockConfig.Setup(config => config[It.IsAny<string>()])

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/PlatformServiceProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/PlatformServiceProviderTests.cs
@@ -53,7 +53,7 @@ public class PlatformServiceProviderTests : TestContainer
     {
         // Arrange.
         var testMethod = new Mock<Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel.ITestMethod>();
-        var properties = new Dictionary<string, object?> { { "prop", "value" } };
+        var properties = new Dictionary<string, object?> { ["prop"] = "value" };
         testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
         testMethod.Setup(tm => tm.Name).Returns("M");
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -303,7 +303,7 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(ProcessInfoArgs))
         {
-            return new ProcessInfoArgs("program", "arts", "workingDir", new Dictionary<string, string?> { { "key", "value" } });
+            return new ProcessInfoArgs("program", "arts", "workingDir", new Dictionary<string, string?> { ["key"] = "value" });
         }
 
         if (type == typeof(KeyValuePair<string, string>))
@@ -313,7 +313,7 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(TelemetryEventArgs))
         {
-            return new TelemetryEventArgs("eventName", new Dictionary<string, object> { { "key", 1 } });
+            return new TelemetryEventArgs("eventName", new Dictionary<string, object> { ["key"] = 1 });
         }
 
         if (type == typeof(CancelRequestArgs))


### PR DESCRIPTION
Replace `{ key, value }` dictionary initializer syntax with `[key] = value` indexer syntax across test files, consistent with the IDE0028 analyzer rule already configured in `.editorconfig`.