### PR TITLE
Bump Microsoft.TestPlatform.Filter.Source to 18.8.0-preview-26264-09

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageVersion Include="Microsoft.TestPlatform.Filter.Source" Version="18.7.0-preview-26213-05" />
+    <PackageVersion Include="Microsoft.TestPlatform.Filter.Source" Version="18.8.0-preview-26264-09" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />


### PR DESCRIPTION
Bumps `Microsoft.TestPlatform.Filter.Source` from `18.7.0-preview-26213-05` to `18.8.0-preview-26264-09` (latest version available on the `test-tools` feed).