### PR TITLE
Apply structured assertion messages (RFC 012) to Assert.Contains family

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -120,7 +120,30 @@ public sealed partial class Assert
     /// </param>
     /// <returns>The item.</returns>
     public static T ContainsSingle<T>(IEnumerable<T> collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsSingle(static _ => true, collection, message, predicateExpression: string.Empty, collectionExpression);
+    {
+        T item = default!;
+        int count = 0;
+
+        foreach (T current in collection)
+        {
+            if (count == 0)
+            {
+                item = current;
+            }
+
+            count++;
+        }
+
+        if (count == 1)
+        {
+            return item;
+        }
+
+        ReportAssertContainsSingleFailed(count, message, collectionExpression);
+
+        // Unreachable code but compiler cannot work it out
+        return default!;
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains exactly one element.
@@ -133,7 +156,30 @@ public sealed partial class Assert
     /// </param>
     /// <returns>The item.</returns>
     public static object? ContainsSingle(IEnumerable collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsSingle(static _ => true, collection, message, predicateExpression: string.Empty, collectionExpression);
+    {
+        object? item = null;
+        int count = 0;
+
+        foreach (object? current in collection)
+        {
+            if (count == 0)
+            {
+                item = current;
+            }
+
+            count++;
+        }
+
+        if (count == 1)
+        {
+            return item;
+        }
+
+        ReportAssertContainsSingleFailed(count, message, collectionExpression);
+
+        // Unreachable code but compiler cannot work it out
+        return default;
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains exactly one element that matches the given predicate.
@@ -176,17 +222,10 @@ public sealed partial class Assert
             return firstMatch;
         }
 
-        if (string.IsNullOrEmpty(predicateExpression))
-        {
-            ReportAssertContainsSingleFailed(matchCount, message, collectionExpression);
-        }
-        else
-        {
-            ReportAssertSingleMatchFailed(matchCount, message, predicateExpression, collectionExpression);
-        }
+        ReportAssertSingleMatchFailed(matchCount, message, predicateExpression, collectionExpression);
 
         // Unreachable code but compiler cannot work it out
-        return default;
+        return default!;
     }
 
     /// <summary>
@@ -222,12 +261,6 @@ public sealed partial class Assert
             }
 
             matchCount++;
-
-            // Early exit optimization - no need to continue if we already have more than one match
-            if (matchCount > 1)
-            {
-                break;
-            }
         }
 
         if (matchCount == 1)
@@ -235,15 +268,9 @@ public sealed partial class Assert
             return firstMatch;
         }
 
-        if (string.IsNullOrEmpty(predicateExpression))
-        {
-            ReportAssertContainsSingleFailed(matchCount, message, collectionExpression);
-        }
-        else
-        {
-            ReportAssertSingleMatchFailed(matchCount, message, predicateExpression, collectionExpression);
-        }
+        ReportAssertSingleMatchFailed(matchCount, message, predicateExpression, collectionExpression);
 
+        // Unreachable code but compiler cannot work it out
         return default;
     }
 
@@ -923,12 +950,10 @@ public sealed partial class Assert
             return null;
         }
 
-        string minArg = emptyMin || ContainsLineBreak(minValueExpression) ? "<minValue>" : minValueExpression;
-        string maxArg = emptyMax || ContainsLineBreak(maxValueExpression) ? "<maxValue>" : maxValueExpression;
-        string valueArg = emptyValue || ContainsLineBreak(valueExpression) ? "<value>" : valueExpression;
+        string minArg = emptyMin || IsMultiline(minValueExpression) ? "<minValue>" : minValueExpression;
+        string maxArg = emptyMax || IsMultiline(maxValueExpression) ? "<maxValue>" : maxValueExpression;
+        string valueArg = emptyValue || IsMultiline(valueExpression) ? "<value>" : valueExpression;
+
         return $"Assert.IsInRange({minArg}, {maxArg}, {valueArg})";
     }
-
-    private static bool ContainsLineBreak(string s)
-        => s.IndexOf('\n') >= 0 || s.IndexOf('\r') >= 0;
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
@@ -39,8 +39,7 @@ public sealed partial class Assert
         {
             if (_builder is not null)
             {
-                _builder.Insert(0, string.Format(CultureInfo.CurrentCulture, FrameworkMessages.CallerArgumentExpressionSingleParameterMessage, "collection", collectionExpression) + " ");
-                ReportAssertContainsSingleFailed(_actualCount, _builder.ToString());
+                ReportAssertContainsSingleFailed(_actualCount, _builder.ToString(), collectionExpression);
             }
 
             return _item!;
@@ -179,13 +178,11 @@ public sealed partial class Assert
 
         if (string.IsNullOrEmpty(predicateExpression))
         {
-            string userMessage = BuildUserMessageForCollectionExpression(message, collectionExpression);
-            ReportAssertContainsSingleFailed(matchCount, userMessage);
+            ReportAssertContainsSingleFailed(matchCount, message, collectionExpression);
         }
         else
         {
-            string userMessage = BuildUserMessageForPredicateExpressionAndCollectionExpression(message, predicateExpression, collectionExpression);
-            ReportAssertSingleMatchFailed(matchCount, userMessage);
+            ReportAssertSingleMatchFailed(matchCount, message, predicateExpression, collectionExpression);
         }
 
         // Unreachable code but compiler cannot work it out
@@ -240,13 +237,11 @@ public sealed partial class Assert
 
         if (string.IsNullOrEmpty(predicateExpression))
         {
-            string userMessage = BuildUserMessageForCollectionExpression(message, collectionExpression);
-            ReportAssertContainsSingleFailed(matchCount, userMessage);
+            ReportAssertContainsSingleFailed(matchCount, message, collectionExpression);
         }
         else
         {
-            string userMessage = BuildUserMessageForPredicateExpressionAndCollectionExpression(message, predicateExpression, collectionExpression);
-            ReportAssertSingleMatchFailed(matchCount, userMessage);
+            ReportAssertSingleMatchFailed(matchCount, message, predicateExpression, collectionExpression);
         }
 
         return default;
@@ -275,8 +270,7 @@ public sealed partial class Assert
     {
         if (!collection.Contains(expected))
         {
-            string userMessage = BuildUserMessageForExpectedExpressionAndCollectionExpression(message, expectedExpression, collectionExpression);
-            ReportAssertContainsItemFailed(userMessage);
+            ReportAssertContainsItemFailed(expected, message, expectedExpression, collectionExpression);
         }
     }
 
@@ -306,8 +300,7 @@ public sealed partial class Assert
             }
         }
 
-        string userMessage = BuildUserMessageForExpectedExpressionAndCollectionExpression(message, expectedExpression, collectionExpression);
-        ReportAssertContainsItemFailed(userMessage);
+        ReportAssertContainsItemFailed(expected, message, expectedExpression, collectionExpression);
     }
 
     /// <summary>
@@ -330,8 +323,7 @@ public sealed partial class Assert
     {
         if (!collection.Contains(expected, comparer))
         {
-            string userMessage = BuildUserMessageForExpectedExpressionAndCollectionExpression(message, expectedExpression, collectionExpression);
-            ReportAssertContainsItemFailed(userMessage);
+            ReportAssertContainsItemFailed(expected, message, expectedExpression, collectionExpression, comparer);
         }
     }
 
@@ -363,8 +355,7 @@ public sealed partial class Assert
             }
         }
 
-        string userMessage = BuildUserMessageForExpectedExpressionAndCollectionExpression(message, expectedExpression, collectionExpression);
-        ReportAssertContainsItemFailed(userMessage);
+        ReportAssertContainsItemFailed(expected, message, expectedExpression, collectionExpression, comparer);
     }
 
     /// <summary>
