### PR TITLE
[Test Improver] test: add unit tests for StopPoliciesService

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/StopPoliciesServiceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/StopPoliciesServiceTests.cs
@@ -96,13 +96,16 @@ public sealed class StopPoliciesServiceTests : IDisposable
     [TestMethod]
     public async Task RegisterOnMaxFailedTestsCallbackAsync_ThrowsIfNotTestHost()
     {
-        StopPoliciesService service = new(_cancellationTokenSource.Object)
+        foreach (TestProcessRole? processRole in new TestProcessRole?[] { null, TestProcessRole.TestHostController })
         {
-            ProcessRole = TestProcessRole.TestHostController,
-        };
+            StopPoliciesService service = new(_cancellationTokenSource.Object)
+            {
+                ProcessRole = processRole,
+            };
 
-        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-            () => service.RegisterOnMaxFailedTestsCallbackAsync((_, _) => Task.CompletedTask));
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => service.RegisterOnMaxFailedTestsCallbackAsync((_, _) => Task.CompletedTask));
+        }
     }
 
     [TestMethod]
@@ -114,14 +117,19 @@ public sealed class StopPoliciesServiceTests : IDisposable
         };
         await service.ExecuteMaxFailedTestsCallbacksAsync(3, CancellationToken.None);
 
+        int invocationCount = 0;
         int capturedCount = -1;
         await service.RegisterOnMaxFailedTestsCallbackAsync((count, _) =>
         {
+            invocationCount++;
             capturedCount = count;
             return Task.CompletedTask;
         });
 
-        Assert.AreEqual(3, capturedCount);
+        await service.ExecuteMaxFailedTestsCallbacksAsync(10, CancellationToken.None);
+
+        Assert.AreEqual(2, invocationCount);
+        Assert.AreEqual(10, capturedCount);
     }
 
     [TestMethod]
@@ -130,14 +138,16 @@ public sealed class StopPoliciesServiceTests : IDisposable
         StopPoliciesService service = new(_cancellationTokenSource.Object);
         await service.ExecuteAbortCallbacksAsync();
 
-        bool callbackInvoked = false;
+        int invocationCount = 0;
         await service.RegisterOnAbortCallbackAsync(() =>
         {
-            callbackInvoked = true;
+            invocationCount++;
             return Task.CompletedTask;
         });
 
-        Assert.IsTrue(callbackInvoked);
+        await service.ExecuteAbortCallbacksAsync();
+
+        Assert.AreEqual(2, invocationCount);
     }
 
     [TestMethod]
@@ -145,18 +155,22 @@ public sealed class StopPoliciesServiceTests : IDisposable
     {
         StopPoliciesService service = new(_cancellationTokenSource.Object);
 
-        bool callbackInvoked = false;
+        TaskCompletionSource<bool> callbackInvoked = new(TaskCreationOptions.RunContinuationsAsynchronously);
         await service.RegisterOnAbortCallbackAsync(() =>
         {
-            callbackInvoked = true;
+            callbackInvoked.TrySetResult(true);
             return Task.CompletedTask;
         });
 
+#if NETCOREAPP
         await _cts.CancelAsync();
+#else
+        _cts.Cancel();
+#endif
 
-        // Allow async callback time to complete
-        await Task.Delay(200, TestContext.CancellationToken);
+        Task completedTask = await Task.WhenAny(callbackInvoked.Task, Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken));
+        Assert.AreSame(callbackInvoked.Task, completedTask);
 
