### PR TITLE
Apply structured assertion messages (RFC 012) to Assert.IComparable family

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs
@@ -49,8 +49,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessageForLowerBoundExpressionAndValueExpression(message, lowerBoundExpression, valueExpression);
-        ReportAssertIsGreaterThanFailed(lowerBound, value, userMessage);
+        ReportAssertIsGreaterThanFailed(lowerBound, value, message, lowerBoundExpression, valueExpression);
     }
 
     #endregion // IsGreaterThan
@@ -94,8 +93,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessageForLowerBoundExpressionAndValueExpression(message, lowerBoundExpression, valueExpression);
-        ReportAssertIsGreaterThanOrEqualToFailed(lowerBound, value, userMessage);
+        ReportAssertIsGreaterThanOrEqualToFailed(lowerBound, value, message, lowerBoundExpression, valueExpression);
     }
 
     #endregion // IsGreaterThanOrEqualTo
@@ -139,8 +137,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessageForUpperBoundExpressionAndValueExpression(message, upperBoundExpression, valueExpression);
-        ReportAssertIsLessThanFailed(upperBound, value, userMessage);
+        ReportAssertIsLessThanFailed(upperBound, value, message, upperBoundExpression, valueExpression);
     }
 
     #endregion // IsLessThan
@@ -184,8 +181,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessageForUpperBoundExpressionAndValueExpression(message, upperBoundExpression, valueExpression);
-        ReportAssertIsLessThanOrEqualToFailed(upperBound, value, userMessage);
+        ReportAssertIsLessThanOrEqualToFailed(upperBound, value, message, upperBoundExpression, valueExpression);
     }
 
     #endregion // IsLessThanOrEqualTo
@@ -219,17 +215,9 @@ public sealed partial class Assert
         var zero = default(T);
 
         // Handle special case for floating point NaN values
-        if (value is float.NaN)
+        if (value is float.NaN or double.NaN)
         {
-            string userMessage = BuildUserMessageForValueExpression(message, valueExpression);
-            ReportAssertIsPositiveFailed(value, userMessage);
-            return;
-        }
-
-        if (value is double.NaN)
-        {
-            string userMessage = BuildUserMessageForValueExpression(message, valueExpression);
-            ReportAssertIsPositiveFailed(value, userMessage);
+            ReportAssertIsPositiveFailed(value, message, valueExpression);
             return;
         }
 
@@ -238,8 +226,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage2 = BuildUserMessageForValueExpression(message, valueExpression);
-        ReportAssertIsPositiveFailed(value, userMessage2);
+        ReportAssertIsPositiveFailed(value, message, valueExpression);
     }
 
     #endregion // IsPositive
@@ -273,17 +260,9 @@ public sealed partial class Assert
         var zero = default(T);
 
         // Handle special case for floating point NaN values
-        if (value is float.NaN)
+        if (value is float.NaN or double.NaN)
         {
-            string userMessage = BuildUserMessageForValueExpression(message, valueExpression);
-            ReportAssertIsNegativeFailed(value, userMessage);
-            return;
-        }
-
-        if (value is double.NaN)
-        {
-            string userMessage = BuildUserMessageForValueExpression(message, valueExpression);
-            ReportAssertIsNegativeFailed(value, userMessage);
+            ReportAssertIsNegativeFailed(value, message, valueExpression);
             return;
         }
 
@@ -292,79 +271,67 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage2 = BuildUserMessageForValueExpression(message, valueExpression);
-        ReportAssertIsNegativeFailed(value, userMessage2);
+        ReportAssertIsNegativeFailed(value, message, valueExpression);
     }
 
     #endregion // IsNegative
 
     [DoesNotReturn]