@@ -386,8 +377,7 @@ public sealed partial class Assert
     {
         if (!collection.Any(predicate))
         {
-            string userMessage = BuildUserMessageForPredicateExpressionAndCollectionExpression(message, predicateExpression, collectionExpression);
-            ReportAssertContainsPredicateFailed(userMessage);
+            ReportAssertContainsPredicateFailed(message, predicateExpression, collectionExpression);
         }
     }
 
@@ -418,8 +408,7 @@ public sealed partial class Assert
             }
         }
 
-        string userMessage = BuildUserMessageForPredicateExpressionAndCollectionExpression(message, predicateExpression, collectionExpression);
-        ReportAssertContainsPredicateFailed(userMessage);
+        ReportAssertContainsPredicateFailed(message, predicateExpression, collectionExpression);
     }
 
     /// <summary>
@@ -495,9 +484,7 @@ public sealed partial class Assert
         if (value.IndexOf(substring, comparisonType) < 0)
 #endif
         {
-            string userMessage = BuildUserMessageForSubstringExpressionAndValueExpression(message, substringExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.ContainsFail, value, substring, userMessage);
-            ReportAssertFailed("Assert.Contains", finalMessage);
+            ReportAssertContainsSubstringFailed(substring, value, comparisonType, message, substringExpression, valueExpression);
         }
     }
 
@@ -524,8 +511,7 @@ public sealed partial class Assert
     {
         if (collection.Contains(notExpected))
         {
-            string userMessage = BuildUserMessageForNotExpectedExpressionAndCollectionExpression(message, notExpectedExpression, collectionExpression);
-            ReportAssertDoesNotContainItemFailed(userMessage);
+            ReportAssertDoesNotContainItemFailed(notExpected, message, notExpectedExpression, collectionExpression);
         }
     }
 
@@ -551,8 +537,7 @@ public sealed partial class Assert
         {
             if (object.Equals(notExpected, item))
             {
-                string userMessage = BuildUserMessageForNotExpectedExpressionAndCollectionExpression(message, notExpectedExpression, collectionExpression);
-                ReportAssertDoesNotContainItemFailed(userMessage);
+                ReportAssertDoesNotContainItemFailed(notExpected, message, notExpectedExpression, collectionExpression);
             }
         }
     }
@@ -577,8 +562,7 @@ public sealed partial class Assert
     {
         if (collection.Contains(notExpected, comparer))
         {
-            string userMessage = BuildUserMessageForNotExpectedExpressionAndCollectionExpression(message, notExpectedExpression, collectionExpression);
-            ReportAssertDoesNotContainItemFailed(userMessage);
+            ReportAssertDoesNotContainItemFailed(notExpected, message, notExpectedExpression, collectionExpression, comparer);
         }
     }
 
@@ -606,8 +590,7 @@ public sealed partial class Assert
         {
             if (comparer.Equals(item, notExpected))
             {
-                string userMessage = BuildUserMessageForNotExpectedExpressionAndCollectionExpression(message, notExpectedExpression, collectionExpression);
-                ReportAssertDoesNotContainItemFailed(userMessage);
+                ReportAssertDoesNotContainItemFailed(notExpected, message, notExpectedExpression, collectionExpression, comparer);
             }
         }
     }
@@ -631,8 +614,7 @@ public sealed partial class Assert
     {
         if (collection.Any(predicate))
         {
-            string userMessage = BuildUserMessageForPredicateExpressionAndCollectionExpression(message, predicateExpression, collectionExpression);
-            ReportAssertDoesNotContainPredicateFailed(userMessage);
+            ReportAssertDoesNotContainPredicateFailed(message, predicateExpression, collectionExpression);
         }
     }
 
@@ -659,8 +641,7 @@ public sealed partial class Assert
         {
             if (predicate(item))
             {
-                string userMessage = BuildUserMessageForPredicateExpressionAndCollectionExpression(message, predicateExpression, collectionExpression);
-                ReportAssertDoesNotContainPredicateFailed(userMessage);
+                ReportAssertDoesNotContainPredicateFailed(message, predicateExpression, collectionExpression);
             }
         }
     }
@@ -738,9 +719,7 @@ public sealed partial class Assert
         if (value.IndexOf(substring, comparisonType) >= 0)
 #endif
         {
-            string userMessage = BuildUserMessageForSubstringExpressionAndValueExpression(message, substringExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.DoesNotContainFail, value, substring, userMessage);
-            ReportAssertFailed("Assert.DoesNotContain", finalMessage);
+            ReportAssertDoesNotContainSubstringFailed(substring, value, comparisonType, message, substringExpression, valueExpression);
         }
     }
 
@@ -779,73 +758,177 @@ public sealed partial class Assert
 
         if (value.CompareTo(minValue) < 0 || value.CompareTo(maxValue) > 0)
         {
-            string userMessage = BuildUserMessageForMinValueExpressionAndMaxValueExpressionAndValueExpression(message, minValueExpression, maxValueExpression, valueExpression);
-            string finalMessage = string.Format(CultureInfo.CurrentCulture, FrameworkMessages.IsInRangeFail, value, minValue, maxValue, userMessage);
-            ReportAssertFailed("IsInRange", finalMessage);
+            ReportAssertIsInRangeFailed(minValue, maxValue, value, message, minValueExpression, maxValueExpression, valueExpression);
         }
     }
 
     #endregion // IsInRange
 
     [DoesNotReturn]
-    private static void ReportAssertSingleMatchFailed(int actualCount, string userMessage)
+    private static void ReportAssertContainsSingleFailed(int actualCount, string? userMessage, string collectionExpression)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.ContainsSingleMatchFailMsg,
-            userMessage,
-            actualCount);
-        ReportAssertFailed("Assert.ContainsSingle", finalMessage);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected count:", "1")
+            .AddLine("actual count:", actualCount.ToString(CultureInfo.CurrentCulture));
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.ContainsSingleFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual("1", actualCount.ToString(CultureInfo.CurrentCulture));
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.ContainsSingle", collectionExpression, "<collection>"));
+
+        ReportAssertFailed(structured);
     }
 
     [DoesNotReturn]
-    private static void ReportAssertContainsSingleFailed(int actualCount, string userMessage)
+    private static void ReportAssertSingleMatchFailed(int actualCount, string? userMessage, string predicateExpression, string collectionExpression)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.ContainsSingleFailMsg,
-            userMessage,
-            actualCount);
-        ReportAssertFailed("Assert.ContainsSingle", finalMessage);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected matches:", "1")
+            .AddLine("actual matches:", actualCount.ToString(CultureInfo.CurrentCulture));
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.ContainsSingleMatchFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual("1", actualCount.ToString(CultureInfo.CurrentCulture));
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.ContainsSingle", predicateExpression, collectionExpression, "<predicate>", "<collection>"));
+
+        ReportAssertFailed(structured);
     }
 
     [DoesNotReturn]
-    private static void ReportAssertContainsItemFailed(string userMessage)
+    private static void ReportAssertContainsItemFailed(object? expected, string? userMessage, string expectedExpression, string collectionExpression, object? comparer = null)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.ContainsItemFailMsg,
-            userMessage);
-        ReportAssertFailed("Assert.Contains", finalMessage);
+        string expectedText = AssertionValueRenderer.RenderValue(expected);
+        EvidenceBlock evidence = EvidenceBlock.Create().AddLine("expected:", expectedText);
+        if (comparer is not null)
+        {
+            evidence.AddLine("comparer:", comparer.GetType().Name);
+        }
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.ContainsItemFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(expectedText, null);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.Contains", expectedExpression, collectionExpression, "<expected>", "<collection>"));
+
+        ReportAssertFailed(structured);
     }
 
     [DoesNotReturn]
-    private static void ReportAssertContainsPredicateFailed(string userMessage)
+    private static void ReportAssertContainsPredicateFailed(string? userMessage, string predicateExpression, string collectionExpression)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.ContainsPredicateFailMsg,
-            userMessage);
-        ReportAssertFailed("Assert.Contains", finalMessage);
+        StructuredAssertionMessage structured = new(FrameworkMessages.ContainsPredicateFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.Contains", predicateExpression, collectionExpression, "<predicate>", "<collection>"));
+
+        ReportAssertFailed(structured);
     }
 
     [DoesNotReturn]
