### PR TITLE
Fix TelemetryTests flake from parallel dotnet test races

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -8,6 +8,12 @@ using Microsoft.Testing.Platform.Helpers;
 namespace MSTest.Acceptance.IntegrationTests;
 
 [TestClass]
+// The VSTest_* tests below invoke `dotnet test` against the same shared VSTest project
+// path for every target framework. Running them in parallel races on MSBuild outputs
+// such as `bin/Release/<tfm>/TelemetryVSTestProject.runtimeconfig.json` and shared
+// `obj/` files, which causes intermittent `GenerateRuntimeConfigurationFiles` failures.
+// Serialize all tests in this class to keep the suite deterministic.
+[DoNotParallelize]
 public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture>
 {
     private const string MTPAssetName = "TelemetryMTPProject";


### PR DESCRIPTION
## Problem

`TelemetryTests.VSTest_RunTests_Succeeds` and `VSTest_DiscoverTests_Succeeds` are parameterised by target framework via `[DynamicData(TargetFrameworks.AllForDynamicData)]` and both invoke:

`dotnet test -c Release {AssetFixture.VSTestProjectPath} --framework {tfm}`

against the **same** shared `vstest/TelemetryVSTestProject.csproj`. With MSTest parallelism enabled, multiple TFM instances run concurrently and race on MSBuild outputs such as `bin/Release/<tfm>/TelemetryVSTestProject.runtimeconfig.json` and shared `obj/` files.

Observed CI failure:

```
error MSB4018: The ""GenerateRuntimeConfigurationFiles"" task failed unexpectedly.
System.IO.IOException: The process cannot access the file
'...\TelemetryTests\vstest\bin\Release\net10.0\TelemetryVSTestProject.runtimeconfig.json'
because it is being used by another process.
```

## Fix

Apply `[DoNotParallelize]` at the `TelemetryTests` class level to serialize all tests in the class. This is a one-line change, preserves test coverage, and only has a small impact on suite duration.

## Blocked PRs

This flake has been intermittently blocking: #8284 #8259 #8234 #8268 #8270 #8256 #8255 #8189 #8262 #8237 #8231