-    private static void ReportAssertIsGreaterThanFailed<T>(T lowerBound, T value, string userMessage)
+    private static void ReportAssertIsGreaterThanFailed<T>(T lowerBound, T value, string? userMessage, string lowerBoundExpression, string valueExpression)
+        => ReportComparisonFailed("Assert.IsGreaterThan", FrameworkMessages.IsGreaterThanFailedSummary, "lower bound:", lowerBound, value, userMessage, lowerBoundExpression, valueExpression, "<lowerBound>");
+
+    [DoesNotReturn]
+    private static void ReportAssertIsGreaterThanOrEqualToFailed<T>(T lowerBound, T value, string? userMessage, string lowerBoundExpression, string valueExpression)
+        => ReportComparisonFailed("Assert.IsGreaterThanOrEqualTo", FrameworkMessages.IsGreaterThanOrEqualToFailedSummary, "lower bound:", lowerBound, value, userMessage, lowerBoundExpression, valueExpression, "<lowerBound>");
+
+    [DoesNotReturn]
+    private static void ReportAssertIsLessThanFailed<T>(T upperBound, T value, string? userMessage, string upperBoundExpression, string valueExpression)
+        => ReportComparisonFailed("Assert.IsLessThan", FrameworkMessages.IsLessThanFailedSummary, "upper bound:", upperBound, value, userMessage, upperBoundExpression, valueExpression, "<upperBound>");
+
+    [DoesNotReturn]
+    private static void ReportAssertIsLessThanOrEqualToFailed<T>(T upperBound, T value, string? userMessage, string upperBoundExpression, string valueExpression)
+        => ReportComparisonFailed("Assert.IsLessThanOrEqualTo", FrameworkMessages.IsLessThanOrEqualToFailedSummary, "upper bound:", upperBound, value, userMessage, upperBoundExpression, valueExpression, "<upperBound>");
+
+    [DoesNotReturn]
+    private static void ReportComparisonFailed<T>(string assertionName, string summary, string boundLabel, T bound, T value, string? userMessage, string boundExpression, string valueExpression, string boundPlaceholder)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.IsGreaterThanFailMsg,
-            userMessage,
-            ReplaceNulls(lowerBound),
-            ReplaceNulls(value));
-        ReportAssertFailed("Assert.IsGreaterThan", finalMessage);
+        string boundText = AssertionValueRenderer.RenderValue(bound);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine(boundLabel, boundText)
+            .AddLine("actual:", actualText);
+
+        StructuredAssertionMessage structured = new(summary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(boundText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression(assertionName, boundExpression, valueExpression, boundPlaceholder, "<value>"));
+
+        ReportAssertFailed(structured);
     }
 
     [DoesNotReturn]
-    private static void ReportAssertIsGreaterThanOrEqualToFailed<T>(T lowerBound, T value, string userMessage)
-    {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.IsGreaterThanOrEqualToFailMsg,
-            userMessage,
-            ReplaceNulls(lowerBound),
-            ReplaceNulls(value));
-        ReportAssertFailed("Assert.IsGreaterThanOrEqualTo", finalMessage);
-    }
+    private static void ReportAssertIsPositiveFailed<T>(T value, string? userMessage, string valueExpression)
+        => ReportSignFailed("Assert.IsPositive", FrameworkMessages.IsPositiveFailedSummary, "> 0", value, userMessage, valueExpression);
 
     [DoesNotReturn]
-    private static void ReportAssertIsLessThanFailed<T>(T upperBound, T value, string userMessage)
-    {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.IsLessThanFailMsg,
-            userMessage,
-            ReplaceNulls(upperBound),
-            ReplaceNulls(value));
-        ReportAssertFailed("Assert.IsLessThan", finalMessage);
-    }
+    private static void ReportAssertIsNegativeFailed<T>(T value, string? userMessage, string valueExpression)
+        => ReportSignFailed("Assert.IsNegative", FrameworkMessages.IsNegativeFailedSummary, "< 0", value, userMessage, valueExpression);
 
     [DoesNotReturn]
-    private static void ReportAssertIsLessThanOrEqualToFailed<T>(T upperBound, T value, string userMessage)
+    private static void ReportSignFailed<T>(string assertionName, string summary, string expectedText, T value, string? userMessage, string valueExpression)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.IsLessThanOrEqualToFailMsg,
-            userMessage,
-            ReplaceNulls(upperBound),
-            ReplaceNulls(value));
-        ReportAssertFailed("Assert.IsLessThanOrEqualTo", finalMessage);
-    }
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected:", expectedText)
+            .AddLine("actual:", actualText);
 
-    [DoesNotReturn]
-    private static void ReportAssertIsPositiveFailed<T>(T value, string userMessage)
-    {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.IsPositiveFailMsg,
-            userMessage,
-            ReplaceNulls(value));
-        ReportAssertFailed("Assert.IsPositive", finalMessage);
-    }
+        StructuredAssertionMessage structured = new(summary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(expectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression(assertionName, valueExpression, nameof(value)));
 
-    [DoesNotReturn]
-    private static void ReportAssertIsNegativeFailed<T>(T value, string userMessage)
-    {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.IsNegativeFailMsg,
-            userMessage,
-            ReplaceNulls(value));
-        ReportAssertFailed("Assert.IsNegative", finalMessage);
+        ReportAssertFailed(structured);
     }
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -286,9 +286,6 @@ public sealed partial class Assert
             : $"{callerArgMessagePart} {userMessage}";
     }
 
