### PR TITLE
Add Assert.AreEquivalent for deep structural comparison

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.ExceptionServices;
+
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 public sealed partial class Assert
@@ -702,12 +704,13 @@ public sealed partial class Assert
         /// Rethrows a framework assertion exception (e.g., from a user-defined property getter or
         /// IEquatable.Equals that called <c>Assert.Fail</c>) unwrapped from <see cref="TargetInvocationException"/>,
         /// so user assertions propagate untouched instead of being rewritten as a structured equivalence failure.
+        /// Uses <see cref="ExceptionDispatchInfo"/> to preserve the original throw site in the stack trace.
         /// </summary>
         private static void ThrowIfAssertException(Exception? inner)
         {
-            if (inner is UnitTestAssertException assertEx)
+            if (inner is UnitTestAssertException)
             {
-                throw assertEx;
+                ExceptionDispatchInfo.Capture(inner).Throw();
             }
         }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -205,6 +205,7 @@ public sealed partial class Assert
             }
             catch (TargetInvocationException tie)
             {
+                ThrowIfAssertException(tie.InnerException);
                 return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
             }
             catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
@@ -228,6 +229,7 @@ public sealed partial class Assert
                     }
                     catch (TargetInvocationException tie)
                     {
+                        ThrowIfAssertException(tie.InnerException);
                         return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
                     }
                     catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
@@ -258,6 +260,7 @@ public sealed partial class Assert
             }
             catch (TargetInvocationException tie)
             {
+                ThrowIfAssertException(tie.InnerException);
                 result = default!;
                 return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
             }
@@ -388,6 +391,7 @@ public sealed partial class Assert
                 }
                 catch (TargetInvocationException ex)
                 {
+                    ThrowIfAssertException(ex.InnerException);
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: true, ex.InnerException ?? ex);
                 }
                 catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
@@ -401,6 +405,7 @@ public sealed partial class Assert
                 }
                 catch (TargetInvocationException ex)
                 {
+                    ThrowIfAssertException(ex.InnerException);
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: false, ex.InnerException ?? ex);
                 }
                 catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
@@ -427,6 +432,7 @@ public sealed partial class Assert
             }
             catch (TargetInvocationException tie)
             {
+                ThrowIfAssertException(tie.InnerException);
                 enumerator = default!;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
@@ -446,6 +452,7 @@ public sealed partial class Assert
             }
             catch (TargetInvocationException tie)
             {
+                ThrowIfAssertException(tie.InnerException);
                 hasNext = false;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
@@ -465,6 +472,7 @@ public sealed partial class Assert
             }
             catch (TargetInvocationException tie)
             {
+                ThrowIfAssertException(tie.InnerException);
                 current = default;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
@@ -558,6 +566,7 @@ public sealed partial class Assert
             }
             catch (TargetInvocationException ex)
             {
+                ThrowIfAssertException(ex.InnerException);
                 thrown = ex.InnerException ?? ex;
                 return IEquatableOutcome.Threw;
             }
@@ -688,6 +697,19 @@ public sealed partial class Assert
                 string? fullName = t.FullName;
                 return fullName is "System.DateOnly" or "System.TimeOnly" or "System.Half" or "System.Int128" or "System.UInt128";
             });
+
+        /// <summary>
+        /// Rethrows a framework assertion exception (e.g., from a user-defined property getter or
+        /// IEquatable.Equals that called <c>Assert.Fail</c>) unwrapped from <see cref="TargetInvocationException"/>,
+        /// so user assertions propagate untouched instead of being rewritten as a structured equivalence failure.
+        /// </summary>
+        private static void ThrowIfAssertException(Exception? inner)
+        {
+            if (inner is UnitTestAssertException assertEx)
+            {
+                throw assertEx;
+            }
+        }
 
         private static bool TryCreateDictionaryView(object value, out DictionaryView? view)
         {

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -207,7 +207,7 @@ public sealed partial class Assert
             {
                 return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
             {
                 return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, ex);
             }
@@ -230,7 +230,7 @@ public sealed partial class Assert
                     {
                         return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
                     }
-                    catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                    catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
                     {
                         return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, ex);
                     }
@@ -261,7 +261,7 @@ public sealed partial class Assert
                 result = default!;
                 return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
             {
                 result = default!;
                 return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, ex);
@@ -390,7 +390,7 @@ public sealed partial class Assert
                 {
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: true, ex.InnerException ?? ex);
                 }
-                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
                 {
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: true, ex);
                 }
@@ -403,7 +403,7 @@ public sealed partial class Assert
                 {
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: false, ex.InnerException ?? ex);
                 }
-                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
                 {
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: false, ex);
                 }
