### PR TITLE
Assert.That: additional test cases for object-typed sub-expressions (stacks on #8307)

### DIFF
--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
@@ -1343,6 +1343,52 @@ public partial class AssertTests : TestContainer
         ex.Message.Should().Contain("Callback");
         ex.Message.Should().Contain("null");
     }
+
+    // ---- Object-typed sub-expressions: locks down current behavior when two side-effecting
+    // method calls return the same mutable reference. The cache stores reference values, so by
+    // the time details are extracted both slots point to the post-mutation object; with
+    // first-occurrence-by-name and "same value -> dedupe" semantics in TryAddExpressionValue,
+    // only one entry surfaces. This is a known UX limitation worth pinning down with a test.
+    public void That_TwoCallsReturningSameMutatedReference_DeduplicatesInDetails()
+    {
+        var box = new BoxOfShapes();
+
+        // Same reference returned twice but mutated between calls; the != check therefore returns
+        // false (same reference) so the assertion fails.
+        Action act = () => Assert.That(() => box.GetValueWithSideEffect() != box.GetValueWithSideEffect());
+
+        act.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assert.That(() => box.GetValueWithSideEffect() != box.GetValueWithSideEffect()) failed.
+                Details:
+                  box.GetValueWithSideEffect() = Shape: Circle
+                """);
+    }
+
+    private sealed class Shape
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public override string ToString() => $"Shape: {Name}";
+    }
+
+    private sealed class BoxOfShapes
+    {
+        private Shape? _c;
+
+        public Shape GetValueWithSideEffect()
+        {
+            if (_c is null)
+            {
+                _c = new Shape { Name = "Square" };
+                return _c;
+            }
+
+            _c.Name = "Circle";
+            return _c;
+        }
+    }
 }
 
 internal static class MutableBoxHelper


### PR DESCRIPTION
Stacks on top of #8307 (`dev/amauryleve/assert-that`).

Adds an extra test case from @jakubjares exploring `Assert.That` behavior when sub-expressions evaluate to `object` references (where the diagnostic message can be confusing). The test `That_DoesEvaluateTwice_WhenMethodIsLeaf2` and helper types (`Shape`, `BoxOfShapes`) were authored on 2025-11-25.

> [!WARNING]
> Marked as draft because the new test currently asserts `WithMessage(""""""non"""""")`, which is clearly a placeholder. The test expectation needs to be updated to the real expected failure message (and the test renamed if appropriate) before this PR is ready for review.

## Merge notes
This branch was rebased onto `main` (commit 6b0bae4ac). Same resolution strategy as #8307:
- `Assert.That.cs`: kept the new `EvaluateExpression` / cache logic; adopted main's `StringBuilder.Append(char, int)` overload while preserving the `MaxConsecutiveParentheses` constant.
- `FrameworkMessages.resx`: kept `AssertThatFailedToEvaluate` alongside all new RFC 012 summary entries from main; `xlf` files regenerated via `dotnet msbuild /t:UpdateXlf`.
- Guarded `[RequiresDynamicCode(...)]` attributes with `#if NET7_0_OR_GREATER` for `netstandard2.0` / `net462` compatibility.

## Validation
- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj -c Debug` -> clean across netstandard2.0, net462, net8.0, net9.0.
- Tests not run here because the new test has a placeholder expectation; run them after fixing the expectation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
