### PR TITLE
Apply structured assertion messages (RFC 012) to Assert.StartsWith / EndsWith

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
@@ -76,10 +76,27 @@ public sealed partial class Assert
         CheckParameterNotNull(expectedSuffix, "Assert.EndsWith", "expectedSuffix");
         if (!value.EndsWith(expectedSuffix, comparisonType))
         {
-            string userMessage = BuildUserMessageForExpectedSuffixExpressionAndValueExpression(message, expectedSuffixExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.EndsWithFail, value, expectedSuffix, userMessage);
-            ReportAssertFailed("Assert.EndsWith", finalMessage);
+            ReportAssertEndsWithFailed(expectedSuffix, value, comparisonType, message, expectedSuffixExpression, valueExpression);
         }
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertEndsWithFailed(string expectedSuffix, string value, StringComparison comparisonType, string? userMessage, string expectedSuffixExpression, string valueExpression)
+    {
+        string expectedText = AssertionValueRenderer.RenderValue(expectedSuffix);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected suffix:", expectedText)
+            .AddLine("actual:", actualText)
+            .AddLine("comparison:", comparisonType.ToString());
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.EndsWithFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(expectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.EndsWith", expectedSuffixExpression, valueExpression, "<expectedSuffix>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 
     /// <summary>
@@ -150,9 +167,26 @@ public sealed partial class Assert
         CheckParameterNotNull(notExpectedSuffix, "Assert.DoesNotEndWith", "notExpectedSuffix");
         if (value.EndsWith(notExpectedSuffix, comparisonType))
         {
-            string userMessage = BuildUserMessageForNotExpectedSuffixExpressionAndValueExpression(message, notExpectedSuffixExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DoesNotEndWithFail, value, notExpectedSuffix, userMessage);
-            ReportAssertFailed("Assert.DoesNotEndWith", finalMessage);
+            ReportAssertDoesNotEndWithFailed(notExpectedSuffix, value, comparisonType, message, notExpectedSuffixExpression, valueExpression);
         }
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertDoesNotEndWithFailed(string notExpectedSuffix, string value, StringComparison comparisonType, string? userMessage, string notExpectedSuffixExpression, string valueExpression)
+    {
+        string notExpectedText = AssertionValueRenderer.RenderValue(notExpectedSuffix);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("unexpected suffix:", notExpectedText)
+            .AddLine("actual:", actualText)
+            .AddLine("comparison:", comparisonType.ToString());
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.DoesNotEndWithFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(notExpectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.DoesNotEndWith", notExpectedSuffixExpression, valueExpression, "<notExpectedSuffix>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
@@ -76,10 +76,27 @@ public sealed partial class Assert
         CheckParameterNotNull(expectedPrefix, "Assert.StartsWith", "expectedPrefix");
         if (!value.StartsWith(expectedPrefix, comparisonType))
         {
-            string userMessage = BuildUserMessageForExpectedPrefixExpressionAndValueExpression(message, expectedPrefixExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.StartsWithFail, value, expectedPrefix, userMessage);
-            ReportAssertFailed("Assert.StartsWith", finalMessage);
+            ReportAssertStartsWithFailed(expectedPrefix, value, comparisonType, message, expectedPrefixExpression, valueExpression);
         }
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertStartsWithFailed(string expectedPrefix, string value, StringComparison comparisonType, string? userMessage, string expectedPrefixExpression, string valueExpression)
+    {
+        string expectedText = AssertionValueRenderer.RenderValue(expectedPrefix);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected prefix:", expectedText)
+            .AddLine("actual:", actualText)
+            .AddLine("comparison:", comparisonType.ToString());
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.StartsWithFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(expectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.StartsWith", expectedPrefixExpression, valueExpression, "<expectedPrefix>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 
     /// <summary>
@@ -148,9 +165,26 @@ public sealed partial class Assert
         CheckParameterNotNull(notExpectedPrefix, "Assert.DoesNotStartWith", "notExpectedPrefix");
         if (value.StartsWith(notExpectedPrefix, comparisonType))
         {
-            string userMessage = BuildUserMessageForNotExpectedPrefixExpressionAndValueExpression(message, notExpectedPrefixExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DoesNotStartWithFail, value, notExpectedPrefix, userMessage);
-            ReportAssertFailed("Assert.DoesNotStartWith", finalMessage);
+            ReportAssertDoesNotStartWithFailed(notExpectedPrefix, value, comparisonType, message, notExpectedPrefixExpression, valueExpression);
         }
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertDoesNotStartWithFailed(string notExpectedPrefix, string value, StringComparison comparisonType, string? userMessage, string notExpectedPrefixExpression, string valueExpression)
+    {
+        string notExpectedText = AssertionValueRenderer.RenderValue(notExpectedPrefix);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("unexpected prefix:", notExpectedText)
+            .AddLine("actual:", actualText)
+            .AddLine("comparison:", comparisonType.ToString());
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.DoesNotStartWithFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(notExpectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.DoesNotStartWith", notExpectedPrefixExpression, valueExpression, "<notExpectedPrefix>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -295,18 +295,6 @@ public sealed partial class Assert
     private static string BuildUserMessageForSubstringExpressionAndValueExpression(string? format, string substringExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, substringExpression, "substring", valueExpression, "value");
 
-    private static string BuildUserMessageForExpectedSuffixExpressionAndValueExpression(string? format, string expectedSuffixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, expectedSuffixExpression, "expectedSuffix", valueExpression, "value");
-
-    private static string BuildUserMessageForNotExpectedSuffixExpressionAndValueExpression(string? format, string notExpectedSuffixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, notExpectedSuffixExpression, "notExpectedSuffix", valueExpression, "value");
-
-    private static string BuildUserMessageForExpectedPrefixExpressionAndValueExpression(string? format, string expectedPrefixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, expectedPrefixExpression, "expectedPrefix", valueExpression, "value");
-
-    private static string BuildUserMessageForNotExpectedPrefixExpressionAndValueExpression(string? format, string notExpectedPrefixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, notExpectedPrefixExpression, "notExpectedPrefix", valueExpression, "value");
-
     private static string BuildUserMessageForPatternExpressionAndValueExpression(string? format, string patternExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, patternExpression, "pattern", valueExpression, "value");
 

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -420,4 +420,16 @@ Actual: {2}</value>
   <data name="IsNotNullFailedSummary" xml:space="preserve">
     <value>Expected value to not be null.</value>
   </data>
+  <data name="StartsWithFailedSummary" xml:space="preserve">
+    <value>Expected string to start with the specified prefix.</value>
+  </data>
+  <data name="DoesNotStartWithFailedSummary" xml:space="preserve">
+    <value>Expected string to not start with the specified prefix.</value>
+  </data>
+  <data name="EndsWithFailedSummary" xml:space="preserve">
+    <value>Expected string to end with the specified suffix.</value>
+  </data>
+  <data name="DoesNotEndWithFailedSummary" xml:space="preserve">
+    <value>Expected string to not end with the specified suffix.</value>
+  </data>
 </root>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -203,9 +203,19 @@
         <target state="translated">Řetězec „{0}“ končí řetězcem „{1}“. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Řetězec „{0}“ začíná řetězcem „{1}“. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Skutečnost: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">Selhalo: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Skutečnost: {2}</target>
         <source>(object)</source>
         <target state="translated">(objekt)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -203,9 +203,19 @@
         <target state="translated">Die Zeichenfolge „{0}“ endet mit der Zeichenfolge „{1}“. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Die Zeichenfolge „{0}“ beginnt mit der Zeichenfolge „{1}“. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Tatsächlich: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} fehlgeschlagen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Tatsächlich: {2}</target>
         <source>(object)</source>
         <target state="translated">(Objekt)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -203,9 +203,19 @@
         <target state="translated">La cadena "{0}" termina con la cadena "{1}". {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">La cadena "{0}" comienza con la cadena "{1}". {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Real: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} erróneo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Real: {2}</target>
         <source>(object)</source>
         <target state="translated">(objeto)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -203,9 +203,19 @@
         <target state="translated">La chaîne '{0}' se termine par la chaîne '{1}'. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">La chaîne '{0}' commence par la chaîne '{1}'. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Réel : {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">Échec de {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Réel : {2}</target>
         <source>(object)</source>
         <target state="translated">(objet)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -203,9 +203,19 @@
         <target state="translated">La stringa '{0}' termina con la stringa '{1}'. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">La stringa '{0}' inizia con la stringa '{1}'. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Effettivo: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} non riuscito.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Effettivo: {2}</target>
         <source>(object)</source>
         <target state="translated">(oggetto)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -203,9 +203,19 @@
         <target state="translated">文字列 '{0}' の末尾は文字列 '{1}' です。{2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">文字列 '{0}' は文字列 '{1}' で始まります。 {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Actual: {2}</source>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} に失敗しました。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Actual: {2}</source>
         <source>(object)</source>
         <target state="translated">(オブジェクト)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -203,9 +203,19 @@
         <target state="translated">문자열 '{0}'은 문자열 '{1}'(으)로 끝납니다. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">문자열 '{0}'은 문자열 '{1}'(으)로 시작합니다. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Actual: {2}</source>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0}이(가) 실패했습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Actual: {2}</source>
         <source>(object)</source>
         <target state="translated">(개체)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -203,9 +203,19 @@
         <target state="translated">Ciąg „{0}” kończy się ciągiem „{1}”. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Ciąg „{0}” rozpoczyna się od ciągu „{1}”. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Rzeczywiste: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">Niepowodzenie asercji {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Rzeczywiste: {2}</target>
         <source>(object)</source>
         <target state="translated">(obiekt)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -203,9 +203,19 @@
         <target state="translated">A cadeia de caracteres “{0}” termina com cadeia de caracteres “{1}”. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">A cadeia de caracteres “{0}” começa com a cadeia de caracteres “{1}”. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Real: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} falhou.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Real: {2}</target>
         <source>(object)</source>
         <target state="translated">(objeto)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -203,9 +203,19 @@
         <target state="translated">Строка "{0}" заканчивается строкой "{1}". {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Строка "{0}" начинается со строки "{1}". {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Actual: {2}</source>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">Сбой {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Actual: {2}</source>
         <source>(object)</source>
         <target state="translated">(объект)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -203,9 +203,19 @@
         <target state="translated">'{0}' dizesi '{1}' dizesi ile bitiyor. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">'{0}' dizesi '{1}' dizesi ile başlıyor. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Gerçekte olan: {2}</target>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} başarısız oldu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Gerçekte olan: {2}</target>
         <source>(object)</source>
         <target state="translated">(nesne)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -203,9 +203,19 @@
         <target state="translated">字符串 '{0}' 以字符串 '{1}'结尾。{2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">字符串 '{0}' 以字符串 '{1}' 开头。{2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Actual: {2}</source>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} 失败。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Actual: {2}</source>
         <source>(object)</source>
         <target state="translated">(对象)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -203,9 +203,19 @@
         <target state="translated">字串 '{0}' 以字串 '{1}' 結尾。{2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotEndWithFailedSummary">
+        <source>Expected string to not end with the specified suffix.</source>
+        <target state="new">Expected string to not end with the specified suffix.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">字串 '{0}' 以字串 '{1}' 開頭。{2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotStartWithFailedSummary">
+        <source>Expected string to not start with the specified prefix.</source>
+        <target state="new">Expected string to not start with the specified prefix.</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicDataInvalidFieldLayout">
@@ -255,6 +265,11 @@ Actual: {2}</source>
       <trans-unit id="AssertionFailed">
         <source>{0} failed.</source>
         <target state="translated">{0} 失敗。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EndsWithFailedSummary">
+        <source>Expected string to end with the specified suffix.</source>
+        <target state="new">Expected string to end with the specified suffix.</target>
         <note />
       </trans-unit>
       <trans-unit id="HasCountFailMsg">
@@ -402,6 +417,11 @@ Actual: {2}</source>
         <source>(object)</source>
         <target state="translated">(物件)</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="StartsWithFailedSummary">
+        <source>Expected string to start with the specified prefix.</source>
+        <target state="new">Expected string to start with the specified prefix.</target>
+        <note />
       </trans-unit>
       <trans-unit id="UTF_FailedToGetExceptionMessage">
         <source>(Failed to get the message for an exception of type {0} due to an exception.)</source>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.StartsWithEndsWith.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.StartsWithEndsWith.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
+
+public partial class AssertTests
+{
+    public void StartsWith_WhenValueStartsWithPrefix_DoesNotThrow()
+        => Assert.StartsWith("foo", "foobar");
+
+    public void StartsWith_OnFailure_ShouldIncludeStructuredMessageAndPayload()
+    {
+        string value = "bar";
+        Action action = () => Assert.StartsWith("foo", value, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to start with the specified prefix.
+                User-provided message
+
+                expected prefix: "foo"
+                actual:          "bar"
+                comparison:      Ordinal
+
+                Assert.StartsWith("foo", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"foo\"");
+        ex.ActualText.Should().Be("\"bar\"");
+        ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
+        ex.Data["assert.actual"].Should().Be(ex.ActualText);
+    }
+
+    public void DoesNotStartWith_WhenValueDoesNotStartWithPrefix_DoesNotThrow()
+        => Assert.DoesNotStartWith("foo", "barfoo");
+
+    public void DoesNotStartWith_OnFailure_ShouldIncludeStructuredMessageAndPayload()
+    {
+        string value = "foobar";
+        Action action = () => Assert.DoesNotStartWith("foo", value, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to not start with the specified prefix.
+                User-provided message
+
+                unexpected prefix: "foo"
+                actual:            "foobar"
+                comparison:        Ordinal
+
+                Assert.DoesNotStartWith("foo", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"foo\"");
+        ex.ActualText.Should().Be("\"foobar\"");
+        ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
+        ex.Data["assert.actual"].Should().Be(ex.ActualText);
+    }
+
+    public void EndsWith_WhenValueEndsWithSuffix_DoesNotThrow()
+        => Assert.EndsWith("bar", "foobar");
+
+    public void EndsWith_OnFailure_ShouldIncludeStructuredMessageAndPayload()
+    {
+        string value = "foobar";
+        Action action = () => Assert.EndsWith("baz", value, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to end with the specified suffix.
+                User-provided message
+
+                expected suffix: "baz"
+                actual:          "foobar"
+                comparison:      Ordinal
+
+                Assert.EndsWith("baz", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"baz\"");
+        ex.ActualText.Should().Be("\"foobar\"");
+        ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
+        ex.Data["assert.actual"].Should().Be(ex.ActualText);
+    }
+
+    public void DoesNotEndWith_WhenValueDoesNotEndWithSuffix_DoesNotThrow()
+        => Assert.DoesNotEndWith("baz", "foobar");
+
+    public void DoesNotEndWith_OnFailure_ShouldIncludeStructuredMessageAndPayload()
+    {
+        string value = "foobar";
+        Action action = () => Assert.DoesNotEndWith("bar", value, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to not end with the specified suffix.
+                User-provided message
+
+                unexpected suffix: "bar"
+                actual:            "foobar"
+                comparison:        Ordinal
+
+                Assert.DoesNotEndWith("bar", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"bar\"");
+        ex.ActualText.Should().Be("\"foobar\"");
+        ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
+        ex.Data["assert.actual"].Should().Be(ex.ActualText);
+    }
+}


### PR DESCRIPTION
Continues the rollout of [RFC 012 — Structured Assertion Messages](docs/RFCs/012-Structured-Assertion-Messages.md) by migrating `Assert.StartsWith` / `Assert.DoesNotStartWith` / `Assert.EndsWith` / `Assert.DoesNotEndWith` to the structured-message format. Follows the patterns used by previously migrated assertions (#8170, #8187, #8210, #8214).

## Output format

`Assert.StartsWith(""world"", ""hello world"")`:

```text
Assertion failed. Expected string to start with the specified prefix.

expected prefix: ""world""
actual:          ""hello world""
comparison:      Ordinal

Assert.StartsWith(""world"", ""hello world"")
```

`Assert.DoesNotEndWith(""world"", ""hello world"", StringComparison.OrdinalIgnoreCase, ""should not end with world"")`:

```text
Assertion failed. Expected string to not end with the specified suffix.
should not end with world

unexpected suffix: ""world""
actual:            ""hello world""
comparison:        OrdinalIgnoreCase

Assert.DoesNotEndWith(""world"", ""hello world"")
```

## Notes

- Adds `StartsWithFailedSummary` / `DoesNotStartWithFailedSummary` / `EndsWithFailedSummary` / `DoesNotEndWithFailedSummary` resource entries (XLF files regenerated via `UpdateXlf`).
- Removes the now-unused `BuildUserMessageFor*PrefixExpression*` / `*SuffixExpression*` helpers from `Assert.cs` since the call-site is now reconstructed by `FormatCallSiteExpression`.
- `StringAssert.StartsWith` / `StringAssert.EndsWith` are intentionally unchanged and continue to use `FrameworkMessages.StartsWithFail` / `EndsWithFail`.

## Validation

- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj -c Debug` — clean.
- `dotnet test test/UnitTests/TestFramework.UnitTests/TestFramework.UnitTests.csproj -c Debug` — 3535/3535 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