@@ -430,7 +430,7 @@ public sealed partial class Assert
                 enumerator = default!;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
             {
                 enumerator = default!;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
@@ -449,7 +449,7 @@ public sealed partial class Assert
                 hasNext = false;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
             {
                 hasNext = false;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
@@ -468,7 +468,7 @@ public sealed partial class Assert
                 current = default;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
             {
                 current = default;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
@@ -561,7 +561,7 @@ public sealed partial class Assert
                 thrown = ex.InnerException ?? ex;
                 return IEquatableOutcome.Threw;
             }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException and not UnitTestAssertException)
             {
                 thrown = ex;
                 return IEquatableOutcome.Threw;
@@ -670,7 +670,7 @@ public sealed partial class Assert
         private static bool IsPrimitiveLike(Type type)
             => IsPrimitiveLikeCache.GetOrAdd(type, static t =>
             {
-                if (t.IsPrimitive || t.IsEnum || t.IsPointer)
+                if (t.IsPrimitive || t.IsEnum)
                 {
                     return true;
                 }
@@ -691,6 +691,11 @@ public sealed partial class Assert
 
         private static bool TryCreateDictionaryView(object value, out DictionaryView? view)
         {
+            // Non-generic IDictionary takes precedence over IDictionary<,> / IReadOnlyDictionary<,>:
+            // most BCL dictionaries implement both and route both surfaces to the same backing store
+            // (so the choice is observationally equivalent), while custom hybrid types are expected
+            // to keep their non-generic surface consistent with the generic one. Picking the non-
+            // generic path first avoids reflection-based dispatch where possible.
             if (value is IDictionary nonGeneric)
             {
                 view = new NonGenericDictionaryView(nonGeneric);
@@ -738,7 +743,13 @@ public sealed partial class Assert
         private static MemberLookup GetMembers(Type type)
             => MemberCache.GetOrAdd(type, static t =>
             {
-                List<MemberAccessor> list = [];
+                // Collect candidates per name, preferring the most-derived declaration so that
+                // `new`-shadowed properties/fields are deterministically resolved to the most-derived
+                // member regardless of metadata ordering.
+#pragma warning disable IDE0028 // Collection initialization can be simplified — target-typed `new` cannot pass the comparer in the same syntactic form expected.
+                Dictionary<string, MemberAccessor> byName = new(StringComparer.Ordinal);
+                Dictionary<string, Type> declaringTypes = new(StringComparer.Ordinal);
+#pragma warning restore IDE0028
 
                 foreach (PropertyInfo p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
@@ -753,7 +764,7 @@ public sealed partial class Assert
                         continue;
                     }
 
-                    list.Add(new MemberAccessor(p.Name, p.PropertyType, p));
+                    TryRegisterMostDerived(byName, declaringTypes, p, new MemberAccessor(p.Name, p.PropertyType, p));
                 }
 
                 foreach (FieldInfo f in t.GetFields(BindingFlags.Public | BindingFlags.Instance))
@@ -763,23 +774,38 @@ public sealed partial class Assert
                         continue;
                     }
 
-                    list.Add(new MemberAccessor(f.Name, f.FieldType, f));
+                    TryRegisterMostDerived(byName, declaringTypes, f, new MemberAccessor(f.Name, f.FieldType, f));
                 }
 
-                // Sort alphabetically for stable diagnostics across runtimes.
-                list.Sort(static (a, b) => StringComparer.Ordinal.Compare(a.Name, b.Name));
-
-                MemberAccessor[] sorted = list.ToArray();
-                Dictionary<string, MemberAccessor> byName = new(sorted.Length, StringComparer.Ordinal);
-                foreach (MemberAccessor m in sorted)
+                var sorted = new MemberAccessor[byName.Count];
+                int i = 0;
+                foreach (MemberAccessor accessor in byName.Values)
                 {
-                    // Property/field name shadowing is rare; keep the first one we encounter
-                    // (alphabetical order is deterministic).
-                    byName[m.Name] = m;
+                    sorted[i++] = accessor;
                 }
+
+                Array.Sort(sorted, static (a, b) => StringComparer.Ordinal.Compare(a.Name, b.Name));
 
                 return new MemberLookup(sorted, byName);
             });
+
+        private static void TryRegisterMostDerived(Dictionary<string, MemberAccessor> byName, Dictionary<string, Type> declaringTypes, MemberInfo member, MemberAccessor accessor)
+        {
+            if (byName.ContainsKey(member.Name)
+                && !IsMoreDerivedThan(member.DeclaringType, declaringTypes[member.Name]))
+            {
+                return;
+            }
+
+            byName[member.Name] = accessor;
+            declaringTypes[member.Name] = member.DeclaringType ?? typeof(object);
+        }
+
+        private static bool IsMoreDerivedThan(Type? candidate, Type? incumbent)
+            => candidate is not null
+                && incumbent is not null
+                && candidate != incumbent
+                && incumbent.IsAssignableFrom(candidate);
 
         private static MemberAccessor? FindMember(Type type, string name)
             => GetMembers(type).ByName.TryGetValue(name, out MemberAccessor? found) ? found : null;
@@ -986,6 +1012,8 @@ public sealed partial class Assert
         {
             foreach (object? item in (IEnumerable)source)
             {
+                // KeyValuePair<,> is a value type, so `item` cannot be null when iterated as object;
+                // we still dereference defensively in case a custom IEnumerable yields a boxed null.
                 if (item is null)
                 {
                     continue;

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -1,0 +1,1004 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+public sealed partial class Assert
+{
+    /// <summary>
+    /// Walks two object graphs and reports the first structural difference, if any.
+    /// </summary>
+    private sealed class EquivalenceComparer
+    {
+        // Member info caches keyed by runtime type.
+        private static readonly ConcurrentDictionary<Type, MemberLookup> MemberCache = new();
+        private static readonly ConcurrentDictionary<Type, MethodInfo?> IEquatableEqualsCache = new();
+        private static readonly ConcurrentDictionary<Type, bool> IsPrimitiveLikeCache = new();
+        private static readonly ConcurrentDictionary<Type, Type?> EnumerableElementTypeCache = new();
+        private static readonly ConcurrentDictionary<Type, Type?> DictionaryValueTypeCache = new();
+
+        private readonly bool _strict;
+
+        // Topology maps: once we've paired expected `e` with actual `a`, both maps remember the pairing.
+        // Re-encountering the same pair short-circuits as a match (cycle handled). Re-encountering one
+        // side paired with a different counterpart on the other side is a topology mismatch.
+#pragma warning disable IDE0028 // Collection initialization can be simplified - target-typed `new` cannot pass the comparer in the same syntactic form expected.
+        private readonly Dictionary<object, object> _expectedToActual = new(ReferenceObjectComparer.Instance);
+        private readonly Dictionary<object, object> _actualToExpected = new(ReferenceObjectComparer.Instance);
+#pragma warning restore IDE0028
+
+        internal EquivalenceComparer(bool strict)
+            => _strict = strict;
+
+        internal EquivalenceMismatch? Compare<T>(T? expected, T? actual)
+            => Compare(expected, actual, typeof(T), path: string.Empty);
+
+        private EquivalenceMismatch? Compare(object? expected, object? actual, Type declaredType, string path)
+        {
+            if (ReferenceEquals(expected, actual))
+            {
+                return null;
+            }
+
+            if (expected is null || actual is null)
+            {
+                return EquivalenceMismatch.NullMismatch(path, expected, actual);
+            }
+
+            Type expectedRuntimeType = expected.GetType();
+            Type actualRuntimeType = actual.GetType();
+
+            // Primitive-ish types: trust Equals.
+            if (IsPrimitiveLike(expectedRuntimeType) || IsPrimitiveLike(actualRuntimeType))
+            {
+                return Equals(expected, actual)
+                    ? null
+                    : EquivalenceMismatch.ValueMismatch(path, expected, actual);
+            }
+
+            // IEquatable<T> shortcut on the declared (compile-time) type, when it is more specific
+            // than `object`. We deliberately ignore plain object.Equals overrides and only honor
+            // the explicit IEquatable<T> contract.
+            if (declaredType != typeof(object))
+            {
+                switch (InvokeIEquatable(expected, actual, declaredType, out Exception? thrownByUser))
+                {
+                    case IEquatableOutcome.Equal:
+                        return null;
+                    case IEquatableOutcome.NotEqual:
+                        return EquivalenceMismatch.ValueMismatch(path, expected, actual);
+                    case IEquatableOutcome.Threw:
+                        return EquivalenceMismatch.IEquatableThrew(path, thrownByUser!);
+                }
+            }
+
+            // Topology check + cycle guard: we record the pair persistently so that:
+            //   * if we re-enter the same pair (via a cycle), we treat it as a match;
+            //   * if we re-enter with a different counterpart on either side, that's a topology
+            //     mismatch (the two graphs do not have the same shape of references).
+            // Skip value types: they cannot form reference cycles, and boxing them into the topology
+            // maps would both miss subsequent visits (each box is a fresh reference) and grow the
+            // dictionaries unnecessarily.
+            if (!expectedRuntimeType.IsValueType && !actualRuntimeType.IsValueType)
+            {
+                if (_expectedToActual.TryGetValue(expected, out object? mappedActual))
+                {
+                    return ReferenceEquals(mappedActual, actual)
+                        ? null
+                        : EquivalenceMismatch.TopologyMismatch(path);
+                }
+
+                if (_actualToExpected.TryGetValue(actual, out object? mappedExpected))
+                {
+                    return ReferenceEquals(mappedExpected, expected)
+                        ? null
+                        : EquivalenceMismatch.TopologyMismatch(path);
+                }
+
+                _expectedToActual[expected] = actual;
+                _actualToExpected[actual] = expected;
+            }
+
+            bool expectedIsDictionary = TryCreateDictionaryView(expected, out DictionaryView? expectedDict);
+            bool actualIsDictionary = TryCreateDictionaryView(actual, out DictionaryView? actualDict);
+
+            if (expectedIsDictionary && actualIsDictionary)
+            {
+                Type valueDeclaredType = GetDictionaryValueType(declaredType, expectedRuntimeType, actualRuntimeType);
+                return CompareDictionaries(expectedDict!, actualDict!, valueDeclaredType, path);
+            }
+
+            // If exactly one side is a dictionary, treat as a structural mismatch rather than
+            // collapsing into KeyValuePair-by-KeyValuePair enumeration which would be confusing.
+            if (expectedIsDictionary != actualIsDictionary)
+            {
+                return EquivalenceMismatch.TypeMismatch(path, expectedRuntimeType, actualRuntimeType);
+            }
+
+            if (expected is IEnumerable expectedEnum && actual is IEnumerable actualEnum)
+            {
+                Type elementDeclaredType = GetEnumerableElementType(declaredType, expectedRuntimeType, actualRuntimeType);
+                return CompareEnumerables(expectedEnum, actualEnum, elementDeclaredType, path);
+            }
+
+            return CompareMembers(expected, actual, expectedRuntimeType, actualRuntimeType, path);
+        }
+
+        private EquivalenceMismatch? CompareDictionaries(DictionaryView expected, DictionaryView actual, Type valueDeclaredType, string path)
+        {
+            EquivalenceMismatch? failure = ForEachEntry(expected, isExpected: true, path, kvp =>
+            {
+                string childPath = AppendDictionaryKey(path, kvp.Key);
+
+                EquivalenceMismatch? lookup = SafeDictionaryOp(
+                    actual.TryGetValuePair,
+                    kvp.Key,
+                    isExpected: false,
+                    childPath,
+                    out DictionaryLookup lookupResult);
+                return lookup is not null
+                    ? lookup
+                    : !lookupResult.Found
+                        ? EquivalenceMismatch.MissingKey(childPath, kvp.Key)
+                        : Compare(kvp.Value, lookupResult.Value, valueDeclaredType, childPath);
+            });
+            if (failure is not null)
+            {
+                return failure;
+            }
+
+            // In strict mode, additional keys on actual are a mismatch. In non-strict mode, they
+            // are ignored (matching xUnit's `Assert.Equivalent` behaviour and the public docs).
+            if (_strict)
+            {
+                failure = ForEachEntry(actual, isExpected: false, path, kvp =>
+                {
+                    string childPath = AppendDictionaryKey(path, kvp.Key);
+                    EquivalenceMismatch? lookup = SafeDictionaryOp(
+                        expected.ContainsKey,
+                        kvp.Key,
+                        isExpected: true,
+                        childPath,
+                        out bool exists);
+                    return lookup is not null
+                        ? lookup
+                        : exists
+                            ? null
+                            : EquivalenceMismatch.UnexpectedKey(childPath, kvp.Key);
+                });
+            }
+
+            return failure;
+        }
+
+        /// <summary>
+        /// Iterates the entries of a <see cref="DictionaryView"/>, catching any user-supplied exceptions
+        /// thrown by the underlying enumerator and surfacing them as a structured mismatch.
+        /// </summary>
+        private static EquivalenceMismatch? ForEachEntry(DictionaryView view, bool isExpected, string path, Func<KeyValuePair<object, object?>, EquivalenceMismatch?> onEntry)
+        {
+            IEnumerator<KeyValuePair<object, object?>>? enumerator;
+            try
+            {
+                enumerator = view.Entries.GetEnumerator();
+            }
+            catch (TargetInvocationException tie)
+            {
+                return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, ex);
+            }
+
+            using (enumerator)
+            {
+                while (true)
+                {
+                    KeyValuePair<object, object?> kvp;
+                    try
+                    {
+                        if (!enumerator.MoveNext())
+                        {
+                            return null;
+                        }
+
+                        kvp = enumerator.Current;
+                    }
+                    catch (TargetInvocationException tie)
+                    {
+                        return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
+                    }
+                    catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                    {
+                        return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, ex);
+                    }
+
+                    EquivalenceMismatch? nested = onEntry(kvp);
+                    if (nested is not null)
+                    {
+                        return nested;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Runs a single dictionary access operation that takes one argument, catching user-supplied
+        /// exceptions and surfacing them as a structured mismatch. On success, the operation's return
+        /// value is exposed via <paramref name="result"/>.
+        /// </summary>
+        private static EquivalenceMismatch? SafeDictionaryOp<TArg, TResult>(Func<TArg, TResult> op, TArg arg, bool isExpected, string path, out TResult result)
+        {
+            try
+            {
+                result = op(arg);
+                return null;
+            }
+            catch (TargetInvocationException tie)
+            {
+                result = default!;
+                return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, tie.InnerException ?? tie);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                result = default!;
+                return EquivalenceMismatch.DictionaryAccessFailure(path, isExpected, ex);
+            }
+        }
+
+        private EquivalenceMismatch? CompareEnumerables(IEnumerable expected, IEnumerable actual, Type elementDeclaredType, string path)
+        {
+            // Materialize once so we can report length and walk in parallel.
+            List<object?> expectedItems = ToList(expected);
+            List<object?> actualItems = ToList(actual);
+
+            if (expectedItems.Count != actualItems.Count)
+            {
+                return EquivalenceMismatch.LengthMismatch(path, expectedItems.Count, actualItems.Count);
+            }
+
+            for (int i = 0; i < expectedItems.Count; i++)
+            {
+                EquivalenceMismatch? nested = Compare(expectedItems[i], actualItems[i], elementDeclaredType, AppendIndex(path, i));
+                if (nested is not null)
+                {
+                    return nested;
+                }
+            }
+
+            return null;
+        }
+
+        private EquivalenceMismatch? CompareMembers(object expected, object actual, Type expectedType, Type actualType, string path)
+        {
+            MemberLookup expectedMembers = GetMembers(expectedType);
+
+            // When strict mode is on AND runtime types differ, ensure the actual side declares no extra
+            // members beyond what's present on expected.
+            if (_strict && expectedType != actualType)
+            {
+                MemberLookup actualMembers = GetMembers(actualType);
+
+                List<string>? extras = null;
+                foreach (MemberAccessor am in actualMembers.Sorted)
+                {
+                    if (!expectedMembers.ByName.ContainsKey(am.Name))
+                    {
+                        (extras ??= []).Add(am.Name);
+                    }
+                }
+
+                if (extras is { Count: > 0 })
+                {
+                    extras.Sort(StringComparer.Ordinal);
+                    return EquivalenceMismatch.ExtraMembers(path, extras);
+                }
+            }
+
+            foreach (MemberAccessor member in expectedMembers.Sorted)
+            {
+                MemberAccessor? matchingActual = FindMember(actualType, member.Name);
+                string childPath = AppendMember(path, member.Name);
+
+                if (matchingActual is null)
+                {
+                    return EquivalenceMismatch.MissingMember(childPath, member.Name);
+                }
+
+                object? expectedValue;
+                object? actualValue;
+                try
+                {
+                    expectedValue = member.GetValue(expected);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: true, ex.InnerException ?? ex);
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                {
+                    return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: true, ex);
+                }
+
+                try
+                {
+                    actualValue = matchingActual.GetValue(actual);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: false, ex.InnerException ?? ex);
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                {
+                    return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: false, ex);
+                }
+
+                EquivalenceMismatch? nested = Compare(expectedValue, actualValue, member.MemberType, childPath);
+                if (nested is not null)
+                {
+                    return nested;
+                }
+            }
+
+            return null;
+        }
+
+        private static List<object?> ToList(IEnumerable source)
+        {
+#pragma warning disable IDE0028 // Collection initialization can be simplified - we want the capacity-aware ctor when ICollection is available.
+            List<object?> list = source is ICollection collection
+                ? new List<object?>(collection.Count)
+                : [];
+#pragma warning restore IDE0028
+            foreach (object? item in source)
+            {
+                list.Add(item);
+            }
+
+            return list;
+        }
+
+        private enum IEquatableOutcome
+        {
+            NotApplicable,
+            Equal,
+            NotEqual,
+            Threw,
+        }
+
+        private static IEquatableOutcome InvokeIEquatable(object expected, object actual, Type declaredType, out Exception? thrown)
+        {
+            thrown = null;
+            MethodInfo? equalsMethod = IEquatableEqualsCache.GetOrAdd(declaredType, GetIEquatableEqualsMethod);
+            if (equalsMethod is null)
+            {
+                return IEquatableOutcome.NotApplicable;
+            }
+
+            // Both sides must be assignable to declaredType for the call to be safe. Since the method
+            // came in via the static type, this is true at the public entry point. For nested members
+            // (and collection elements), we resolve the method against the *declared* property/field/element
+            // type, but the runtime values can be derived types. As long as actual is also assignable, we
+            // can still call.
+            if (!declaredType.IsInstanceOfType(expected) || !declaredType.IsInstanceOfType(actual))
+            {
+                return IEquatableOutcome.NotApplicable;
+            }
+
+            try
+            {
+                bool isEqual = (bool)equalsMethod.Invoke(expected, [actual])!;
+                return isEqual ? IEquatableOutcome.Equal : IEquatableOutcome.NotEqual;
+            }
+            catch (TargetInvocationException ex)
+            {
+                thrown = ex.InnerException ?? ex;
+                return IEquatableOutcome.Threw;
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                thrown = ex;
+                return IEquatableOutcome.Threw;
+            }
+        }
+
+        private static MethodInfo? GetIEquatableEqualsMethod(Type declaredType)
+        {
+            if (declaredType == typeof(object) || declaredType == typeof(string))
+            {
+                // string is already handled via the primitive-like path; skip the IEquatable lookup.
+                return null;
+            }
+
+            Type ieq;
+            try
+            {
+                ieq = typeof(IEquatable<>).MakeGenericType(declaredType);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+
+            if (!ieq.IsAssignableFrom(declaredType))
+            {
+                return null;
+            }
+
+            // Resolve the IEquatable<T>.Equals(T) method on the interface itself. Invoking via reflection
+            // performs virtual/interface dispatch, so this finds both implicit and explicit interface
+            // implementations on the actual instance.
+            return ieq.GetMethod("Equals", [declaredType]);
+        }
+
+        private static Type GetEnumerableElementType(Type declaredType, Type expectedRuntimeType, Type actualRuntimeType)
+            => TryGetEnumerableElementType(declaredType)
+                ?? TryGetEnumerableElementType(expectedRuntimeType)
+                ?? TryGetEnumerableElementType(actualRuntimeType)
+                ?? typeof(object);
+
+        private static Type? TryGetEnumerableElementType(Type type)
+            => EnumerableElementTypeCache.GetOrAdd(type, static t =>
+            {
+                if (t.IsArray)
+                {
+                    return t.GetElementType();
+                }
+
+                if (t.IsConstructedGenericType && t.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    return t.GetGenericArguments()[0];
+                }
+
+                Type? best = null;
+                foreach (Type i in t.GetInterfaces())
+                {
+                    if (i.IsConstructedGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    {
+                        Type elem = i.GetGenericArguments()[0];
+
+                        // If multiple IEnumerable<T> are implemented, prefer the most specific (non-object) one.
+                        if (best is null || best == typeof(object))
+                        {
+                            best = elem;
+                        }
+                    }
+                }
+
+                return best;
+            });
+
+        private static Type GetDictionaryValueType(Type declaredType, Type expectedRuntimeType, Type actualRuntimeType)
+            => TryGetDictionaryValueType(declaredType)
+                ?? TryGetDictionaryValueType(expectedRuntimeType)
+                ?? TryGetDictionaryValueType(actualRuntimeType)
+                ?? typeof(object);
+
+        private static Type? TryGetDictionaryValueType(Type type)
+            => DictionaryValueTypeCache.GetOrAdd(type, static t =>
+            {
+                if (t.IsConstructedGenericType)
+                {
+                    Type def = t.GetGenericTypeDefinition();
+                    if (def == typeof(IDictionary<,>) || def == typeof(IReadOnlyDictionary<,>))
+                    {
+                        return t.GetGenericArguments()[1];
+                    }
+                }
+
+                foreach (Type i in t.GetInterfaces())
+                {
+                    if (i.IsConstructedGenericType)
+                    {
+                        Type def = i.GetGenericTypeDefinition();
+                        if (def == typeof(IDictionary<,>) || def == typeof(IReadOnlyDictionary<,>))
+                        {
+                            return i.GetGenericArguments()[1];
+                        }
+                    }
+                }
+
+                return null;
+            });
+
+        private static bool IsPrimitiveLike(Type type)
+            => IsPrimitiveLikeCache.GetOrAdd(type, static t =>
+            {
+                if (t.IsPrimitive || t.IsEnum || t.IsPointer)
+                {
+                    return true;
+                }
+
+                if (t == typeof(string) || t == typeof(decimal) ||
+                    t == typeof(DateTime) || t == typeof(DateTimeOffset) ||
+                    t == typeof(TimeSpan) || t == typeof(Guid) ||
+                    t == typeof(Uri) || t == typeof(Type) ||
+                    t == typeof(Version))
+                {
+                    return true;
+                }
+
+                // DateOnly / TimeOnly / Half / Int128 exist only on newer TFMs; match by full name to avoid #if.
+                string? fullName = t.FullName;
+                if (fullName is "System.DateOnly" or "System.TimeOnly" or "System.Half" or "System.Int128" or "System.UInt128")
+                {
+                    return true;
+                }
+
+                // Compare reflection types as primitive (they all derive from System.Type).
+                return typeof(Type).IsAssignableFrom(t);
+            });
+
+        private static bool TryCreateDictionaryView(object value, out DictionaryView? view)
+        {
+            if (value is IDictionary nonGeneric)
+            {
+                view = new NonGenericDictionaryView(nonGeneric);
+                return true;
+            }
+
+            // Look for an IDictionary<TKey, TValue> implementation first; fall back to
+            // IReadOnlyDictionary<TKey, TValue> if only the read-only surface is present.
+            // When a type implements both (which is the case for most BCL dictionaries), the mutating
+            // contract wins deterministically — that's the same precedence System.Collections.Generic.Dictionary
+            // expresses, and it lets users override semantics by implementing IDictionary<,> explicitly.
+            Type? dictInterface = null;
+            Type? readOnlyDictInterface = null;
+            foreach (Type i in value.GetType().GetInterfaces())
+            {
+                if (!i.IsGenericType)
+                {
+                    continue;
+                }
+
+                Type def = i.GetGenericTypeDefinition();
+                if (def == typeof(IDictionary<,>))
+                {
+                    dictInterface = i;
+                    break;
+                }
+
+                if (def == typeof(IReadOnlyDictionary<,>))
+                {
+                    readOnlyDictInterface = i;
+                }
+            }
+
+            Type? selected = dictInterface ?? readOnlyDictInterface;
+            if (selected is not null)
+            {
+                view = GenericDictionaryView.Create(value, selected);
+                return true;
+            }
+
+            view = null;
+            return false;
+        }
+
+        private static MemberLookup GetMembers(Type type)
+            => MemberCache.GetOrAdd(type, static t =>
+            {
+                List<MemberAccessor> list = [];
+
+                foreach (PropertyInfo p in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (!p.CanRead || p.GetIndexParameters().Length > 0)
+                    {
+                        continue;
+                    }
+
+                    MethodInfo? getter = p.GetGetMethod(nonPublic: false);
+                    if (getter is null)
+                    {
+                        continue;
+                    }
+
+                    list.Add(new MemberAccessor(p.Name, p.PropertyType, p));
+                }
+
+                foreach (FieldInfo f in t.GetFields(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    if (f.IsStatic)
+                    {
+                        continue;
+                    }
+
+                    list.Add(new MemberAccessor(f.Name, f.FieldType, f));
+                }
+
+                // Sort alphabetically for stable diagnostics across runtimes.
+                list.Sort(static (a, b) => StringComparer.Ordinal.Compare(a.Name, b.Name));
+
+                MemberAccessor[] sorted = list.ToArray();
+                Dictionary<string, MemberAccessor> byName = new(sorted.Length, StringComparer.Ordinal);
+                foreach (MemberAccessor m in sorted)
+                {
+                    // Property/field name shadowing is rare; keep the first one we encounter
+                    // (alphabetical order is deterministic).
+                    byName[m.Name] = m;
+                }
+
+                return new MemberLookup(sorted, byName);
+            });
+
+        private static MemberAccessor? FindMember(Type type, string name)
+            => GetMembers(type).ByName.TryGetValue(name, out MemberAccessor? found) ? found : null;
+
+        private static string AppendMember(string parent, string name)
+            => parent.Length == 0 ? name : $"{parent}.{name}";
+
+        private static string AppendIndex(string parent, int index)
+            => $"{parent}[{index.ToString(CultureInfo.InvariantCulture)}]";
+
+        private static string AppendDictionaryKey(string parent, object key)
+        {
+            string rendered = key is string s
+                ? $"\"{s}\""
+                : Convert.ToString(key, CultureInfo.InvariantCulture) ?? key.GetType().Name;
+            string keyPart = $"[{rendered}]";
+            return parent.Length == 0 ? keyPart : parent + keyPart;
+        }
+    }
+
+    /// <summary>
+    /// Reference-equality comparer used for keys in the topology maps of <see cref="EquivalenceComparer"/>.
+    /// </summary>
+    private sealed class ReferenceObjectComparer : IEqualityComparer<object>
+    {
+        internal static readonly ReferenceObjectComparer Instance = new();
+
+        private ReferenceObjectComparer()
+        {
+        }
+
+        bool IEqualityComparer<object>.Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        int IEqualityComparer<object>.GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+    }
+
+    /// <summary>
+    /// Cached set of public instance properties and fields for a type, with both an alphabetically-sorted
+    /// array (for deterministic traversal) and a name-keyed dictionary (for O(1) lookup).
+    /// </summary>
+    private sealed class MemberLookup
+    {
+        internal MemberLookup(MemberAccessor[] sorted, IReadOnlyDictionary<string, MemberAccessor> byName)
+        {
+            Sorted = sorted;
+            ByName = byName;
+        }
+
+        internal MemberAccessor[] Sorted { get; }
+
+        internal IReadOnlyDictionary<string, MemberAccessor> ByName { get; }
+    }
+
+    /// <summary>
+    /// Abstraction over both <see cref="IDictionary"/> and generic
+    /// <see cref="IDictionary{TKey, TValue}"/> / <see cref="IReadOnlyDictionary{TKey, TValue}"/> instances.
+    /// Routes lookups back to the source dictionary so the source's own
+    /// <see cref="IEqualityComparer{T}"/> for keys is preserved.
+    /// </summary>
+    private abstract class DictionaryView
+    {
+        internal abstract IEnumerable<KeyValuePair<object, object?>> Entries { get; }
+
+        internal abstract bool TryGetValue(object key, out object? value);
+
+        internal abstract bool ContainsKey(object key);
+
+        /// <summary>
+        /// Variant of <see cref="TryGetValue(object, out object?)"/> for use from contexts that can't
+        /// capture an <c>out</c> parameter (e.g., lambdas).
+        /// </summary>
+        internal DictionaryLookup TryGetValuePair(object key)
+        {
+            bool found = TryGetValue(key, out object? value);
+            return new DictionaryLookup(found, value);
+        }
+    }
+
+    private readonly struct DictionaryLookup
+    {
+        internal DictionaryLookup(bool found, object? value)
+        {
+            Found = found;
+            Value = value;
+        }
+
+        internal bool Found { get; }
+
+        internal object? Value { get; }
+    }
+
+    private sealed class NonGenericDictionaryView : DictionaryView
+    {
+        private readonly IDictionary _source;
+
+        internal NonGenericDictionaryView(IDictionary source) => _source = source;
+
+        internal override IEnumerable<KeyValuePair<object, object?>> Entries
+        {
+            get
+            {
+                IDictionaryEnumerator e = _source.GetEnumerator();
+                try
+                {
+                    while (e.MoveNext())
+                    {
+                        DictionaryEntry entry = e.Entry;
+                        yield return new KeyValuePair<object, object?>(entry.Key, entry.Value);
+                    }
+                }
+                finally
+                {
+                    (e as IDisposable)?.Dispose();
+                }
+            }
+        }
+
+        internal override bool ContainsKey(object key) => _source.Contains(key);
+
+        internal override bool TryGetValue(object key, out object? value)
+        {
+            if (!_source.Contains(key))
+            {
+                value = null;
+                return false;
+            }
+
+            value = _source[key];
+            return true;
+        }
+    }
+
+    private sealed class GenericDictionaryView : DictionaryView
+    {
+        private static readonly ConcurrentDictionary<Type, GenericDictionaryAccessors> AccessorCache = new();
+
+        private readonly object _source;
+        private readonly GenericDictionaryAccessors _accessors;
+
+        private GenericDictionaryView(object source, GenericDictionaryAccessors accessors)
+        {
+            _source = source;
+            _accessors = accessors;
+        }
+
+        internal static GenericDictionaryView Create(object source, Type dictionaryInterface)
+            => new(source, AccessorCache.GetOrAdd(dictionaryInterface, GenericDictionaryAccessors.Build));
+
+        internal override IEnumerable<KeyValuePair<object, object?>> Entries
+            => _accessors.Enumerate(_source);
+
+        internal override bool ContainsKey(object key)
+            => _accessors.KeyType.IsInstanceOfType(key) && _accessors.ContainsKey(_source, key);
+
+        internal override bool TryGetValue(object key, out object? value)
+        {
+            if (!_accessors.KeyType.IsInstanceOfType(key))
+            {
+                value = null;
+                return false;
+            }
+
+            return _accessors.TryGetValue(_source, key, out value);
+        }
+    }
+
+    /// <summary>
+    /// Per-generic-dictionary-interface set of cached reflection accessors. Routes lookups to the
+    /// source's native methods (<c>TryGetValue</c>, <c>ContainsKey</c>) so the source's
+    /// <see cref="IEqualityComparer{TKey}"/> is honored.
+    /// </summary>
+    private sealed class GenericDictionaryAccessors
+    {
+        private readonly MethodInfo _tryGetValueMethod;
+        private readonly MethodInfo _containsKeyMethod;
+        private readonly PropertyInfo _kvpKey;
+        private readonly PropertyInfo _kvpValue;
+
+        private GenericDictionaryAccessors(Type keyType, MethodInfo tryGetValueMethod, MethodInfo containsKeyMethod, PropertyInfo kvpKey, PropertyInfo kvpValue)
+        {
+            KeyType = keyType;
+            _tryGetValueMethod = tryGetValueMethod;
+            _containsKeyMethod = containsKeyMethod;
+            _kvpKey = kvpKey;
+            _kvpValue = kvpValue;
+        }
+
+        internal Type KeyType { get; }
+
+        internal static GenericDictionaryAccessors Build(Type dictionaryInterface)
+        {
+            Type[] args = dictionaryInterface.GetGenericArguments();
+            Type keyType = args[0];
+            Type valueType = args[1];
+
+            MethodInfo tryGet = dictionaryInterface.GetMethod("TryGetValue")!;
+            MethodInfo contains = dictionaryInterface.GetMethod("ContainsKey")!;
+
+            Type kvpType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
+            PropertyInfo keyProp = kvpType.GetProperty("Key")!;
+            PropertyInfo valueProp = kvpType.GetProperty("Value")!;
+
+            return new GenericDictionaryAccessors(keyType, tryGet, contains, keyProp, valueProp);
+        }
+
+        internal IEnumerable<KeyValuePair<object, object?>> Enumerate(object source)
+        {
+            foreach (object? item in (IEnumerable)source)
+            {
+                if (item is null)
+                {
+                    continue;
+                }
+
+                object key = _kvpKey.GetValue(item)!;
+                object? val = _kvpValue.GetValue(item);
+                yield return new KeyValuePair<object, object?>(key, val);
+            }
+        }
+
+        internal bool ContainsKey(object source, object key)
+            => (bool)_containsKeyMethod.Invoke(source, [key])!;
+
+        internal bool TryGetValue(object source, object key, out object? value)
+        {
+            object?[] args = [key, null];
+            bool found = (bool)_tryGetValueMethod.Invoke(source, args)!;
+            value = args[1];
+            return found;
+        }
+    }
+
+    /// <summary>
+    /// Describes how to read a single member (property or field) from an instance.
+    /// </summary>
+    private sealed class MemberAccessor
+    {
+        private readonly PropertyInfo? _property;
+        private readonly FieldInfo? _field;
+
+        internal MemberAccessor(string name, Type memberType, PropertyInfo property)
+        {
+            Name = name;
+            MemberType = memberType;
+            _property = property;
+        }
+
+        internal MemberAccessor(string name, Type memberType, FieldInfo field)
+        {
+            Name = name;
+            MemberType = memberType;
+            _field = field;
+        }
+
+        internal string Name { get; }
+
+        internal Type MemberType { get; }
+
+        internal object? GetValue(object instance)
+            => _property is not null ? _property.GetValue(instance) : _field!.GetValue(instance);
+    }
+
+    /// <summary>
+    /// A single structural mismatch found by <see cref="EquivalenceComparer"/>, carrying the dotted
+    /// member path, a localized reason summary, and any expected/actual snippets to render.
+    /// </summary>
+    private sealed class EquivalenceMismatch
+    {
+        private EquivalenceMismatch(string path, string reason, string? expectedText, string? actualText)
+        {
+            Path = path;
+            Reason = reason;
+            ExpectedText = expectedText;
+            ActualText = actualText;
+        }
+
+        internal string Path { get; }
+
+        internal string Reason { get; }
+
+        internal string? ExpectedText { get; }
+
+        internal string? ActualText { get; }
+
+        internal static EquivalenceMismatch ValueMismatch(string path, object? expected, object? actual)
+            => new(
+                path,
+                FrameworkMessages.AreEquivalentMismatchValue,
+                AssertionValueRenderer.RenderValue(expected),
+                AssertionValueRenderer.RenderValue(actual));
+
+        internal static EquivalenceMismatch NullMismatch(string path, object? expected, object? actual)
+            => new(
+                path,
+                FrameworkMessages.AreEquivalentMismatchNull,
+                AssertionValueRenderer.RenderValue(expected),
+                AssertionValueRenderer.RenderValue(actual));
+
+        internal static EquivalenceMismatch TypeMismatch(string path, Type expectedType, Type actualType)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchType, expectedType.FullName ?? expectedType.Name, actualType.FullName ?? actualType.Name),
+                expectedType.FullName ?? expectedType.Name,
+                actualType.FullName ?? actualType.Name);
+
+        internal static EquivalenceMismatch TopologyMismatch(string path)
+            => new(
+                path,
+                FrameworkMessages.AreEquivalentMismatchTopology,
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch LengthMismatch(string path, int expectedCount, int actualCount)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchLength, expectedCount, actualCount),
+                expectedCount.ToString(CultureInfo.InvariantCulture),
+                actualCount.ToString(CultureInfo.InvariantCulture));
+
+        internal static EquivalenceMismatch MissingKey(string path, object key)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchMissingKey, AssertionValueRenderer.RenderValue(key)),
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch UnexpectedKey(string path, object key)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchUnexpectedKey, AssertionValueRenderer.RenderValue(key)),
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch MissingMember(string path, string memberName)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchMissingMember, memberName),
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch ExtraMembers(string path, IReadOnlyList<string> extras)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchExtraMembers, string.Join(", ", extras)),
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch IEquatableThrew(string path, Exception thrown)
+            => new(
+                path,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    FrameworkMessages.AreEquivalentMismatchIEquatableThrew,
+                    thrown.GetType().Name,
+                    thrown.Message),
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch DictionaryAccessFailure(string path, bool isExpected, Exception inner)
+            => new(
+                path,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    isExpected ? FrameworkMessages.AreEquivalentMismatchExpectedDictionaryThrew : FrameworkMessages.AreEquivalentMismatchActualDictionaryThrew,
+                    inner.GetType().Name,
+                    inner.Message),
+                expectedText: null,
+                actualText: null);
+
+        internal static EquivalenceMismatch MemberAccessFailure(string path, bool isExpected, Exception inner)
+            => new(
+                path,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    isExpected ? FrameworkMessages.AreEquivalentMismatchExpectedMemberThrew : FrameworkMessages.AreEquivalentMismatchActualMemberThrew,
+                    inner.GetType().Name,
+                    inner.Message),
+                expectedText: null,
+                actualText: null);
+    }
+}

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -311,12 +311,7 @@ public sealed partial class Assert
                             }
 
                             failure = TryGetEnumerableCount(actualEnumerator, actualHasNext, isExpected: false, path, index, out int actualCount);