-    private static void ReportAssertDoesNotContainItemFailed(string userMessage)
+    private static void ReportAssertContainsSubstringFailed(string substring, string value, StringComparison comparisonType, string? userMessage, string substringExpression, string valueExpression)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.DoesNotContainItemFailMsg,
-            userMessage);
-        ReportAssertFailed("Assert.DoesNotContain", finalMessage);
+        string expectedText = AssertionValueRenderer.RenderValue(substring);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected substring:", expectedText)
+            .AddLine("actual:", actualText)
+            .AddLine("comparison:", comparisonType.ToString());
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.ContainsSubstringFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(expectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.Contains", substringExpression, valueExpression, "<substring>", "<value>"));
+
+        ReportAssertFailed(structured);
     }
 
     [DoesNotReturn]
-    private static void ReportAssertDoesNotContainPredicateFailed(string userMessage)
+    private static void ReportAssertDoesNotContainItemFailed(object? notExpected, string? userMessage, string notExpectedExpression, string collectionExpression, object? comparer = null)
     {
-        string finalMessage = string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.DoesNotContainPredicateFailMsg,
-            userMessage);
-        ReportAssertFailed("Assert.DoesNotContain", finalMessage);
+        string notExpectedText = AssertionValueRenderer.RenderValue(notExpected);
+        EvidenceBlock evidence = EvidenceBlock.Create().AddLine("unexpected:", notExpectedText);
+        if (comparer is not null)
+        {
+            evidence.AddLine("comparer:", comparer.GetType().Name);
+        }
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.DoesNotContainItemFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(notExpectedText, null);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.DoesNotContain", notExpectedExpression, collectionExpression, "<notExpected>", "<collection>"));
+
+        ReportAssertFailed(structured);
     }
