### PR TITLE
Remove IVT from Microsoft.Testing.Platform to Microsoft.Testing.Platform.MSBuild

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
@@ -9,7 +9,8 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\*.cs" Link="IPC\%(RecursiveDir)%(Filename)%(Extension)" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\BaseSerializer.cs" Link="IPC\Serializers\BaseSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\VoidResponseSerializer.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
-    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Models\VoidResponse.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\ObjectFieldIds.cs" Link="IPC\ObjectFieldIds.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
 
     <!-- Embedded helpers from Microsoft.Testing.Platform -->
@@ -19,6 +20,11 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeoutHelper.cs" Link="Helpers\TimeoutHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeSpanParser.cs" Link="Helpers\TimeSpanParser.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\StringBuilderExtensions.cs" Link="Helpers\StringBuilderExtensions.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\IEnvironment.cs" Link="Helpers\System\IEnvironment.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\SystemEnvironment.cs" Link="Helpers\System\SystemEnvironment.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\ITask.cs" Link="Helpers\System\ITask.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\System\SystemTask.cs" Link="Helpers\System\SystemTask.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
@@ -118,11 +118,4 @@ This package provides MSBuild integration of the platform, its extensions and co
     <Using Include="Polyfills" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- NOTE: SDK already adds Linux, macOS, and Windows. -->
-    <!-- See https://github.com/dotnet/sdk/blob/cb459ebc2d9374b2bc5ce944cc633a6e79ed8275/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props -->
-    <SupportedPlatform Include="browser" />
-    <SupportedPlatform Include="wasi" />
-  </ItemGroup>
-
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj
@@ -118,4 +118,11 @@ This package provides MSBuild integration of the platform, its extensions and co
     <Using Include="Polyfills" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- NOTE: SDK already adds Linux, macOS, and Windows. -->
+    <!-- See https://github.com/dotnet/sdk/blob/cb459ebc2d9374b2bc5ce944cc633a6e79ed8275/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.SupportedPlatforms.props -->
+    <SupportedPlatform Include="browser" />
+    <SupportedPlatform Include="wasi" />
+  </ItemGroup>
+
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/ITask.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/ITask.cs
@@ -12,8 +12,10 @@ internal interface ITask
 
     Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken);
 
+#if !MTP_MSBUILD_TASKS
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("wasi")]
+#endif
     Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken);
 
     Task WhenAll(params Task[] tasks);

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemTask.cs
@@ -14,8 +14,10 @@ internal sealed class SystemTask : ITask
     public Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken)
         => Task.Run(function, cancellationToken);
 
+#if !MTP_MSBUILD_TASKS
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("wasi")]
+#endif
     public Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken)
     {
         // We create custom thread so we can assign the name that will help us to identify the thread in the dump

--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -54,7 +54,6 @@ This package provides the core platform and the .NET implementation of the proto
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.Acceptance.IntegrationTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.AI" Key="$(VsPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.Testing.Platform.MSBuild" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.TestInfrastructure" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTest.Engine" Key="$(VsPublicKey)" />


### PR DESCRIPTION
## Summary

Remove the `InternalsVisibleTo` declaration from `Microsoft.Testing.Platform` to `Microsoft.Testing.Platform.MSBuild` by embedding all required internal types as source-linked files.

## Changes

**Microsoft.Testing.Platform.MSBuild.csproj**: Added source links for types that were previously accessed through IVT:
- `IEnvironment.cs` + `SystemEnvironment.cs` — system abstraction for the embedded IPC infrastructure
- `ITask.cs` + `SystemTask.cs` — task abstraction for the embedded IPC infrastructure
- `StringBuilderExtensions.cs` — polyfill for `StringBuilder.Append/AppendLine(IFormatProvider, ...)` on netstandard2.0
- `ObjectFieldIds.cs` — field ID constants referenced by the embedded `VoidResponseSerializer`
- Fixed incorrect `Link` path for `VoidResponse.cs`

**Microsoft.Testing.Platform.csproj**: Removed the `InternalsVisibleTo` entry for `Microsoft.Testing.Platform.MSBuild`.

## Context

This is the first PR in a series to reduce IVT coupling between core `Microsoft.Testing.Platform` and extension assemblies. `Microsoft.Testing.Platform.MSBuild` was the cleanest candidate since it only used internal types that are self-contained utilities (system abstractions for IPC, polyfills, and constants).

### Next candidates
- `Microsoft.Testing.Extensions.MSBuild` — same IPC types + only needs `TestRequestExecutionTimeInfo` through IVT
- Other IPC-heavy extensions (Retry, HangDump, TrxReport) need the same system abstraction types