### PR TITLE
Update changelogs for v4.2.3 / v2.2.3 release

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## <a name="2.2.3" />[2.2.3] - 2026-05-14
+
+See full log [of v4.2.2...v4.2.3](https://github.com/microsoft/testfx/compare/v4.2.2...v4.2.3)
+
+### Artifacts
+
+* Microsoft.Testing.Platform: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Platform/2.2.3)
+* Microsoft.Testing.Platform.MSBuild: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild/2.2.3)
+* Microsoft.Testing.Extensions.CrashDump: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CrashDump/2.2.3)
+* Microsoft.Testing.Extensions.HangDump: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HangDump/2.2.3)
+* Microsoft.Testing.Extensions.HotReload: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload/2.2.3)
+* Microsoft.Testing.Extensions.Retry: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/2.2.3)
+* Microsoft.Testing.Extensions.Telemetry: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Telemetry/2.2.3)
+* Microsoft.Testing.Extensions.TrxReport: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/2.2.3)
+* Microsoft.Testing.Extensions.TrxReport.Abstractions: [2.2.3](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport.Abstractions/2.2.3)
+
 ## <a name="2.2.2" />[2.2.2] - 2026-04-30
 
 See full log [of v4.2.1...v4.2.2](https://github.com/microsoft/testfx/compare/v4.2.1...v4.2.2)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,15 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## <a name="4.2.3" />[4.2.3] - 2026-05-XX
+## <a name="4.2.3" />[4.2.3] - 2026-05-14
 
-See full log [of v4.2.2...v4.2.3](https://github.com/microsoft/testfx/compare/v4.2.1...v4.2.2)
+See full log [of v4.2.2...v4.2.3](https://github.com/microsoft/testfx/compare/v4.2.2...v4.2.3)
 
 ### Fixed
 
 * Fix log accumulation across DynamicData test invocations by @Evangelink in [#7925](https://github.com/microsoft/testfx/pull/7925)
+* Fix async TestInitialize/TestCleanup causing COMException in WinUI UITestMethod by @Copilot in [#8119](https://github.com/microsoft/testfx/pull/8119)
 
 ### Artifacts
+
+* MSTest: [4.2.3](https://www.nuget.org/packages/MSTest/4.2.3)
+* MSTest.TestFramework: [4.2.3](https://www.nuget.org/packages/MSTest.TestFramework/4.2.3)
+* MSTest.TestAdapter: [4.2.3](https://www.nuget.org/packages/MSTest.TestAdapter/4.2.3)
+* MSTest.Analyzers: [4.2.3](https://www.nuget.org/packages/MSTest.Analyzers/4.2.3)
+* MSTest.Sdk: [4.2.3](https://www.nuget.org/packages/MSTest.Sdk/4.2.3)
+* MSTest.SourceGeneration: [2.0.0-alpha.26228.3](https://www.nuget.org/packages/MSTest.SourceGeneration/2.0.0-alpha.26228.3)
+* MSTest.Engine: [2.0.0-alpha.26228.3](https://www.nuget.org/packages/MSTest.Engine/2.0.0-alpha.26228.3)
 
 ## <a name="4.2.2" />[4.2.2] - 2026-04-30
 


### PR DESCRIPTION
Prepares the changelog entries for the upcoming **MSTest 4.2.3** and **Microsoft.Testing.Platform 2.2.3** servicing release.

### MSTest 4.2.3 (`docs/Changelog.md`)

The previous stub for 4.2.3 incorrectly carried over PR #7925 (which already shipped in 4.2.2) and a wrong compare link. Replaced with the actual content of `rel/4.2`:

- Fixed compare link to `v4.2.2...v4.2.3`.
- Single user-facing fix on `rel/4.2`: `Fix async TestInitialize/TestCleanup causing COMException in WinUI UITestMethod` (#8119, backported via #8172).
- Filled in the Artifacts list following the 4.2.2 layout.

### Microsoft.Testing.Platform 2.2.3 (`docs/Changelog-Platform.md`)

`rel/4.2` carries no functional MTP changes since 2.2.2 — only the MSTest backport and a `.gitignore` update — so the new 2.2.3 entry mirrors the 2.2.2 format with just the Artifacts list bumped.

### Notes

- Date set to 2026-05-14; adjust if the release ships on a different day.
- Attribution for #8119 uses `@Copilot` (matches the merged commit author and existing convention in earlier entries).
- `MSTest.SourceGeneration` / `MSTest.Engine` alpha versions reuse the 4.2.2 stamp (`2.0.0-alpha.26228.3`); update if a fresher build is published for 4.2.3.