### PR TITLE
Revert "Guard server telemetry against duplicate result updates per test UID (#8192)"

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PerRequestServerDataConsumerService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PerRequestServerDataConsumerService.cs
@@ -243,11 +243,6 @@ internal sealed class PerRequestServerDataConsumer(IServiceProvider serviceProvi
             return;
         }
 
-        if (existingStatistics.HasPassed == hasPassed)
-        {
-            return;
-        }
-
         if (hasPassed)
         {
             existingStatistics.TotalPassedRetries++;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerDataConsumerServiceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerDataConsumerServiceTests.cs
@@ -133,12 +133,12 @@ public sealed class ServerDataConsumerServiceTests : IDisposable
         Assert.AreEqual(0, statistics.TotalDiscoveredTests);
         Assert.AreEqual(1, statistics.TotalPassedTests);
         Assert.AreEqual(0, statistics.TotalFailedTests);
-        Assert.AreEqual(0, statistics.TotalPassedRetries);
+        Assert.AreEqual(1, statistics.TotalPassedRetries);
         Assert.AreEqual(0, statistics.TotalFailedRetries);
     }
 
     [TestMethod]
-    public void PopulateTestNodeStatistics_WithOutcomeChangeForSameUid_CountsAsRetry()
+    public void PopulateTestNodeStatistics_WithEventsForSameUid()
     {
         PropertyBag properties = new(
             new FailedTestNodeStateProperty("failed"));
@@ -148,54 +148,10 @@ public sealed class ServerDataConsumerServiceTests : IDisposable
         PropertyBag otherProperties = new(
             PassedTestNodeStateProperty.CachedInstance);
 
-        TestNodeUpdateMessage otherTestNode = new(new SessionUid("2"), new TestNode { Uid = new TestNodeUid("test()"), DisplayName = string.Empty, Properties = otherProperties });
+        TestNodeUpdateMessage otherTestNode = new(new SessionUid(string.Empty), new TestNode { Uid = new TestNodeUid("test()"), DisplayName = string.Empty, Properties = otherProperties });
 
         _service.PopulateTestNodeStatistics(testNode);
         _service.PopulateTestNodeStatistics(otherTestNode);
-
-        TestNodeStatistics statistics = _service.GetTestNodeStatistics();
-        Assert.AreEqual(0, statistics.TotalDiscoveredTests);
-        Assert.AreEqual(1, statistics.TotalPassedTests);
-        Assert.AreEqual(0, statistics.TotalFailedTests);
-        Assert.AreEqual(1, statistics.TotalPassedRetries);
-        Assert.AreEqual(0, statistics.TotalFailedRetries);
-    }
-
-    [TestMethod]
-    public void PopulateTestNodeStatistics_WithDuplicateFailedEvents_DoesNotCountAsRetry()
-    {
-        PropertyBag properties = new(
-            new FailedTestNodeStateProperty("failed"));
-
-        TestNodeUpdateMessage testNode = new(new SessionUid("1"), new TestNode { Uid = new TestNodeUid("test()"), DisplayName = string.Empty, Properties = properties });
-
-        _service.PopulateTestNodeStatistics(testNode);
-        _service.PopulateTestNodeStatistics(testNode);
-
-        TestNodeStatistics statistics = _service.GetTestNodeStatistics();
-        Assert.AreEqual(0, statistics.TotalDiscoveredTests);
-        Assert.AreEqual(0, statistics.TotalPassedTests);
-        Assert.AreEqual(1, statistics.TotalFailedTests);
-        Assert.AreEqual(0, statistics.TotalPassedRetries);
-        Assert.AreEqual(0, statistics.TotalFailedRetries);
-    }
-
-    [TestMethod]
-    public void PopulateTestNodeStatistics_WithDuplicateEventAfterOutcomeChange_OnlyCountsFirstRetry()
-    {
-        PropertyBag failedProperties = new(
-            new FailedTestNodeStateProperty("failed"));
-
-        TestNodeUpdateMessage failedTestNode = new(new SessionUid("1"), new TestNode { Uid = new TestNodeUid("test()"), DisplayName = string.Empty, Properties = failedProperties });
-
-        PropertyBag passedProperties = new(
-            PassedTestNodeStateProperty.CachedInstance);
-
-        TestNodeUpdateMessage passedTestNode = new(new SessionUid("1"), new TestNode { Uid = new TestNodeUid("test()"), DisplayName = string.Empty, Properties = passedProperties });
-
-        _service.PopulateTestNodeStatistics(failedTestNode);
-        _service.PopulateTestNodeStatistics(passedTestNode);
-        _service.PopulateTestNodeStatistics(passedTestNode);
 
         TestNodeStatistics statistics = _service.GetTestNodeStatistics();
         Assert.AreEqual(0, statistics.TotalDiscoveredTests);


### PR DESCRIPTION
## Summary

Reverts #8192.

## Why

After the merge, @Youssef1313 pointed out (https://github.com/microsoft/testfx/pull/8192#discussion_r3240664374) that the deduplication guard introduces an asymmetric retry-counting semantic. Under #8192's guard, the retry count became:

| 1st result | 2nd result | retries counted |
|---|---|---|
| pass | pass | 0 |
| pass | fail | 1 |
| fail | fail | 0 |
| fail | pass | 1 |

The "retry" count then depends on outcome shape rather than on how many results were actually reported — particularly noticeable for "folded" tests where multiple sub-cases share one `TestNode.Uid`. The pre-#8192 behavior (every subsequent update for the same UID counts as a retry) is at least symmetric and consistent.

This revert restores that prior behavior. If retry/dedup semantics need to change, that should be a separate, design-led PR rather than the post-hoc guard from #8192.

## Validation

- `ServerDataConsumerServiceTests` runs green (8/8).
- No public API changes, no localization changes.