-                            if (failure is not null)
-                            {
-                                return failure;
-                            }
-
-                            return EquivalenceMismatch.LengthMismatch(path, expectedCount, actualCount);
+                            return failure ?? EquivalenceMismatch.LengthMismatch(path, expectedCount, actualCount);
                         }
 
                         return null;

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -46,7 +46,7 @@ public sealed partial class Assert
                 return EquivalenceMismatch.NullMismatch(path, expected, actual);
             }
 
-            if (depth > MaxComparisonDepth)
+            if (depth >= MaxComparisonDepth)
             {
                 return EquivalenceMismatch.MaxDepthExceeded(path, MaxComparisonDepth);
             }
@@ -270,34 +270,84 @@ public sealed partial class Assert
 
         private EquivalenceMismatch? CompareEnumerables(IEnumerable expected, IEnumerable actual, Type elementDeclaredType, string path, int depth)
         {
-            // Materialize once so we can report length and walk in parallel.
-            EquivalenceMismatch? failure = TryToList(expected, isExpected: true, path, out List<object?> expectedItems);
+            EquivalenceMismatch? failure = TryGetEnumerator(expected, isExpected: true, path, out IEnumerator expectedEnumerator);
             if (failure is not null)
             {
                 return failure;
             }
 
-            failure = TryToList(actual, isExpected: false, path, out List<object?> actualItems);
+            failure = TryGetEnumerator(actual, isExpected: false, path, out IEnumerator actualEnumerator);
             if (failure is not null)
             {
+                DisposeEnumerator(expectedEnumerator);
                 return failure;
             }
 
-            if (expectedItems.Count != actualItems.Count)
+            try
             {
-                return EquivalenceMismatch.LengthMismatch(path, expectedItems.Count, actualItems.Count);
-            }
-
-            for (int i = 0; i < expectedItems.Count; i++)
-            {
-                EquivalenceMismatch? nested = Compare(expectedItems[i], actualItems[i], elementDeclaredType, AppendIndex(path, i), depth + 1);
-                if (nested is not null)
+                int index = 0;
+                while (true)
                 {
-                    return nested;
+                    failure = TryMoveNext(expectedEnumerator, isExpected: true, path, out bool expectedHasNext);
+                    if (failure is not null)
+                    {
+                        return failure;
+                    }
+
+                    failure = TryMoveNext(actualEnumerator, isExpected: false, path, out bool actualHasNext);
+                    if (failure is not null)
+                    {
+                        return failure;
+                    }
+
+                    if (!expectedHasNext || !actualHasNext)
+                    {
+                        if (expectedHasNext != actualHasNext)
+                        {
+                            failure = TryGetEnumerableCount(expectedEnumerator, expectedHasNext, isExpected: true, path, index, out int expectedCount);
+                            if (failure is not null)
+                            {
+                                return failure;
+                            }
+
+                            failure = TryGetEnumerableCount(actualEnumerator, actualHasNext, isExpected: false, path, index, out int actualCount);
+                            if (failure is not null)
+                            {
+                                return failure;
+                            }
+
+                            return EquivalenceMismatch.LengthMismatch(path, expectedCount, actualCount);
+                        }
+
+                        return null;
+                    }
+
+                    failure = TryGetCurrent(expectedEnumerator, isExpected: true, path, out object? expectedItem);
+                    if (failure is not null)
+                    {
+                        return failure;
+                    }
+
+                    failure = TryGetCurrent(actualEnumerator, isExpected: false, path, out object? actualItem);
+                    if (failure is not null)
+                    {
+                        return failure;
+                    }
+
+                    EquivalenceMismatch? nested = Compare(expectedItem, actualItem, elementDeclaredType, AppendIndex(path, index), depth + 1);
+                    if (nested is not null)
+                    {
+                        return nested;
+                    }
+
+                    index++;
                 }
             }
-
-            return null;
+            finally
+            {
+                DisposeEnumerator(expectedEnumerator);
+                DisposeEnumerator(actualEnumerator);
+            }
         }
 
         private EquivalenceMismatch? CompareMembers(object expected, object actual, Type expectedType, Type actualType, string path, int depth)
@@ -373,31 +423,109 @@ public sealed partial class Assert
             return null;
         }
 
-        private static EquivalenceMismatch? TryToList(IEnumerable source, bool isExpected, string path, out List<object?> list)
+        private static EquivalenceMismatch? TryGetEnumerator(IEnumerable source, bool isExpected, string path, out IEnumerator enumerator)
         {
             try
             {
-#pragma warning disable IDE0028 // Collection initialization can be simplified - we want the capacity-aware ctor when ICollection is available.
-                list = source is ICollection collection
-                    ? new List<object?>(collection.Count)
-                    : [];
-#pragma warning restore IDE0028
-                foreach (object? item in source)
-                {
-                    list.Add(item);
-                }
-
+                enumerator = source.GetEnumerator();
                 return null;
             }
             catch (TargetInvocationException tie)
             {
-                list = [];
+                enumerator = default!;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
             }
             catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
             {
-                list = [];
+                enumerator = default!;
                 return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
+            }
+        }
+
+        private static EquivalenceMismatch? TryMoveNext(IEnumerator enumerator, bool isExpected, string path, out bool hasNext)
+        {
+            try
+            {
+                hasNext = enumerator.MoveNext();
+                return null;
+            }
+            catch (TargetInvocationException tie)
+            {
+                hasNext = false;
+                return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                hasNext = false;
+                return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
+            }
+        }
+
+        private static EquivalenceMismatch? TryGetCurrent(IEnumerator enumerator, bool isExpected, string path, out object? current)
+        {
+            try
+            {
+                current = enumerator.Current;
+                return null;
+            }
+            catch (TargetInvocationException tie)
+            {
+                current = default;
+                return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                current = default;
+                return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
+            }
+        }
+
+        private static EquivalenceMismatch? TryGetEnumerableCount(IEnumerator enumerator, bool hasCurrent, bool isExpected, string path, int matchedItemCount, out int count)
+        {
+            count = matchedItemCount;
+            if (!hasCurrent)
+            {
+                return null;
+            }
+
+            EquivalenceMismatch? failure = TryGetCurrent(enumerator, isExpected, path, out _);
+            if (failure is not null)
+            {
+                count = 0;
+                return failure;
+            }
+
+            count++;
+            while (true)
+            {
+                failure = TryMoveNext(enumerator, isExpected, path, out bool hasNext);
+                if (failure is not null)
+                {
+                    count = 0;
+                    return failure;
+                }
+
+                if (!hasNext)
+                {
+                    return null;
+                }
+
+                failure = TryGetCurrent(enumerator, isExpected, path, out _);
+                if (failure is not null)
+                {
+                    count = 0;
+                    return failure;
+                }
+
+                count++;
+            }
+        }
+
+        private static void DisposeEnumerator(IEnumerator enumerator)
+        {
+            if (enumerator is IDisposable disposable)
+            {
+                disposable.Dispose();
             }
         }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -11,6 +11,7 @@ public sealed partial class Assert
     private sealed class EquivalenceComparer
     {
         // Member info caches keyed by runtime type.
+        private const int MaxComparisonDepth = 256;
         private static readonly ConcurrentDictionary<Type, MemberLookup> MemberCache = new();
         private static readonly ConcurrentDictionary<Type, MethodInfo?> IEquatableEqualsCache = new();
         private static readonly ConcurrentDictionary<Type, bool> IsPrimitiveLikeCache = new();
@@ -31,9 +32,9 @@ public sealed partial class Assert
             => _strict = strict;
 
         internal EquivalenceMismatch? Compare<T>(T? expected, T? actual)
-            => Compare(expected, actual, typeof(T), path: string.Empty);
+            => Compare(expected, actual, typeof(T), path: string.Empty, depth: 0);
 
-        private EquivalenceMismatch? Compare(object? expected, object? actual, Type declaredType, string path)
+        private EquivalenceMismatch? Compare(object? expected, object? actual, Type declaredType, string path, int depth)
         {
             if (ReferenceEquals(expected, actual))
             {
@@ -45,15 +46,32 @@ public sealed partial class Assert
                 return EquivalenceMismatch.NullMismatch(path, expected, actual);
             }
 
+            if (depth > MaxComparisonDepth)
+            {
+                return EquivalenceMismatch.MaxDepthExceeded(path, MaxComparisonDepth);
+            }
+
             Type expectedRuntimeType = expected.GetType();
             Type actualRuntimeType = actual.GetType();
 
-            // Primitive-ish types: trust Equals.
+            if (expected is Type || actual is Type)
+            {
+                return expected is Type && actual is Type
+                    ? Equals(expected, actual)
+                        ? null
+                        : EquivalenceMismatch.ValueMismatch(path, expected, actual)
+                    : EquivalenceMismatch.TypeMismatch(path, expectedRuntimeType, actualRuntimeType);
+            }
+
+            // Primitive-ish types: trust Equals, but report runtime-type mismatches explicitly when
+            // boxed through a wider declared type such as object.
             if (IsPrimitiveLike(expectedRuntimeType) || IsPrimitiveLike(actualRuntimeType))
             {
-                return Equals(expected, actual)
-                    ? null
-                    : EquivalenceMismatch.ValueMismatch(path, expected, actual);
+                return expectedRuntimeType == actualRuntimeType
+                    ? Equals(expected, actual)
+                        ? null
+                        : EquivalenceMismatch.ValueMismatch(path, expected, actual)
+                    : EquivalenceMismatch.TypeMismatch(path, expectedRuntimeType, actualRuntimeType);
             }
 
             // IEquatable<T> shortcut on the declared (compile-time) type, when it is more specific
@@ -79,6 +97,9 @@ public sealed partial class Assert
             // Skip value types: they cannot form reference cycles, and boxing them into the topology
             // maps would both miss subsequent visits (each box is a fresh reference) and grow the
             // dictionaries unnecessarily.
+            // These mappings are intentionally not unwound when a deeper comparison later fails.
+            // Comparison is fail-fast, so a non-null mismatch immediately aborts traversal and the
+            // comparer instance is never reused to continue from a sibling branch.
             if (!expectedRuntimeType.IsValueType && !actualRuntimeType.IsValueType)
             {
                 if (_expectedToActual.TryGetValue(expected, out object? mappedActual))
@@ -105,7 +126,7 @@ public sealed partial class Assert
             if (expectedIsDictionary && actualIsDictionary)
             {
                 Type valueDeclaredType = GetDictionaryValueType(declaredType, expectedRuntimeType, actualRuntimeType);
-                return CompareDictionaries(expectedDict!, actualDict!, valueDeclaredType, path);
+                return CompareDictionaries(expectedDict!, actualDict!, valueDeclaredType, path, depth);
             }
 
             // If exactly one side is a dictionary, treat as a structural mismatch rather than
@@ -118,13 +139,13 @@ public sealed partial class Assert
             if (expected is IEnumerable expectedEnum && actual is IEnumerable actualEnum)
             {
                 Type elementDeclaredType = GetEnumerableElementType(declaredType, expectedRuntimeType, actualRuntimeType);
-                return CompareEnumerables(expectedEnum, actualEnum, elementDeclaredType, path);
+                return CompareEnumerables(expectedEnum, actualEnum, elementDeclaredType, path, depth);
             }
 
-            return CompareMembers(expected, actual, expectedRuntimeType, actualRuntimeType, path);
+            return CompareMembers(expected, actual, expectedRuntimeType, actualRuntimeType, path, depth);
         }
 
-        private EquivalenceMismatch? CompareDictionaries(DictionaryView expected, DictionaryView actual, Type valueDeclaredType, string path)
+        private EquivalenceMismatch? CompareDictionaries(DictionaryView expected, DictionaryView actual, Type valueDeclaredType, string path, int depth)
         {
             EquivalenceMismatch? failure = ForEachEntry(expected, isExpected: true, path, kvp =>
             {
@@ -140,7 +161,7 @@ public sealed partial class Assert
                     ? lookup
                     : !lookupResult.Found
                         ? EquivalenceMismatch.MissingKey(childPath, kvp.Key)
-                        : Compare(kvp.Value, lookupResult.Value, valueDeclaredType, childPath);
+                        : Compare(kvp.Value, lookupResult.Value, valueDeclaredType, childPath, depth + 1);
             });
             if (failure is not null)
             {
@@ -247,11 +268,20 @@ public sealed partial class Assert
             }
         }
 
-        private EquivalenceMismatch? CompareEnumerables(IEnumerable expected, IEnumerable actual, Type elementDeclaredType, string path)
+        private EquivalenceMismatch? CompareEnumerables(IEnumerable expected, IEnumerable actual, Type elementDeclaredType, string path, int depth)
         {
             // Materialize once so we can report length and walk in parallel.
-            List<object?> expectedItems = ToList(expected);
-            List<object?> actualItems = ToList(actual);
+            EquivalenceMismatch? failure = TryToList(expected, isExpected: true, path, out List<object?> expectedItems);
+            if (failure is not null)
+            {
+                return failure;
+            }
+
+            failure = TryToList(actual, isExpected: false, path, out List<object?> actualItems);
+            if (failure is not null)
+            {
+                return failure;
+            }
 
             if (expectedItems.Count != actualItems.Count)
             {
@@ -260,7 +290,7 @@ public sealed partial class Assert
 
             for (int i = 0; i < expectedItems.Count; i++)
             {
-                EquivalenceMismatch? nested = Compare(expectedItems[i], actualItems[i], elementDeclaredType, AppendIndex(path, i));
+                EquivalenceMismatch? nested = Compare(expectedItems[i], actualItems[i], elementDeclaredType, AppendIndex(path, i), depth + 1);
                 if (nested is not null)
                 {
                     return nested;
@@ -270,7 +300,7 @@ public sealed partial class Assert
             return null;
         }
 
-        private EquivalenceMismatch? CompareMembers(object expected, object actual, Type expectedType, Type actualType, string path)
+        private EquivalenceMismatch? CompareMembers(object expected, object actual, Type expectedType, Type actualType, string path, int depth)
         {
             MemberLookup expectedMembers = GetMembers(expectedType);
 
@@ -291,7 +321,6 @@ public sealed partial class Assert
 
                 if (extras is { Count: > 0 })
                 {
-                    extras.Sort(StringComparer.Ordinal);
                     return EquivalenceMismatch.ExtraMembers(path, extras);
                 }
             }
@@ -334,7 +363,7 @@ public sealed partial class Assert
                     return EquivalenceMismatch.MemberAccessFailure(childPath, isExpected: false, ex);
                 }
 
-                EquivalenceMismatch? nested = Compare(expectedValue, actualValue, member.MemberType, childPath);
+                EquivalenceMismatch? nested = Compare(expectedValue, actualValue, member.MemberType, childPath, depth + 1);
                 if (nested is not null)
                 {
                     return nested;
@@ -344,19 +373,32 @@ public sealed partial class Assert
             return null;
         }
 
-        private static List<object?> ToList(IEnumerable source)
+        private static EquivalenceMismatch? TryToList(IEnumerable source, bool isExpected, string path, out List<object?> list)
         {
-#pragma warning disable IDE0028 // Collection initialization can be simplified - we want the capacity-aware ctor when ICollection is available.
-            List<object?> list = source is ICollection collection
-                ? new List<object?>(collection.Count)
-                : [];
-#pragma warning restore IDE0028
-            foreach (object? item in source)
+            try
             {
-                list.Add(item);
-            }
+#pragma warning disable IDE0028 // Collection initialization can be simplified - we want the capacity-aware ctor when ICollection is available.
+                list = source is ICollection collection
+                    ? new List<object?>(collection.Count)
+                    : [];
+#pragma warning restore IDE0028
+                foreach (object? item in source)
+                {
+                    list.Add(item);
+                }
 
-            return list;
+                return null;
+            }
+            catch (TargetInvocationException tie)
+            {
+                list = [];
+                return EquivalenceMismatch.EnumerationFailure(path, isExpected, tie.InnerException ?? tie);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                list = [];
+                return EquivalenceMismatch.EnumerationFailure(path, isExpected, ex);
+            }
         }
 
         private enum IEquatableOutcome
@@ -521,13 +563,7 @@ public sealed partial class Assert
 
                 // DateOnly / TimeOnly / Half / Int128 exist only on newer TFMs; match by full name to avoid #if.
                 string? fullName = t.FullName;
-                if (fullName is "System.DateOnly" or "System.TimeOnly" or "System.Half" or "System.Int128" or "System.UInt128")
-                {
-                    return true;
-                }
-
-                // Compare reflection types as primitive (they all derive from System.Type).
-                return typeof(Type).IsAssignableFrom(t);
+                return fullName is "System.DateOnly" or "System.TimeOnly" or "System.Half" or "System.Int128" or "System.UInt128";
             });
 
         private static bool TryCreateDictionaryView(object value, out DictionaryView? view)
@@ -633,10 +669,7 @@ public sealed partial class Assert
 
         private static string AppendDictionaryKey(string parent, object key)
         {
-            string rendered = key is string s
-                ? $"\"{s}\""
-                : Convert.ToString(key, CultureInfo.InvariantCulture) ?? key.GetType().Name;
-            string keyPart = $"[{rendered}]";
+            string keyPart = $"[{AssertionValueRenderer.RenderValue(key)}]";
             return parent.Length == 0 ? keyPart : parent + keyPart;
         }
     }