-    private static string BuildUserMessageForValueExpression(string? format, string valueExpression)
-        => BuildUserMessageForSingleExpression(format, valueExpression, "value");
-
     private static string BuildUserMessageForCollectionExpression(string? format, string collectionExpression)
         => BuildUserMessageForSingleExpression(format, collectionExpression, "collection");
 
@@ -309,12 +306,6 @@ public sealed partial class Assert
 
     private static string BuildUserMessageForPatternExpressionAndValueExpression(string? format, string patternExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, patternExpression, "pattern", valueExpression, "value");
-
-    private static string BuildUserMessageForLowerBoundExpressionAndValueExpression(string? format, string lowerBoundExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, lowerBoundExpression, "lowerBound", valueExpression, "value");
-
-    private static string BuildUserMessageForUpperBoundExpressionAndValueExpression(string? format, string upperBoundExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, upperBoundExpression, "upperBound", valueExpression, "value");
 
     private static string BuildUserMessageForExpectedExpressionAndCollectionExpression(string? format, string expectedExpression, string collectionExpression)
         => BuildUserMessageForTwoExpressions(format, expectedExpression, "expected", collectionExpression, "collection");

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -328,24 +328,6 @@ Actual: {2}</value>
   <data name="DoesNotContainFail" xml:space="preserve">
     <value>String '{0}' does contain string '{1}'. {2}.</value>
   </data>
-  <data name="IsGreaterThanFailMsg" xml:space="preserve">
-    <value>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</value>
-  </data>
-  <data name="IsGreaterThanOrEqualToFailMsg" xml:space="preserve">
-    <value>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</value>
-  </data>
-  <data name="IsLessThanFailMsg" xml:space="preserve">
-    <value>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</value>
-  </data>
-  <data name="IsLessThanOrEqualToFailMsg" xml:space="preserve">
-    <value>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</value>
-  </data>
-  <data name="IsPositiveFailMsg" xml:space="preserve">
-    <value>Expected value &lt;{1}&gt; to be positive. {0}</value>
-  </data>
-  <data name="IsNegativeFailMsg" xml:space="preserve">
-    <value>Expected value &lt;{1}&gt; to be negative. {0}</value>
-  </data>
   <data name="DoesNotEndWithFail" xml:space="preserve">
     <value>String '{0}' ends with string '{1}'. {2}</value>
   </data>

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -420,4 +420,22 @@ Actual: {2}</value>
   <data name="IsNotNullFailedSummary" xml:space="preserve">
     <value>Expected value to not be null.</value>
   </data>
+  <data name="IsGreaterThanFailedSummary" xml:space="preserve">
+    <value>Expected value to be greater than the lower bound.</value>
+  </data>
+  <data name="IsGreaterThanOrEqualToFailedSummary" xml:space="preserve">
+    <value>Expected value to be greater than or equal to the lower bound.</value>
+  </data>
+  <data name="IsLessThanFailedSummary" xml:space="preserve">
+    <value>Expected value to be less than the upper bound.</value>
+  </data>
+  <data name="IsLessThanOrEqualToFailedSummary" xml:space="preserve">
+    <value>Expected value to be less than or equal to the upper bound.</value>
+  </data>
+  <data name="IsPositiveFailedSummary" xml:space="preserve">
+    <value>Expected value to be positive.</value>
+  </data>
+  <data name="IsNegativeFailedSummary" xml:space="preserve">
+    <value>Expected value to be negative.</value>
+  </data>
 </root>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -473,36 +473,6 @@ Skutečnost: {2}</target>
         <target state="translated">Vlastnost nebo metoda {0} ve třídě {1} vrací prázdné IEnumerable&lt;object[]&gt;.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Skutečná hodnota &lt;{2}&gt; není větší než očekávaná hodnota &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Skutečná hodnota &lt;{2}&gt; není větší nebo rovna očekávané hodnotě &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Skutečná hodnota &lt;{2}&gt; není menší než očekávaná hodnota &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Skutečná hodnota &lt;{2}&gt; není menší nebo rovna očekávané hodnotě &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Očekávaná hodnota &lt;{1}&gt; má být kladná. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Očekávaná hodnota &lt;{1}&gt; má být záporná. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals by neměla být pro kontrolní výrazy používána. Použijte prosím místo toho Assert.AreEqual a její přetížení.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -277,6 +277,16 @@ Skutečnost: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Hodnota {0} není v očekávaném rozsahu [{1}..{2}]. {3}</target>
