### PR TITLE
[code-simplifier] refactor: remove duplicate top-level interface declarations from LoggingManagerTests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggingManagerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggingManagerTests.cs
@@ -9,12 +9,6 @@ using Moq;
 
 namespace Microsoft.Testing.Platform.UnitTests;
 
-internal interface IExtensionLoggerProvider : ILoggerProvider, IExtension;
-
-internal interface IInitializableLoggerProvider : ILoggerProvider, IAsyncInitializableExtension;
-
-internal interface IInitializableExtensionLoggerProvider : ILoggerProvider, IExtension, IAsyncInitializableExtension;
-
 [TestClass]
 public sealed class LoggingManagerTests
 {


### PR DESCRIPTION
The three top-level namespace interfaces (IExtensionLoggerProvider,
IInitializableLoggerProvider, IInitializableExtensionLoggerProvider)
were stale leftovers. The test class already declares the interfaces it
needs as private nested types (IExtensionLoggerProvider,
IExtensionInitializableLoggerProvider, IInitializableLoggerProvider).
The top-level IInitializableExtensionLoggerProvider was also unused.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #8182
