### PR TITLE
Pin Nerdbank.MessagePack to fix CVE in Playground

### DIFF
--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <PackageReference Include="Nerdbank.MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />


### PR DESCRIPTION
`StreamJsonRpc 2.24.84` pulls in `Nerdbank.MessagePack 1.0.2` transitively in `Playground.csproj`. This older version has a known CVE flagged by the microsoft-testfx (Windows) pipeline.

Adding a direct `PackageReference` to `Nerdbank.MessagePack` makes the centrally managed version (1.1.62) take precedence, resolving the vulnerability. This is the same pattern already used in `FSharpPlayground.fsproj` and the acceptance test projects.