### PR TITLE
Move RFC 012 (Structured Assertion Messages) into Implementation status

### DIFF
--- a/docs/RFCs/012-Structured-Assertion-Messages.md
+++ b/docs/RFCs/012-Structured-Assertion-Messages.md
@@ -1,8 +1,8 @@
 # RFC 012 - Structured Assertion Messages
 
-- [ ] Approved in principle
-- [x] Under discussion
-- [ ] Implementation
+- [x] Approved in principle
+- [ ] Under discussion
+- [x] Implementation
 - [ ] Shipped
 
 ## Summary


### PR DESCRIPTION
Following the merges of #8170 (infrastructure), #8187 (IsTrue/IsFalse/IsNull/IsNotNull), #8210 (exception assertions), and #8214 (reference and type assertions), RFC 012 has effectively moved past the discussion phase. This PR updates the RFC status checkboxes accordingly:

- [x] Approved in principle
- [ ] Under discussion
- [x] Implementation
- [ ] Shipped

The remaining assertion families (`AreEqual`/`AreNotEqual`, `IsSubsetOf`/`IsNotSubsetOf`, `AllItemsAreNotNull`/`AreUnique`/`AreInstancesOfType`, `StringAssert`, `CollectionAssert`, `Assert.Contains`/`Count`, etc.) will continue to be migrated in follow-up PRs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