@@ -292,9 +302,24 @@ Skutečnost: {2}</target>
         <target state="translated">{0} Očekávaný typ:&lt;{1}&gt;. Aktuální typ:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">Řetězec „{0}“ neodpovídá vzoru „{1}“. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Skutečnost: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -473,36 +473,6 @@ Tatsächlich: {2}</target>
         <target state="translated">Eigenschaft oder Methode "{0}" in "{1}" gibt leeres IEnumerable&lt;object[]&gt; zurück.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Der tatsächliche Wert &lt;{2}&gt; ist nicht größer als der erwartete Wert &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Der tatsächliche Wert &lt;{2}&gt; ist nicht größer oder gleich dem erwarteten Wert &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Der tatsächliche Wert &lt;{2}&gt; ist nicht kleiner als der erwartete Wert &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Der tatsächliche Wert &lt;{2}&gt; ist nicht kleiner oder gleich dem erwarteten Wert &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Es wurde erwartet, dass der Wert &lt;{1}&gt; positiv ist. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Es wurde erwartet, dass der Wert &lt;{1}&gt; negativ ist. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals sollte nicht für Assertions verwendet werden. Verwenden Sie stattdessen Assert.AreEqual und Überladungen.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -277,6 +277,16 @@ Tatsächlich: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Der Wert „{0}“ liegt nicht im erwarteten Bereich [{1}..{2}]. {3}</target>
@@ -292,9 +302,24 @@ Tatsächlich: {2}</target>
         <target state="translated">{0}Erwarteter Typ:&lt;{1}&gt;. Tatsächlicher Typ:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">Die Zeichenfolge „{0}“ stimmt nicht mit dem Muster „{1}“ überein. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Tatsächlich: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -277,6 +277,16 @@ Real: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">El valor "{0}" no está dentro del rango esperado [{1}..{2}]. {3}</target>
@@ -292,9 +302,24 @@ Real: {2}</target>
         <target state="translated">{0} Tipo esperado:&lt;{1}&gt;. Tipo real:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">La cadena "{0}" no coincide con el patrón "{1}". {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Real: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -473,36 +473,6 @@ Real: {2}</target>
         <target state="translated">La propiedad o el método {0} en {1} devuelve un elemento IEnumerable&lt;object[]&gt; vacío.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">El valor real &lt;{2}&gt; no es mayor que el valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">El valor real &lt;{2}&gt; no es mayor o igual que el valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">El valor real &lt;{2}&gt; no es menor que el valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">El valor real &lt;{2}&gt; no es menor o igual que el valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Se esperaba que el valor &lt;{1}&gt; ser positivo. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Se esperaba que el valor &lt;{1}&gt; ser negativo. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">No se debe usar Assert.Equals para aserciones. Use Assert.AreEqual y Overloads en su lugar.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -277,6 +277,16 @@ Réel : {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">La valeur « {0} » n'est pas dans la plage attendue [{1}..{2}]. {3}</target>
@@ -292,9 +302,24 @@ Réel : {2}</target>
         <target state="translated">{0}Type attendu :&lt;{1}&gt;. Type réel :&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">La chaîne '{0}' ne correspond pas au modèle '{1}'. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Réel : {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -473,36 +473,6 @@ Réel : {2}</target>
         <target state="translated">La propriété ou la méthode {0} sur {1} retourne un IEnumerable&lt;object[]&gt; vide.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">La valeur réelle &lt;{2}&gt; n’est pas supérieure à la valeur attendue &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">La valeur réelle &lt;{2}&gt; n’est pas supérieure ou égale à la valeur attendue &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">La valeur réelle &lt;{2}&gt; n’est pas inférieure à la valeur attendue &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">La valeur réelle &lt;{2}&gt; n’est pas inférieure ou égale à la valeur attendue &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">La valeur attendue &lt;{1}&gt; doit être positive. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">La valeur attendue &lt;{1}&gt; doit être négative. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals ne doit pas être utilisé pour les assertions. Utilisez Assert.AreEqual &amp; overloads à la place.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -277,6 +277,16 @@ Effettivo: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Il valore '{0}' non è compreso nell'intervallo previsto [{1}, {2}]. {3}</target>