+
+    [DoesNotReturn]
+    private static void ReportAssertDoesNotContainPredicateFailed(string? userMessage, string predicateExpression, string collectionExpression)
+    {
+        StructuredAssertionMessage structured = new(FrameworkMessages.DoesNotContainPredicateFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.DoesNotContain", predicateExpression, collectionExpression, "<predicate>", "<collection>"));
+
+        ReportAssertFailed(structured);
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertDoesNotContainSubstringFailed(string substring, string value, StringComparison comparisonType, string? userMessage, string substringExpression, string valueExpression)
+    {
+        string notExpectedText = AssertionValueRenderer.RenderValue(substring);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("unexpected substring:", notExpectedText)
+            .AddLine("actual:", actualText)
+            .AddLine("comparison:", comparisonType.ToString());
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.DoesNotContainSubstringFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual(notExpectedText, actualText);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.DoesNotContain", substringExpression, valueExpression, "<substring>", "<value>"));
+
+        ReportAssertFailed(structured);
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertIsInRangeFailed<T>(T minValue, T maxValue, T value, string? userMessage, string minValueExpression, string maxValueExpression, string valueExpression)
+    {
+        string minText = AssertionValueRenderer.RenderValue(minValue);
+        string maxText = AssertionValueRenderer.RenderValue(maxValue);
+        string actualText = AssertionValueRenderer.RenderValue(value);
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("expected:", $"[{minText}, {maxText}]")
+            .AddLine("actual:", actualText);
+
+        StructuredAssertionMessage structured = new(FrameworkMessages.IsInRangeFailedSummary);
+        structured.WithUserMessage(userMessage);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual($"[{minText}, {maxText}]", actualText);
+        // The middle "value" arg comes after minValue, maxValue — keep all three in the call-site for clarity.
+        string? callSite = FormatIsInRangeCallSite(minValueExpression, maxValueExpression, valueExpression);
+        structured.WithCallSiteExpression(callSite);
+
+        ReportAssertFailed(structured);
+    }
+
+    private static string? FormatIsInRangeCallSite(string minValueExpression, string maxValueExpression, string valueExpression)
+    {
+        bool emptyMin = string.IsNullOrWhiteSpace(minValueExpression);
+        bool emptyMax = string.IsNullOrWhiteSpace(maxValueExpression);
+        bool emptyValue = string.IsNullOrWhiteSpace(valueExpression);
+        if (emptyMin && emptyMax && emptyValue)
+        {
+            return null;
+        }
+
+        string minArg = emptyMin || ContainsLineBreak(minValueExpression) ? "<minValue>" : minValueExpression;
+        string maxArg = emptyMax || ContainsLineBreak(maxValueExpression) ? "<maxValue>" : maxValueExpression;
+        string valueArg = emptyValue || ContainsLineBreak(valueExpression) ? "<value>" : valueExpression;
+        return $"Assert.IsInRange({minArg}, {maxArg}, {valueArg})";
+    }
+
+    private static bool ContainsLineBreak(string s)
+        => s.IndexOf('\n') >= 0 || s.IndexOf('\r') >= 0;
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -272,28 +272,11 @@ public sealed partial class Assert
             : $"{callerArgMessagePart} {userMessage}";
     }
 
-    private static string BuildUserMessageForThreeExpressions(string? format, string callerArgExpression1, string parameterName1, string callerArgExpression2, string parameterName2, string callerArgExpression3, string parameterName3)
-    {
-        string userMessage = BuildUserMessage(format);
-        if (string.IsNullOrEmpty(callerArgExpression1) || string.IsNullOrEmpty(callerArgExpression2) || string.IsNullOrEmpty(callerArgExpression3))
-        {
-            return userMessage;
-        }
-
-        string callerArgMessagePart = string.Format(CultureInfo.InvariantCulture, FrameworkMessages.CallerArgumentExpressionThreeParametersMessage, parameterName1, callerArgExpression1, parameterName2, callerArgExpression2, parameterName3, callerArgExpression3);
-        return string.IsNullOrEmpty(userMessage)
-            ? callerArgMessagePart
-            : $"{callerArgMessagePart} {userMessage}";
-    }
-
     private static string BuildUserMessageForValueExpression(string? format, string valueExpression)
         => BuildUserMessageForSingleExpression(format, valueExpression, "value");
 
     private static string BuildUserMessageForCollectionExpression(string? format, string collectionExpression)
         => BuildUserMessageForSingleExpression(format, collectionExpression, "collection");
-
-    private static string BuildUserMessageForSubstringExpressionAndValueExpression(string? format, string substringExpression, string valueExpression)
-        => BuildUserMessageForTwoExpressions(format, substringExpression, "substring", valueExpression, "value");
 
     private static string BuildUserMessageForExpectedSuffixExpressionAndValueExpression(string? format, string expectedSuffixExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, expectedSuffixExpression, "expectedSuffix", valueExpression, "value");
@@ -316,23 +299,11 @@ public sealed partial class Assert
     private static string BuildUserMessageForUpperBoundExpressionAndValueExpression(string? format, string upperBoundExpression, string valueExpression)
         => BuildUserMessageForTwoExpressions(format, upperBoundExpression, "upperBound", valueExpression, "value");
 
-    private static string BuildUserMessageForExpectedExpressionAndCollectionExpression(string? format, string expectedExpression, string collectionExpression)
-        => BuildUserMessageForTwoExpressions(format, expectedExpression, "expected", collectionExpression, "collection");
-
-    private static string BuildUserMessageForNotExpectedExpressionAndCollectionExpression(string? format, string notExpectedExpression, string collectionExpression)
-        => BuildUserMessageForTwoExpressions(format, notExpectedExpression, "notExpected", collectionExpression, "collection");
-
-    private static string BuildUserMessageForPredicateExpressionAndCollectionExpression(string? format, string predicateExpression, string collectionExpression)
-        => BuildUserMessageForTwoExpressions(format, predicateExpression, "predicate", collectionExpression, "collection");
-
     private static string BuildUserMessageForExpectedExpressionAndActualExpression(string? format, string expectedExpression, string actualExpression)
         => BuildUserMessageForTwoExpressions(format, expectedExpression, "expected", actualExpression, "actual");
 
     private static string BuildUserMessageForNotExpectedExpressionAndActualExpression(string? format, string notExpectedExpression, string actualExpression)
         => BuildUserMessageForTwoExpressions(format, notExpectedExpression, "notExpected", actualExpression, "actual");
-
-    private static string BuildUserMessageForMinValueExpressionAndMaxValueExpressionAndValueExpression(string? format, string minValueExpression, string maxValueExpression, string valueExpression)
-        => BuildUserMessageForThreeExpressions(format, minValueExpression, "minValue", maxValueExpression, "maxValue", valueExpression, "value");
 
     /// <summary>
     /// Checks the parameter for valid conditions.

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -420,4 +420,31 @@ Actual: {2}</value>
   <data name="IsNotNullFailedSummary" xml:space="preserve">
     <value>Expected value to not be null.</value>
   </data>
+  <data name="ContainsSingleFailedSummary" xml:space="preserve">
+    <value>Expected collection to contain exactly one element.</value>
+  </data>
+  <data name="ContainsSingleMatchFailedSummary" xml:space="preserve">
+    <value>Expected collection to contain exactly one element matching the predicate.</value>
+  </data>
+  <data name="ContainsItemFailedSummary" xml:space="preserve">
+    <value>Expected collection to contain the specified element.</value>
+  </data>
+  <data name="ContainsPredicateFailedSummary" xml:space="preserve">
+    <value>Expected collection to contain an element matching the predicate.</value>
+  </data>
+  <data name="ContainsSubstringFailedSummary" xml:space="preserve">
+    <value>Expected string to contain the specified substring.</value>
+  </data>
+  <data name="DoesNotContainItemFailedSummary" xml:space="preserve">
+    <value>Expected collection to not contain the specified element.</value>
+  </data>
+  <data name="DoesNotContainPredicateFailedSummary" xml:space="preserve">
+    <value>Expected collection to not contain an element matching the predicate.</value>
+  </data>
+  <data name="DoesNotContainSubstringFailedSummary" xml:space="preserve">
+    <value>Expected string to not contain the specified substring.</value>
+  </data>
+  <data name="IsInRangeFailedSummary" xml:space="preserve">
+    <value>Expected value to be within the inclusive range.</value>
+  </data>
 </root>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Očekávala se kolekce, která bude obsahovat zadanou položku. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Očekávala se alespoň jedna položka odpovídající predikátu. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Očekávalo se, že kolekce bude obsahovat přesně jeden prvek, ale našlo se tolik elementů: {1}. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Očekávala se přesně jedna položka odpovídající predikátu, ale našlo se tolik položek: {1}. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Očekávalo se, že kolekce nebude obsahovat zadanou položku. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Očekávaly se žádné položky, které by odpovídaly predikátu. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Skutečnost: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Hodnota {0} není v očekávaném rozsahu [{1}..{2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Es wurde erwartet, dass die Sammlung das angegebene Element enthält. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Es wurde erwartet, dass mindestens ein Element mit dem Prädikat übereinstimmt. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Es wurde erwartet, dass die Sammlung genau ein Element enthält, es wurden jedoch {1} gefunden. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Es wurde erwartet, dass genau ein Element mit dem Prädikat übereinstimmt, es wurden jedoch {1} Element(e) gefunden. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Es wurde erwartet, dass die Sammlung das angegebene Element nicht enthält. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Es wurden erwartet, dass keine Elemente mit dem Prädikat übereinstimmen. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Tatsächlich: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Der Wert „{0}“ liegt nicht im erwarteten Bereich [{1}..{2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Se esperaba que la colección contuviera el elemento especificado. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Se esperaba al menos un elemento para que coincida con el predicado. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Se esperaba que la colección contuviera exactamente un elemento, pero se encontraron {1} elementos. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Se esperaba exactamente un elemento para que coincida con el predicado, pero se encontraron {1} elementos. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Se esperaba que la colección no contenga el elemento especificado. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">No se esperaba que ningún elemento coincidía con el predicado. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Real: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">El valor "{0}" no está dentro del rango esperado [{1}..{2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Collection attendue pour contenir l’élément spécifié. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Au moins un élément doit correspondre au prédicat. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Collection attendue pour contenir exactement un élément mais {1} élément(s) trouvé(s). {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Un seul élément était attendu pour correspondre au prédicat, mais {1} élément(s) trouvé(s). {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Collection attendue pour ne pas contenir l’élément spécifié. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Aucun élément ne doit correspondre au prédicat. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Réel : {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">La valeur « {0} » n'est pas dans la plage attendue [{1}..{2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -168,9 +168,19 @@
         <target state="translated">La raccolta dovrebbe contenere l'elemento specificato. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Almeno un elemento dovrebbe corrispondere al predicato. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">La raccolta dovrebbe contenere un unico elemento, ma ne sono stati trovati {1}. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Un unico elemento dovrebbe corrispondere al predicato, ma ne sono stati trovati {1}. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">La raccolta non dovrebbe contenere l'elemento specificato. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Nessun elemento dovrebbe corrispondere al predicato. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Effettivo: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Il valore '{0}' non è compreso nell'intervallo previsto [{1}, {2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -168,9 +168,19 @@
         <target state="translated">指定された項目を含むコレクションが必要です。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">述語と一致する項目が少なくとも 1 つ必要です。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">コレクションには 1 つの要素だけを含める必要がありますが、{1} 要素が見つかりました。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">述語と一致する項目が 1 つだけ必要ですが、{1} 項目が見つかりました。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">指定された項目を含まないコレクションが必要です。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">述語に一致する項目が必要ありません。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Actual: {2}</source>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">値 '{0}' は予期される範囲 [{1}..{2}] 内にありません。{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -168,9 +168,19 @@
         <target state="translated">지정한 항목을 포함할 컬렉션이 필요합니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">조건자와 일치하는 항목이 하나 이상 필요합니다. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">정확히 하나의 요소를 포함할 컬렉션이 필요하지만 {1}개 요소가 발견되었습니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">조건자에 일치하는 항목이 하나만 필요하지만 {1}개 항목이 발견되었습니다. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">지정한 항목을 포함하지 않을 컬렉션이 필요합니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">조건자와 일치하는 항목이 필요하지 않습니다. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Actual: {2}</source>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">'{0}' 값이 예상 범위 [{1}..{2}] 내에 있지 않습니다. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Oczekiwano, że kolekcja będzie zawierać określony element. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Oczekiwano co najmniej jednego elementu zgodnego z predykatem. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Oczekiwano, że kolekcja będzie zawierać dokładnie jeden element, ale znaleziono {1} elementów. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Oczekiwano dokładnie jednego elementu zgodnego z predykatem, ale znaleziono {1} elementów. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Oczekiwano, że kolekcja nie będzie zawierać określonego elementu. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Nie oczekiwano elementów zgodnych z predykatem. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Rzeczywiste: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Wartość „{0}” nie mieści się w oczekiwanym zakresie [{1}..{2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -168,9 +168,19 @@
         <target state="translated">A coleção esperada contém o item especificado. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Esperava-se que pelo menos um item correspondesse ao predicado. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">A coleção esperada contém exatamente um elemento, mas encontrou {1} elementos. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Esperava-se exatamente um item para corresponder ao predicado, mas encontrou {1} itens. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">A coleção esperada não contém o item especificado. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Não era esperado nenhum item que corresponda ao predicado. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Real: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">O valor '{0}' não está dentro do intervalo esperado [{1}.. {2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Ожидалось, что коллекция будет содержать указанный элемент. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">Ожидался по крайней мере один элемент, соответствующий предикату. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Ожидалось, что коллекция будет содержать ровно один элемент, но найдено элементов: {1}. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Ожидался ровно один элемент, соответствующий предикату, но найдено элементов: {1}. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Ожидалось, что коллекция не будет содержать указанный элемент. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Ожидалось, что ни один элемент не будет соответствовать предикату. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Actual: {2}</source>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Значение "{0}" не находится в пределах ожидаемого диапазона [{1}..{2}]. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -168,9 +168,19 @@
         <target state="translated">Koleksiyonun belirtilen öğeyi içermesi bekleniyordu. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">En az bir öğenin koşulla eşleşmesi bekleniyordu. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">Beklenen koleksiyonun tam olarak bir öğe içermesi beklenirken, {1} öğe bulundu. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">Özellikle bir öğenin koşulla eşleşmesi beklenirken {1} öğe bulundu. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">Koleksiyonun belirtilen öğeyi içermemesi bekleniyordu. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">Hiçbir öğenin koşulla eşleşmesi beklenmiyordu. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Gerçekte olan: {2}</target>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">Değer '{0}' beklenen aralık [{1}..{2}] içinde değil. {3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -168,9 +168,19 @@
         <target state="translated">预期集合包含指定项。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">应至少有一项与谓词匹配。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">预期集合仅包含一个元素，但找到 {1} 个元素。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">应恰好只有一项与谓词匹配，但找到 {1} 项。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">预期集合不包含指定项。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">预期没有与谓词匹配的项。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Actual: {2}</source>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">值 "{0}" 不在预期范围 [{1}..{2}] 内。{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -168,9 +168,19 @@
         <target state="translated">預期集合包含指定的項目。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsItemFailedSummary">
+        <source>Expected collection to contain the specified element.</source>
+        <target state="new">Expected collection to contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsPredicateFailMsg">
         <source>Expected at least one item to match the predicate. {0}</source>
         <target state="translated">必須至少有一個項目符合述詞。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsPredicateFailedSummary">
+        <source>Expected collection to contain an element matching the predicate.</source>
+        <target state="new">Expected collection to contain an element matching the predicate.</target>
         <note />
       </trans-unit>
       <trans-unit id="ContainsSingleFailMsg">
@@ -178,9 +188,24 @@
         <target state="translated">預期集合應僅包含一個元素，但發現 {1} 個元素。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainsSingleFailedSummary">
+        <source>Expected collection to contain exactly one element.</source>
+        <target state="new">Expected collection to contain exactly one element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ContainsSingleMatchFailMsg">
         <source>Expected exactly one item to match the predicate but found {1} item(s). {0}</source>
         <target state="translated">預期只有一個項目符合述詞，但找到 {1} 個項目。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSingleMatchFailedSummary">
+        <source>Expected collection to contain exactly one element matching the predicate.</source>
+        <target state="new">Expected collection to contain exactly one element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ContainsSubstringFailedSummary">
+        <source>Expected string to contain the specified substring.</source>
+        <target state="new">Expected string to contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotContainFail">
@@ -193,9 +218,24 @@
         <target state="translated">預期集合不包含指定的項目。{0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoesNotContainItemFailedSummary">
+        <source>Expected collection to not contain the specified element.</source>
+        <target state="new">Expected collection to not contain the specified element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoesNotContainPredicateFailMsg">
         <source>Expected no items to match the predicate. {0}</source>
         <target state="translated">預期沒有任何項目符合述詞。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainPredicateFailedSummary">
+        <source>Expected collection to not contain an element matching the predicate.</source>
+        <target state="new">Expected collection to not contain an element matching the predicate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoesNotContainSubstringFailedSummary">
+        <source>Expected string to not contain the specified substring.</source>
+        <target state="new">Expected string to not contain the specified substring.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotEndWithFail">
@@ -280,6 +320,11 @@ Actual: {2}</source>
       <trans-unit id="IsInRangeFail">
         <source>Value '{0}' is not within the expected range [{1}..{2}]. {3}</source>
         <target state="translated">值 '{0}' 不在預期的範圍 [{1}, {2}] 內。{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IsInRangeFailedSummary">
+        <source>Expected value to be within the inclusive range.</source>
+        <target state="new">Expected value to be within the inclusive range.</target>
         <note />
       </trans-unit>
       <trans-unit id="IsInRangeMaxValueMustBeGreaterThanOrEqualMinValue">

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
@@ -372,6 +372,21 @@ public partial class AssertTests : TestContainer
     }
 
     /// <summary>
+    /// Tests the ContainsSingle method without message parameters where the collection has multiple elements.
+    /// </summary>
+    public void ContainsSingle_InNonGenericCollection_NoMessage_WithMultipleElements_ThrowsException()
+    {
+        // Arrange
+        var collection = new ArrayList { 1, 2, 3 };
+
+        // Act
+        Action action = () => Assert.ContainsSingle(collection);
+
+        // Assert
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain exactly one element.*expected count: 1*actual count:   3*Assert.ContainsSingle(collection)*");
+    }
+
+    /// <summary>
     /// Tests the ContainsSingle method with message parameter where the collection has a no element (empty collection).
     /// </summary>
     public void ContainsSingle_InNonGenericCollection_AssertCustomMessage_WithEmptyCollection_ThrowsException()
@@ -1494,6 +1509,40 @@ public partial class AssertTests : TestContainer
     }
 
     /// <summary>
+    /// Tests the ContainsSingle method with predicate when the predicate expression is unavailable.
+    /// Expects a predicate-specific exception using placeholders.
+    /// </summary>
+    public void ContainsSinglePredicate_EmptyPredicateExpression_UsesPredicateFailureMessage()
+    {
+        // Arrange
+        var collection = new List<int> { 1, 3, 5 };
+
+        // Act
+        Action action = () => Assert.ContainsSingle(static x => x % 2 == 0, collection, predicateExpression: string.Empty);
+
+        // Assert
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   0*Assert.ContainsSingle(<predicate>, collection)*");
+    }
+
+    /// <summary>
+    /// Tests the ContainsSingle method with predicate when the predicate expression is unavailable in non-generic collections.
+    /// Expects a predicate-specific exception using placeholders.
+    /// </summary>
+    public void ContainsSinglePredicate_InNonGenericCollection_EmptyPredicateExpression_UsesPredicateFailureMessage()
+    {
+        // Arrange
+        var collection = new ArrayList { 1, 3, 5, "a" };
+
+        // Act
+        Action action = () => Assert.ContainsSingle(static x => x is int i && i % 2 == 0, collection, predicateExpression: string.Empty);
+
+        // Assert
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   0*Assert.ContainsSingle(<predicate>, collection)*");
+    }
+
+    /// <summary>
     /// Tests the ContainsSingle method with predicate when multiple elements match.
     /// Expects an exception.
     /// </summary>
@@ -1517,14 +1566,14 @@ public partial class AssertTests : TestContainer
     public void ContainsSinglePredicate_InNonGenericCollection_MultipleItemsMatch_ThrowsException()
     {
         // Arrange
-        var collection = new ArrayList { 2, 4, "a" };
+        var collection = new ArrayList { 2, 4, 6, 8, "a" };
 
         // Act
         Action action = () => Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection);
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   2*Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection)*");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   4*Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection)*");
     }
 
     /// <summary>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Contains.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -338,7 +338,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.ContainsSingle(collection, ref handler);
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). 'collection' expression: 'collection'. ");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain exactly one element.*expected count:*1*actual count:*3*Assert.ContainsSingle(collection)*");
     }
 
     /// <summary>
@@ -368,7 +368,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.ContainsSingle(collection);
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 0 element(s). 'collection' expression: 'collection'.");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain exactly one element.*expected count: 1*actual count:   0*Assert.ContainsSingle(collection)*");
     }
 
     /// <summary>
@@ -383,7 +383,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.ContainsSingle(collection, "my custom message");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 0 element(s). 'collection' expression: 'collection'. my custom message");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain exactly one element.*my custom message*expected count: 1*actual count:   0*Assert.ContainsSingle(collection)*");
     }
     #endregion
 
@@ -417,7 +417,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains(20, collection, "Item 20 not found");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. Expected collection to contain the specified item. 'expected' expression: '20', 'collection' expression: 'collection'. Item 20 not found");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain the specified element.*Item 20 not found*expected:*Assert.Contains(20, collection)*");
     }
 
     /// <summary>
@@ -528,7 +528,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains("cherry", collection, comparer, "Missing cherry");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. Expected collection to contain the specified item. 'expected' expression: '\"cherry\"', 'collection' expression: 'collection'. Missing cherry");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain the specified element.*Missing cherry*expected:*Assert.Contains(\"cherry\", collection)*");
     }
 
     /// <summary>
@@ -574,7 +574,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains(IsEven, collection, "No even number found");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. Expected at least one item to match the predicate. 'predicate' expression: 'IsEven', 'collection' expression: 'collection'. No even number found");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain an element matching the predicate.*No even number found*Assert.Contains(IsEven, collection)*");
     }
 
     /// <summary>
