### PR TITLE
Apply structured assertion messages (RFC 012) to Assert.MatchesRegex / DoesNotMatchRegex

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
@@ -44,10 +44,26 @@ public sealed partial class Assert
 
         if (!pattern.IsMatch(value))
         {
-            string userMessage = BuildUserMessageForPatternExpressionAndValueExpression(message, patternExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsMatchFail, value, pattern, userMessage);
-            ReportAssertFailed("Assert.MatchesRegex", finalMessage);
+            ReportAssertMatchesRegexFailed(pattern, value, message, patternExpression, valueExpression);
         }
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertMatchesRegexFailed(Regex pattern, string value, string? userMessage, string patternExpression, string valueExpression)
+    {
+        string patternText = AssertionValueRenderer.RenderValue(pattern.ToString());
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected pattern:", patternText)
+            .AddLine("actual:", actualText);
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.MatchesRegexFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(patternText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.MatchesRegex", patternExpression, valueExpression, "<pattern>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 
     /// <summary>
@@ -120,10 +136,26 @@ public sealed partial class Assert
 
         if (pattern.IsMatch(value))
         {
-            string userMessage = BuildUserMessageForPatternExpressionAndValueExpression(message, patternExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsNotMatchFail, value, pattern, userMessage);
-            ReportAssertFailed("Assert.DoesNotMatchRegex", finalMessage);
+            ReportAssertDoesNotMatchRegexFailed(pattern, value, message, patternExpression, valueExpression);
         }
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertDoesNotMatchRegexFailed(Regex pattern, string value, string? userMessage, string patternExpression, string valueExpression)
+    {
+        string patternText = AssertionValueRenderer.RenderValue(pattern.ToString());
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("unexpected pattern:", patternText)
+            .AddLine("actual:", actualText);
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.DoesNotMatchRegexFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(patternText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.DoesNotMatchRegex", patternExpression, valueExpression, "<pattern>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 
     /// <summary>

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -307,9 +307,6 @@ public sealed partial class Assert
     private static string BuildUserMessageForNotExpectedPrefixExpressionAndValueExpression(string? format, string notExpectedPrefixExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, notExpectedPrefixExpression, "notExpectedPrefix", valueExpression, "value");
 
-    private static string BuildUserMessageForPatternExpressionAndValueExpression(string? format, string patternExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, patternExpression, "pattern", valueExpression, "value");
-
     private static string BuildUserMessageForLowerBoundExpressionAndValueExpression(string? format, string lowerBoundExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, lowerBoundExpression, "lowerBound", valueExpression, "value");
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -275,21 +275,6 @@ public sealed partial class Assert
     private static string BuildUserMessageForCollectionExpression(string? format, string collectionExpression)
         => BuildUserMessageForSingleExpression(format, collectionExpression, "collection");
 
-    private static string BuildUserMessageForSubstringExpressionAndValueExpression(string? format, string substringExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, substringExpression, "substring", valueExpression, "value");
-
-    private static string BuildUserMessageForExpectedSuffixExpressionAndValueExpression(string? format, string expectedSuffixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, expectedSuffixExpression, "expectedSuffix", valueExpression, "value");
-
-    private static string BuildUserMessageForNotExpectedSuffixExpressionAndValueExpression(string? format, string notExpectedSuffixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, notExpectedSuffixExpression, "notExpectedSuffix", valueExpression, "value");
-
-    private static string BuildUserMessageForExpectedPrefixExpressionAndValueExpression(string? format, string expectedPrefixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, expectedPrefixExpression, "expectedPrefix", valueExpression, "value");
-
-    private static string BuildUserMessageForNotExpectedPrefixExpressionAndValueExpression(string? format, string notExpectedPrefixExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, notExpectedPrefixExpression, "notExpectedPrefix", valueExpression, "value");
-
     private static string BuildUserMessageForExpectedExpressionAndActualExpression(string? format, string expectedExpression, string actualExpression)
         => BuildUserMessageForTwoExpressions(format, expectedExpression, "expected", actualExpression, "actual");
 

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -420,4 +420,10 @@ Actual: {2}</value>
   <data name="IsNotNullFailedSummary" xml:space="preserve">
     <value>Expected value to not be null.</value>
   </data>
+  <data name="MatchesRegexFailedSummary" xml:space="preserve">
+    <value>Expected string to match the specified regular expression.</value>
+  </data>
+  <data name="DoesNotMatchRegexFailedSummary" xml:space="preserve">
+    <value>Expected string to not match the specified regular expression.</value>
+  </data>
 </root>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -203,6 +203,11 @@
         <target state="translated">Řetězec „{0}“ končí řetězcem „{1}“. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Řetězec „{0}“ začíná řetězcem „{1}“. {2}</target>
@@ -335,6 +340,11 @@ Skutečnost: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -203,6 +203,11 @@
         <target state="translated">Die Zeichenfolge „{0}“ endet mit der Zeichenfolge „{1}“. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Die Zeichenfolge „{0}“ beginnt mit der Zeichenfolge „{1}“. {2}</target>
@@ -335,6 +340,11 @@ Tatsächlich: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -203,6 +203,11 @@
         <target state="translated">La cadena "{0}" termina con la cadena "{1}". {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">La cadena "{0}" comienza con la cadena "{1}". {2}</target>
@@ -335,6 +340,11 @@ Real: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -203,6 +203,11 @@
         <target state="translated">La chaîne '{0}' se termine par la chaîne '{1}'. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">La chaîne '{0}' commence par la chaîne '{1}'. {2}</target>
@@ -335,6 +340,11 @@ Réel : {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -203,6 +203,11 @@
         <target state="translated">La stringa '{0}' termina con la stringa '{1}'. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">La stringa '{0}' inizia con la stringa '{1}'. {2}</target>
@@ -335,6 +340,11 @@ Effettivo: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -203,6 +203,11 @@
         <target state="translated">文字列 '{0}' の末尾は文字列 '{1}' です。{2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">文字列 '{0}' は文字列 '{1}' で始まります。 {2}</target>
@@ -335,6 +340,11 @@ Actual: {2}</source>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -203,6 +203,11 @@
         <target state="translated">문자열 '{0}'은 문자열 '{1}'(으)로 끝납니다. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">문자열 '{0}'은 문자열 '{1}'(으)로 시작합니다. {2}</target>
@@ -335,6 +340,11 @@ Actual: {2}</source>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -203,6 +203,11 @@
         <target state="translated">Ciąg „{0}” kończy się ciągiem „{1}”. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Ciąg „{0}” rozpoczyna się od ciągu „{1}”. {2}</target>
@@ -335,6 +340,11 @@ Rzeczywiste: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -203,6 +203,11 @@
         <target state="translated">A cadeia de caracteres “{0}” termina com cadeia de caracteres “{1}”. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">A cadeia de caracteres “{0}” começa com a cadeia de caracteres “{1}”. {2}</target>
@@ -335,6 +340,11 @@ Real: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -203,6 +203,11 @@
         <target state="translated">Строка "{0}" заканчивается строкой "{1}". {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">Строка "{0}" начинается со строки "{1}". {2}</target>
@@ -335,6 +340,11 @@ Actual: {2}</source>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -203,6 +203,11 @@
         <target state="translated">'{0}' dizesi '{1}' dizesi ile bitiyor. {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">'{0}' dizesi '{1}' dizesi ile başlıyor. {2}</target>
@@ -335,6 +340,11 @@ Gerçekte olan: {2}</target>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -203,6 +203,11 @@
         <target state="translated">字符串 '{0}' 以字符串 '{1}'结尾。{2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">字符串 '{0}' 以字符串 '{1}' 开头。{2}</target>
@@ -335,6 +340,11 @@ Actual: {2}</source>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -203,6 +203,11 @@
         <target state="translated">字串 '{0}' 以字串 '{1}' 結尾。{2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotMatchRegexFailedSummary">
+        <source>Expected string to not match the specified regular expression.</source>
+        <target state="new">Expected string to not match the specified regular expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
         <source>String '{0}' starts with string '{1}'. {2}</source>
         <target state="translated">字串 '{0}' 以字串 '{1}' 開頭。{2}</target>
@@ -335,6 +340,11 @@ Actual: {2}</source>
       <trans-unit id="IsTrueFailedSummary">
         <source>Expected condition to be true.</source>
         <target state="new">Expected condition to be true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MatchesRegexFailedSummary">
+        <source>Expected string to match the specified regular expression.</source>
+        <target state="new">Expected string to match the specified regular expression.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
+
+public partial class AssertTests
+{
+    public void MatchesRegex_WithRegexPattern_OnSuccess_DoesNotThrow()
+        => FluentActions.Invoking(() => Assert.MatchesRegex(new Regex("^he"), "hello"))
+            .Should().NotThrow();
+
+    public void MatchesRegex_WithStringPattern_OnSuccess_DoesNotThrow()
+        => FluentActions.Invoking(() => Assert.MatchesRegex("^he", "hello"))
+            .Should().NotThrow();
+
+    public void MatchesRegex_WithRegexPattern_OnFailure_UsesStructuredMessageAndPayload()
+    {
+        Action action = () => Assert.MatchesRegex(new Regex("^foo"), "hello", "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to match the specified regular expression.
+                User-provided message
+
+                expected pattern: "^foo"
+                actual:           "hello"
+
+                Assert.MatchesRegex(new Regex("^foo"), "hello")
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"^foo\"");
+        ex.ActualText.Should().Be("\"hello\"");
+        ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
+        ex.Data["assert.actual"].Should().Be(ex.ActualText);
+    }
+
+    public void MatchesRegex_WithStringPattern_OnFailure_UsesStructuredMessage()
+    {
+        string pattern = "^foo";
+        string value = "hello";
+        Action action = () => Assert.MatchesRegex(pattern, value);
+
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to match the specified regular expression.
+
+                expected pattern: "^foo"
+                actual:           "hello"
+
+                Assert.MatchesRegex(pattern, value)
+                """);
+    }
+
+    public void DoesNotMatchRegex_WithRegexPattern_OnSuccess_DoesNotThrow()
+        => FluentActions.Invoking(() => Assert.DoesNotMatchRegex(new Regex("world"), "hello"))
+            .Should().NotThrow();
+
+    public void DoesNotMatchRegex_WithStringPattern_OnSuccess_DoesNotThrow()
+        => FluentActions.Invoking(() => Assert.DoesNotMatchRegex("world", "hello"))
+            .Should().NotThrow();
+
+    public void DoesNotMatchRegex_WithRegexPattern_OnFailure_UsesStructuredMessageAndPayload()
+    {
+        Action action = () => Assert.DoesNotMatchRegex(new Regex("world"), "hello world", "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to not match the specified regular expression.
+                User-provided message
+
+                unexpected pattern: "world"
+                actual:             "hello world"
+
+                Assert.DoesNotMatchRegex(new Regex("world"), "hello world")
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"world\"");
+        ex.ActualText.Should().Be("\"hello world\"");
+        ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
+        ex.Data["assert.actual"].Should().Be(ex.ActualText);
+    }
+
+    public void DoesNotMatchRegex_WithStringPattern_OnFailure_UsesStructuredMessage()
+    {
+        string pattern = "world";
+        string value = "hello world";
+        Action action = () => Assert.DoesNotMatchRegex(pattern, value);
+
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to not match the specified regular expression.
+
+                unexpected pattern: "world"
+                actual:             "hello world"
+
+                Assert.DoesNotMatchRegex(pattern, value)
+                """);
+    }
+}


### PR DESCRIPTION
Continues the rollout of [RFC 012 — Structured Assertion Messages](docs/RFCs/012-Structured-Assertion-Messages.md) by migrating `Assert.MatchesRegex` / `Assert.DoesNotMatchRegex` to the structured-message format. Follows the pattern established by previously migrated assertions (#8170, #8187, #8210, #8214) and the in-flight #8258 (StartsWith/EndsWith).

## Output format

`Assert.MatchesRegex(new Regex(""^foo""), ""hello"")`:

```text
Assertion failed. Expected string to match the specified regular expression.

expected pattern: ""^foo""
actual:           ""hello""

Assert.MatchesRegex(new Regex(""^foo""), ""hello"")
```

`Assert.DoesNotMatchRegex(new Regex(""world""), ""hello world"", ""value should not match"")`:

```text
Assertion failed. Expected string to not match the specified regular expression.
value should not match

unexpected pattern: ""world""
actual:             ""hello world""

Assert.DoesNotMatchRegex(new Regex(""world""), ""hello world"")
```

## Notes

- Adds `MatchesRegexFailedSummary` / `DoesNotMatchRegexFailedSummary` resource entries (XLF files regenerated via `UpdateXlf`).
- Removes the now-unused `BuildUserMessageForPatternExpressionAndValueExpression` helper from `Assert.cs` because the call-site is now reconstructed by `FormatCallSiteExpression`.
- `StringAssert.Matches` / `StringAssert.DoesNotMatch` are intentionally unchanged and continue to use `FrameworkMessages.IsMatchFail` / `IsNotMatchFail`.

## Validation

- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj -c Debug` — clean.
- `dotnet test test/UnitTests/TestFramework.UnitTests/TestFramework.UnitTests.csproj -c Debug` — 3535/3535 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