@@ -292,9 +302,24 @@ Effettivo: {2}</target>
         <target state="translated">{0} Tipo previsto:&lt;{1}&gt;. Tipo effettivo:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">La stringa '{0}' non corrisponde al criterio '{1}'. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Effettivo: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -473,36 +473,6 @@ Effettivo: {2}</target>
         <target state="translated">La proprietà o il metodo {0} nella classe {1} restituisce un elemento IEnumerable&lt;object[]&gt; vuoto.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Il valore effettivo &lt;{2}&gt; non è maggiore del valore previsto &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Il valore effettivo &lt;{2}&gt; non è maggiore o uguale al valore previsto &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Il valore effettivo &lt;{2}&gt; non è minore del valore previsto &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Il valore effettivo &lt;{2}&gt; non è minore o uguale al valore previsto &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Il valore &lt;{1}{0}&gt; dovrebbe essere positivo.</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Il valore &lt;{1}{0}&gt; dovrebbe essere negativo.</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Non è possibile usare Assert.Equals per le asserzioni. Usare Assert.AreEqual e gli overload.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -473,36 +473,6 @@ Actual: {2}</source>
         <target state="translated">{1} 上のプロパティまたはメソッド {0} は空の IEnumerable&lt;object[]&gt; を返します。</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">実際の値 &lt;{2}&gt; は、予期された値 &lt;{1}&gt; より大きくありません。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">実際の値 &lt;{2}&gt; は、予期された値 &lt;{1}&gt; 以上ではありません。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">実際の値 &lt;{2}&gt; は、予期された値 &lt;{1}&gt; より小さくありません。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">実際の値 &lt;{2}&gt; は、予期された値 &lt;{1}&gt; 以下ではありません。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">正の値 &lt;{1}&gt; が必要です。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">負の値 &lt;{1}&gt; が必要です。{0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">アサーションには Assert.Equals を使用せずに、Assert.AreEqual とオーバーロードを使用してください。(&amp; )</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -277,6 +277,16 @@ Actual: {2}</source>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">値 '{0}' は予期される範囲 [{1}..{2}] 内にありません。{3}</target>
@@ -292,9 +302,24 @@ Actual: {2}</source>
         <target state="translated">{0} には型 &lt;{1}&gt; が必要ですが、型 &lt;{2}&gt; が指定されました。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">文字列 '{0}' はパターン '{1}' と一致しません。{2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Actual: {2}</source>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -473,36 +473,6 @@ Actual: {2}</source>
         <target state="translated">{1}의 속성 또는 메서드 {0}이(가) 빈 IEnumerable&lt;object[]&gt;를 반환합니다.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">실제 값 &lt;{2}&gt;은(는)는 예상 값 &lt;{1}&gt;보다 크지 않습니다. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">실제 값 &lt;{2}&gt;은(는)는 예상 값 &lt;{1}&gt;보다 크거나 같지 않습니다. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">실제 값 &lt;{2}&gt;은(는)는 예상 값 &lt;{1}&gt;보다 작지 않습니다. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">실제 값 &lt;{2}&gt;은(는)는 예상 값 &lt;{1}&gt;보다 작거나 같지 않습니다. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">예상 값 &lt;{1}&gt;은(는) 양수일 것으로 예상합니다. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">예상 값 &lt;{1}&gt;은(는) 음수일 것으로 예상합니다. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">어설션에 Assert.Equals를 사용할 수 없습니다. 대신 Assert.AreEqual 및 오버로드를 사용하세요.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -277,6 +277,16 @@ Actual: {2}</source>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">'{0}' 값이 예상 범위 [{1}..{2}] 내에 있지 않습니다. {3}</target>
@@ -292,9 +302,24 @@ Actual: {2}</source>
         <target state="translated">{0} 예상 형식: &lt;{1}&gt;, 실제 형식: &lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">'{0}' 문자열이 '{1}' 패턴과 일치하지 않습니다. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Actual: {2}</source>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -473,36 +473,6 @@ Rzeczywiste: {2}</target>
         <target state="translated">Właściwość lub metoda {0} w elemencie {1} zwraca pusty interfejs IEnumerable&lt;object[]&gt;.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Wartość rzeczywista &lt;{2}&gt; nie jest większa niż oczekiwana wartość &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Wartość rzeczywista &lt;{2}&gt; nie jest większa lub równa oczekiwanej wartości &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Wartość rzeczywista &lt;{2}&gt; nie jest mniejsza niż oczekiwana wartość &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Wartość rzeczywista &lt;{2}&gt; nie jest mniejsza lub równa oczekiwanej wartości &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Oczekiwana wartość &lt;{1}&gt; powinna być dodatnia. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Oczekiwana wartość &lt;{1}&gt; powinna być negatywna. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals nie powinno być używane do potwierdzania. Zamiast tego użyj Assert.AreEqual i przeciążeń.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -277,6 +277,16 @@ Rzeczywiste: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Wartość „{0}” nie mieści się w oczekiwanym zakresie [{1}..{2}]. {3}</target>
@@ -292,9 +302,24 @@ Rzeczywiste: {2}</target>
         <target state="translated">{0} Oczekiwany typ:&lt;{1}&gt;. Rzeczywisty typ:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">Ciąg „{0}” nie jest zgodny ze wzorcem „{1}”. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Rzeczywiste: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -473,36 +473,6 @@ Real: {2}</target>
         <target state="translated">A propriedade ou o método {0} em {1} retorna um IEnumerable&lt;object[]&gt; vazio.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">O valor &lt;{2}&gt; real não é maior que o valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">O valor &lt;{2}&gt; real não é maior ou igual ao valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">O valor &lt;{2}&gt; real não é menor que o valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">O valor &lt;{2}&gt; real não é menor ou igual ao valor esperado &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">O valor &lt;{1}&gt; esperado deve ser positivo. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">O valor &lt;{1}&gt; esperado deve ser negativo. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals não deveria ser usado para Declarações. Use Assert.AreEqual e sobrecargas em seu lugar.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -277,6 +277,16 @@ Real: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">O valor '{0}' não está dentro do intervalo esperado [{1}.. {2}]. {3}</target>
@@ -292,9 +302,24 @@ Real: {2}</target>
         <target state="translated">{0} Tipo esperado:&lt;{1}&gt;. Tipo real:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">A cadeia de caracteres “{0}” não corresponde ao padrão “{1}”. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Real: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -277,6 +277,16 @@ Actual: {2}</source>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Значение "{0}" не находится в пределах ожидаемого диапазона [{1}..{2}]. {3}</target>
@@ -292,9 +302,24 @@ Actual: {2}</source>
         <target state="translated">{0}Ожидается тип: &lt;{1}&gt;. Фактический тип: &lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">Строка "{0}" не соответствует шаблону "{1}". {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Actual: {2}</source>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -473,36 +473,6 @@ Actual: {2}</source>
         <target state="translated">Свойство или метод {0} класса {1} возвращает пустой IEnumerable&lt;object[]&gt;.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Действительное значение &lt;{2}&gt; не больше ожидаемого значения &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Действительное значение &lt;{2}&gt; не больше или не равно ожидаемому значению &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Действительное значение &lt;{2}&gt; не меньше ожидаемого значения &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Действительное значение &lt;{2}&gt; не меньше или не равно ожидаемому значению &lt;{1}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Ожидалось, что значение &lt;{1}&gt; будет положительным. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Ожидалось, что значение &lt;{1}&gt; будет отрицательным. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Нельзя использовать Assert.Equals для Assertions. Вместо этого используйте Assert.AreEqual и перегрузки.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -473,36 +473,6 @@ Gerçekte olan: {2}</target>
         <target state="translated">{1} üzerindeki {0} özelliği veya metodu boş IEnumerable&lt;object[]&gt; döndürür.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Geçerli &lt;{2}&gt; değeri, beklenen &lt;{1}&gt; değerinden daha büyük değil. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Geçerli &lt;{2}&gt; değeri, beklenen &lt;{1}&gt; değerinden büyük veya bu değere eşit değil. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Geçerli &lt;{2}&gt; değeri, beklenen &lt;{1}&gt; değerinden daha küçük değil. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">Geçerli &lt;{2}&gt; değeri, beklenen &lt;{1}&gt; değerinden küçük veya bu değere eşit değil. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">Beklenen &lt;{1}&gt; değeri pozitif olmalıdır. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">Beklenen &lt;{1}&gt; değeri negatif olmalıdır. {0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals, Onaylama için kullanılmamalı. Lütfen yerine Assert.AreEqual &amp; aşırı yüklemeleri kullanın.</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -277,6 +277,16 @@ Gerçekte olan: {2}</target>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Değer '{0}' beklenen aralık [{1}..{2}] içinde değil. {3}</target>
@@ -292,9 +302,24 @@ Gerçekte olan: {2}</target>
         <target state="translated">{0} Beklenen tür:&lt;{1}&gt;. Gerçek tür:&lt;{2}&gt;.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">'{0}' dizesi, '{1}' deseni ile eşleşmiyor. {2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Gerçekte olan: {2}</target>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -473,36 +473,6 @@ Actual: {2}</source>
         <target state="translated">{1} 上的属性或方法 {0} 返回空 IEnumerable&lt;object[]&gt;。</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">实际值 &lt;{2}&gt; 不大于预期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">实际值 &lt;{2}&gt; 不大于或等于预期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">实际值 &lt;{2}&gt; 不小于预期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">实际值 &lt;{2}&gt; 不小于或等于预期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">预期值 &lt;{1}&gt; 为正值。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">预期值 &lt;{1}&gt; 为负值。{0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals 不应用于断言。请改用 Assert.AreEqual 和重载。</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -277,6 +277,16 @@ Actual: {2}</source>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">值 "{0}" 不在预期范围 [{1}..{2}] 内。{3}</target>
@@ -292,9 +302,24 @@ Actual: {2}</source>
         <target state="translated">{0} 类型应为: &lt;{1}&gt;。类型实为: &lt;{2}&gt;。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">字符串 '{0}' 与模式 '{1}' 不匹配。{2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Actual: {2}</source>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -473,36 +473,6 @@ Actual: {2}</source>
         <target state="translated">{1} 上的屬性或方法 {0} 傳回空的 IEnumerable&lt;object[]&gt;。</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="IsGreaterThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">實際值 &lt;{2}&gt; 不大於預期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsGreaterThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not greater than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">實際值 &lt;{2}&gt; 不大於或等於預期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">實際值 &lt;{2}&gt; 不小於預期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsLessThanOrEqualToFailMsg">
-        <source>Actual value &lt;{2}&gt; is not less than or equal to expected value &lt;{1}&gt;. {0}</source>
-        <target state="translated">實際值 &lt;{2}&gt; 不小於或等於預期值 &lt;{1}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsPositiveFailMsg">
-        <source>Expected value &lt;{1}&gt; to be positive. {0}</source>
-        <target state="translated">預期值 &lt;{1}&gt; 為正數。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="IsNegativeFailMsg">
-        <source>Expected value &lt;{1}&gt; to be negative. {0}</source>
-        <target state="translated">預期值 &lt;{1}&gt; 為負數。{0}</target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="DoNotUseAssertEquals">
         <source>Assert.Equals should not be used for Assertions. Please use Assert.AreEqual &amp; overloads instead.</source>
         <target state="translated">Assert.Equals 不應使用於判斷提示。請改用 Assert.AreEqual 及多載。</target>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -277,6 +277,16 @@ Actual: {2}</source>
         <target state="new">Expected condition to be false.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IsGreaterThanFailedSummary">
+        <source>Expected value to be greater than the lower bound.</source>
+        <target state="new">Expected value to be greater than the lower bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsGreaterThanOrEqualToFailedSummary">
+        <source>Expected value to be greater than or equal to the lower bound.</source>
+        <target state="new">Expected value to be greater than or equal to the lower bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">值 '{0}' 不在預期的範圍 [{1}, {2}] 內。{3}</target>
@@ -292,9 +302,24 @@ Actual: {2}</source>
         <target state="translated">{0} 預期的類型: &lt;{1}&gt;，實際的類型: &lt;{2}&gt;。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="IsLessThanFailedSummary">
+        <source>Expected value to be less than the upper bound.</source>
+        <target state="new">Expected value to be less than the upper bound.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsLessThanOrEqualToFailedSummary">
+        <source>Expected value to be less than or equal to the upper bound.</source>
+        <target state="new">Expected value to be less than or equal to the upper bound.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IsMatchFail">
         <source>String '{0}' does not match pattern '{1}'. {2}</source>
         <target state="translated">字串 '{0}' 與模式 '{1}' 不符。{2}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsNegativeFailedSummary">
+        <source>Expected value to be negative.</source>
+        <target state="new">Expected value to be negative.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsNotEmptyFailMsg">
@@ -330,6 +355,11 @@ Actual: {2}</source>
       <trans-unit id="IsNullFailedSummary">
         <source>Expected value to be null.</source>
         <target state="new">Expected value to be null.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsPositiveFailedSummary">
+        <source>Expected value to be positive.</source>
+        <target state="new">Expected value to be positive.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsTrueFailedSummary">

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IComparableTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IComparableTests.cs
@@ -42,7 +42,16 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsGreaterThan failed. Actual value <5> is not greater than expected value <10>. 'lowerBound' expression: '10', 'value' expression: '5'. A Message");
+            .WithMessage(
+                """
+                Assertion failed. Expected value to be greater than the lower bound.
+                A Message
+
+                lower bound: 10
+                actual:      5
+
+                Assert.IsGreaterThan(10, 5)
+                """);
     }
 
     public void IsGreaterThanShouldWorkWithDoubles() =>
@@ -86,7 +95,16 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsGreaterThanOrEqualTo failed. Actual value <5> is not greater than or equal to expected value <10>. 'lowerBound' expression: '10', 'value' expression: '5'. A Message");
+            .WithMessage(
+                """
+                Assertion failed. Expected value to be greater than or equal to the lower bound.
+                A Message
+
+                lower bound: 10
+                actual:      5
+
+                Assert.IsGreaterThanOrEqualTo(10, 5)
+                """);
     }
 
     public void IsGreaterThanOrEqualToShouldWorkWithDoubles() =>