-        Assert.IsTrue(callbackInvoked);
+        await callbackInvoked.Task;
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/StopPoliciesServiceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/StopPoliciesServiceTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class StopPoliciesServiceTests : IDisposable
+{
+    private readonly Mock<ITestApplicationCancellationTokenSource> _cancellationTokenSource = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    public TestContext TestContext { get; set; } = null!;
+
+    public void Dispose() => _cts.Dispose();
+
+    [TestInitialize]
+    public void Initialize()
+        => _cancellationTokenSource.SetupGet(x => x.CancellationToken).Returns(_cts.Token);
+
+    [TestMethod]
+    public void IsMaxFailedTestsTriggered_InitiallyFalse()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+        Assert.IsFalse(service.IsMaxFailedTestsTriggered);
+    }
+
+    [TestMethod]
+    public void IsAbortTriggered_InitiallyFalse()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+        Assert.IsFalse(service.IsAbortTriggered);
+    }
+
+    [TestMethod]
+    public async Task ExecuteMaxFailedTestsCallbacksAsync_SetsIsMaxFailedTestsTriggered()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+
+        await service.ExecuteMaxFailedTestsCallbacksAsync(5, CancellationToken.None);
+
+        Assert.IsTrue(service.IsMaxFailedTestsTriggered);
+    }
+
+    [TestMethod]
+    public async Task ExecuteMaxFailedTestsCallbacksAsync_InvokesRegisteredCallback()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object)
+        {
+            ProcessRole = TestProcessRole.TestHost,
+        };
+
+        int capturedMaxFailedTests = -1;
+        await service.RegisterOnMaxFailedTestsCallbackAsync((count, _) =>
+        {
+            capturedMaxFailedTests = count;
+            return Task.CompletedTask;
+        });
+
+        await service.ExecuteMaxFailedTestsCallbacksAsync(7, CancellationToken.None);
+
+        Assert.AreEqual(7, capturedMaxFailedTests);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAbortCallbacksAsync_SetsIsAbortTriggered()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+
+        await service.ExecuteAbortCallbacksAsync();
+
+        Assert.IsTrue(service.IsAbortTriggered);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAbortCallbacksAsync_InvokesRegisteredCallback()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+
+        bool callbackInvoked = false;
+        await service.RegisterOnAbortCallbackAsync(() =>
+        {
+            callbackInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        await service.ExecuteAbortCallbacksAsync();
+
+        Assert.IsTrue(callbackInvoked);
+    }
+
+    [TestMethod]
+    public async Task RegisterOnMaxFailedTestsCallbackAsync_ThrowsIfNotTestHost()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object)
+        {
+            ProcessRole = TestProcessRole.TestHostController,
+        };
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => service.RegisterOnMaxFailedTestsCallbackAsync((_, _) => Task.CompletedTask));
+    }
+
+    [TestMethod]
+    public async Task RegisterOnMaxFailedTestsCallbackAsync_ImmediatelyInvokesCallbackIfAlreadyTriggered()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object)
+        {
+            ProcessRole = TestProcessRole.TestHost,
+        };
+        await service.ExecuteMaxFailedTestsCallbacksAsync(3, CancellationToken.None);
+
+        int capturedCount = -1;
+        await service.RegisterOnMaxFailedTestsCallbackAsync((count, _) =>
+        {
+            capturedCount = count;
+            return Task.CompletedTask;
+        });
+
+        Assert.AreEqual(3, capturedCount);
+    }
+
+    [TestMethod]
+    public async Task RegisterOnAbortCallbackAsync_ImmediatelyInvokesCallbackIfAlreadyTriggered()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+        await service.ExecuteAbortCallbacksAsync();
+
+        bool callbackInvoked = false;
+        await service.RegisterOnAbortCallbackAsync(() =>
+        {
+            callbackInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.IsTrue(callbackInvoked);
+    }
+
+    [TestMethod]
+    public async Task CancellationToken_Cancelled_TriggersAbortCallbacks()
+    {
+        StopPoliciesService service = new(_cancellationTokenSource.Object);
+
+        bool callbackInvoked = false;
+        await service.RegisterOnAbortCallbackAsync(() =>
+        {
+            callbackInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        await _cts.CancelAsync();
+
+        // Allow async callback time to complete
+        await Task.Delay(200, TestContext.CancellationToken);
+
+        Assert.IsTrue(callbackInvoked);
+    }
+}


### PR DESCRIPTION
Cover key behaviors of StopPoliciesService:
- Initial state (IsMaxFailedTestsTriggered/IsAbortTriggered are false)
- ExecuteMaxFailedTestsCallbacksAsync sets the flag and invokes callbacks
- ExecuteAbortCallbacksAsync sets the flag and invokes callbacks
- RegisterOnMaxFailedTestsCallbackAsync throws if ProcessRole != TestHost
- RegisterOnMaxFailedTestsCallbackAsync immediately invokes callback if already triggered
- RegisterOnAbortCallbackAsync immediately invokes callback if already triggered
- CancellationToken cancellation triggers abort callbacks via constructor registration

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #8205