@@ -590,7 +590,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains(IsEven, collection, "No even number found");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. Expected at least one item to match the predicate. 'predicate' expression: 'IsEven', 'collection' expression: 'collection'. No even number found");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain an element matching the predicate.*No even number found*Assert.Contains(IsEven, collection)*");
     }
 
     /// <summary>
@@ -623,7 +623,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains(substring, value, StringComparison.Ordinal, "Missing substring");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. String 'The quick brown fox' does not contain string 'lazy'. 'substring' expression: 'substring', 'value' expression: 'value'. Missing substring.");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected string to contain the specified substring.*Missing substring*expected substring: \"lazy\"*actual:*\"The quick brown fox\"*Assert.Contains(substring, value)*");
     }
 
     public void Contains_HashSetWithCustomComparer_ItemExists_DoesNotThrow()
@@ -699,7 +699,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains("banana", collection, comparer);
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. Expected collection to contain the specified item. 'expected' expression: '\"banana\"', 'collection' expression: 'collection'.");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to contain the specified element.*expected:*Assert.Contains(\"banana\", collection)*");
     }
 
     /// <summary>
@@ -834,7 +834,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.Contains(substring, value);
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.Contains failed. String '' does not contain string 'test'. 'substring' expression: 'substring', 'value' expression: 'value'..");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected string to contain the specified substring.*expected substring: \"test\"*actual:*\"\"*Assert.Contains(substring, value)*");
     }
 
     /// <summary>
