### PR TITLE
AzureDevOpsReporter: skip Assert frames by type name instead of filename (fixes #6925)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -21,6 +21,19 @@ internal sealed class AzureDevOpsReporter :
 {
     private const string DeterministicBuildRoot = "/_/";
 
+    // Fully-qualified type prefixes for MSTest assertion implementations. A stack frame whose
+    // 'code' (i.e., the "Namespace.Type.Method(args)" portion) starts with any of these is treated
+    // as framework internals and skipped when looking for the user's call site to annotate.
+    // Matching on the type name (rather than the source file name) is robust to partial-class
+    // splits (e.g. Assert.AreEqual.cs, Assert.IComparable.cs) and avoids false positives on user
+    // files innocently named *Assert.cs. See https://github.com/microsoft/testfx/issues/6925.
+    private static readonly string[] AssertionImplementationCodePrefixes =
+    [
+        "Microsoft.VisualStudio.TestTools.UnitTesting.Assert.",
+        "Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.",
+        "Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert.",
+    ];
+
     private readonly IOutputDevice _outputDisplay;
     private readonly ILogger _logger;
     private static readonly char[] NewlineCharacters = ['\r', '\n'];
@@ -210,13 +223,13 @@ internal sealed class AzureDevOpsReporter :
             }
 
             string file = location.Value.File;
+            string code = location.Value.Code;
 
-            // TODO: We need better rule for stackframes to opt out from being interesting.
-            if (file.EndsWith("Assert.cs", StringComparison.Ordinal))
+            if (IsAssertionImplementationFrame(code))
             {
                 if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    logger.LogTrace("StackFrame location ends with 'Assert.cs' this is a special pattern that we skip, continuing to next.");
+                    logger.LogTrace($"StackFrame code '{code}' is an MSTest assertion implementation, continuing to next.");
                 }
 
                 continue;
@@ -310,6 +323,19 @@ internal sealed class AzureDevOpsReporter :
     private static string GetTargetFrameworkMoniker()
         => TargetFrameworkParser.GetShortTargetFramework(Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
             ?? TargetFrameworkParser.GetShortTargetFramework(RuntimeInformation.FrameworkDescription);
+
+    private static bool IsAssertionImplementationFrame(string code)
+    {
+        foreach (string prefix in AssertionImplementationCodePrefixes)
+        {
+            if (code.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static (string Code, string File, int LineNumber)? GetStackFrameLocation(string stackTraceLine)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -25,11 +25,13 @@ internal sealed class AzureDevOpsReporter :
     // 'code' (i.e., the "Namespace.Type.Method(args)" portion) starts with any of these is treated
     // as framework internals and skipped when looking for the user's call site to annotate.
     // Matching on the type name (rather than the source file name) is robust to partial-class
-    // splits (e.g. Assert.AreEqual.cs, Assert.IComparable.cs) and avoids false positives on user
+    // splits (e.g. Assert.AreEqual.cs, Assert.IComparable.cs) and extension-based assertion
+    // implementations such as Assert.That in Assert.That.cs, and it avoids false positives on user
     // files innocently named *Assert.cs. See https://github.com/microsoft/testfx/issues/6925.
     private static readonly string[] AssertionImplementationCodePrefixes =
     [
         "Microsoft.VisualStudio.TestTools.UnitTesting.Assert.",
+        "Microsoft.VisualStudio.TestTools.UnitTesting.AssertExtensions.",
         "Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.",
         "Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert.",
     ];

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -303,7 +303,7 @@ internal sealed class AzureDevOpsReporter :
                 logger.LogTrace($"Normalized path for GitHub '{relativeNormalizedPath}'.");
             }
 
-            string formattedMessage = $"[{testDisplayName}] [{targetFrameworkMoniker}] {message}";
+            string formattedMessage = FormatErrorMessage(testDisplayName, targetFrameworkMoniker, message);
             string line = $"##vso[task.logissue type={severity};sourcepath={relativeNormalizedPath};linenumber={location.Value.LineNumber};columnnumber=1]{AzDoEscaper.Escape(formattedMessage)}";
             if (logger.IsEnabled(LogLevel.Trace))
             {
@@ -325,6 +325,30 @@ internal sealed class AzureDevOpsReporter :
     private static string GetTargetFrameworkMoniker()
         => TargetFrameworkParser.GetShortTargetFramework(Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
             ?? TargetFrameworkParser.GetShortTargetFramework(RuntimeInformation.FrameworkDescription);
+
+    /// <summary>
+    /// Formats the reporter message so the test name lands on its own line.
+    /// PR check UIs (GitHub Checks via the dotnet problem matcher and Azure DevOps)
+    /// render the first line of the message as the bold annotation title, so we
+    /// keep the test display name compact and push the assertion text to the body.
+    /// </summary>
+    /// <remarks>
+    /// MTP includes the TFM in the display name in multi-TFM mode (e.g. "MyTest (net8.0)").
+    /// To avoid noise like "MyTest (net8.0) [net8.0]" we skip the bracketed TFM
+    /// suffix when the display name already ends with "({tfm})" or "(\"{tfm}\")".
+    /// </remarks>
+    internal static /* for testing */ string FormatErrorMessage(string testDisplayName, string targetFrameworkMoniker, string message)
+    {
+        string titleLine = DisplayNameContainsTfm(testDisplayName, targetFrameworkMoniker)
+            ? testDisplayName
+            : $"{testDisplayName} [{targetFrameworkMoniker}]";
+
+        return $"{titleLine}\n{message}";
+    }
+
+    private static bool DisplayNameContainsTfm(string displayName, string tfm)
+        => displayName.EndsWith($"({tfm})", StringComparison.Ordinal)
+            || displayName.EndsWith($"(\"{tfm}\")", StringComparison.Ordinal);
 
     private static bool IsAssertionImplementationFrame(string code)
     {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
@@ -118,7 +118,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 ["SLEEPTIMEMS2"] = "600000",
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
+        AssertTemplateHangDumpCompleted(testHostResult);
 
         // Verify the dump file uses the template format
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "*_hang.dmp", SearchOption.AllDirectories);
@@ -151,7 +151,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
                 ["SLEEPTIMEMS2"] = "600000",
             },
             cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
+        AssertTemplateHangDumpCompleted(testHostResult);
 
         // Verify the dump file was created inside a subdirectory named after the assembly
         string[] dumpFiles = Directory.GetFiles(resultDirectory, "*_hang.dmp", SearchOption.AllDirectories);
@@ -165,6 +165,17 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
         Assert.AreNotEqual(resultDirectory, parentDir, "Dump file should be in a subdirectory created from the {asm} placeholder");
         Assert.AreEqual("HangDump", Path.GetFileName(parentDir),
             $"Subdirectory should be named after the assembly ('HangDump'). Actual: {Path.GetFileName(parentDir)}");
+    }
+
+    private static void AssertTemplateHangDumpCompleted(TestHostResult testHostResult)
+    {
+        testHostResult.AssertOutputContains("Hang dump timeout");
+
+        // These template-focused tests only need to prove that hang dump triggered and the file was created.
+        // On macOS, createdump can finish after the test host reports success, so the process may still exit with 0.
+        Assert.IsTrue(
+            testHostResult.ExitCode is (int)ExitCode.Success or (int)ExitCode.TestHostProcessExitedNonGracefully,
+            $"Expected hang dump template scenarios to exit with {(int)ExitCode.Success} or {(int)ExitCode.TestHostProcessExitedNonGracefully}, but got {testHostResult.ExitCode}.{Environment.NewLine}{testHostResult}");
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
@@ -4,6 +4,9 @@
 using Microsoft.Testing.Extensions.AzureDevOpsReport;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.TestInfrastructure;
+
+using Moq;
 
 namespace Microsoft.Testing.Extensions.UnitTests;
 
@@ -26,7 +29,7 @@ public sealed class AzureDevOpsTests
         // Trim ##. If we keep it, then when the test fails, the assertion failure will get printed to screen and picked up incorrectly by AzDO, because it scans all output for the ##vso... pattern
         var logger = new TextLogger();
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
-        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=19;columnnumber=1][MyTestDisplayName] [net9.0] this is an error%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=22;columnnumber=1][MyTestDisplayName] [net9.0] this is an error%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
 
     [TestMethod]
@@ -45,7 +48,147 @@ public sealed class AzureDevOpsTests
         // Trim ##. If we keep it, then when the test fails, the assertion failure will get printed to screen and picked up incorrectly by AzDO, because it scans all output for the ##vso... pattern
         var logger = new TextLogger();
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", "Some custom reason\nwith\rnewline", error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
-        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=38;columnnumber=1][MyTestDisplayName] [net9.0] Some custom reason%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=41;columnnumber=1][MyTestDisplayName] [net9.0] Some custom reason%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
+    public void SkipsMSTestAssertImplementationFrameInPartialClassFile()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/6925.
+        //
+        // The Assert class is split into partial-class files such as Assert.IComparable.cs and
+        // Assert.AreEqual.cs. Their file names do not end with "Assert.cs", so the previous
+        // filename-based skip heuristic missed them and the reporter incorrectly annotated the
+        // framework implementation. The fix matches on the fully-qualified type prefix in the
+        // 'code' capture instead, so every Assert/CollectionAssert/StringAssert partial is
+        // correctly recognized as framework internals.
+        (string userFile, int userLine) = GetCurrentLocation();
+
+        // The Assert.IComparable.cs file actually exists in the repo, so the file-existence
+        // check would happily accept the framework frame if we did not skip it.
+        string stackTrace = string.Join(
+            Environment.NewLine,
+            "   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsInstanceOfType[T](T value, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs:line 99",
+            $"   at Microsoft.Testing.Extensions.UnitTests.AzureDevOpsTests.SkipsMSTestAssertImplementationFrameInPartialClassFile() in {userFile}:line {userLine}");
+
+        var error = new SyntheticStackTraceException("boom", stackTrace);
+
+        var logger = new TextLogger();
+        string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
+
+        Assert.AreEqual(
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            text,
+            $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
+    public void SkipsMSTestCollectionAssertImplementationFrameInPartialClassFile()
+    {
+        (string userFile, int userLine) = GetCurrentLocation();
+
+        string stackTrace = string.Join(
+            Environment.NewLine,
+            "   at Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(ICollection expected, ICollection actual, String message) in /_/src/TestFramework/TestFramework/Assertions/CollectionAssert.Equality.cs:line 42",
+            $"   at Microsoft.Testing.Extensions.UnitTests.AzureDevOpsTests.SkipsMSTestCollectionAssertImplementationFrameInPartialClassFile() in {userFile}:line {userLine}");
+
+        var error = new SyntheticStackTraceException("boom", stackTrace);
+
+        var logger = new TextLogger();
+        string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
+
+        Assert.AreEqual(
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            text,
+            $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
+    public void SkipsMSTestStringAssertImplementationFrame()
+    {
+        (string userFile, int userLine) = GetCurrentLocation();
+
+        string stackTrace = string.Join(
+            Environment.NewLine,
+            "   at Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert.Contains(String value, String substring, String message) in /_/src/TestFramework/TestFramework/Assertions/StringAssert.cs:line 17",
+            $"   at Microsoft.Testing.Extensions.UnitTests.AzureDevOpsTests.SkipsMSTestStringAssertImplementationFrame() in {userFile}:line {userLine}");
+
+        var error = new SyntheticStackTraceException("boom", stackTrace);
+
+        var logger = new TextLogger();
+        string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
+
+        Assert.AreEqual(
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            text,
+            $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
+    public void DoesNotSkipUserFrameWhoseFileNameEndsWithAssertCs()
+    {
+        // The previous heuristic skipped any frame whose file path ended with "Assert.cs",
+        // which incorrectly hid user code in files named e.g. MyAssert.cs from PR annotations.
+        // The fix is based on the fully-qualified type name in the frame, so user types are
+        // never confused with the framework's Assert/CollectionAssert/StringAssert types.
+        string repoRoot = RootFinder.Find();
+        string userFile = Path.Combine(repoRoot, "src", "MyCompany", "MyAssert.cs");
+
+        string stackTrace =
+            $"   at MyCompany.Verification.MyAssert.Verify(Object value) in {userFile}:line 17";
+
+        var error = new SyntheticStackTraceException("boom", stackTrace);
+
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+
+        var logger = new TextLogger();
+        string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", fileSystem.Object, logger, "net9.0")?.TrimStart('#');
+
+        Assert.AreEqual(
+            "vso[task.logissue type=severity;sourcepath=src/MyCompany/MyAssert.cs;linenumber=17;columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            text,
+            $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
+    public void DoesNotSkipUserFrameWhoseTypeNameStartsWithAssert()
+    {
+        // A user type literally named "Assert" (e.g. MyCompany.Tests.Assert) must not be
+        // mistaken for Microsoft.VisualStudio.TestTools.UnitTesting.Assert. The prefix check
+        // is anchored on the full MSTest namespace, so user types in other namespaces are safe.
+        string repoRoot = RootFinder.Find();
+        string userFile = Path.Combine(repoRoot, "src", "MyCompany", "MyAssertions.cs");
+
+        string stackTrace =
+            $"   at MyCompany.Tests.Assert.Equal[T](T expected, T actual) in {userFile}:line 25";
+
+        var error = new SyntheticStackTraceException("boom", stackTrace);
+
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+
+        var logger = new TextLogger();
+        string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", fileSystem.Object, logger, "net9.0")?.TrimStart('#');
+
+        Assert.AreEqual(
+            "vso[task.logissue type=severity;sourcepath=src/MyCompany/MyAssertions.cs;linenumber=25;columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            text,
+            $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    private static (string FilePath, int LineNumber) GetCurrentLocation(
+        [CallerFilePath] string? filePath = null,
+        [CallerLineNumber] int lineNumber = 0)
+        => (filePath!, lineNumber);
+
+    private sealed class SyntheticStackTraceException : Exception
+    {
+        public SyntheticStackTraceException(string message, string stackTrace)
+            : base(message)
+            => StackTrace = stackTrace;
+
+        public override string? StackTrace { get; }
     }
 
     private class TextLogger : ILogger

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
@@ -68,7 +68,7 @@ public sealed class AzureDevOpsTests
         // check would happily accept the framework frame if we did not skip it.
         string stackTrace = string.Join(
             Environment.NewLine,
-            "   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsInstanceOfType[T](T value, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs:line 99",
+            "   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsLessThan[T](T upperBound, T value, String message) in /_/src/TestFramework/TestFramework/Assertions/Assert.IComparable.cs:line 138",
             $"   at Microsoft.Testing.Extensions.UnitTests.AzureDevOpsTests.SkipsMSTestAssertImplementationFrameInPartialClassFile() in {userFile}:line {userLine}");
 
         var error = new SyntheticStackTraceException("boom", stackTrace);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport;
@@ -29,7 +29,7 @@ public sealed class AzureDevOpsTests
         // Trim ##. If we keep it, then when the test fails, the assertion failure will get printed to screen and picked up incorrectly by AzDO, because it scans all output for the ##vso... pattern
         var logger = new TextLogger();
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
-        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=22;columnnumber=1][MyTestDisplayName] [net9.0] this is an error%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=22;columnnumber=1]MyTestDisplayName [net9.0]%0Athis is an error%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
 
     [TestMethod]
@@ -48,7 +48,7 @@ public sealed class AzureDevOpsTests
         // Trim ##. If we keep it, then when the test fails, the assertion failure will get printed to screen and picked up incorrectly by AzDO, because it scans all output for the ##vso... pattern
         var logger = new TextLogger();
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", "Some custom reason\nwith\rnewline", error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
-        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=41;columnnumber=1][MyTestDisplayName] [net9.0] Some custom reason%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+        Assert.AreEqual("vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber=41;columnnumber=1]MyTestDisplayName [net9.0]%0ASome custom reason%0Awith%0Dnewline", text, $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
 
     [TestMethod]
@@ -77,7 +77,7 @@ public sealed class AzureDevOpsTests
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
 
         Assert.AreEqual(
-            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1]MyTestDisplayName [net9.0]%0Aboom",
             text,
             $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
@@ -98,7 +98,7 @@ public sealed class AzureDevOpsTests
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
 
         Assert.AreEqual(
-            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1]MyTestDisplayName [net9.0]%0Aboom",
             text,
             $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
@@ -119,7 +119,7 @@ public sealed class AzureDevOpsTests
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
 
         Assert.AreEqual(
-            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1]MyTestDisplayName [net9.0]%0Aboom",
             text,
             $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
@@ -140,7 +140,7 @@ public sealed class AzureDevOpsTests
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
 
         Assert.AreEqual(
-            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1]MyTestDisplayName [net9.0]%0Aboom",
             text,
             $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
@@ -167,7 +167,7 @@ public sealed class AzureDevOpsTests
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", fileSystem.Object, logger, "net9.0")?.TrimStart('#');
 
         Assert.AreEqual(
-            "vso[task.logissue type=severity;sourcepath=src/MyCompany/MyAssert.cs;linenumber=17;columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            "vso[task.logissue type=severity;sourcepath=src/MyCompany/MyAssert.cs;linenumber=17;columnnumber=1]MyTestDisplayName [net9.0]%0Aboom",
             text,
             $"\nLogs:\n{string.Join("\n", logger.Logs)}");
     }
@@ -193,9 +193,64 @@ public sealed class AzureDevOpsTests
         string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", fileSystem.Object, logger, "net9.0")?.TrimStart('#');
 
         Assert.AreEqual(
-            "vso[task.logissue type=severity;sourcepath=src/MyCompany/MyAssertions.cs;linenumber=25;columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            "vso[task.logissue type=severity;sourcepath=src/MyCompany/MyAssertions.cs;linenumber=25;columnnumber=1]MyTestDisplayName [net9.0]%0Aboom",
             text,
             $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
+    public void FormatErrorMessage_PlacesTestNameAsTitleOnFirstLine()
+    {
+        // The reporter emits one message that is rendered both by AzDO and by GitHub PR
+        // checks (via the dotnet problem matcher). Both UIs treat the first line as the
+        // bold annotation title, so the test name should live there and the assertion
+        // text should follow on the next line (encoded by AzDoEscaper as %0A).
+        string formatted = AzureDevOpsReporter.FormatErrorMessage(
+            "MyTestDisplayName",
+            "net9.0",
+            "Assert.AreEqual failed. Expected:<7>. Actual:<0>.");
+
+        Assert.AreEqual("MyTestDisplayName [net9.0]\nAssert.AreEqual failed. Expected:<7>. Actual:<0>.", formatted);
+    }
+
+    [TestMethod]
+    public void FormatErrorMessage_DoesNotDuplicateTfmWhenAlreadyInDisplayName()
+    {
+        // In multi-TFM runs MTP appends the TFM to the display name (e.g. "MyTest (net9.0)").
+        // We must not append it again or annotations end up reading "MyTest (net9.0) [net9.0]".
+        string formatted = AzureDevOpsReporter.FormatErrorMessage(
+            "MyTest (net9.0)",
+            "net9.0",
+            "boom");
+
+        Assert.AreEqual("MyTest (net9.0)\nboom", formatted);
+    }
+
+    [TestMethod]
+    public void FormatErrorMessage_DoesNotDuplicateTfmWhenQuotedInDisplayName()
+    {
+        // Acceptance tests' display names sometimes show the TFM quoted, e.g.
+        // 'HangDump_TemplateFileName_CreateDump ("net10.0")'. The dedup must catch that too.
+        string formatted = AzureDevOpsReporter.FormatErrorMessage(
+            "HangDump_TemplateFileName_CreateDump (\"net10.0\")",
+            "net10.0",
+            "boom");
+
+        Assert.AreEqual("HangDump_TemplateFileName_CreateDump (\"net10.0\")\nboom", formatted);
+    }
+
+    [TestMethod]
+    public void FormatErrorMessage_KeepsTfmSuffixWhenDisplayNameContainsDifferentTfm()
+    {
+        // Test asset's TFM (in display name) can legitimately differ from the host TFM
+        // when an acceptance test runs against a target asset built for an older TFM.
+        // In that case both pieces of info are useful and we should keep them.
+        string formatted = AzureDevOpsReporter.FormatErrorMessage(
+            "HangDump_TemplateFileName_CreateDump (\"net10.0\")",
+            "net11.0",
+            "boom");
+
+        Assert.AreEqual("HangDump_TemplateFileName_CreateDump (\"net10.0\") [net11.0]\nboom", formatted);
     }
 
     private static (string FilePath, int LineNumber) GetCurrentLocation(

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs
@@ -125,6 +125,27 @@ public sealed class AzureDevOpsTests
     }
 
     [TestMethod]
+    public void SkipsMSTestAssertThatImplementationFrame()
+    {
+        (string userFile, int userLine) = GetCurrentLocation();
+
+        string stackTrace = string.Join(
+            Environment.NewLine,
+            "   at Microsoft.VisualStudio.TestTools.UnitTesting.AssertExtensions.That(Expression`1 condition, String message, String conditionExpression) in /_/src/TestFramework/TestFramework/Assertions/Assert.That.cs:line 27",
+            $"   at Microsoft.Testing.Extensions.UnitTests.AzureDevOpsTests.SkipsMSTestAssertThatImplementationFrame() in {userFile}:line {userLine}");
+
+        var error = new SyntheticStackTraceException("boom", stackTrace);
+
+        var logger = new TextLogger();
+        string? text = AzureDevOpsReporter.GetErrorText("MyTestDisplayName", null, error, "severity", new SystemFileSystem(), logger, "net9.0")?.TrimStart('#');
+
+        Assert.AreEqual(
+            $"vso[task.logissue type=severity;sourcepath=test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTests.cs;linenumber={userLine};columnnumber=1][MyTestDisplayName] [net9.0] boom",
+            text,
+            $"\nLogs:\n{string.Join("\n", logger.Logs)}");
+    }
+
+    [TestMethod]
     public void DoesNotSkipUserFrameWhoseFileNameEndsWithAssertCs()
     {
         // The previous heuristic skipped any frame whose file path ended with "Assert.cs",


### PR DESCRIPTION
Fixes #6925. Closes #8278.

## Problem

AzureDevOpsReporter.GetErrorText walks a failing test's stack frames and skips the frame if the file path ends with `Assert.cs`, so the reporter annotates the user's call site rather than the framework's assertion implementation:

https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs#L215-L223

But `Assert` / `CollectionAssert` / `StringAssert` are split into partial-class files (`Assert.AreEqual.cs`, `Assert.IComparable.cs`, `Assert.IsInstanceOfType.cs`, `CollectionAssert.Equality.cs`, etc.) whose file names do **not** end with `Assert.cs`. The filter misses every one of them, so for cases like the `Assert.IsInstanceOfType` failure in #6925 the reporter incorrectly annotates the framework file instead of the user's test.

The filter also has the opposite problem: a user file innocently named `MyAssert.cs` would be wrongly skipped.

## Fix

Switch the skip decision from the **file name** to the fully-qualified **type name** captured in the stack frame's `code` field (already parsed by `StackTraceHelper.GetFrameRegex` and previously unused). A frame is skipped iff its `code` starts with one of:

- `Microsoft.VisualStudio.TestTools.UnitTesting.Assert.`
- `Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.`
- `Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert.`

This naturally covers every partial-class file (current and future), is robust against file renames/splits, and removes the `MyAssert.cs` false positive.

A complementary follow-up — adding `[StackTraceHidden]` on the same APIs once RFC 012 lands — is tracked separately in #8277 and would obviate the reporter heuristic entirely on .NET 6+. This PR is still needed for .NET Framework.

## Tests

Added 5 tests to `AzureDevOpsTests`:

- `SkipsMSTestAssertImplementationFrameInPartialClassFile` — regression test for #6925: synthetic stack with a frame in `Assert.IComparable.cs` followed by a user frame; asserts the user frame is reported.
- `SkipsMSTestCollectionAssertImplementationFrameInPartialClassFile` — same for `CollectionAssert.Equality.cs`.
- `SkipsMSTestStringAssertImplementationFrame` — same for `StringAssert.cs`.
- `DoesNotSkipUserFrameWhoseFileNameEndsWithAssertCs` — verifies the previous false positive on user files named `*Assert.cs` is gone (mocked `IFileSystem`).
- `DoesNotSkipUserFrameWhoseTypeNameStartsWithAssert` — verifies a user type in a non-MSTest namespace named `Assert` is not mistaken for the framework's `Assert`.

The two pre-existing tests' expected line numbers were updated because the `using Moq;` directive shifted the throw statements down.

All 7 tests pass on `net9.0`, `net8.0`, and `net472`. Full `Microsoft.Testing.Extensions.UnitTests` suite (124 tests) passes.