### PR TITLE
Add timeout tests for GlobalTestInitializeAttribute and GlobalTestCleanupAttribute

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutCooperativeGlobalTestCancellationTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutCooperativeGlobalTestCancellationTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class TimeoutCooperativeGlobalTestCancellationTests : AcceptanceTestBase<TimeoutCooperativeGlobalTestCancellationTests.TestAssetFixture>
+{
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalInitializeMethodAsync is currently discarded in TestMethodInfo.Execution.cs, so timeouts on global test initialize methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenGlobalTestInitTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_GLOBALTESTINIT"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("GlobalTestInit started");
+        testHostResult.AssertOutputContains("Test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
+        testHostResult.AssertOutputDoesNotContain("GlobalTestInit Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("GlobalTestInit completed");
+    }
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalInitializeMethodAsync is currently discarded in TestMethodInfo.Execution.cs, so timeouts on global test initialize methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenGlobalTestInitTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_GLOBALTESTINIT"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("GlobalTestInit started");
+        testHostResult.AssertOutputContains("GlobalTestInit Thread.Sleep completed");
+        testHostResult.AssertOutputContains("Test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
+        testHostResult.AssertOutputDoesNotContain("GlobalTestInit completed");
+    }
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalCleanupMethodAsync is currently discarded in TestMethodInfo.Lifecycle.cs, so timeouts on global test cleanup methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenGlobalTestCleanupTimeoutExpires_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["TASKDELAY_GLOBALTESTCLEANUP"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("GlobalTestCleanup started");
+        testHostResult.AssertOutputContains("Test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
+        testHostResult.AssertOutputDoesNotContain("GlobalTestCleanup Thread.Sleep completed");
+        testHostResult.AssertOutputDoesNotContain("GlobalTestCleanup completed");
+    }
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalCleanupMethodAsync is currently discarded in TestMethodInfo.Lifecycle.cs, so timeouts on global test cleanup methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task CooperativeCancellation_WhenGlobalTestCleanupTimeoutExpiresAndUserChecksToken_StepThrows(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            new() { ["CHECKTOKEN_GLOBALTESTCLEANUP"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("GlobalTestCleanup started");
+        testHostResult.AssertOutputContains("GlobalTestCleanup Thread.Sleep completed");
+        testHostResult.AssertOutputContains("Test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
+        testHostResult.AssertOutputDoesNotContain("GlobalTestCleanup completed");
+    }
+
+    public sealed class TestAssetFixture : TestAssetFixtureBase
+    {
+        public const string ProjectName = "TimeoutCooperativeGlobalTimeout";
+
+        public string TargetAssetPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchCodeWithReplace("$ProjectName$", ProjectName)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file $ProjectName$.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="*.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>
+
+#file my.runsettings
+<RunSettings>
+  <MSTest>
+    <CaptureTraceOutput>false</CaptureTraceOutput>
+  </MSTest>
+</RunSettings>
+
+#file UnitTest1.cs
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class TestClass
+{
+    public TestContext TestContext { get; set; }
+
+    [Timeout(1000, CooperativeCancellation = true)]
+    [GlobalTestInitialize]
+    public static async Task GlobalTestInit(TestContext testContext)
+        => await DoWork("GLOBALTESTINIT", "GlobalTestInit", testContext);
+
+    [Timeout(1000, CooperativeCancellation = true)]
+    [GlobalTestCleanup]
+    public static async Task GlobalTestCleanup(TestContext testContext)
+        => await DoWork("GLOBALTESTCLEANUP", "GlobalTestCleanup", testContext);
+
+    [TestMethod]
+    public void TestMethod()
+    {
+    }
+
+    private static async Task DoWork(string envVarSuffix, string stepName, TestContext testContext)
+    {
+        Console.WriteLine($"{stepName} started");
+
+        if (Environment.GetEnvironmentVariable($"TASKDELAY_{envVarSuffix}") == "1")
+        {
+            await Task.Delay(10_000, testContext.CancellationTokenSource.Token);
+        }
+        else
+        {
+            // We want to wait more than the timeout value to ensure the timeout is hit
+            await Task.Delay(2_000);
+            Console.WriteLine($"{stepName} Thread.Sleep completed");
+            if (Environment.GetEnvironmentVariable($"CHECKTOKEN_{envVarSuffix}") == "1")
+            {
+                testContext.CancellationTokenSource.Token.ThrowIfCancellationRequested();
+            }
+        }
+
+        Console.WriteLine($"{stepName} completed");
+    }
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenCanceledTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenCanceledTests.cs
@@ -14,6 +14,8 @@ public sealed class TimeoutWhenCanceledTests : AcceptanceTestBase<TimeoutWhenCan
         ["assemblyInit"] = ("TestClass.AssemblyInit", "Assembly initialize", "ASSEMBLYINIT", "AssemblyInitializeTimeout"),
         ["classInit"] = ("TestClass.ClassInit", "Class initialize", "CLASSINIT", "ClassInitializeTimeout"),
         ["baseClassInit"] = ("TestClassBase.ClassInitBase", "Class initialize", "BASE_CLASSINIT", "ClassInitializeTimeout"),
+        ["globalTestInit"] = ("TestClass.GlobalTestInit", "Test initialize", "GLOBALTESTINIT", "TestInitializeTimeout"),
+        ["globalTestCleanup"] = ("TestClass.GlobalTestCleanupMethod", "Test cleanup", "GLOBALTESTCLEANUP", "TestCleanupTimeout"),
     };
 
     [TestMethod]
@@ -30,6 +32,18 @@ public sealed class TimeoutWhenCanceledTests : AcceptanceTestBase<TimeoutWhenCan
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     public async Task ClassInitBase_WhenTestContextCanceled_ClassInitializeTaskIsCanceled(string tfm)
         => await RunAndAssertTestWasCanceledAsync(tfm, "TESTCONTEXT_CANCEL_", "baseClassInit");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalInitializeMethodAsync is currently discarded in TestMethodInfo.Execution.cs, so cancellations on global test initialize methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestInitialize_WhenTestContextCanceled_GlobalTestInitializeTaskIsCanceled(string tfm)
+        => await RunAndAssertTestWasCanceledAsync(tfm, "TESTCONTEXT_CANCEL_", "globalTestInit");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalCleanupMethodAsync is currently discarded in TestMethodInfo.Lifecycle.cs, so cancellations on global test cleanup methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestCleanup_WhenTestContextCanceled_GlobalTestCleanupTaskIsCanceled(string tfm)
+        => await RunAndAssertTestWasCanceledAsync(tfm, "TESTCONTEXT_CANCEL_", "globalTestCleanup");
 
     private static async Task RunAndAssertTestWasCanceledAsync(string tfm, string envVarPrefix, string entryKind)
     {
@@ -212,6 +226,36 @@ public class TestClass : TestClassBase
     {
         if (Environment.GetEnvironmentVariable("LONG_WAIT_TESTCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_TESTCLEANUP") == "1")
         {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [GlobalTestInitialize]
+    public static async Task GlobalTestInit(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_GLOBALTESTINIT") == "1")
+        {
+            testContext.CancellationTokenSource.Cancel();
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [GlobalTestCleanup]
+    public static async Task GlobalTestCleanupMethod(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_GLOBALTESTCLEANUP") == "1")
+        {
+            testContext.CancellationTokenSource.Cancel();
             await Task.Delay(10_000);
         }
         else

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
@@ -19,6 +19,8 @@ public sealed class TimeoutWhenExpiresTests : AcceptanceTestBase<TimeoutWhenExpi
         ["baseClassCleanup"] = ("TestClassBase.ClassCleanupBase", "Class cleanup", "BASE_CLASSCLEANUP", "ClassCleanupTimeout"),
         ["testInit"] = ("TestClass.TestInit", "Test initialize", "TESTINIT", "TestInitializeTimeout"),
         ["testCleanup"] = ("TestClass.TestCleanupMethod", "Test cleanup", "TESTCLEANUP", "TestCleanupTimeout"),
+        ["globalTestInit"] = ("TestClass.GlobalTestInit", "Test initialize", "GLOBALTESTINIT", "TestInitializeTimeout"),
+        ["globalTestCleanup"] = ("TestClass.GlobalTestCleanupMethod", "Test cleanup", "GLOBALTESTCLEANUP", "TestCleanupTimeout"),
     };
 
     [TestMethod]
@@ -115,6 +117,36 @@ public sealed class TimeoutWhenExpiresTests : AcceptanceTestBase<TimeoutWhenExpi
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     public async Task TestCleanup_WhenTimeoutExpires_TestCleanupIsCanceled_AttributeTakesPrecedence(string tfm)
         => await RunAndAssertAttributeTakesPrecedenceAsync(tfm, "testCleanup");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalInitializeMethodAsync is currently discarded in TestMethodInfo.Execution.cs, so timeouts on global test initialize methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestInitialize_WhenTimeoutExpires_GlobalTestInitializeTaskIsCanceled(string tfm)
+        => await RunAndAssertTestTimedOutAsync(tfm, "LONG_WAIT_", "globalTestInit");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalInitializeMethodAsync is currently discarded in TestMethodInfo.Execution.cs, so timeouts on global test initialize methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestInitialize_WhenTimeoutExpiresAndTestContextTokenIsUsed_GlobalTestInitializeExits(string tfm)
+        => await RunAndAssertTestTimedOutAsync(tfm, "TIMEOUT_", "globalTestInit");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalInitializeMethodAsync is currently discarded in TestMethodInfo.Execution.cs, so timeouts on global test initialize methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestInitialize_WhenTimeoutExpires_GlobalTestInitializeIsCanceled_AttributeTakesPrecedence(string tfm)
+        => await RunAndAssertAttributeTakesPrecedenceAsync(tfm, "globalTestInit");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalCleanupMethodAsync is currently discarded in TestMethodInfo.Lifecycle.cs, so timeouts on global test cleanup methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestCleanup_WhenTimeoutExpires_GlobalTestCleanupTaskIsCanceled(string tfm)
+        => await RunAndAssertTestTimedOutAsync(tfm, "LONG_WAIT_", "globalTestCleanup");
+
+    [TestMethod]
+    [Ignore("Tracked by https://github.com/microsoft/testfx/issues/6198. The TestFailedException returned by InvokeGlobalCleanupMethodAsync is currently discarded in TestMethodInfo.Lifecycle.cs, so timeouts on global test cleanup methods do not fail the test.")]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestCleanup_WhenTimeoutExpires_GlobalTestCleanupIsCanceled_AttributeTakesPrecedence(string tfm)
+        => await RunAndAssertAttributeTakesPrecedenceAsync(tfm, "globalTestCleanup");
 
     private static async Task RunAndAssertTestTimedOutAsync(string tfm, string envVarPrefix, string entryKind)
     {
@@ -324,6 +356,42 @@ public class TestClass : TestClassBase
         if (Environment.GetEnvironmentVariable("LONG_WAIT_TESTCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_TESTCLEANUP") == "1")
         {
             await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [GlobalTestInitialize]
+    public static async Task GlobalTestInit(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_GLOBALTESTINIT") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("TIMEOUT_GLOBALTESTINIT") == "1")
+        {
+            await Task.Delay(10_000, testContext.CancellationTokenSource.Token);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [GlobalTestCleanup]
+    public static async Task GlobalTestCleanupMethod(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_GLOBALTESTCLEANUP") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("TIMEOUT_GLOBALTESTCLEANUP") == "1")
+        {
+            await Task.Delay(10_000, testContext.CancellationTokenSource.Token);
         }
         else
         {


### PR DESCRIPTION
Re-adds the timeout test coverage for ``GlobalTestInitializeAttribute`` and ``GlobalTestCleanupAttribute`` requested in #6198 (originally added in #6200, reverted in #6978).

## Changes

Tests are added in three places, mirroring the existing patterns for assembly/class/test init/cleanup:

- **`TimeoutWhenExpiresTests`** — adds 5 tests covering ``LONG_WAIT_``/``TIMEOUT_`` timeout-expires scenarios and ``AttributeTakesPrecedence`` variants for global test init/cleanup, plus the matching ``GlobalTestInit`` / ``GlobalTestCleanupMethod`` methods in the shared test asset.
- **`TimeoutWhenCanceledTests`** — adds 2 tests covering ``TestContext`` cancellation scenarios for global test init/cleanup, plus the matching methods in the shared test asset.
- **`TimeoutCooperativeGlobalTestCancellationTests`** (new file) — adds 4 cooperative cancellation tests for global test init/cleanup. These live in a dedicated test class with its own asset because the shared ``TimeoutCooperativeCancellationTests`` asset uses cooperative cancellation tied to ``TestContext.CancellationTokenSource``; injecting global init/cleanup into that asset would cancel the same token source and break unrelated cooperative tests.

## Tests are marked `[Ignore]`

All 11 new test methods are decorated with ``[Ignore("...")]`` referencing #6198 because the underlying implementation currently discards the ``TestFailedException?`` returned by ``InvokeGlobalInitializeMethodAsync`` / ``InvokeGlobalCleanupMethodAsync`` (see ``TestMethodInfo.Execution.cs:81`` and ``TestMethodInfo.Lifecycle.cs:82``). As a result, timeouts and cancellations on global test init/cleanup do not actually fail the test, so the assertions cannot pass yet. The tests should be unskipped once the underlying bug is fixed.

This was the same root cause that made #6200 silently pass before being reverted in #6978; this time the tests are explicitly skipped (with a clear pointer to #6198) rather than appearing to pass while validating nothing.

## Validation

- `.\build.cmd -projects test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj` — succeeds.
- `dotnet test ... --filter "FullyQualifiedName~Timeout"` — 234 tests, 201 passed, 33 skipped (the new global test init/cleanup tests, multiplied by the 3 target frameworks via `DynamicData`), 0 failed.

Fixes #6198 by adding the test scaffolding; the bug fix that allows them to be unskipped is tracked separately under the same issue.