@@ -937,7 +937,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(10, collection, "Item 10 should not be found");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. Expected collection to not contain the specified item. 'notExpected' expression: '10', 'collection' expression: 'collection'. Item 10 should not be found");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to not contain the specified element.*Item 10 should not be found*unexpected:*Assert.DoesNotContain(10, collection)*");
     }
 
     /// <summary>
@@ -968,7 +968,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(10, collection, "Assert.DoesNotContain failed. Expected collection to not contain the specified item. Item {0} should not be found");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. Expected collection to not contain the specified item. 'notExpected' expression: '10', 'collection' expression: 'collection'. Assert.DoesNotContain failed. Expected collection to not contain the specified item. Item {0} should not be found");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to not contain the specified element.*Assert.DoesNotContain failed. Expected collection to not contain the specified item. Item {0} should not be found*unexpected:*Assert.DoesNotContain(10, collection)*");
     }
 
     /// <summary>
@@ -1017,7 +1017,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain("APPLE", collection, comparer, "Unexpected \"APPLE\"");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. Expected collection to not contain the specified item. 'notExpected' expression: '\"APPLE\"', 'collection' expression: 'collection'. Unexpected \"APPLE\"");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to not contain the specified element.*Unexpected \"APPLE\"*unexpected:*Assert.DoesNotContain(\"APPLE\", collection)*");
     }
 
     /// <summary>
@@ -1034,7 +1034,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain("APPLE", collection, comparer, "APPLE");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. Expected collection to not contain the specified item. 'notExpected' expression: '\"APPLE\"', 'collection' expression: 'collection'. APPLE");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to not contain the specified element.*APPLE*unexpected:*Assert.DoesNotContain(\"APPLE\", collection)*");
     }
 
     /// <summary>
@@ -1080,7 +1080,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(IsEven, collection, "An even number exists");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. Expected no items to match the predicate. 'predicate' expression: 'IsEven', 'collection' expression: 'collection'. An even number exists");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to not contain an element matching the predicate.*An even number exists*Assert.DoesNotContain(IsEven, collection)*");
     }
 
     /// <summary>
@@ -1096,7 +1096,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(IsEven, collection, "An even number exists");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. Expected no items to match the predicate. 'predicate' expression: 'IsEven', 'collection' expression: 'collection'. An even number exists");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected collection to not contain an element matching the predicate.*An even number exists*Assert.DoesNotContain(IsEven, collection)*");
     }
 
     /// <summary>
@@ -1129,7 +1129,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(substring, value, StringComparison.Ordinal, "Unexpected substring");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. String 'The quick brown fox' does contain string 'brown'. 'substring' expression: 'substring', 'value' expression: 'value'. Unexpected substring.");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected string to not contain the specified substring*Unexpected substring*unexpected substring: \"brown\"*actual:*\"The quick brown fox\"*Assert.DoesNotContain(substring, value)*");
     }
 
     /// <summary>
@@ -1164,7 +1164,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(substring, value, StringComparison.OrdinalIgnoreCase, "Found unexpected substring");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. String 'The quick brown fox' does contain string 'BROWN'. 'substring' expression: 'substring', 'value' expression: 'value'. Found unexpected substring.");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected string to not contain the specified substring.*Found unexpected substring*unexpected substring: \"BROWN\"*actual:*\"The quick brown fox\"*Assert.DoesNotContain(substring, value)*");
     }
 
     /// <summary>
@@ -1197,7 +1197,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(substring, value);
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. String 'The quick brown fox' does contain string 'brown'. 'substring' expression: 'substring', 'value' expression: 'value'..");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected string to not contain the specified substring.*unexpected substring: \"brown\"*actual:*\"The quick brown fox\"*Assert.DoesNotContain(substring, value)*");
     }
 
     /// <summary>
@@ -1230,7 +1230,7 @@ public partial class AssertTests : TestContainer
         Action action = () => Assert.DoesNotContain(substring, value, "Found unexpected substring");
 
         // Assert
-        action.Should().Throw<AssertFailedException>().WithMessage("Assert.DoesNotContain failed. String 'The quick brown fox' does contain string 'brown'. 'substring' expression: 'substring', 'value' expression: 'value'. Found unexpected substring.");
+        action.Should().Throw<AssertFailedException>().WithMessage("*Expected string to not contain the specified substring.*Found unexpected substring*unexpected substring: \"brown\"*actual:*\"The quick brown fox\"*Assert.DoesNotContain(substring, value)*");
     }
 
     /// <summary>
@@ -1473,7 +1473,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   0*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1490,7 +1490,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). 'predicate' expression: 'x => x is int i && i % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   0*Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1507,7 +1507,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 4 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   4*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1524,7 +1524,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 2 item(s). 'predicate' expression: 'x => x is int i && i % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches: 1*actual matches:   2*Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1541,7 +1541,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'. No even numbers found in collection with 3 items");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*No even numbers found in collection with 3 items*expected matches: 1*actual matches:   0*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1558,7 +1558,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). 'predicate' expression: 'x => x is int i && i % 2 == 0', 'collection' expression: 'collection'. No even numbers found in collection with 3 items");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*No even numbers found in collection with 3 items*expected matches: 1*actual matches:   0*Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1575,7 +1575,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 3 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'. Too many even numbers found: 3");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*Too many even numbers found: 3*expected matches: 1*actual matches:   3*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1592,7 +1592,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 2 item(s). 'predicate' expression: 'x => x is int i && i % 2 == 0', 'collection' expression: 'collection'. Too many even numbers found: 2");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*Too many even numbers found: 2*expected matches: 1*actual matches:   2*Assert.ContainsSingle(x => x is int i && i % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1684,7 +1684,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.Contains failed. Expected collection to contain the specified item. 'expected' expression: '5', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain the specified element.*expected:*Assert.Contains(5, collection)*");
     }
 
     /// <summary>