@@ -889,12 +922,13 @@ public sealed partial class Assert
     /// </summary>
     private sealed class EquivalenceMismatch
     {
-        private EquivalenceMismatch(string path, string reason, string? expectedText, string? actualText)
+        private EquivalenceMismatch(string path, string reason, string? expectedText, string? actualText, bool isComparisonFailure)
         {
             Path = path;
             Reason = reason;
             ExpectedText = expectedText;
             ActualText = actualText;
+            IsComparisonFailure = isComparisonFailure;
         }
 
         internal string Path { get; }
@@ -905,68 +939,79 @@ public sealed partial class Assert
 
         internal string? ActualText { get; }
 
+        internal bool IsComparisonFailure { get; }
+
         internal static EquivalenceMismatch ValueMismatch(string path, object? expected, object? actual)
             => new(
                 path,
                 FrameworkMessages.AreEquivalentMismatchValue,
                 AssertionValueRenderer.RenderValue(expected),
-                AssertionValueRenderer.RenderValue(actual));
+                AssertionValueRenderer.RenderValue(actual),
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch NullMismatch(string path, object? expected, object? actual)
             => new(
                 path,
                 FrameworkMessages.AreEquivalentMismatchNull,
                 AssertionValueRenderer.RenderValue(expected),
-                AssertionValueRenderer.RenderValue(actual));
+                AssertionValueRenderer.RenderValue(actual),
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch TypeMismatch(string path, Type expectedType, Type actualType)
             => new(
                 path,
                 string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchType, expectedType.FullName ?? expectedType.Name, actualType.FullName ?? actualType.Name),
                 expectedType.FullName ?? expectedType.Name,
-                actualType.FullName ?? actualType.Name);
+                actualType.FullName ?? actualType.Name,
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch TopologyMismatch(string path)
             => new(
                 path,
                 FrameworkMessages.AreEquivalentMismatchTopology,
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch LengthMismatch(string path, int expectedCount, int actualCount)
             => new(
                 path,
                 string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchLength, expectedCount, actualCount),
                 expectedCount.ToString(CultureInfo.InvariantCulture),
-                actualCount.ToString(CultureInfo.InvariantCulture));
+                actualCount.ToString(CultureInfo.InvariantCulture),
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch MissingKey(string path, object key)
             => new(
                 path,
                 string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchMissingKey, AssertionValueRenderer.RenderValue(key)),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch UnexpectedKey(string path, object key)
             => new(
                 path,
                 string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchUnexpectedKey, AssertionValueRenderer.RenderValue(key)),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch MissingMember(string path, string memberName)
             => new(
                 path,
                 string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchMissingMember, memberName),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch ExtraMembers(string path, IReadOnlyList<string> extras)
             => new(
                 path,
                 string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchExtraMembers, string.Join(", ", extras)),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: false);
 
         internal static EquivalenceMismatch IEquatableThrew(string path, Exception thrown)
             => new(
@@ -977,7 +1022,8 @@ public sealed partial class Assert
                     thrown.GetType().Name,
                     thrown.Message),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: true);
 
         internal static EquivalenceMismatch DictionaryAccessFailure(string path, bool isExpected, Exception inner)
             => new(
@@ -988,7 +1034,20 @@ public sealed partial class Assert
                     inner.GetType().Name,
                     inner.Message),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: true);
+
+        internal static EquivalenceMismatch EnumerationFailure(string path, bool isExpected, Exception inner)
+            => new(
+                path,
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    isExpected ? FrameworkMessages.AreEquivalentMismatchExpectedEnumerationThrew : FrameworkMessages.AreEquivalentMismatchActualEnumerationThrew,
+                    inner.GetType().Name,
+                    inner.Message),
+                expectedText: null,
+                actualText: null,
+                isComparisonFailure: true);
 
         internal static EquivalenceMismatch MemberAccessFailure(string path, bool isExpected, Exception inner)
             => new(
@@ -999,6 +1058,15 @@ public sealed partial class Assert
                     inner.GetType().Name,
                     inner.Message),
                 expectedText: null,
-                actualText: null);
+                actualText: null,
+                isComparisonFailure: true);
+
+        internal static EquivalenceMismatch MaxDepthExceeded(string path, int maxDepth)
+            => new(
+                path,
+                string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEquivalentMismatchMaxDepth, maxDepth),
+                expectedText: null,
+                actualText: null,
+                isComparisonFailure: true);
     }
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
@@ -39,6 +39,11 @@ public sealed partial class Assert
     /// </exception>
     /// <remarks>
     /// <para>
+    /// This assertion performs a deep, order-sensitive structural comparison of two object graphs.
+    /// It differs from <see cref="CollectionAssert.AreEquivalent(System.Collections.ICollection?, System.Collections.ICollection?)"/>,
+    /// which checks only top-level collection equivalence without regard to element order.
+    /// </para>
+    /// <para>
     /// The comparison rules are:
     /// </para>
     /// <list type="bullet">
@@ -98,6 +103,12 @@ public sealed partial class Assert
     ///     If a user-defined <see cref="IEquatable{T}.Equals(T)"/>, member getter, or dictionary
     ///     access (<c>TryGetValue</c>, <c>ContainsKey</c>, or enumeration) throws while being
     ///     evaluated, the assertion fails with a message describing the exception type and message.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Comparison stops after a bounded recursion depth to avoid <see cref="StackOverflowException"/>
+    ///     on unusually deep object graphs, and reports that condition as an assertion failure.
     ///     </description>
     ///   </item>
     /// </list>
@@ -182,7 +193,8 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> and <paramref name="actual"/> are structurally equivalent.
+    /// Thrown if <paramref name="notExpected"/> and <paramref name="actual"/> are structurally equivalent,
+    /// or if the structural comparison cannot be completed.
     /// </exception>
     /// <remarks>
     /// See <see cref="AreEquivalent{T}(T, T, string, string, string)"/> and
@@ -223,32 +235,70 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     /// <exception cref="AssertFailedException">
-    /// Thrown if <paramref name="notExpected"/> and <paramref name="actual"/> are structurally equivalent.
+    /// Thrown if <paramref name="notExpected"/> and <paramref name="actual"/> are structurally equivalent,
+    /// or if the structural comparison cannot be completed.
     /// </exception>
     public static void AreNotEquivalent<T>(T? notExpected, T? actual, bool strict, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
     {
         EquivalenceComparer comparer = new(strict);
         EquivalenceMismatch? mismatch = comparer.Compare(notExpected, actual);
-        if (mismatch is not null)
+        if (mismatch is null)
         {
-            return;
+            ReportAssertAreNotEquivalentFailed(notExpected, actual, strict, message, notExpectedExpression, actualExpression);
         }
 
-        ReportAssertAreNotEquivalentFailed(notExpected, actual, strict, message, notExpectedExpression, actualExpression);
+        if (mismatch.IsComparisonFailure)
+        {
+            ReportAssertAreNotEquivalentComparisonFailed(mismatch, strict, message, notExpectedExpression, actualExpression);
+        }
+
+        return;
     }
 
     [DoesNotReturn]
     private static void ReportAssertAreEquivalentFailed(EquivalenceMismatch mismatch, bool strict, string? userMessage, string expectedExpression, string actualExpression)
+    {
+        string summary = strict
+            ? FrameworkMessages.AreEquivalentFailedSummaryStrict
+            : FrameworkMessages.AreEquivalentFailedSummary;
+
+        ReportAssertEquivalenceMismatch(
+            mismatch,
+            summary,
+            userMessage,
+            "Assert.AreEquivalent",
+            expectedExpression,
+            actualExpression,
+            "<expected>",
+            "<actual>");
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertAreNotEquivalentComparisonFailed(EquivalenceMismatch mismatch, bool strict, string? userMessage, string notExpectedExpression, string actualExpression)
+    {
+        string summary = strict
+            ? FrameworkMessages.AreNotEquivalentComparisonFailedSummaryStrict
+            : FrameworkMessages.AreNotEquivalentComparisonFailedSummary;
+
+        ReportAssertEquivalenceMismatch(
+            mismatch,
+            summary,
+            userMessage,
+            "Assert.AreNotEquivalent",
+            notExpectedExpression,
+            actualExpression,
+            "<notExpected>",
+            "<actual>");
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertEquivalenceMismatch(EquivalenceMismatch mismatch, string summary, string? userMessage, string assertionMethodName, string leftExpression, string rightExpression, string leftPlaceholder, string rightPlaceholder)
     {
         string locationLine = string.Format(
             CultureInfo.CurrentCulture,
             FrameworkMessages.AreEquivalentMismatchAt,
             mismatch.Path.Length == 0 ? FrameworkMessages.AreEquivalentRootPath : mismatch.Path,
             mismatch.Reason);
-
-        string summary = strict
-            ? FrameworkMessages.AreEquivalentFailedSummaryStrict
-            : FrameworkMessages.AreEquivalentFailedSummary;
 
         StructuredAssertionMessage structured = new(summary);
         structured.WithAdditionalSummaryLine(locationLine);
@@ -263,7 +313,7 @@ public sealed partial class Assert
             structured.WithExpectedAndActual(mismatch.ExpectedText, mismatch.ActualText);
         }
 
-        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreEquivalent", expectedExpression, actualExpression, "<expected>", "<actual>"));
+        structured.WithCallSiteExpression(FormatCallSiteExpression(assertionMethodName, leftExpression, rightExpression, leftPlaceholder, rightPlaceholder));
 
         ReportAssertFailed(structured);
     }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
@@ -57,7 +57,9 @@ public sealed partial class Assert
     ///     Primitive-like types (numerics, <see cref="bool"/>, <see cref="char"/>, <see cref="string"/>,
     ///     enums, <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, <see cref="TimeSpan"/>,
     ///     <see cref="Guid"/>, <see cref="Uri"/>, <see cref="Type"/>, <see cref="Version"/>) are compared with
-    ///     <see cref="object.Equals(object?)"/>.
+    ///     <see cref="object.Equals(object?)"/>. On target frameworks that ship them,
+    ///     <c>DateOnly</c>, <c>TimeOnly</c>, <c>Half</c>, <c>Int128</c>, and <c>UInt128</c> are also
+    ///     treated as primitive-like.
     ///     </description>
     ///   </item>
     ///   <item>
@@ -267,7 +269,9 @@ public sealed partial class Assert
             expectedExpression,
             actualExpression,
             "<expected>",
-            "<actual>");
+            "<actual>",
+            "expected:",
+            "actual:");
     }
 
     [DoesNotReturn]
@@ -285,11 +289,13 @@ public sealed partial class Assert
             notExpectedExpression,
             actualExpression,
             "<notExpected>",
-            "<actual>");
+            "<actual>",
+            "not expected:",
+            "actual:");
     }
 
     [DoesNotReturn]
