### PR TITLE
Make 'never APPROVE' rule prominent in expert-reviewer prompt

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -11,6 +11,14 @@ You are an expert code reviewer for the MSTest testing framework and Microsoft.T
 
 ---
 
+## Absolute Rules (read first, must never be violated)
+
+1. **NEVER submit a `submit_pull_request_review` with `event: "APPROVE"`.** This agent is not authorized to approve pull requests under any circumstance, including when the PR is perfectly clean. The only allowed values for `event` are `"COMMENT"` and `"REQUEST_CHANGES"`. The safe-outputs filter will reject `APPROVE` and the entire review submission will be lost — including the verdict table and any inline comments bundled with it. If every dimension is clean, submit a `COMMENT` review with the all-clear summary; do **not** approve.
+2. **Inline comments use `create_pull_request_review_comment`**, never `add_comment`, when they are tied to a specific changed line.
+3. **Do not post empty praise.** Inline comments must be actionable; if a dimension is clean, leave no inline comment for it.
+
+---
+
 ## Overarching Principles
 
 1. **Backward Compatibility Is Sacred** — MSTest and MTP are NuGet-shipped packages consumed by millions. Any behavioral change requires opt-in mechanisms, deprecation warnings before removal, and multi-version transition periods. New warnings are breaking changes for `-WarnAsError` users.
@@ -630,7 +638,8 @@ Before analyzing the diff, load the repository history knowledge base produced b
    ```
 
    `[ ]` = dimensions with findings. Any BLOCKING → event: **REQUEST_CHANGES**. Otherwise (including all-clear) → event: **COMMENT**.
-   **Never use APPROVE** — the agent must not count as a PR approval.
+
+   ⛔ **NEVER use `event: "APPROVE"`.** See [Absolute Rules](#absolute-rules-read-first-must-never-be-violated). The safe-outputs configuration only accepts `COMMENT` and `REQUEST_CHANGES`; an `APPROVE` submission is rejected and the entire review (including inline comments bundled into it) is dropped. When every dimension is clean, the correct event is `COMMENT` with the all-clear summary above — not `APPROVE`.
 
    All inline comments from step 4 are automatically bundled into this review submission.
 

--- a/.github/workflows/shared/review-shared.md
+++ b/.github/workflows/shared/review-shared.md
@@ -39,7 +39,7 @@ Review pull request #${{ github.event.pull_request.number || github.event.issue.
 ## Instructions
 
 1. Fetch the full diff for the pull request.
-2. Call the `expert-reviewer` agent as a **background** task (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`, `mode: "background"`). Include the PR number, repository owner/name, and the full diff content in the subagent prompt.
+2. Call the `expert-reviewer` agent as a **background** task (`task` tool, `agent_type: "general-purpose"`, `model: "claude-opus-4.6"`, `mode: "background"`). Include the PR number, repository owner/name, and the full diff content in the subagent prompt. Also remind the subagent in its prompt that the `submit_pull_request_review` safe-output only accepts `event: "COMMENT"` or `event: "REQUEST_CHANGES"` — `APPROVE` is not allowed and will cause the entire review to be dropped.
 3. **Immediately after launching the background task** — do NOT wait for it to finish and do NOT read its result — call `noop` with a brief status message such as `"Expert-reviewer launched in background for PR #N. It will post the review directly."`. Then stop. The subagent has direct access to the safe-output tools and will post its own review (`create_pull_request_review_comment`, `add_comment`, `submit_pull_request_review`) without any further action from you.
 
 > **Important**: Reading the background agent result would pull its entire conversation (2+ million tokens from spawning 21 dimension sub-agents) into your context, causing a server error. Do not call `read_agent` or any equivalent after calling `noop`.


### PR DESCRIPTION
## Symptom

When the `Expert Code Review (on open)` workflow ran on PR #8220, the agent successfully reviewed the change but tried to submit it with `event: APPROVE`. The safe-outputs filter (`allowed-events: [COMMENT, REQUEST_CHANGES]`) correctly rejected it, and the whole `safe_outputs` job failed:

> https://github.com/microsoft/testfx/actions/runs/25860787433/job/75991405833

```
##[warning]Review event 'APPROVE' is not allowed. Allowed events: COMMENT, REQUEST_CHANGES
##[error]✗ Message 2 (submit_pull_request_review) failed: Review event 'APPROVE' is not allowed by safe-outputs configuration. Allowed events: COMMENT, REQUEST_CHANGES
##[error]1 safe output(s) failed
```

The verdict summary table — and all inline review comments bundled into that `submit_pull_request_review` call — were dropped on the floor as a side effect.

## Root cause

`submit-pull-request-review.allowed-events: [COMMENT, REQUEST_CHANGES]` is intentional: this agent must not be able to count as a PR approval. The agent's prompt does say `Never use APPROVE`, but the rule sits ~630 lines into `.github/agents/expert-reviewer.agent.md`, well after 21 dimension definitions and a four-wave workflow. The model didn't carry it through to the final tool call.

## Fix

Reinforce the constraint in three places to make it impossible to miss:

1. **`.github/agents/expert-reviewer.agent.md`** — Add an `Absolute Rules (read first, must never be violated)` section right under the title. Rule #1 explicitly forbids `event: ""APPROVE""` and spells out the consequence (entire review, including bundled inline comments, is dropped).
2. **`.github/agents/expert-reviewer.agent.md`** — Strengthen the existing Wave 4 step-6 reminder with a stop sign and a back-reference to the Absolute Rules section, and re-emphasise that the all-clear case is `COMMENT` (not `APPROVE`).
3. **`.github/workflows/shared/review-shared.md`** — Instruct the launcher agent to forward the same constraint to the subagent's prompt when it spawns it.

Both files are imported at runtime via gh-aw `{{#runtime-import}}` (verified in the lock files), so no lock-file regeneration is required and the diff is purely the two `.md` files. `gh aw compile` was still run to verify there are no warnings.

We deliberately do **not** add `APPROVE` to `allowed-events` — the safe-outputs filter is doing exactly what it was configured to do, and the security model (no automated approvals) should stay intact.