@@ -1700,7 +1700,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.Contains failed. Expected collection to contain the specified item. 'expected' expression: '5', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain the specified element.*expected:*Assert.Contains(5, collection)*");
     }
 
     /// <summary>
@@ -1716,7 +1716,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.Contains failed. Expected at least one item to match the predicate. 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain an element matching the predicate.*Assert.Contains(x => x % 2 == 0, collection)*");
     }
 
     /// <summary>
@@ -1732,7 +1732,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.DoesNotContain failed. Expected collection to not contain the specified item. 'notExpected' expression: '2', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to not contain the specified element.*unexpected:*Assert.DoesNotContain(2, collection)*");
     }
 
     /// <summary>
@@ -1748,7 +1748,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().Throw<AssertFailedException>()
-            .WithMessage("Assert.DoesNotContain failed. Expected no items to match the predicate. 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to not contain an element matching the predicate.*Assert.DoesNotContain(x => x % 2 == 0, collection)*");
     }
 
     public void DoesNotContains_HashSetWithCustomComparer_ItemDoesNotExist_DoesNotThrow()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInRange.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInRange.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -57,7 +57,7 @@ public partial class AssertTests : TestContainer
         // Act & Assert
         Action action = () => Assert.IsInRange(minValue, maxValue, value);
         action.Should().Throw<Exception>()
-            .And.Message.Should().Contain("Value '3' is not within the expected range [5..10]");
+            .And.Message.Should().Contain("expected: [5, 10]");
     }
 
     public void IsInRange_WithValueAboveRange_ThrowsAssertFailedException()
@@ -70,7 +70,7 @@ public partial class AssertTests : TestContainer
         // Act & Assert
         Action action = () => Assert.IsInRange(minValue, maxValue, value);
         action.Should().Throw<Exception>()
-            .And.Message.Should().Contain("Value '8' is not within the expected range [1..5]");
+            .And.Message.Should().Contain("expected: [1, 5]");
     }
 
     public void IsInRange_WithCustomMessage_IncludesCustomMessage()
@@ -86,7 +86,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '10' is not within the expected range [1..5]")
+            .And.Message.Should().Contain("expected: [1, 5]")
             .And.Contain(customMessage);
     }
 
@@ -102,7 +102,7 @@ public partial class AssertTests : TestContainer
         Assert.IsInRange(minValue, maxValue, valueInRange);
         Action action = () => Assert.IsInRange(minValue, maxValue, valueOutOfRange);
         action.Should().Throw<Exception>()
-            .And.Message.Should().Contain("Value '6' is not within the expected range [1.5..5.5]");
+            .And.Message.Should().Contain("expected: [1.5, 5.5]");
     }
 
     public void IsInRange_WithDateTimeValues_WorksCorrectly()
@@ -119,7 +119,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("is not within the expected range");
+            .And.Message.Should().Contain("Expected value to be within the inclusive range");
     }
 
     public void IsInRange_WithCharValues_WorksCorrectly()
@@ -136,7 +136,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value 'a' is not within the expected range [A..Z]");
+            .And.Message.Should().Contain("expected: ['A', 'Z']");
     }
 
     public void IsInRange_WithNullMessage_DoesNotThrow()
@@ -195,7 +195,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '-12' is not within the expected range [-10..-5]");
+            .And.Message.Should().Contain("expected: [-10, -5]");
     }
 
     public void IsInRange_WithAllNegativeValuesAboveRange_ThrowsAssertFailedException()
@@ -210,7 +210,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '-3' is not within the expected range [-10..-5]");
+            .And.Message.Should().Contain("expected: [-10, -5]");
     }
 
     public void IsInRange_WithRangeSpanningNegativeToPositive_ValueInRange_DoesNotThrow()
@@ -258,7 +258,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '-7' is not within the expected range [-5..5]");
+            .And.Message.Should().Contain("expected: [-5, 5]");
     }
 
     public void IsInRange_WithRangeSpanningNegativeToPositive_ValueAboveRange_ThrowsAssertFailedException()
@@ -273,7 +273,7 @@ public partial class AssertTests : TestContainer
 
         // Assert
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '7' is not within the expected range [-5..5]");
+            .And.Message.Should().Contain("expected: [-5, 5]");
     }
 
     public void IsInRange_WithNegativeDoubleValues_WorksCorrectly()
@@ -322,7 +322,7 @@ public partial class AssertTests : TestContainer
 
         Action action = () => Assert.IsInRange(minValue, maxValue, value);
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '4' is not within the expected range [5..5]");
+            .And.Message.Should().Contain("expected: [5, 5]");
     }
 
     public void IsInRange_WithMaxValueEqualToMinValue_Int_ShouldFailIfValueIsLarger()
@@ -334,7 +334,7 @@ public partial class AssertTests : TestContainer
 
         Action action = () => Assert.IsInRange(minValue, maxValue, value);
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '6' is not within the expected range [5..5]");
+            .And.Message.Should().Contain("expected: [5, 5]");
     }
 
     public void IsInRange_WithMaxValueEqualToMinValue_Float_ShouldPassIfValueIsEqual()
@@ -357,7 +357,7 @@ public partial class AssertTests : TestContainer
 
         Action action = () => Assert.IsInRange(minValue, maxValue, value);
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '4' is not within the expected range [5..5]");
+            .And.Message.Should().Contain("expected: [5, 5]");
     }
 
     public void IsInRange_WithMaxValueEqualToMinValue_Float_ShouldFailIfValueIsLarger()
@@ -369,7 +369,7 @@ public partial class AssertTests : TestContainer
 
         Action action = () => Assert.IsInRange(minValue, maxValue, value);
         action.Should().ThrowExactly<AssertFailedException>()
-            .And.Message.Should().Contain("Value '6' is not within the expected range [5..5]");
+            .And.Message.Should().Contain("expected: [5, 5]");
     }
 
     #endregion // IsInRange Tests

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInRange.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.IsInRange.cs
@@ -372,5 +372,20 @@ public partial class AssertTests : TestContainer
             .And.Message.Should().Contain("expected: [5, 5]");
     }
 
+    public void IsInRange_WithMultilineMinValueExpression_UsesPlaceholderInCallSite()
+    {
+        // Arrange
+        int minValue = 1;
+        int maxValue = 2;
+        int value = 3;
+
+        // Act
+        Action action = () => Assert.IsInRange(minValue, maxValue, value, minValueExpression: "minValue\r\ncontinued");
+
+        // Assert
+        action.Should().ThrowExactly<AssertFailedException>()
+            .And.Message.Should().Contain("Assert.IsInRange(<minValue>, maxValue, value)");
+    }
+
     #endregion // IsInRange Tests
 }

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -86,14 +86,14 @@ public partial class AssertTests
     {
         Action action = () => Assert.ContainsSingle(Array.Empty<int>());
         action.Should().Throw<Exception>()
-            .WithMessage("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 0 element(s). 'collection' expression: 'Array.Empty<int>()'.");
+            .WithMessage("*Expected collection to contain exactly one element.*expected count:*1*actual count:*0*Assert.ContainsSingle(Array.Empty<int>())*");
     }
 
     public void Single_WhenMultipleItems_ShouldFail()
     {
         Action action = () => Assert.ContainsSingle([1, 2, 3]);
         action.Should().Throw<Exception>()
-            .WithMessage("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). 'collection' expression: '[1, 2, 3]'.");
+            .WithMessage("*Expected collection to contain exactly one element.*expected count:*1*actual count:*3*Assert.ContainsSingle([1, 2, 3])*");
     }
 
     public async Task Single_InterpolatedString_WhenNoItem_ShouldFail()