@@ -130,7 +148,16 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsLessThan failed. Actual value <10> is not less than expected value <5>. 'upperBound' expression: '5', 'value' expression: '10'. A Message");
+            .WithMessage(
+                """
+                Assertion failed. Expected value to be less than the upper bound.
+                A Message
+
+                upper bound: 5
+                actual:      10
+
+                Assert.IsLessThan(5, 10)
+                """);
     }
 
     public void IsLessThanShouldWorkWithDoubles() =>
@@ -174,7 +201,16 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsLessThanOrEqualTo failed. Actual value <10> is not less than or equal to expected value <5>. 'upperBound' expression: '5', 'value' expression: '10'. A Message");
+            .WithMessage(
+                """
+                Assertion failed. Expected value to be less than or equal to the upper bound.
+                A Message
+
+                upper bound: 5
+                actual:      10
+
+                Assert.IsLessThanOrEqualTo(5, 10)
+                """);
     }
 
     public void IsLessThanOrEqualToShouldWorkWithDoubles() =>
@@ -233,7 +269,16 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsPositive failed. Expected value <-5> to be positive. 'value' expression: '-5'. A Message");
+            .WithMessage(
+                """
+                Assertion failed. Expected value to be positive.
+                A Message
+
+                expected: > 0
+                actual:   -5
+
+                Assert.IsPositive(-5)
+                """);
     }
 
     public void IsPositiveShouldWorkWithDoubles() =>
