### PR TITLE
Exclude xlf files from PR build trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ pr:
       - SECURITY.md
       - azure-pipelines-official.yml
       - azure-pipelines-codeql.yml
+      - "**/*.xlf"
 
 parameters:
 # This option should be used with caution. This is useful for unblocking circular deps issue with testanywhere


### PR DESCRIPTION
Adds `**/*.xlf` to the PR path excludes in `azure-pipelines.yml` so that PRs only updating localized XLF translation files do not trigger the build pipeline.