-    private static void ReportAssertEquivalenceMismatch(EquivalenceMismatch mismatch, string summary, string? userMessage, string assertionMethodName, string leftExpression, string rightExpression, string leftPlaceholder, string rightPlaceholder)
+    private static void ReportAssertEquivalenceMismatch(EquivalenceMismatch mismatch, string summary, string? userMessage, string assertionMethodName, string leftExpression, string rightExpression, string leftPlaceholder, string rightPlaceholder, string leftLabel, string rightLabel)
     {
         string locationLine = string.Format(
             CultureInfo.CurrentCulture,
@@ -304,8 +310,8 @@ public sealed partial class Assert
         if (mismatch.ExpectedText is not null && mismatch.ActualText is not null)
         {
             EvidenceBlock evidence = EvidenceBlock.Create()
-                .AddLine("expected:", mismatch.ExpectedText)
-                .AddLine("actual:", mismatch.ActualText);
+                .AddLine(leftLabel, mismatch.ExpectedText)
+                .AddLine(rightLabel, mismatch.ActualText);
             structured.WithEvidence(evidence);
             structured.WithExpectedAndActual(mismatch.ExpectedText, mismatch.ActualText);
         }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
@@ -1,0 +1,294 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+public sealed partial class Assert
+{
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+#pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+    /// <summary>
+    /// Tests whether two object graphs are structurally equivalent (deep equality) and throws an
+    /// exception if they are not.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of values to compare.
+    /// </typeparam>
+    /// <param name="expected">
+    /// The first value to compare. This is the value the test expects.
+    /// </param>
+    /// <param name="actual">
+    /// The second value to compare. This is the value produced by the code under test.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception when <paramref name="actual"/>
+    /// is not equivalent to <paramref name="expected"/>. The message is shown in
+    /// test results.
+    /// </param>
+    /// <param name="expectedExpression">
+    /// The syntactic expression of expected as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <param name="actualExpression">
+    /// The syntactic expression of actual as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="expected"/> and <paramref name="actual"/> are not structurally equivalent.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The comparison rules are:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///     Reference-equal values (including both <see langword="null"/>) are considered equivalent.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Primitive-like types (numerics, <see cref="bool"/>, <see cref="char"/>, <see cref="string"/>,
+    ///     enums, <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, <see cref="TimeSpan"/>,
+    ///     <see cref="Guid"/>, <see cref="Uri"/>, <see cref="Type"/>, <see cref="Version"/>) are compared with
+    ///     <see cref="object.Equals(object?)"/>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     If the static (compile-time) type of a value implements <see cref="IEquatable{T}"/> for itself,
+    ///     <see cref="IEquatable{T}.Equals(T)"/> is used and recursion stops at that point.
+    ///     Plain <see cref="object.Equals(object?)"/> overrides are ignored — the comparer always
+    ///     recurses into members for those.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Dictionaries (<see cref="IDictionary"/>, <see cref="IDictionary{TKey, TValue}"/>, or
+    ///     <see cref="IReadOnlyDictionary{TKey, TValue}"/>) are compared by key set, with values compared
+    ///     recursively. Lookups are routed through the source dictionary so its
+    ///     <see cref="IEqualityComparer{T}"/> for keys is preserved.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Other enumerables (excluding <see cref="string"/>) are compared element-by-element in the
+    ///     iteration order. Comparison is <b>order-sensitive</b>; if order is irrelevant, use
+    ///     <see cref="CollectionAssert.AreEquivalent(System.Collections.ICollection?, System.Collections.ICollection?)"/>
+    ///     on the collection itself.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Other reference types are compared by recursing into all public instance properties (with a public
+    ///     getter and no index parameters) and public instance fields. Static, non-public, and indexed members
+    ///     are ignored.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     Reference cycles are tracked and traversed at most once per (expected, actual) pair. The same
+    ///     mechanism enforces graph topology: if the same reference on one side is paired with different
+    ///     references on the other side, the assertion fails.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///     If a user-defined <see cref="IEquatable{T}.Equals(T)"/>, member getter, or dictionary
+    ///     access (<c>TryGetValue</c>, <c>ContainsKey</c>, or enumeration) throws while being
+    ///     evaluated, the assertion fails with a message describing the exception type and message.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
+    public static void AreEquivalent<T>(T? expected, T? actual, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
+        => AreEquivalent(expected, actual, strict: false, message, expectedExpression, actualExpression);
+
+    /// <summary>
+    /// Tests whether two object graphs are structurally equivalent (deep equality) and throws an
+    /// exception if they are not.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of values to compare.
+    /// </typeparam>
+    /// <param name="expected">
+    /// The first value to compare. This is the value the test expects.
+    /// </param>
+    /// <param name="actual">
+    /// The second value to compare. This is the value produced by the code under test.
+    /// </param>
+    /// <param name="strict">
+    /// When <see langword="true"/>, the comparison fails if <paramref name="actual"/> declares any
+    /// public properties or fields that are not present on <paramref name="expected"/>'s runtime type,
+    /// or if any extra dictionary keys are present on <paramref name="actual"/>. When <see langword="false"/>
+    /// (the default), additional members and dictionary keys on <paramref name="actual"/> are ignored.
+    /// When the runtime types of <paramref name="expected"/> and <paramref name="actual"/> are identical,
+    /// this flag has no effect on the public-member comparison, but it still rejects extra dictionary keys
+    /// on <paramref name="actual"/> when comparing dictionaries.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception when <paramref name="actual"/>
+    /// is not equivalent to <paramref name="expected"/>. The message is shown in
+    /// test results.
+    /// </param>
+    /// <param name="expectedExpression">
+    /// The syntactic expression of expected as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <param name="actualExpression">
+    /// The syntactic expression of actual as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="expected"/> and <paramref name="actual"/> are not structurally equivalent.
+    /// </exception>
+    public static void AreEquivalent<T>(T? expected, T? actual, bool strict, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
+    {
+        EquivalenceComparer comparer = new(strict);
+        EquivalenceMismatch? mismatch = comparer.Compare(expected, actual);
+        if (mismatch is null)
+        {
+            return;
+        }
+
+        ReportAssertAreEquivalentFailed(mismatch, strict, message, expectedExpression, actualExpression);
+    }
+
+    /// <summary>
+    /// Tests whether two object graphs are NOT structurally equivalent and throws an exception if they are.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of values to compare.
+    /// </typeparam>
+    /// <param name="notExpected">
+    /// The first value to compare. This is the value the test expects not to match
+    /// <paramref name="actual"/>.
+    /// </param>
+    /// <param name="actual">
+    /// The second value to compare. This is the value produced by the code under test.
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception when <paramref name="actual"/>
+    /// is equivalent to <paramref name="notExpected"/>. The message is shown in
+    /// test results.
+    /// </param>
+    /// <param name="notExpectedExpression">
+    /// The syntactic expression of notExpected as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <param name="actualExpression">
+    /// The syntactic expression of actual as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="notExpected"/> and <paramref name="actual"/> are structurally equivalent.
+    /// </exception>
+    /// <remarks>
+    /// See <see cref="AreEquivalent{T}(T, T, string, string, string)"/> and
+    /// <see cref="AreEquivalent{T}(T, T, bool, string, string, string)"/> for the full set of comparison rules.
+    /// </remarks>
+    public static void AreNotEquivalent<T>(T? notExpected, T? actual, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
+        => AreNotEquivalent(notExpected, actual, strict: false, message, notExpectedExpression, actualExpression);
+
+    /// <summary>
+    /// Tests whether two object graphs are NOT structurally equivalent and throws an exception if they are.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of values to compare.
+    /// </typeparam>
+    /// <param name="notExpected">
+    /// The first value to compare. This is the value the test expects not to match
+    /// <paramref name="actual"/>.
+    /// </param>
+    /// <param name="actual">
+    /// The second value to compare. This is the value produced by the code under test.
+    /// </param>
+    /// <param name="strict">
+    /// When <see langword="true"/>, the equivalence check used to decide whether the assertion fails is
+    /// performed in strict mode (extra members or dictionary keys on <paramref name="actual"/> are
+    /// considered a difference, so the assertion succeeds in their presence).
+    /// </param>
+    /// <param name="message">
+    /// The message to include in the exception when <paramref name="actual"/>
+    /// is equivalent to <paramref name="notExpected"/>. The message is shown in
+    /// test results.
+    /// </param>
+    /// <param name="notExpectedExpression">
+    /// The syntactic expression of notExpected as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <param name="actualExpression">
+    /// The syntactic expression of actual as given by the compiler via caller argument expression.
+    /// Users shouldn't pass a value for this parameter.
+    /// </param>
+    /// <exception cref="AssertFailedException">
+    /// Thrown if <paramref name="notExpected"/> and <paramref name="actual"/> are structurally equivalent.
+    /// </exception>
+    public static void AreNotEquivalent<T>(T? notExpected, T? actual, bool strict, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
+    {
+        EquivalenceComparer comparer = new(strict);
+        EquivalenceMismatch? mismatch = comparer.Compare(notExpected, actual);
+        if (mismatch is not null)
+        {
+            return;
+        }
+
+        ReportAssertAreNotEquivalentFailed(notExpected, actual, strict, message, notExpectedExpression, actualExpression);
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertAreEquivalentFailed(EquivalenceMismatch mismatch, bool strict, string? userMessage, string expectedExpression, string actualExpression)
+    {
+        string locationLine = string.Format(
+            CultureInfo.CurrentCulture,
+            FrameworkMessages.AreEquivalentMismatchAt,
+            mismatch.Path.Length == 0 ? FrameworkMessages.AreEquivalentRootPath : mismatch.Path,
+            mismatch.Reason);
+
+        string summary = strict
+            ? FrameworkMessages.AreEquivalentFailedSummaryStrict
+            : FrameworkMessages.AreEquivalentFailedSummary;
+
+        StructuredAssertionMessage structured = new(summary);
+        structured.WithAdditionalSummaryLine(locationLine);
+        structured.WithUserMessage(userMessage);
+
+        if (mismatch.ExpectedText is not null && mismatch.ActualText is not null)
+        {
+            EvidenceBlock evidence = EvidenceBlock.Create()
+                .AddLine("expected:", mismatch.ExpectedText)
+                .AddLine("actual:", mismatch.ActualText);
+            structured.WithEvidence(evidence);
+            structured.WithExpectedAndActual(mismatch.ExpectedText, mismatch.ActualText);
+        }
+
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreEquivalent", expectedExpression, actualExpression, "<expected>", "<actual>"));
+
+        ReportAssertFailed(structured);
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertAreNotEquivalentFailed<T>(T? notExpected, T? actual, bool strict, string? userMessage, string notExpectedExpression, string actualExpression)
+    {
+        string summary = strict
+            ? FrameworkMessages.AreNotEquivalentFailedSummaryStrict
+            : FrameworkMessages.AreNotEquivalentFailedSummary;
+
+        string actualText = AssertionValueRenderer.RenderValue(actual);
+        string notExpectedText = AssertionValueRenderer.RenderValue(notExpected);
+
+        StructuredAssertionMessage structured = new(summary);
+        structured.WithUserMessage(userMessage);
+
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine("notExpected:", notExpectedText)
+            .AddLine("actual:", actualText);
+        structured.WithEvidence(evidence);
+        structured.WithExpectedAndActual($"not equivalent to {notExpectedText}", actualText);
+
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreNotEquivalent", notExpectedExpression, actualExpression, "<notExpected>", "<actual>"));
+
+        ReportAssertFailed(structured);
+    }
+}

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
@@ -246,13 +246,10 @@ public sealed partial class Assert
         {
             ReportAssertAreNotEquivalentFailed(notExpected, actual, strict, message, notExpectedExpression, actualExpression);
         }
-
-        if (mismatch.IsComparisonFailure)
+        else if (mismatch.IsComparisonFailure)
         {
             ReportAssertAreNotEquivalentComparisonFailed(mismatch, strict, message, notExpectedExpression, actualExpression);
         }
-
-        return;
     }
 
     [DoesNotReturn]

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
@@ -329,7 +329,7 @@ public sealed partial class Assert
         structured.WithUserMessage(userMessage);
 
         EvidenceBlock evidence = EvidenceBlock.Create()
-            .AddLine("notExpected:", notExpectedText)
+            .AddLine("not expected:", notExpectedText)
             .AddLine("actual:", actualText);
         structured.WithEvidence(evidence);
         structured.WithExpectedAndActual($"not equivalent to {notExpectedText}", actualText);

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -2,3 +2,7 @@
 [MSTESTEXP]static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.Scope() -> System.IDisposable!
 Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException.ActualText.get -> string?
 Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException.ExpectedText.get -> string?
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEquivalent<T>(T? expected, T? actual, bool strict, string? message = "", string! expectedExpression = "", string! actualExpression = "") -> void
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEquivalent<T>(T? expected, T? actual, string? message = "", string! expectedExpression = "", string! actualExpression = "") -> void
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEquivalent<T>(T? notExpected, T? actual, bool strict, string? message = "", string! notExpectedExpression = "", string! actualExpression = "") -> void
+static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreNotEquivalent<T>(T? notExpected, T? actual, string? message = "", string! notExpectedExpression = "", string! actualExpression = "") -> void

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -234,10 +234,10 @@
     <value>Could not complete structural comparison (strict mode).</value>
   </data>
   <data name="AreNotEquivalentFailedSummary" xml:space="preserve">
-    <value>Expected values to NOT be structurally equivalent.</value>
+    <value>Expected values to be structurally different.</value>
   </data>
   <data name="AreNotEquivalentFailedSummaryStrict" xml:space="preserve">
-    <value>Expected values to NOT be structurally equivalent (strict mode).</value>
+    <value>Expected values to be structurally different (strict mode).</value>
   </data>
   <data name="AreSameExpectedIsNull" xml:space="preserve">
     <value>Expected is &lt;null&gt;. {0}</value>

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -156,20 +156,76 @@
   <data name="AreEqualStringDiffLengthDifferentMsg" xml:space="preserve">
     <value>Expected string length {0} but was {1}.</value>
   </data>
-  <data name="AreNotEqualFailMsg" xml:space="preserve">
-    <value>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</value>
-  </data>
   <data name="AreEquivalentFailedSummary" xml:space="preserve">
     <value>Expected values to be structurally equivalent.</value>
   </data>
   <data name="AreEquivalentFailedSummaryStrict" xml:space="preserve">
     <value>Expected values to be structurally equivalent (strict mode).</value>
   </data>
-  <data name="AreNotEquivalentFailedSummary" xml:space="preserve">
-    <value>Expected values to NOT be structurally equivalent.</value>
+  <data name="AreEquivalentMismatchActualDictionaryThrew" xml:space="preserve">
+    <value>reading the actual dictionary threw {0}: {1}.</value>
   </data>
-  <data name="AreNotEquivalentFailedSummaryStrict" xml:space="preserve">
-    <value>Expected values to NOT be structurally equivalent (strict mode).</value>
+  <data name="AreEquivalentMismatchActualEnumerationThrew" xml:space="preserve">
+    <value>enumerating the actual collection threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchActualMemberThrew" xml:space="preserve">
+    <value>reading the actual member threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchAt" xml:space="preserve">
+    <value>Mismatch at '{0}': {1}</value>
+    <comment>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</comment>
+  </data>
+  <data name="AreEquivalentMismatchExpectedDictionaryThrew" xml:space="preserve">
+    <value>reading the expected dictionary threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchExpectedEnumerationThrew" xml:space="preserve">
+    <value>enumerating the expected collection threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchExpectedMemberThrew" xml:space="preserve">
+    <value>reading the expected member threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchExtraMembers" xml:space="preserve">
+    <value>actual has unexpected members not present on expected: {0}.</value>
+  </data>
+  <data name="AreEquivalentMismatchIEquatableThrew" xml:space="preserve">
+    <value>IEquatable.Equals threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchLength" xml:space="preserve">
+    <value>collections differ in length (expected {0} elements, actual {1}).</value>
+  </data>
+  <data name="AreEquivalentMismatchMaxDepth" xml:space="preserve">
+    <value>comparison exceeded the maximum supported depth of {0}.</value>
+  </data>
+  <data name="AreEquivalentMismatchMissingKey" xml:space="preserve">
+    <value>key {0} present on expected is missing from actual.</value>
+  </data>
+  <data name="AreEquivalentMismatchMissingMember" xml:space="preserve">
+    <value>member '{0}' present on expected is missing from actual.</value>
+  </data>
+  <data name="AreEquivalentMismatchNull" xml:space="preserve">
+    <value>one side is null, the other is not.</value>
+  </data>
+  <data name="AreEquivalentMismatchTopology" xml:space="preserve">
+    <value>graph topology differs (the same reference on one side appears paired with different references on the other side).</value>
+  </data>
+  <data name="AreEquivalentMismatchType" xml:space="preserve">
+    <value>incompatible types (expected '{0}', actual '{1}').</value>
+  </data>
+  <data name="AreEquivalentMismatchUnexpectedKey" xml:space="preserve">
+    <value>key {0} present on actual is not on expected.</value>
+  </data>
+  <data name="AreEquivalentMismatchValue" xml:space="preserve">
+    <value>values are not equal.</value>
+  </data>
+  <data name="AreEquivalentRootPath" xml:space="preserve">
+    <value>&lt;root&gt;</value>
+    <comment>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</comment>
+  </data>
+  <data name="AreNotEqualDeltaFailMsg" xml:space="preserve">
+    <value>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</value>
+  </data>
+  <data name="AreNotEqualFailMsg" xml:space="preserve">
+    <value>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</value>
   </data>
   <data name="AreNotEquivalentComparisonFailedSummary" xml:space="preserve">
     <value>Could not complete structural comparison.</value>
@@ -177,67 +233,11 @@
   <data name="AreNotEquivalentComparisonFailedSummaryStrict" xml:space="preserve">
     <value>Could not complete structural comparison (strict mode).</value>
   </data>
-  <data name="AreEquivalentRootPath" xml:space="preserve">
-    <value>&lt;root&gt;</value>
-    <comment>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</comment>
+  <data name="AreNotEquivalentFailedSummary" xml:space="preserve">
+    <value>Expected values to NOT be structurally equivalent.</value>
   </data>
-  <data name="AreEquivalentMismatchAt" xml:space="preserve">
-    <value>Mismatch at '{0}': {1}</value>
-    <comment>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</comment>
-  </data>
-  <data name="AreEquivalentMismatchValue" xml:space="preserve">
-    <value>values are not equal.</value>
-  </data>
-  <data name="AreEquivalentMismatchNull" xml:space="preserve">
-    <value>one side is null, the other is not.</value>
-  </data>
-  <data name="AreEquivalentMismatchType" xml:space="preserve">
-    <value>incompatible types (expected '{0}', actual '{1}').</value>
-  </data>
-  <data name="AreEquivalentMismatchLength" xml:space="preserve">
-    <value>collections differ in length (expected {0} elements, actual {1}).</value>
-  </data>
-  <data name="AreEquivalentMismatchMissingKey" xml:space="preserve">
-    <value>key {0} present on expected is missing from actual.</value>
-  </data>
-  <data name="AreEquivalentMismatchUnexpectedKey" xml:space="preserve">
-    <value>key {0} present on actual is not on expected.</value>
-  </data>
-  <data name="AreEquivalentMismatchMissingMember" xml:space="preserve">
-    <value>member '{0}' present on expected is missing from actual.</value>
-  </data>
-  <data name="AreEquivalentMismatchExtraMembers" xml:space="preserve">
-    <value>actual has unexpected members not present on expected: {0}.</value>
-  </data>
-  <data name="AreEquivalentMismatchTopology" xml:space="preserve">
-    <value>graph topology differs (the same reference on one side appears paired with different references on the other side).</value>
-  </data>
-  <data name="AreEquivalentMismatchMaxDepth" xml:space="preserve">
-    <value>comparison exceeded the maximum supported depth of {0}.</value>
-  </data>
-  <data name="AreEquivalentMismatchIEquatableThrew" xml:space="preserve">
-    <value>IEquatable.Equals threw {0}: {1}.</value>
-  </data>
-  <data name="AreEquivalentMismatchExpectedDictionaryThrew" xml:space="preserve">
-    <value>reading the expected dictionary threw {0}: {1}.</value>
-  </data>
-  <data name="AreEquivalentMismatchActualDictionaryThrew" xml:space="preserve">
-    <value>reading the actual dictionary threw {0}: {1}.</value>
-  </data>
-  <data name="AreEquivalentMismatchExpectedEnumerationThrew" xml:space="preserve">
-    <value>enumerating the expected collection threw {0}: {1}.</value>
-  </data>
-  <data name="AreEquivalentMismatchActualEnumerationThrew" xml:space="preserve">
-    <value>enumerating the actual collection threw {0}: {1}.</value>
-  </data>
-  <data name="AreEquivalentMismatchExpectedMemberThrew" xml:space="preserve">
-    <value>reading the expected member threw {0}: {1}.</value>
-  </data>
-  <data name="AreEquivalentMismatchActualMemberThrew" xml:space="preserve">
-    <value>reading the actual member threw {0}: {1}.</value>
-  </data>
-  <data name="AreNotEqualDeltaFailMsg" xml:space="preserve">
-    <value>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</value>
+  <data name="AreNotEquivalentFailedSummaryStrict" xml:space="preserve">
+    <value>Expected values to NOT be structurally equivalent (strict mode).</value>
   </data>
   <data name="AreSameExpectedIsNull" xml:space="preserve">
     <value>Expected is &lt;null&gt;. {0}</value>

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -159,6 +159,68 @@
   <data name="AreNotEqualFailMsg" xml:space="preserve">
     <value>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</value>
   </data>
+  <data name="AreEquivalentFailedSummary" xml:space="preserve">
+    <value>Expected values to be structurally equivalent.</value>
+  </data>
+  <data name="AreEquivalentFailedSummaryStrict" xml:space="preserve">
+    <value>Expected values to be structurally equivalent (strict mode).</value>
+  </data>
+  <data name="AreNotEquivalentFailedSummary" xml:space="preserve">
+    <value>Expected values to NOT be structurally equivalent.</value>
+  </data>
+  <data name="AreNotEquivalentFailedSummaryStrict" xml:space="preserve">
+    <value>Expected values to NOT be structurally equivalent (strict mode).</value>
+  </data>
+  <data name="AreEquivalentRootPath" xml:space="preserve">
+    <value>&lt;root&gt;</value>
+    <comment>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</comment>
+  </data>
+  <data name="AreEquivalentMismatchAt" xml:space="preserve">
+    <value>Mismatch at '{0}': {1}</value>
+    <comment>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</comment>
+  </data>
+  <data name="AreEquivalentMismatchValue" xml:space="preserve">
+    <value>values are not equal.</value>
+  </data>
+  <data name="AreEquivalentMismatchNull" xml:space="preserve">
+    <value>one side is null, the other is not.</value>
+  </data>
+  <data name="AreEquivalentMismatchType" xml:space="preserve">
+    <value>incompatible types (expected '{0}', actual '{1}').</value>
+  </data>
+  <data name="AreEquivalentMismatchLength" xml:space="preserve">
+    <value>collections differ in length (expected {0} elements, actual {1}).</value>
+  </data>
+  <data name="AreEquivalentMismatchMissingKey" xml:space="preserve">
+    <value>key {0} present on expected is missing from actual.</value>
+  </data>
+  <data name="AreEquivalentMismatchUnexpectedKey" xml:space="preserve">
+    <value>key {0} present on actual is not on expected.</value>
+  </data>
+  <data name="AreEquivalentMismatchMissingMember" xml:space="preserve">
+    <value>member '{0}' present on expected is missing from actual.</value>
+  </data>
+  <data name="AreEquivalentMismatchExtraMembers" xml:space="preserve">
+    <value>actual has unexpected members not present on expected: {0}.</value>
+  </data>
+  <data name="AreEquivalentMismatchTopology" xml:space="preserve">
+    <value>graph topology differs (the same reference on one side appears paired with different references on the other side).</value>
+  </data>
+  <data name="AreEquivalentMismatchIEquatableThrew" xml:space="preserve">
+    <value>IEquatable.Equals threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchExpectedDictionaryThrew" xml:space="preserve">
+    <value>reading the expected dictionary threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchActualDictionaryThrew" xml:space="preserve">
+    <value>reading the actual dictionary threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchExpectedMemberThrew" xml:space="preserve">
+    <value>reading the expected member threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchActualMemberThrew" xml:space="preserve">
+    <value>reading the actual member threw {0}: {1}.</value>
+  </data>
   <data name="AreNotEqualDeltaFailMsg" xml:space="preserve">
     <value>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</value>
   </data>

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -171,6 +171,12 @@
   <data name="AreNotEquivalentFailedSummaryStrict" xml:space="preserve">
     <value>Expected values to NOT be structurally equivalent (strict mode).</value>
   </data>
+  <data name="AreNotEquivalentComparisonFailedSummary" xml:space="preserve">
+    <value>Could not complete structural comparison.</value>
+  </data>
+  <data name="AreNotEquivalentComparisonFailedSummaryStrict" xml:space="preserve">
+    <value>Could not complete structural comparison (strict mode).</value>
+  </data>
   <data name="AreEquivalentRootPath" xml:space="preserve">
     <value>&lt;root&gt;</value>
     <comment>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</comment>
@@ -206,6 +212,9 @@
   <data name="AreEquivalentMismatchTopology" xml:space="preserve">
     <value>graph topology differs (the same reference on one side appears paired with different references on the other side).</value>
   </data>
+  <data name="AreEquivalentMismatchMaxDepth" xml:space="preserve">
+    <value>comparison exceeded the maximum supported depth of {0}.</value>
+  </data>
   <data name="AreEquivalentMismatchIEquatableThrew" xml:space="preserve">
     <value>IEquatable.Equals threw {0}: {1}.</value>
   </data>
@@ -214,6 +223,12 @@
   </data>
   <data name="AreEquivalentMismatchActualDictionaryThrew" xml:space="preserve">
     <value>reading the actual dictionary threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchExpectedEnumerationThrew" xml:space="preserve">
+    <value>enumerating the expected collection threw {0}: {1}.</value>
+  </data>
+  <data name="AreEquivalentMismatchActualEnumerationThrew" xml:space="preserve">
+    <value>enumerating the actual collection threw {0}: {1}.</value>
   </data>
   <data name="AreEquivalentMismatchExpectedMemberThrew" xml:space="preserve">
     <value>reading the expected member threw {0}: {1}.</value>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Očekáván rozdíl, který je větší jak &lt;{3}&gt; mezi očekávanou hodnotou &lt;{1}&gt; a aktuální hodnotou &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Očekávaná délka řetězce je {0}, ale byla {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Nebyla očekávána žádná hodnota kromě:&lt;{1}&gt;. Aktuálně:&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Očekáván rozdíl, který je větší jak &lt;{3}&gt; mezi očekávanou hodnotou &lt;{1}&gt; a aktuální hodnotou &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Es wurde eine Differenz größer als &lt;{3}&gt; zwischen dem erwarteten Wert &lt;{1}&gt; und dem tatsächlichen Wert &lt;{2}&gt; erwartet. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Die erwartete Länge der Zeichenfolge ist {0}, war aber {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Es wurde ein beliebiger Wert erwartet außer:&lt;{1}&gt;. Tatsächlich:&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Es wurde eine Differenz größer als &lt;{3}&gt; zwischen dem erwarteten Wert &lt;{1}&gt; und dem tatsächlichen Wert &lt;{2}&gt; erwartet. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Se esperaba una diferencia mayor que &lt;{3}&gt; entre el valor esperado &lt;{1}&gt; y el valor actual &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Se esperaba una longitud de cadena {0} pero fue {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Se esperaba cualquier valor excepto &lt;{1}&gt;, pero es &lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Se esperaba una diferencia mayor que &lt;{3}&gt; entre el valor esperado &lt;{1}&gt; y el valor actual &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -68,6 +68,96 @@
         <target state="translated">La longueur de chaîne attendue {0} mais était {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Toute valeur attendue sauf :&lt;{1}&gt;. Réel :&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Différence attendue supérieure à &lt;{3}&gt; comprise entre la valeur attendue &lt;{1}&gt; et la valeur réelle &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Différence attendue supérieure à &lt;{3}&gt; comprise entre la valeur attendue &lt;{1}&gt; et la valeur réelle &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -68,6 +68,96 @@
         <target state="translated">La lunghezza della stringa prevista è {0} ma era {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Previsto qualsiasi valore tranne:&lt;{1}&gt;. Effettivo:&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Prevista una differenza maggiore di &lt;{3}&gt; tra il valore previsto &lt;{1}&gt; e il valore effettivo &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Prevista una differenza maggiore di &lt;{3}&gt; tra il valore previsto &lt;{1}&gt; e il valore effettivo &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">指定する値 &lt;{1}&gt; と実際の値 &lt;{2}&gt; との間には、&lt;{3}&gt; を超える差が必要です。{0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -68,6 +68,96 @@
         <target state="translated">期待される文字列の長さは {0} ですが、実際は {1} でした。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">&lt;{1}&gt; 以外の任意の値が必要ですが、&lt;{2}&gt; が指定されています。{0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">指定する値 &lt;{1}&gt; と実際の値 &lt;{2}&gt; との間には、&lt;{3}&gt; を超える差が必要です。{0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -68,6 +68,96 @@
         <target state="translated">문자열 길이 {0}(을)를 예상했지만 {1}입니다.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">예상 값: &lt;{1}&gt;을(를) 제외한 모든 값. 실제 값: &lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">예상 값 &lt;{1}&gt;과(와) 실제 값 &lt;{2}&gt;의 차이가 &lt;{3}&gt;보다 커야 합니다. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">예상 값 &lt;{1}&gt;과(와) 실제 값 &lt;{2}&gt;의 차이가 &lt;{3}&gt;보다 커야 합니다. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Oczekiwano ciągu o długości {0}, ale miał wartość {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Oczekiwano dowolnej wartości za wyjątkiem:&lt;{1}&gt;. Rzeczywista:&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Oczekiwano różnicy większej niż &lt;{3}&gt; pomiędzy oczekiwaną wartością &lt;{1}&gt; a rzeczywistą wartością &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Oczekiwano różnicy większej niż &lt;{3}&gt; pomiędzy oczekiwaną wartością &lt;{1}&gt; a rzeczywistą wartością &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Comprimento esperado da cadeia de caracteres {0}, mas foi {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Esperado qualquer valor exceto:&lt;{1}&gt;. Real:&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Esperada uma diferença maior que &lt;{3}&gt; entre o valor esperado &lt;{1}&gt; e o valor real &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Esperada uma diferença maior que &lt;{3}&gt; entre o valor esperado &lt;{1}&gt; e o valor real &lt;{2}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Ожидалась длина строки: {0}, фактическая длина строки: {1}.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Ожидается любое значение, кроме: &lt;{1}&gt;. Фактически: &lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Между ожидаемым значением &lt;{1}&gt; и фактическим значением &lt;{2}&gt; требуется разница более чем &lt;{3}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Между ожидаемым значением &lt;{1}&gt; и фактическим значением &lt;{2}&gt; требуется разница более чем &lt;{3}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Beklenen değer &lt;{1}&gt; ile gerçek değer &lt;{2}&gt; arasında, şundan büyük olan fark bekleniyor: &lt;{3}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -68,6 +68,96 @@
         <target state="translated">Beklenen dize uzunluğu {0} idi, ancak dize uzunluğu {1} oldu.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Şunun dışında bir değer bekleniyor:&lt;{1}&gt;. Gerçek:&lt;{2}&gt;. {0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">Beklenen değer &lt;{1}&gt; ile gerçek değer &lt;{2}&gt; arasında, şundan büyük olan fark bekleniyor: &lt;{3}&gt;. {0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -68,6 +68,96 @@
         <target state="translated">字符串长度应为 {0}，但为 {1}。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">应为: &lt;{1}&gt; 以外的任意值，实际为: &lt;{2}&gt;。{0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">预期值 &lt;{1}&gt; 和实际值 &lt;{2}&gt; 之间的差应大于 &lt;{3}&gt;。{0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">预期值 &lt;{1}&gt; 和实际值 &lt;{2}&gt; 之间的差应大于 &lt;{3}&gt;。{0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -194,13 +194,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
-        <source>Expected values to NOT be structurally equivalent.</source>
-        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <source>Expected values to be structurally different.</source>
+        <target state="new">Expected values to be structurally different.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummaryStrict">
-        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
-        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <source>Expected values to be structurally different (strict mode).</source>
+        <target state="new">Expected values to be structurally different (strict mode).</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -83,6 +83,11 @@
         <target state="new">reading the actual dictionary threw {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualEnumerationThrew">
+        <source>enumerating the actual collection threw {0}: {1}.</source>
+        <target state="new">enumerating the actual collection threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEquivalentMismatchActualMemberThrew">
         <source>reading the actual member threw {0}: {1}.</source>
         <target state="new">reading the actual member threw {0}: {1}.</target>
@@ -96,6 +101,11 @@
       <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
         <source>reading the expected dictionary threw {0}: {1}.</source>
         <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedEnumerationThrew">
+        <source>enumerating the expected collection threw {0}: {1}.</source>
+        <target state="new">enumerating the expected collection threw {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
@@ -116,6 +126,11 @@
       <trans-unit id="AreEquivalentMismatchLength">
         <source>collections differ in length (expected {0} elements, actual {1}).</source>
         <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMaxDepth">
+        <source>comparison exceeded the maximum supported depth of {0}.</source>
+        <target state="new">comparison exceeded the maximum supported depth of {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEquivalentMismatchMissingKey">
@@ -167,6 +182,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">預期值 &lt;{1}&gt; 和實際值 &lt;{2}&gt; 之間的預期差異大於 &lt;{3}&gt;。{0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummary">
+        <source>Could not complete structural comparison.</source>
+        <target state="new">Could not complete structural comparison.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentComparisonFailedSummaryStrict">
+        <source>Could not complete structural comparison (strict mode).</source>
+        <target state="new">Could not complete structural comparison (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentFailedSummary">
         <source>Expected values to NOT be structurally equivalent.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -68,6 +68,96 @@
         <target state="translated">預期的字串長度為 {0}，但為 {1}。</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummary">
+        <source>Expected values to be structurally equivalent.</source>
+        <target state="new">Expected values to be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentFailedSummaryStrict">
+        <source>Expected values to be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to be structurally equivalent (strict mode).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualDictionaryThrew">
+        <source>reading the actual dictionary threw {0}: {1}.</source>
+        <target state="new">reading the actual dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchActualMemberThrew">
+        <source>reading the actual member threw {0}: {1}.</source>
+        <target state="new">reading the actual member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchAt">
+        <source>Mismatch at '{0}': {1}</source>
+        <target state="new">Mismatch at '{0}': {1}</target>
+        <note>{0} is a member path (e.g., 'Order.Items[2].Price'), {1} is a localized reason describing the kind of mismatch.</note>
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedDictionaryThrew">
+        <source>reading the expected dictionary threw {0}: {1}.</source>
+        <target state="new">reading the expected dictionary threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExpectedMemberThrew">
+        <source>reading the expected member threw {0}: {1}.</source>
+        <target state="new">reading the expected member threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchExtraMembers">
+        <source>actual has unexpected members not present on expected: {0}.</source>
+        <target state="new">actual has unexpected members not present on expected: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchIEquatableThrew">
+        <source>IEquatable.Equals threw {0}: {1}.</source>
+        <target state="new">IEquatable.Equals threw {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchLength">
+        <source>collections differ in length (expected {0} elements, actual {1}).</source>
+        <target state="new">collections differ in length (expected {0} elements, actual {1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingKey">
+        <source>key {0} present on expected is missing from actual.</source>
+        <target state="new">key {0} present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchMissingMember">
+        <source>member '{0}' present on expected is missing from actual.</source>
+        <target state="new">member '{0}' present on expected is missing from actual.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchNull">
+        <source>one side is null, the other is not.</source>
+        <target state="new">one side is null, the other is not.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchTopology">
+        <source>graph topology differs (the same reference on one side appears paired with different references on the other side).</source>
+        <target state="new">graph topology differs (the same reference on one side appears paired with different references on the other side).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchType">
+        <source>incompatible types (expected '{0}', actual '{1}').</source>
+        <target state="new">incompatible types (expected '{0}', actual '{1}').</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchUnexpectedKey">
+        <source>key {0} present on actual is not on expected.</source>
+        <target state="new">key {0} present on actual is not on expected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentMismatchValue">
+        <source>values are not equal.</source>
+        <target state="new">values are not equal.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEquivalentRootPath">
+        <source>&lt;root&gt;</source>
+        <target state="new">&lt;root&gt;</target>
+        <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">預期任何值 (&lt;{1}&gt; 除外)。實際: &lt;{2}&gt;。{0}</target>
@@ -77,6 +167,16 @@
         <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
         <target state="translated">預期值 &lt;{1}&gt; 和實際值 &lt;{2}&gt; 之間的預期差異大於 &lt;{3}&gt;。{0}</target>
         <note></note>
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummary">
+        <source>Expected values to NOT be structurally equivalent.</source>
+        <target state="new">Expected values to NOT be structurally equivalent.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEquivalentFailedSummaryStrict">
+        <source>Expected values to NOT be structurally equivalent (strict mode).</source>
+        <target state="new">Expected values to NOT be structurally equivalent (strict mode).</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotSameBothNull">
         <source>Both values are &lt;null&gt;. {0}</source>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -43,6 +43,22 @@ public partial class AssertTests : TestContainer
         Assert.AreEquivalent('z', 'z');
     }
 
+    public void AreEquivalent_BoxedTypeValues_UseTypeEquality()
+    {
+        object expected = typeof(string);
+        object actual = typeof(string);
+        Assert.AreEquivalent(expected, actual);
+    }
+
+    public void AreEquivalent_BoxedPrimitiveLikeAndReferenceType_FailsWithTypeMismatch()
+    {
+        object expected = 42;
+        object actual = new Person("Ada", 36);
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("incompatible types");
+    }
+
     public void AreEquivalent_DifferentInts_Fails()
     {
         Action act = () => Assert.AreEquivalent(1, 2);
@@ -231,6 +247,16 @@ public partial class AssertTests : TestContainer
             .And.Message.Should().Contain("Mismatch at '[42]'");
     }
 
+    public void AreEquivalent_Dictionary_KeyPath_UsesRenderedValue()
+    {
+        string key = "line1\nline2";
+        var a = new Dictionary<string, int> { [key] = 1 };
+        var b = new Dictionary<string, int> { [key] = 2 };
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Mismatch at '[\"line1\\nline2\"]'");
+    }
+
     public void AreEquivalent_Dictionary_CaseInsensitiveComparer_RespectsSourceComparer()
     {
         // The source dictionaries use OrdinalIgnoreCase. The comparer must defer to the source's
@@ -339,6 +365,15 @@ public partial class AssertTests : TestContainer
             .And.Message.Should().Contain("reading the actual dictionary threw").And.Contain("InvalidOperationException");
     }
 
+    public void AreEquivalent_EnumerableThrows_FailsWithExpectedDiagnostic()
+    {
+        IEnumerable<int> expected = [1];
+        IEnumerable<int> actual = new ThrowingEnumerable();
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("enumerating the actual collection threw").And.Contain("InvalidOperationException");
+    }
+
     public void AreEquivalent_ReadOnlyDictionaryOnly_RespectsSourceComparer()
     {
         // Custom IReadOnlyDictionary<,>-only type backed by a case-insensitive Dictionary should
@@ -394,6 +429,15 @@ public partial class AssertTests : TestContainer
         EquatableMoney b = new(100m, "EUR");
         Action act = () => Assert.AreNotEquivalent(a, b);
         act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreNotEquivalent_IEquatableThrows_FailsWithComparisonFailure()
+    {
+        ThrowingEquatable a = new();
+        ThrowingEquatable b = new();
+        Action act = () => Assert.AreNotEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Could not complete structural comparison").And.Contain("IEquatable").And.Contain("InvalidOperationException");
     }
 
     public void AreNotEquivalent_CallSiteExpression_IsRendered()
@@ -460,6 +504,15 @@ public partial class AssertTests : TestContainer
         a.Next = b;
         b.Next = a;
         Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_DeepGraph_ReportsMaxDepthExceeded()
+    {
+        DeepNode expected = CreateDeepNodeChain(300);
+        DeepNode actual = CreateDeepNodeChain(300);
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("maximum supported depth of 256");
     }
 
     #endregion
@@ -569,6 +622,19 @@ public partial class AssertTests : TestContainer
             .And.Message.Should().Contain("Assert.AreEquivalent(x, y)");
     }
 
+    public void AreEquivalent_FailureMessage_FollowsRfc012Layout()
+    {
+        int expected = 1;
+        int actual = 2;
+        Action act = () => Assert.AreEquivalent(expected, actual, "numbers should match");
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().StartWith("Assertion failed. Expected values to be structurally equivalent.");
+        ex.Message.Should().Contain($"{Environment.NewLine}Mismatch at '<root>': values are not equal.");
+        ex.Message.Should().Contain($"{Environment.NewLine}numbers should match");
+        ex.Message.Should().Contain($"{Environment.NewLine}{Environment.NewLine}expected: 1{Environment.NewLine}actual:   2");
+        ex.Message.Should().Contain($"{Environment.NewLine}{Environment.NewLine}Assert.AreEquivalent(expected, actual)");
+    }
+
     #endregion
 
     #region AreNotEquivalent
@@ -610,6 +676,19 @@ public partial class AssertTests : TestContainer
     #endregion
 
     #region Test helpers
+
+    private static DeepNode CreateDeepNodeChain(int length)
+    {
+        DeepNode root = new();
+        DeepNode current = root;
+        for (int i = 1; i < length; i++)
+        {
+            current.Next = new DeepNode();
+            current = current.Next!;
+        }
+
+        return root;
+    }
 
     private sealed class Person
     {
@@ -728,6 +807,11 @@ public partial class AssertTests : TestContainer
         public string Label { get; }
 
         public Node? Next { get; set; }
+    }
+
+    private sealed class DeepNode
+    {
+        public DeepNode? Next { get; set; }
     }
 
     private sealed class NodeWithField
@@ -866,6 +950,13 @@ public partial class AssertTests : TestContainer
             get => throw new InvalidOperationException("actual side boom");
             set { }
         }
+    }
+
+    private sealed class ThrowingEnumerable : IEnumerable<int>
+    {
+        public IEnumerator<int> GetEnumerator() => throw new InvalidOperationException("enumeration boom");
+
+        IEnumerator IEnumerable.GetEnumerator() => throw new InvalidOperationException("enumeration boom");
     }
 
     private sealed class ThrowingDictionary : IDictionary<string, int>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -293,6 +293,20 @@ public partial class AssertTests : TestContainer
             .And.Message.Should().Contain("Mismatch at 'BadProperty'").And.Contain("InvalidOperationException");
     }
 
+    public void AreEquivalent_MemberGetterCallsAssertFail_PropagatesAsAssertFailedException()
+    {
+        // A property getter that calls Assert.Fail() throws AssertFailedException wrapped in a
+        // TargetInvocationException by Reflection. The equivalence comparer must NOT rewrite the
+        // framework exception as a structured "comparison failure" — it must propagate so the user's
+        // assertion surfaces with its original message.
+        AssertFailingGetter a = new();
+        AssertFailingGetter b = new();
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*nested-assert-fail*")
+            .And.Message.Should().NotContain("Mismatch at");
+    }
+
     public void AreEquivalent_IEquatableThrows_FailsWithExpectedDiagnostic()
     {
         ThrowingEquatable a = new();
@@ -714,6 +728,10 @@ public partial class AssertTests : TestContainer
 
     public void AreEquivalent_NewShadowedProperty_UsesMostDerivedDeclaration()
     {
+        // The derived class shadows the base `int Value` with `string Value`.
+        // If the comparer ever picked the base accessor, it would compare base.Value (always 0 on both
+        // sides) and silently pass — masking the genuine derived-value mismatch. The expected outcome
+        // is a failure that mentions the derived string values.
         var expected = new ShadowedDerived { Value = "derived-expected" };
         var actual = new ShadowedDerived { Value = "derived-actual" };
 
@@ -722,15 +740,18 @@ public partial class AssertTests : TestContainer
             .WithMessage("*Value*derived-expected*derived-actual*");
     }
 
-    public void AreEquivalent_NewShadowedProperty_EquivalentDerivedValues_Passes()
+    public void AreEquivalent_NewShadowedProperty_SameType_DetectsDerivedMismatch()
     {
-        var expected = new ShadowedDerived { Value = "same" };
-        var actual = new ShadowedDerived { Value = "same" };
+        // Same-type `new` shadowing (int → int with different defaults). If the comparer picked the
+        // base accessor, both sides would resolve to the base default (100) and the mismatch on the
+        // derived value (200 vs 999) would be silently swallowed. The expected outcome is a failure
+        // that mentions the derived integers.
+        var expected = new SameTypeShadowDerived { Value = 200 };
+        var actual = new SameTypeShadowDerived { Value = 999 };
 
-        // The base sets BaseValueAsString = "base"; the derived `new` Value shadows it as a string.
-        // If the comparer ever picked the base accessor for one side, the comparison would compare
-        // the string "base" against the derived `Value` and fail.
-        Assert.AreEquivalent(expected, actual);
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*Value*200*999*");
     }
 
     private class ShadowedBase
@@ -741,6 +762,16 @@ public partial class AssertTests : TestContainer
     private sealed class ShadowedDerived : ShadowedBase
     {
         public new string Value { get; set; } = "default";
+    }
+
+    private class SameTypeShadowBase
+    {
+        public int Value { get; set; } = 100;
+    }
+
+    private sealed class SameTypeShadowDerived : SameTypeShadowBase
+    {
+        public new int Value { get; set; } = 200;
     }
 
     private sealed class Person
@@ -911,6 +942,18 @@ public partial class AssertTests : TestContainer
     private sealed class ThrowingGetter
     {
         public string BadProperty => throw new InvalidOperationException("nope");
+    }
+
+    private sealed class AssertFailingGetter
+    {
+        public string Value
+        {
+            get
+            {
+                Assert.Fail("nested-assert-fail");
+                return string.Empty;
+            }
+        }
     }
 
     private sealed class ThrowingEquatable : IEquatable<ThrowingEquatable>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -1,0 +1,914 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+using TestFramework.ForTestingMSTest;
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
+
+public partial class AssertTests : TestContainer
+{
+    #region AreEquivalent — primitives, nulls, strings
+
+    public void AreEquivalent_BothNull_Passes()
+        => Assert.AreEquivalent<object>(null, null);
+
+    public void AreEquivalent_SameReference_Passes()
+    {
+        var o = new Person("a", 1);
+        Assert.AreEquivalent(o, o);
+    }
+
+    public void AreEquivalent_ExpectedNull_ActualNotNull_Fails()
+    {
+        Action act = () => Assert.AreEquivalent<object?>(null, new object());
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*structurally equivalent*one side is null*");
+    }
+
+    public void AreEquivalent_ExpectedNotNull_ActualNull_Fails()
+    {
+        Action act = () => Assert.AreEquivalent<object?>(new object(), null);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*one side is null*");
+    }
+
+    public void AreEquivalent_EqualPrimitives_Passes()
+    {
+        Assert.AreEquivalent(42, 42);
+        Assert.AreEquivalent("abc", "abc");
+        Assert.AreEquivalent(3.14, 3.14);
+        Assert.AreEquivalent(true, true);
+        Assert.AreEquivalent('z', 'z');
+    }
+
+    public void AreEquivalent_DifferentInts_Fails()
+    {
+        Action act = () => Assert.AreEquivalent(1, 2);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Mismatch at '<root>'");
+        ex.Message.Should().Contain("values are not equal");
+        ex.ExpectedText.Should().Be("1");
+        ex.ActualText.Should().Be("2");
+    }
+
+    public void AreEquivalent_Strings_DifferentValues_Fails()
+    {
+        Action act = () => Assert.AreEquivalent("foo", "bar");
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("values are not equal");
+        ex.ExpectedText.Should().Be("\"foo\"");
+        ex.ActualText.Should().Be("\"bar\"");
+    }
+
+    public void AreEquivalent_Enums_Equal_Passes()
+        => Assert.AreEquivalent(DayOfWeek.Tuesday, DayOfWeek.Tuesday);
+
+    public void AreEquivalent_Enums_Different_Fails()
+    {
+        Action act = () => Assert.AreEquivalent(DayOfWeek.Monday, DayOfWeek.Tuesday);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreEquivalent_DateTime_Equal_Passes()
+        => Assert.AreEquivalent(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc), new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+
+    public void AreEquivalent_Guid_Different_Fails()
+    {
+        Action act = () => Assert.AreEquivalent(Guid.Parse("11111111-1111-1111-1111-111111111111"), Guid.Parse("22222222-2222-2222-2222-222222222222"));
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    #endregion
+
+    #region AreEquivalent — POCOs
+
+    public void AreEquivalent_IdenticalPocos_Passes()
+        => Assert.AreEquivalent(new Person("Ada", 36), new Person("Ada", 36));
+
+    public void AreEquivalent_PocoWithDifferentField_Fails()
+    {
+        Action act = () => Assert.AreEquivalent(new Person("Ada", 36), new Person("Ada", 37));
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Mismatch at 'Age'");
+        ex.ExpectedText.Should().Be("36");
+        ex.ActualText.Should().Be("37");
+    }
+
+    public void AreEquivalent_NestedPoco_DeepDifference_ReportedWithDottedPath()
+    {
+        Order expected = new("o-1", new Address("street1", "city1"));
+        Order actual = new("o-1", new Address("street1", "different-city"));
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Mismatch at 'ShippingAddress.City'");
+        ex.ExpectedText.Should().Be("\"city1\"");
+        ex.ActualText.Should().Be("\"different-city\"");
+    }
+
+    public void AreEquivalent_PublicFieldsAreCompared()
+    {
+        WithPublicField a = new() { Number = 1 };
+        WithPublicField b = new() { Number = 2 };
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*Mismatch at 'Number'*");
+    }
+
+    public void AreEquivalent_AnonymousTypes_SameShape_Passes()
+        => Assert.AreEquivalent(new { Name = "Ada", Age = 36 }, new { Name = "Ada", Age = 36 });
+
+    public void AreEquivalent_PrivateFieldsAreIgnored()
+    {
+        WithPrivateField a = new(privateValue: "secret-1", publicValue: 1);
+        WithPrivateField b = new(privateValue: "secret-2", publicValue: 1);
+        Assert.AreEquivalent(a, b);
+    }
+
+    #endregion
+
+    #region AreEquivalent — collections
+
+    public void AreEquivalent_EqualLists_Passes()
+        => Assert.AreEquivalent<List<int>>([1, 2, 3], [1, 2, 3]);
+
+    public void AreEquivalent_Lists_DifferentLengths_Fails()
+    {
+        Action act = () => Assert.AreEquivalent<List<int>>([1, 2, 3], [1, 2]);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*Mismatch at '<root>'*collections differ in length*expected 3*actual 2*");
+    }
+
+    public void AreEquivalent_Lists_DifferentElement_ReportsIndex()
+    {
+        Action act = () => Assert.AreEquivalent<int[]>([10, 20, 30], [10, 25, 30]);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Mismatch at '[1]'");
+        ex.ExpectedText.Should().Be("20");
+        ex.ActualText.Should().Be("25");
+    }
+
+    public void AreEquivalent_OrderSensitive_Fails()
+    {
+        Action act = () => Assert.AreEquivalent<int[]>([1, 2], [2, 1]);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*Mismatch at '[0]'*");
+    }
+
+    public void AreEquivalent_NestedCollectionInsidePoco()
+    {
+        Order expected = new("o", new Address("s", "c")) { Items = { 1, 2, 3 } };
+        Order actual = new("o", new Address("s", "c")) { Items = { 1, 999, 3 } };
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Mismatch at 'Items[1]'");
+        ex.ExpectedText.Should().Be("2");
+        ex.ActualText.Should().Be("999");
+    }
+
+    #endregion
+
+    #region AreEquivalent — dictionaries
+
+    public void AreEquivalent_EqualDictionaries_Passes()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var b = new Dictionary<string, int> { ["b"] = 2, ["a"] = 1 };
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_Dictionary_MissingKey_Fails()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var b = new Dictionary<string, int> { ["a"] = 1 };
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("key \"b\"").And.Contain("missing from actual");
+    }
+
+    public void AreEquivalent_Dictionary_DifferentValue_Fails()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        var b = new Dictionary<string, int> { ["a"] = 2 };
+        Action act = () => Assert.AreEquivalent(a, b);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Mismatch at '[\"a\"]'");
+        ex.ExpectedText.Should().Be("1");
+        ex.ActualText.Should().Be("2");
+    }
+
+    public void AreEquivalent_Dictionary_ExtraKeyOnActual_NonStrict_Passes()
+    {
+        // Non-strict mode (default): extra keys on actual are tolerated.
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        var b = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_Dictionary_ExtraKeyOnActual_Strict_Fails()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        var b = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        Action act = () => Assert.AreEquivalent(a, b, strict: true);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("key \"b\"").And.Contain("not on expected");
+    }
+
+    public void AreEquivalent_Dictionary_NonStringKey_Equal_Passes()
+    {
+        var a = new Dictionary<int, string> { [1] = "one", [2] = "two" };
+        var b = new Dictionary<int, string> { [2] = "two", [1] = "one" };
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_Dictionary_NonStringKey_DifferentValue_FailsWithKeyInPath()
+    {
+        var a = new Dictionary<int, string> { [42] = "x" };
+        var b = new Dictionary<int, string> { [42] = "y" };
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Mismatch at '[42]'");
+    }
+
+    public void AreEquivalent_Dictionary_CaseInsensitiveComparer_RespectsSourceComparer()
+    {
+        // The source dictionaries use OrdinalIgnoreCase. The comparer must defer to the source's
+        // own key lookup so "Hello" == "hello" is honored.
+        var a = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["Hello"] = 1 };
+        var b = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["hello"] = 1 };
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_ReadOnlyDictionaryOnlyType_TreatedAsDictionary()
+    {
+        ReadOnlyDictionaryOnly<string, int> a = new() { ["a"] = 1, ["b"] = 2 };
+        ReadOnlyDictionaryOnly<string, int> b = new() { ["b"] = 2, ["a"] = 1 };
+        // Both implement only IReadOnlyDictionary<,> (not IDictionary<,>); should be detected as a
+        // dictionary and compared by key set, not as an ordered KeyValuePair sequence.
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_MixedDictionaryAndNonDictionary_TypeMismatch()
+    {
+        var dict = new Dictionary<string, int> { ["a"] = 1 };
+        var list = new List<KeyValuePair<string, int>> { new("a", 1) };
+        Action act = () => Assert.AreEquivalent<object>(dict, list);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("incompatible types");
+    }
+
+    public void AreEquivalent_MemberGetterThrows_FailsWithExpectedDiagnostic()
+    {
+        ThrowingGetter a = new();
+        ThrowingGetter b = new();
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Mismatch at 'BadProperty'").And.Contain("InvalidOperationException");
+    }
+
+    public void AreEquivalent_IEquatableThrows_FailsWithExpectedDiagnostic()
+    {
+        ThrowingEquatable a = new();
+        ThrowingEquatable b = new();
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("IEquatable").And.Contain("InvalidOperationException");
+    }
+
+    public void AreEquivalent_Strict_MultipleExtraMembers_RenderedSortedAndCommaSeparated()
+    {
+        Person expected = new("Ada", 36);
+        PersonWithMultipleExtras actual = new("Ada", 36, "ada@example.com", "+44");
+        Action act = () => Assert.AreEquivalent<object>(expected, actual, strict: true);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        // Extras (Email, Phone) are sorted alphabetically by Ordinal comparer, comma-separated.
+        ex.Message.Should().Contain("Email, Phone");
+    }
+
+    public void AreEquivalent_TopologyMismatch_SharedSubobjectVsDistinctCopies()
+    {
+        // expected: A → shared → both A.Other and A.OtherAlso point to the *same* node.
+        SharedHolder shared = new() { Value = "x" };
+        TopologyHolder expectedRoot = new() { Other = shared, OtherAlso = shared };
+        // actual: two distinct nodes that compare equal field-by-field.
+        TopologyHolder actualRoot = new() { Other = new() { Value = "x" }, OtherAlso = new() { Value = "x" } };
+
+        Action act = () => Assert.AreEquivalent(expectedRoot, actualRoot);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("graph topology differs");
+    }
+
+    public void AreEquivalent_ValueTypeFieldsInSharedAndDistinctPositions_NoFalseTopologyFailure()
+    {
+        // Value types skip topology tracking, so an int (or struct) appearing in two field positions
+        // on expected vs two distinct copies on actual must still compare as equivalent.
+        TwoIntsHolder expected = new() { First = 7, Second = 7 };
+        TwoIntsHolder actual = new() { First = 7, Second = 7 };
+        Assert.AreEquivalent(expected, actual);
+    }
+
+    public void AreEquivalent_ValueTypeIEquatableThrows_FailsWithExpectedDiagnostic()
+    {
+        // Boxing a struct that throws from IEquatable<T> must still be caught and surfaced as a
+        // structured failure, not propagated.
+        ThrowingEquatableStruct a = default;
+        ThrowingEquatableStruct b = default;
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("IEquatable").And.Contain("InvalidOperationException");
+    }
+
+    public void AreEquivalent_OnlyActualGetterThrows_FailsWithActualSideDiagnostic()
+    {
+        // Only the actual side throws (expected uses the safe base type). Exercises the
+        // isExpected: false branch of MemberAccessFailure.
+        SafeGetter expected = new() { Value = 1 };
+        ActualThrowingGetter actual = new();
+        Action act = () => Assert.AreEquivalent<SafeGetter>(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Mismatch at 'Value'").And.Contain("reading the actual member threw");
+    }
+
+    public void AreEquivalent_DictionaryThrowsFromTryGetValue_FailsWithExpectedDiagnostic()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        ThrowingDictionary actual = new();
+        Action act = () => Assert.AreEquivalent<IDictionary<string, int>>(a, actual);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("reading the actual dictionary threw").And.Contain("InvalidOperationException");
+    }
+
+    public void AreEquivalent_ReadOnlyDictionaryOnly_RespectsSourceComparer()
+    {
+        // Custom IReadOnlyDictionary<,>-only type backed by a case-insensitive Dictionary should
+        // honor the source's comparer through GenericDictionaryAccessors.TryGetValue.
+        var a = ReadOnlyDictionaryOnly<string, int>.CaseInsensitive();
+        var b = ReadOnlyDictionaryOnly<string, int>.CaseInsensitive();
+        a["Hello"] = 1;
+        b["hello"] = 1;
+        Assert.AreEquivalent(a, b);
+    }
+
+    #endregion
+
+    #region AreNotEquivalent — broader mirroring
+
+    public void AreNotEquivalent_DifferentLists_Passes()
+        => Assert.AreNotEquivalent<int[]>([1, 2, 3], [1, 2, 4]);
+
+    public void AreNotEquivalent_EqualLists_Fails()
+    {
+        Action act = () => Assert.AreNotEquivalent<int[]>([1, 2, 3], [1, 2, 3]);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreNotEquivalent_DifferentDictionaries_Passes()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        var b = new Dictionary<string, int> { ["a"] = 2 };
+        Assert.AreNotEquivalent(a, b);
+    }
+
+    public void AreNotEquivalent_EqualDictionaries_Fails()
+    {
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        var b = new Dictionary<string, int> { ["a"] = 1 };
+        Action act = () => Assert.AreNotEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreNotEquivalent_TopologicallyIdenticalCycles_Fails()
+    {
+        Node a = new("v");
+        a.Next = a;
+        Node b = new("v");
+        b.Next = b;
+        Action act = () => Assert.AreNotEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreNotEquivalent_IEquatableSemantics_Fails()
+    {
+        EquatableMoney a = new(100m, "USD");
+        EquatableMoney b = new(100m, "EUR");
+        Action act = () => Assert.AreNotEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreNotEquivalent_CallSiteExpression_IsRendered()
+    {
+        int x = 1;
+        int y = 1;
+        Action act = () => Assert.AreNotEquivalent(x, y);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Assert.AreNotEquivalent(x, y)");
+    }
+
+    #endregion
+
+    #region AreEquivalent — IEquatable shortcut
+
+    public void AreEquivalent_IEquatableType_UsesEquals_NotMembers()
+    {
+        // EquatableMoney has IEquatable<EquatableMoney> that ignores Currency.
+        // So 100 USD vs 100 EUR are considered equivalent by IEquatable.
+        EquatableMoney a = new(100m, "USD");
+        EquatableMoney b = new(100m, "EUR");
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_IEquatableType_DifferentValues_Fails()
+    {
+        EquatableMoney a = new(100m, "USD");
+        EquatableMoney b = new(200m, "USD");
+        Action act = () => Assert.AreEquivalent(a, b);
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        // IEquatableOutcome.NotEqual must surface the rendered values via the structured failure.
+        ex.ExpectedText.Should().NotBeNull();
+        ex.ActualText.Should().NotBeNull();
+    }
+
+    public void AreEquivalent_PlainEqualsOverride_DoesNotShortCircuit_RecursesIntoMembers()
+    {
+        // OnlyEqualsOverride.Equals always returns true, but we should ignore that override
+        // and recurse into the Value property, which differs.
+        OnlyEqualsOverride a = new(1);
+        OnlyEqualsOverride b = new(2);
+        Action act = () => Assert.AreEquivalent(a, b);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*Mismatch at 'Value'*");
+    }
+
+    #endregion
+
+    #region AreEquivalent — cycles
+
+    public void AreEquivalent_Cycles_DoNotStackOverflow()
+    {
+        Node a = new("x");
+        a.Next = a;
+        Node b = new("x");
+        b.Next = b;
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_CrossCycles_Detected_Pass()
+    {
+        Node a = new("v");
+        Node b = new("v");
+        a.Next = b;
+        b.Next = a;
+        Assert.AreEquivalent(a, b);
+    }
+
+    #endregion
+
+    #region AreEquivalent — strict mode
+
+    public void AreEquivalent_Strict_DifferentRuntimeTypes_ExtraMemberOnActual_Fails()
+    {
+        Person expected = new("Ada", 36);
+        PersonWithEmail actual = new("Ada", 36, "ada@example.com");
+        // Non-strict: passes (Email is ignored).
+        Assert.AreEquivalent<object>(expected, actual);
+
+        // Strict: fails because actual has extra member 'Email'.
+        Action act = () => Assert.AreEquivalent<object>(expected, actual, strict: true);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*structurally equivalent (strict mode)*Email*");
+    }
+
+    public void AreEquivalent_Strict_SameRuntimeType_NotAffected()
+        => Assert.AreEquivalent(new Person("Ada", 36), new Person("Ada", 36), strict: true);
+
+    public void AreEquivalent_Strict_Dictionary_ExtraKey_Fails()
+    {
+        // Strict: still fails the same way.
+        var a = new Dictionary<string, int> { ["a"] = 1 };
+        var b = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        Action act = () => Assert.AreEquivalent(a, b, strict: true);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreEquivalent_IEquatableElementInList_UsesIEquatable()
+    {
+        // List<EquatableMoney> recursion preserves the declared element type, so the IEquatable<EquatableMoney>
+        // shortcut applies per element. EUR vs USD differ via members but are equal via IEquatable.
+        var a = new List<EquatableMoney> { new(100m, "USD") };
+        var b = new List<EquatableMoney> { new(100m, "EUR") };
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_IEquatableElementInArray_UsesIEquatable()
+    {
+        EquatableMoney[] a = [new(50m, "USD")];
+        EquatableMoney[] b = [new(50m, "EUR")];
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_IEquatableValueInDictionary_UsesIEquatable()
+    {
+        var a = new Dictionary<string, EquatableMoney> { ["price"] = new(10m, "USD") };
+        var b = new Dictionary<string, EquatableMoney> { ["price"] = new(10m, "EUR") };
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_ExplicitIEquatableImpl_Honored()
+    {
+        // Even though the Equals(T) is implemented explicitly (not as a public concrete method),
+        // reflection-driven interface-method dispatch still finds it.
+        ExplicitEquatable a = new(1);
+        ExplicitEquatable b = new(2);
+        Assert.AreEquivalent(a, b);
+    }
+
+    public void AreEquivalent_TopologyMismatch_Detected()
+    {
+        // expected: a -> b -> a (two distinct nodes in a 2-cycle)
+        Node a = new("x");
+        Node b = new("x");
+        a.Next = b;
+        b.Next = a;
+
+        // actual: c -> c (single self-cycle)
+        Node c = new("x");
+        c.Next = c;
+
+        Action act = () => Assert.AreEquivalent(a, c);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("graph topology differs");
+    }
+
+    public void AreEquivalent_SelfCycleThroughField()
+    {
+        NodeWithField a = new() { Label = "x" };
+        a.Next = a;
+        NodeWithField b = new() { Label = "x" };
+        b.Next = b;
+        Assert.AreEquivalent(a, b);
+    }
+
+    #endregion
+
+    #region AreEquivalent — user message and call-site expression
+
+    public void AreEquivalent_UserMessage_IsIncluded()
+    {
+        Action act = () => Assert.AreEquivalent(1, 2, "boom");
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("boom");
+    }
+
+    public void AreEquivalent_CallSiteExpression_IsRendered()
+    {
+        int x = 1;
+        int y = 2;
+        Action act = () => Assert.AreEquivalent(x, y);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Assert.AreEquivalent(x, y)");
+    }
+
+    #endregion
+
+    #region AreNotEquivalent
+
+    public void AreNotEquivalent_DifferentValues_Passes()
+        => Assert.AreNotEquivalent(new Person("Ada", 36), new Person("Ada", 37));
+
+    public void AreNotEquivalent_EqualValues_Fails()
+    {
+        Action act = () => Assert.AreNotEquivalent(new Person("Ada", 36), new Person("Ada", 36));
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*NOT be structurally equivalent*");
+    }
+
+    public void AreNotEquivalent_BothNull_Fails()
+    {
+        Action act = () => Assert.AreNotEquivalent<object>(null, null);
+        act.Should().Throw<AssertFailedException>();
+    }
+
+    public void AreNotEquivalent_PlainEqualsOverride_StillRecurses_PassesOnDifferentValue()
+        => Assert.AreNotEquivalent(new OnlyEqualsOverride(1), new OnlyEqualsOverride(2));
+
+    public void AreNotEquivalent_StrictMode_ExtraMemberOnActual_Passes()
+    {
+        Person expected = new("Ada", 36);
+        PersonWithEmail actual = new("Ada", 36, "ada@example.com");
+        // Strict mode: extra member on actual makes them NOT equivalent → AreNotEquivalent passes.
+        Assert.AreNotEquivalent<object>(expected, actual, strict: true);
+    }
+
+    public void AreNotEquivalent_UserMessage_IsIncluded()
+    {
+        Action act = () => Assert.AreNotEquivalent(1, 1, "boom");
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("boom");
+    }
+
+    #endregion
+
+    #region Test helpers
+
+    private sealed class Person
+    {
+        public Person(string name, int age)
+        {
+            Name = name;
+            Age = age;
+        }
+
+        public string Name { get; }
+
+        public int Age { get; }
+    }
+
+    private sealed class PersonWithEmail
+    {
+        public PersonWithEmail(string name, int age, string email)
+        {
+            Name = name;
+            Age = age;
+            Email = email;
+        }
+
+        public string Name { get; }
+
+        public int Age { get; }
+
+        public string Email { get; }
+    }
+
+    private sealed class Address
+    {
+        public Address(string street, string city)
+        {
+            Street = street;
+            City = city;
+        }
+
+        public string Street { get; }
+
+        public string City { get; }
+    }
+
+    private sealed class Order
+    {
+        public Order(string id, Address shippingAddress)
+        {
+            Id = id;
+            ShippingAddress = shippingAddress;
+        }
+
+        public string Id { get; }
+
+        public Address ShippingAddress { get; }
+
+        public List<int> Items { get; } = [];
+    }
+
+    private sealed class WithPublicField
+    {
+#pragma warning disable SA1401 // Field should be private - intentional: this type tests public-field comparison.
+        public int Number;
+#pragma warning restore SA1401
+    }
+
+    private sealed class WithPrivateField
+    {
+#pragma warning disable IDE0052 // Remove unread private members - intentional for the test
+        private readonly string _privateValue;
+#pragma warning restore IDE0052
+
+        public WithPrivateField(string privateValue, int publicValue)
+        {
+            _privateValue = privateValue;
+            PublicValue = publicValue;
+        }
+
+        public int PublicValue { get; }
+    }
+
+    private sealed class EquatableMoney : IEquatable<EquatableMoney>
+    {
+        public EquatableMoney(decimal amount, string currency)
+        {
+            Amount = amount;
+            Currency = currency;
+        }
+
+        public decimal Amount { get; }
+
+        public string Currency { get; }
+
+        // Intentionally ignores Currency to demonstrate that IEquatable<T>.Equals takes precedence.
+        public bool Equals(EquatableMoney? other) => other is not null && other.Amount == Amount;
+
+        public override bool Equals(object? obj) => Equals(obj as EquatableMoney);
+
+        public override int GetHashCode() => Amount.GetHashCode();
+    }
+
+    private sealed class OnlyEqualsOverride
+    {
+        public OnlyEqualsOverride(int value) => Value = value;
+
+        public int Value { get; }
+
+        public override bool Equals(object? obj) => true;
+
+        public override int GetHashCode() => 0;
+    }
+
+    private sealed class Node
+    {
+        public Node(string label) => Label = label;
+
+        public string Label { get; }
+
+        public Node? Next { get; set; }
+    }
+
+    private sealed class NodeWithField
+    {
+#pragma warning disable SA1401 // Field should be private - intentional: this type tests public-field cycle handling.
+        public string? Label;
+        public NodeWithField? Next;
+#pragma warning restore SA1401
+    }
+
+    private sealed class ExplicitEquatable : IEquatable<ExplicitEquatable>
+    {
+#pragma warning disable IDE0052 // Remove unread private members - intentional: ensures the type is non-trivial without exposing public members.
+        private readonly int _value;
+#pragma warning restore IDE0052
+
+        public ExplicitEquatable(int value) => _value = value;
+
+        // Explicit interface implementation: Equals always returns true so we can detect that the
+        // comparer dispatched through IEquatable<T> rather than recursing into _value via reflection.
+        bool IEquatable<ExplicitEquatable>.Equals(ExplicitEquatable? other) => true;
+    }
+
+    private sealed class PersonWithMultipleExtras
+    {
+        public PersonWithMultipleExtras(string name, int age, string email, string phone)
+        {
+            Name = name;
+            Age = age;
+            Email = email;
+            Phone = phone;
+        }
+
+        public string Name { get; }
+
+        public int Age { get; }
+
+        // Out-of-order declarations to confirm extras are sorted alphabetically in the message.
+        public string Phone { get; }
+
+        public string Email { get; }
+    }
+
+    private sealed class ThrowingGetter
+    {
+        public string BadProperty => throw new InvalidOperationException("nope");
+    }
+
+    private sealed class ThrowingEquatable : IEquatable<ThrowingEquatable>
+    {
+        public bool Equals(ThrowingEquatable? other) => throw new InvalidOperationException("equality boom");
+
+        public override bool Equals(object? obj) => Equals(obj as ThrowingEquatable);
+
+        public override int GetHashCode() => 0;
+    }
+
+    private sealed class SharedHolder
+    {
+        public string? Value { get; set; }
+    }
+
+    private sealed class TopologyHolder
+    {
+        public SharedHolder? Other { get; set; }
+
+        public SharedHolder? OtherAlso { get; set; }
+    }
+
+    /// <summary>
+    /// Custom dictionary-shaped type that implements ONLY <see cref="IReadOnlyDictionary{TKey, TValue}"/>
+    /// (not <see cref="IDictionary{TKey, TValue}"/> nor <see cref="IDictionary"/>).
+    /// </summary>
+    private sealed class ReadOnlyDictionaryOnly<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull
+    {
+        private readonly Dictionary<TKey, TValue> _inner;
+
+        public ReadOnlyDictionaryOnly() => _inner = [];
+
+#pragma warning disable IDE0028 // Collection initialization can be simplified - target-typed `new` cannot pass the comparer.
+        private ReadOnlyDictionaryOnly(IEqualityComparer<TKey> comparer) => _inner = new(comparer);
+#pragma warning restore IDE0028
+
+        public TValue this[TKey key]
+        {
+            get => _inner[key];
+            set => _inner[key] = value;
+        }
+
+        public IEnumerable<TKey> Keys => _inner.Keys;
+
+        public IEnumerable<TValue> Values => _inner.Values;
+
+        public int Count => _inner.Count;
+
+        internal static ReadOnlyDictionaryOnly<string, TValue> CaseInsensitive()
+            => new ReadOnlyDictionaryOnly<string, TValue>(StringComparer.OrdinalIgnoreCase);
+
+        public bool ContainsKey(TKey key) => _inner.ContainsKey(key);
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _inner.GetEnumerator();
+
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member. - net48 / netstandard target ships TryGetValue without [MaybeNullWhen]; net9.0 does. The mismatch is harmless for the test.
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => _inner.TryGetValue(key, out value);
+#pragma warning restore CS8767
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class TwoIntsHolder
+    {
+        public int First { get; set; }
+
+        public int Second { get; set; }
+    }
+
+    private readonly struct ThrowingEquatableStruct : IEquatable<ThrowingEquatableStruct>
+    {
+        public bool Equals(ThrowingEquatableStruct other) => throw new InvalidOperationException("struct equality boom");
+
+        public override bool Equals(object? obj) => obj is ThrowingEquatableStruct other && Equals(other);
+
+        public override int GetHashCode() => 0;
+    }
+
+    private class SafeGetter
+    {
+        public virtual int Value { get; set; }
+    }
+
+    private sealed class ActualThrowingGetter : SafeGetter
+    {
+        public override int Value
+        {
+            get => throw new InvalidOperationException("actual side boom");
+            set { }
+        }
+    }
+
+    private sealed class ThrowingDictionary : IDictionary<string, int>
+    {
+        public int this[string key]
+        {
+            get => throw new InvalidOperationException("indexer boom");
+            set => throw new InvalidOperationException("indexer boom");
+        }
+
+        public ICollection<string> Keys => throw new InvalidOperationException("Keys boom");
+
+        public ICollection<int> Values => throw new InvalidOperationException("Values boom");
+
+        public int Count => 0;
+
+        public bool IsReadOnly => true;
+
+        public void Add(string key, int value) => throw new NotSupportedException();
+
+        public void Add(KeyValuePair<string, int> item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(KeyValuePair<string, int> item) => throw new InvalidOperationException("Contains boom");
+
+        public bool ContainsKey(string key) => throw new InvalidOperationException("ContainsKey boom");
+
+        public void CopyTo(KeyValuePair<string, int>[] array, int arrayIndex) => throw new NotSupportedException();
+
+        public IEnumerator<KeyValuePair<string, int>> GetEnumerator()
+        {
+            yield break;
+        }
+
+        public bool Remove(string key) => throw new NotSupportedException();
+
+        public bool Remove(KeyValuePair<string, int> item) => throw new NotSupportedException();
+
+        public bool TryGetValue(string key, out int value) => throw new InvalidOperationException("TryGetValue boom");
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    #endregion
+}

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -298,13 +298,17 @@ public partial class AssertTests : TestContainer
         // A property getter that calls Assert.Fail() throws AssertFailedException wrapped in a
         // TargetInvocationException by Reflection. The equivalence comparer must NOT rewrite the
         // framework exception as a structured "comparison failure" — it must propagate so the user's
-        // assertion surfaces with its original message.
+        // assertion surfaces with its original message AND original stack trace.
         AssertFailingGetter a = new();
         AssertFailingGetter b = new();
         Action act = () => Assert.AreEquivalent(a, b);
-        act.Should().Throw<AssertFailedException>()
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>()
             .WithMessage("*nested-assert-fail*")
-            .And.Message.Should().NotContain("Mismatch at");
+            .Which;
+        ex.Message.Should().NotContain("Mismatch at");
+        // The stack trace must point back to the user property getter (via ExceptionDispatchInfo);
+        // a naive `throw assertEx;` rethrow would replace this frame with the rethrow site.
+        ex.StackTrace.Should().NotBeNullOrEmpty().And.Contain(nameof(AssertFailingGetter));
     }
 
     public void AreEquivalent_IEquatableThrows_FailsWithExpectedDiagnostic()

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -374,6 +374,15 @@ public partial class AssertTests : TestContainer
             .And.Message.Should().Contain("enumerating the actual collection threw").And.Contain("InvalidOperationException");
     }
 
+    public void AreEquivalent_EnumerableMismatch_FailsFastWithoutEnumeratingPastMismatch()
+    {
+        IEnumerable<int> expected = [1, 2, 3];
+        IEnumerable<int> actual = new FailIfEnumeratedPastIndexEnumerable(1, 1, 999, 3);
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .And.Message.Should().Contain("Mismatch at '[1]'").And.NotContain("enumerating the actual collection threw");
+    }
+
     public void AreEquivalent_ReadOnlyDictionaryOnly_RespectsSourceComparer()
     {
         // Custom IReadOnlyDictionary<,>-only type backed by a case-insensitive Dictionary should
@@ -506,10 +515,17 @@ public partial class AssertTests : TestContainer
         Assert.AreEquivalent(a, b);
     }
 
+    public void AreEquivalent_DeepGraph_AtMaximumSupportedDepth_Passes()
+    {
+        DeepNode expected = CreateDeepNodeChain(256);
+        DeepNode actual = CreateDeepNodeChain(256);
+        Assert.AreEquivalent(expected, actual);
+    }
+
     public void AreEquivalent_DeepGraph_ReportsMaxDepthExceeded()
     {
-        DeepNode expected = CreateDeepNodeChain(300);
-        DeepNode actual = CreateDeepNodeChain(300);
+        DeepNode expected = CreateDeepNodeChain(257);
+        DeepNode actual = CreateDeepNodeChain(257);
         Action act = () => Assert.AreEquivalent(expected, actual);
         act.Should().Throw<AssertFailedException>()
             .And.Message.Should().Contain("maximum supported depth of 256");
@@ -963,6 +979,33 @@ public partial class AssertTests : TestContainer
         public IEnumerator<int> GetEnumerator() => throw new InvalidOperationException("enumeration boom");
 
         IEnumerator IEnumerable.GetEnumerator() => throw new InvalidOperationException("enumeration boom");
+    }
+
+    private sealed class FailIfEnumeratedPastIndexEnumerable : IEnumerable<int>
+    {
+        private readonly int[] _items;
+        private readonly int _maxIndex;
+
+        public FailIfEnumeratedPastIndexEnumerable(int maxIndex, params int[] items)
+        {
+            _maxIndex = maxIndex;
+            _items = items;
+        }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            for (int i = 0; i < _items.Length; i++)
+            {
+                if (i > _maxIndex)
+                {
+                    throw new InvalidOperationException("enumerated past mismatch");
+                }
+
+                yield return _items[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class ThrowingDictionary : IDictionary<string, int>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -627,12 +627,18 @@ public partial class AssertTests : TestContainer
         int expected = 1;
         int actual = 2;
         Action act = () => Assert.AreEquivalent(expected, actual, "numbers should match");
-        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
-        ex.Message.Should().StartWith("Assertion failed. Expected values to be structurally equivalent.");
-        ex.Message.Should().Contain($"{Environment.NewLine}Mismatch at '<root>': values are not equal.");
-        ex.Message.Should().Contain($"{Environment.NewLine}numbers should match");
-        ex.Message.Should().Contain($"{Environment.NewLine}{Environment.NewLine}expected: 1{Environment.NewLine}actual:   2");
-        ex.Message.Should().Contain($"{Environment.NewLine}{Environment.NewLine}Assert.AreEquivalent(expected, actual)");
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected values to be structurally equivalent.
+                Mismatch at '<root>': values are not equal.
+                numbers should match
+
+                expected: 1
+                actual:   2
+
+                Assert.AreEquivalent(expected, actual)
+                """);
     }
 
     #endregion

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -996,12 +996,9 @@ public partial class AssertTests : TestContainer
         {
             for (int i = 0; i < _items.Length; i++)
             {
-                if (i > _maxIndex)
-                {
-                    throw new InvalidOperationException("enumerated past mismatch");
-                }
-
-                yield return _items[i];
+                yield return i > _maxIndex
+                    ? throw new InvalidOperationException("enumerated past mismatch")
+                    : _items[i];
             }
         }
 

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs
@@ -668,7 +668,7 @@ public partial class AssertTests : TestContainer
     {
         Action act = () => Assert.AreNotEquivalent(new Person("Ada", 36), new Person("Ada", 36));
         act.Should().Throw<AssertFailedException>()
-            .WithMessage("*NOT be structurally equivalent*");
+            .WithMessage("*structurally different*");
     }
 
     public void AreNotEquivalent_BothNull_Fails()
@@ -710,6 +710,37 @@ public partial class AssertTests : TestContainer
         }
 
         return root;
+    }
+
+    public void AreEquivalent_NewShadowedProperty_UsesMostDerivedDeclaration()
+    {
+        var expected = new ShadowedDerived { Value = "derived-expected" };
+        var actual = new ShadowedDerived { Value = "derived-actual" };
+
+        Action act = () => Assert.AreEquivalent(expected, actual);
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage("*Value*derived-expected*derived-actual*");
+    }
+
+    public void AreEquivalent_NewShadowedProperty_EquivalentDerivedValues_Passes()
+    {
+        var expected = new ShadowedDerived { Value = "same" };
+        var actual = new ShadowedDerived { Value = "same" };
+
+        // The base sets BaseValueAsString = "base"; the derived `new` Value shadows it as a string.
+        // If the comparer ever picked the base accessor for one side, the comparison would compare
+        // the string "base" against the derived `Value` and fail.
+        Assert.AreEquivalent(expected, actual);
+    }
+
+    private class ShadowedBase
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class ShadowedDerived : ShadowedBase
+    {
+        public new string Value { get; set; } = "default";
     }
 
     private sealed class Person


### PR DESCRIPTION
## What

Adds `Assert.AreEquivalent<T>` and `Assert.AreNotEquivalent<T>` for deep structural equality comparison of object graphs, addressing the long-standing request in #4776.

```csharp
// Pass: deep structural compare of two POCOs
Assert.AreEquivalent(new Order("o-1", new Address("street", "city")),
                     new Order("o-1", new Address("street", "city")));

// Fail with: Mismatch at 'ShippingAddress.City': values are not equal.
//            expected: "city"
//            actual:   "different"
Assert.AreEquivalent(new Order("o-1", new Address("street", "city")),
                     new Order("o-1", new Address("street", "different")));
```

## Why

MSTest currently has:
- `Assert.AreEqual` — reference / `Equals` / `IEqualityComparer<T>`-based, useless for POCOs with default `object.Equals`.
- `CollectionAssert.AreEqual` — ordered element-by-element.
- `CollectionAssert.AreEquivalent` — set-equivalence.

There's no way to assert that two arbitrary object graphs are structurally equal. Users have been reaching for FluentAssertions' `BeEquivalentTo`, but its license recently changed to commercial. xUnit has had `Assert.Equivalent` for a while.

## Design

API shape follows xUnit's `Assert.Equivalent` more than FluentAssertions' `BeEquivalentTo`, in line with MSTest's preference for a small focused API surface that can grow without breaking changes:

- 8 new public overloads (4 each for `AreEquivalent` and `AreNotEquivalent`), with optional `bool strict` and standard `CallerArgumentExpression` plumbing. No options bag for now — it can be layered on later as a pure addition.
- **Comparison rules** (full list in the XML `<remarks>`):
  - Reference-equal values (and both `null`) are equivalent.
  - **Primitive-like** types (numerics, `string`, `bool`, `char`, enums, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`, `Uri`, `Type`, `Version`, plus `DateOnly`/`TimeOnly`/`Half`/`Int128`/`UInt128` when present) → `Equals`.
  - **Hybrid `IEquatable<T>` shortcut**: when the *static* declared type implements `IEquatable<self>`, dispatch via the interface method (so explicit interface implementations work too). Plain `object.Equals` overrides are intentionally ignored — recursion proceeds.
  - **Dictionaries** (`IDictionary`, `IDictionary<,>`, or `IReadOnlyDictionary<,>`) are compared by key set with values recursive. Lookups are routed through the source dictionary so its `IEqualityComparer<TKey>` is preserved (e.g., `StringComparer.OrdinalIgnoreCase`).
  - **Other enumerables** (excluding `string`) are compared element-by-element in iteration order. Element type is taken from the declared `IEnumerable<T>` so the `IEquatable<T>` shortcut still applies for nested values. (For order-insensitive comparison use `CollectionAssert.AreEquivalent` on the collection itself.)
  - **Other reference types** are compared by recursing into all public instance properties (with a public getter, no index parameters) and public instance fields, sorted by name for stable diagnostics.
  - **Cycles + topology**: tracked via persistent bidirectional ref-equality maps. Re-entering a known pair short-circuits as match. Re-entering with a different counterpart on either side fails as a topology mismatch.
  - **User exceptions**: thrown by `IEquatable<T>.Equals`, member getters, or dictionary access (`TryGetValue`/`ContainsKey`/enumeration) are caught and surfaced as a structured failure rather than escaping `AssertFailedException`.
- **`strict: true`** additionally rejects extra public members on `actual` (when runtime types differ) and any extra dictionary keys on `actual`.

Failure messages use the existing structured assertion infrastructure (RFC 012): a top-line summary, a `Mismatch at '<dotted-path>': <reason>` locator (e.g. `Order.Items[2].Price` or `["x-trace-id"]`), and `expected:` / `actual:` evidence rendered through `AssertionValueRenderer`. `AssertFailedException.ExpectedText`/`ActualText` are populated for any mismatch that can be rendered as two values.

### Naming considered
`Assert.AreEquivalent` was deliberately chosen over `AreDeeplyEqual` / `AreStructurallyEqual` to match xUnit and the wording in #4776, even though `CollectionAssert.AreEquivalent` already means set-equivalence. The two APIs live on different types and accept different parameter types, so there's no compile-time conflict.

## Implementation

Two new files:

- `src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs` — public surface, structured-message reporting helpers. Mirrors the style of `Assert.AreEqual.cs` / `Assert.AreSame.cs`.
- `src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs` — internal `EquivalenceComparer` (recursive walker), `MemberLookup` (cached per type, with both sorted array and O(1) name-keyed dict), `DictionaryView` / `NonGenericDictionaryView` / `GenericDictionaryView` / `GenericDictionaryAccessors` (cached reflection that defers lookups to the source dictionary), `EquivalenceMismatch` (structured failure record).

15 new strings added to `FrameworkMessages.resx`; sibling XLFs regenerated via `dotnet msbuild ... /t:UpdateXlf`. 8 new entries in `PublicAPI.Unshipped.txt`.

## Tests

`test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEquivalentTests.cs` — 62 tests, TestContainer + AwesomeAssertions, covering: primitives/null/strings/dates/enums/Guid; identical and different POCOs (with dotted-path failure locators); public fields; anonymous types; ignored private fields; collections (length/element/order); nested collections; dictionaries (equal, missing key, different value, extra key non-strict vs strict, non-string keys, case-insensitive comparer respected, custom `IReadOnlyDictionary<,>`-only types); `IEquatable<T>` (regular, explicit interface implementation, value-type, throws); plain `Equals` override is ignored; self-cycles and cross-cycles via property and field; topology mismatch detection (shared-vs-distinct); value-type topology skip; member-getter throws on expected and actual sides; dictionary-access throws; strict-mode extra-member rendering (alphabetical); user message and call-site expression rendering; plus broad `AreNotEquivalent` mirroring (collections, dictionaries, cycles, IEquatable, call-site expression).

## Verification

- `dotnet build src/TestFramework/TestFramework -c Debug /p:TreatWarningsAsErrors=true` — clean across `netstandard2.0`, `net462`, `net8.0`, `net9.0`.
- `dotnet build test/UnitTests/TestFramework.UnitTests -c Debug /p:TreatWarningsAsErrors=true` — clean across all TFMs (incl. WinUI).
- 62 `AreEquivalent` tests pass on **net9.0** and **net48**.
- Full `TestFramework.UnitTests` suite (954 tests) green.

## Out of scope (follow-ups)

- `EquivalenceOptions` bag (exclude paths, max-depth, ignore-collection-order, configure key/value rendering). Can be added without breaking changes.
- Analyzer suggesting `Assert.AreEquivalent` over `Assert.AreEqual` when the latter is called on POCO types.

Closes #4776.