@@ -102,7 +102,7 @@ public partial class AssertTests
         DateTime dateTime = DateTime.Now;
         Func<Task> action = async () => Assert.ContainsSingle(Array.Empty<int>(), $"User-provided message. {o}, {o,35}, {await GetHelloStringAsync()}, {new DummyIFormattable()}, {dateTime:tt}, {dateTime,5:tt}");
         (await action.Should().ThrowAsync<Exception>())
-            .WithMessage($"Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 0 element(s). 'collection' expression: 'Array.Empty<int>()'. User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}");
+            .WithMessage($"*Expected collection to contain exactly one element.*User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}*expected count:*1*actual count:*0*Assert.ContainsSingle(Array.Empty<int>())*");
         o.WasToStringCalled.Should().BeTrue();
     }
 
@@ -112,7 +112,7 @@ public partial class AssertTests
         DateTime dateTime = DateTime.Now;
         Func<Task> action = async () => Assert.ContainsSingle([1, 2, 3], $"User-provided message. {o}, {o,35}, {await GetHelloStringAsync()}, {new DummyIFormattable()}, {dateTime:tt}, {dateTime,5:tt}");
         (await action.Should().ThrowAsync<Exception>())
-            .WithMessage($"Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). 'collection' expression: '[1, 2, 3]'. User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}");
+            .WithMessage($"*Expected collection to contain exactly one element.*User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}*expected count:*1*actual count:*3*Assert.ContainsSingle([1, 2, 3])*");
         o.WasToStringCalled.Should().BeTrue();
     }
 
@@ -137,7 +137,7 @@ public partial class AssertTests
         var collection = new List<int> { 1, 3, 5 };
         Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection);
         action.Should().Throw<Exception>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches:*1*actual matches:*0*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     public void SinglePredicate_WhenMultipleItemsMatch_ShouldFail()
@@ -145,7 +145,7 @@ public partial class AssertTests
         var collection = new List<int> { 2, 4, 6 };
         Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection);
         action.Should().Throw<Exception>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 3 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'.");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*expected matches:*1*actual matches:*3*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     public void SinglePredicate_Message_WhenNoItemMatches_ShouldFail()
@@ -153,7 +153,7 @@ public partial class AssertTests
         var collection = new List<int> { 1, 3, 5 };
         Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection, "No even numbers found: test");
         action.Should().Throw<Exception>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 0 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'. No even numbers found: test");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*No even numbers found: test*expected matches:*1*actual matches:*0*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     public void SinglePredicate_Message_WhenMultipleItemsMatch_ShouldFail()
@@ -161,7 +161,7 @@ public partial class AssertTests
         var collection = new List<int> { 2, 4, 6 };
         Action action = () => Assert.ContainsSingle(x => x % 2 == 0, collection, "Too many even numbers: test");
         action.Should().Throw<Exception>()
-            .WithMessage("Assert.ContainsSingle failed. Expected exactly one item to match the predicate but found 3 item(s). 'predicate' expression: 'x => x % 2 == 0', 'collection' expression: 'collection'. Too many even numbers: test");
+            .WithMessage("*Expected collection to contain exactly one element matching the predicate.*Too many even numbers: test*expected matches:*1*actual matches:*3*Assert.ContainsSingle(x => x % 2 == 0, collection)*");
     }
 
     public void Any_WhenOneItem_ShouldPass()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ScopeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ScopeTests.cs
@@ -236,7 +236,13 @@ public partial class AssertTests
             .Which;
 
         innerException.InnerExceptions.Should().HaveCount(2);
-        innerException.InnerExceptions[0].Message.Should().Be("Assert.ContainsSingle failed. Expected collection to contain exactly one element but found 3 element(s). 'collection' expression: 'items'.");
+        innerException.InnerExceptions[0].Message.Should().Be(
+            $"Assertion failed. Expected collection to contain exactly one element.{Environment.NewLine}" +
+            $"{Environment.NewLine}" +
+            $"expected count: 1{Environment.NewLine}" +
+            $"actual count:   3{Environment.NewLine}" +
+            $"{Environment.NewLine}" +
+            $"Assert.ContainsSingle(items)");
         innerException.InnerExceptions[1].Message.Should().Be("Assert.AreEqual failed. Expected:<1>. Actual:<2>. 'expected' expression: '1', 'actual' expression: '2'.");
     }
 }


### PR DESCRIPTION
Continues the rollout of [RFC 012 — Structured Assertion Messages](docs/RFCs/012-Structured-Assertion-Messages.md) by migrating the `Assert` Contains family to the structured-message format. Follows the patterns established by previously merged work (#8170, #8187, #8210, #8214) and the in-flight series (#8258, #8259, #8260, #8262).

## APIs migrated

- `Assert.ContainsSingle` (collection-only and predicate overloads, including the interpolated-string-handler)
- `Assert.Contains` (item, predicate, substring overloads, with optional comparer / `StringComparison`)
- `Assert.DoesNotContain` (item, predicate, substring overloads, with optional comparer / `StringComparison`)
- `Assert.IsInRange`

## Output format

`Assert.ContainsSingle(new[] { 1, 2, 3 })`:

```text
Assertion failed. Expected collection to contain exactly one element.

expected count: 1
actual count:   3

Assert.ContainsSingle(new[] { 1, 2, 3 })
```

`Assert.Contains(20, collection, ""Item 20 not found"")`:

```text
Assertion failed. Expected collection to contain the specified element.
Item 20 not found

expected: 20

Assert.Contains(20, collection)
```

`Assert.DoesNotContain(""brown"", ""The quick brown fox"", StringComparison.Ordinal, ""Unexpected substring"")`:

```text
Assertion failed. Expected string to not contain the specified substring.
Unexpected substring

unexpected substring: ""brown""
actual:               ""The quick brown fox""
comparison:           Ordinal

Assert.DoesNotContain(substring, value)
```

`Assert.IsInRange(1, 5, 10, ""Custom error message"")`:

```text
Assertion failed. Expected value to be within the inclusive range.
Custom error message

expected: [1, 5]
actual:   10

Assert.IsInRange(minValue, maxValue, value)
```

## Notes

- Adds nine new `*FailedSummary` resource entries for ContainsSingle, ContainsSingleMatch, ContainsItem, ContainsPredicate, ContainsSubstring, DoesNotContainItem, DoesNotContainPredicate, DoesNotContainSubstring, IsInRange (XLF files regenerated via `UpdateXlf`).
- A `comparer:` line is added to the evidence block when an item-based `Contains`/`DoesNotContain` is invoked with a non-default `IEqualityComparer`/`IEqualityComparer<T>`.
- `IsInRange` uses a small custom call-site formatter so all three captured arguments (`minValue`, `maxValue`, `value`) appear in the call-site line.
- Removes the now-unused `BuildUserMessageForSubstringExpression*`, `BuildUserMessageForExpected/NotExpected/Predicate*CollectionExpression`, `BuildUserMessageForMinValue*MaxValue*Value*`, and `BuildUserMessageForThreeExpressions` helpers from `Assert.cs`.
- Updates the affected message-format tests in `AssertTests.Contains.cs`, `AssertTests.IsInRange.cs`, `AssertTests.Items.cs` (ContainsSingle scenarios), and `AssertTests.ScopeTests.cs`.

## Validation

- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj -c Debug` — clean.
- `dotnet test test/UnitTests/TestFramework.UnitTests/TestFramework.UnitTests.csproj -c Debug` — 3535/3535 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