@@ -298,7 +343,16 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.IsNegative failed. Expected value <5> to be negative. 'value' expression: '5'. A Message");
+            .WithMessage(
+                """
+                Assertion failed. Expected value to be negative.
+                A Message
+
+                expected: < 0
+                actual:   5
+
+                Assert.IsNegative(5)
+                """);
     }
 
     public void IsNegativeShouldWorkWithDoubles() =>


### PR DESCRIPTION
Continues the rollout of [RFC 012 — Structured Assertion Messages](docs/RFCs/012-Structured-Assertion-Messages.md) by migrating the `Assert` IComparable family to the structured-message format. Follows the patterns established by previously merged work (#8170, #8187, #8210, #8214) and the in-flight #8258 (StartsWith/EndsWith) and #8259 (MatchesRegex/DoesNotMatchRegex).

Migrates: `Assert.IsGreaterThan`, `Assert.IsGreaterThanOrEqualTo`, `Assert.IsLessThan`, `Assert.IsLessThanOrEqualTo`, `Assert.IsPositive`, `Assert.IsNegative`.

## Output format

`Assert.IsGreaterThan(10, 5, ""A Message"")`:

```text
Assertion failed. Expected value to be greater than the lower bound.
A Message

lower bound: 10
actual:      5

Assert.IsGreaterThan(10, 5)
```

`Assert.IsLessThanOrEqualTo(5, 10, ""A Message"")`:

```text
Assertion failed. Expected value to be less than or equal to the upper bound.
A Message

upper bound: 5
actual:      10

Assert.IsLessThanOrEqualTo(5, 10)
```

`Assert.IsPositive(-5, ""A Message"")`:

```text
Assertion failed. Expected value to be positive.
A Message

expected: > 0
actual:   -5

Assert.IsPositive(-5)
```

## Notes

- Adds `IsGreaterThanFailedSummary` / `IsGreaterThanOrEqualToFailedSummary` / `IsLessThanFailedSummary` / `IsLessThanOrEqualToFailedSummary` / `IsPositiveFailedSummary` / `IsNegativeFailedSummary` resource entries (XLF files regenerated via `UpdateXlf`).
- Removes the now-unused `BuildUserMessageForLowerBoundExpression*` / `BuildUserMessageForUpperBoundExpression*` / `BuildUserMessageForValueExpression` helpers from `Assert.cs`.
- Updates the message-format tests in `AssertTests.IComparableTests.cs` to assert against the new layout.

## Validation

- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj -c Debug` — clean.
- `dotnet test test/UnitTests/TestFramework.UnitTests/TestFramework.UnitTests.csproj -c Debug` — 3535/3535 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
