### PR TITLE
Pre-build VSTest project and use --no-build for TelemetryTests

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -129,8 +129,15 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     public async Task VSTest_RunTests_Succeeds(string tfm)
     {
+        // Pre-build the VSTest project for this TFM exactly once, then run `dotnet test`
+        // with `--no-build --no-restore` so the build/restore targets that write to
+        // `bin/<tfm>/TelemetryVSTestProject.runtimeconfig.json` do not run per-test.
+        // This removes the GenerateRuntimeConfigurationFiles race that was still flaking
+        // intermittently even with [DoNotParallelize] on the class.
+        await AssetFixture.EnsureVSTestProjectBuiltAsync(tfm, TestContext.CancellationToken);
+
         DotnetMuxerResult testResult = await DotnetCli.RunAsync(
-            $"test -c Release {AssetFixture.VSTestProjectPath} --framework {tfm}",
+            $"test -c Release {AssetFixture.VSTestProjectPath} --framework {tfm} --no-build --no-restore",
             workingDirectory: AssetFixture.VSTestProjectPath,
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
@@ -147,8 +154,10 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     public async Task VSTest_DiscoverTests_Succeeds(string tfm)
     {
+        await AssetFixture.EnsureVSTestProjectBuiltAsync(tfm, TestContext.CancellationToken);
+
         DotnetMuxerResult testResult = await DotnetCli.RunAsync(
-            $"test -c Release {AssetFixture.VSTestProjectPath} --framework {tfm} --list-tests",
+            $"test -c Release {AssetFixture.VSTestProjectPath} --framework {tfm} --list-tests --no-build --no-restore",
             workingDirectory: AssetFixture.VSTestProjectPath,
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
@@ -192,6 +201,9 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
     {
         private const string AssetId = nameof(TelemetryTests);
 
+        private readonly SemaphoreSlim _vstestBuildLock = new(1, 1);
+        private readonly HashSet<string> _builtVSTestFrameworks = new(StringComparer.OrdinalIgnoreCase);
+
         public string MTPProjectPath => GetAssetPath(AssetId);
 
         public string VSTestProjectPath => Path.Combine(GetAssetPath(AssetId), "vstest");
@@ -202,6 +214,49 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
                 .PatchCodeWithReplace("$MicrosoftNETTestSdkVersion$", MicrosoftNETTestSdkVersion));
+
+        // Pre-builds the VSTest project for the given TFM exactly once per TFM. Callers can
+        // then invoke `dotnet test ... --no-build --no-restore` to avoid having every test
+        // method redo the build, which is what produces the
+        // `GenerateRuntimeConfigurationFiles` file-in-use races on shared build outputs.
+        public async Task EnsureVSTestProjectBuiltAsync(string targetFramework, CancellationToken cancellationToken)
+        {
+            await _vstestBuildLock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_builtVSTestFrameworks.Contains(targetFramework))
+                {
+                    return;
+                }
+
+                DotnetMuxerResult buildResult = await DotnetCli.RunAsync(
+                    $"build -c Release {VSTestProjectPath} --framework {targetFramework}",
+                    workingDirectory: VSTestProjectPath,
+                    cancellationToken: cancellationToken);
+
+                if (buildResult.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to pre-build VSTest project for {targetFramework}:\n{buildResult.StandardOutput}\n{buildResult.StandardError}");
+                }
+
+                _builtVSTestFrameworks.Add(targetFramework);
+            }
+            finally
+            {
+                _vstestBuildLock.Release();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _vstestBuildLock.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
 
         private const string SourceCode = """
 #file TelemetryMTPProject.csproj

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -202,7 +202,7 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         private const string AssetId = nameof(TelemetryTests);
 
         private readonly SemaphoreSlim _vstestBuildLock = new(1, 1);
-        private readonly HashSet<string> _builtVSTestFrameworks = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _builtVSTestFrameworks = [with(StringComparer.OrdinalIgnoreCase)];
 
         public string MTPProjectPath => GetAssetPath(AssetId);
 
@@ -229,16 +229,10 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
                     return;
                 }
 
-                DotnetMuxerResult buildResult = await DotnetCli.RunAsync(
+                await DotnetCli.RunAsync(
                     $"build -c Release {VSTestProjectPath} --framework {targetFramework}",
                     workingDirectory: VSTestProjectPath,
                     cancellationToken: cancellationToken);
-
-                if (buildResult.ExitCode != 0)
-                {
-                    throw new InvalidOperationException(
-                        $"Failed to pre-build VSTest project for {targetFramework}:\n{buildResult.StandardOutput}\n{buildResult.StandardError}");
-                }
 
                 _builtVSTestFrameworks.Add(targetFramework);
             }


### PR DESCRIPTION
Follow-up to #8292 which only added `[DoNotParallelize]` to `TelemetryTests`.

The `VSTest_RunTests_Succeeds` and `VSTest_DiscoverTests_Succeeds` cases were still flaking on SDK 11 preview (`11.0.100-preview.5.26227.104`) with:

```
error MSB4018: The "GenerateRuntimeConfigurationFiles" task failed unexpectedly.
System.IO.IOException: The process cannot access the file
'...bin/Release/<tfm>/TelemetryVSTestProject.runtimeconfig.json' because it is being used by another process.
```

Even though `[DoNotParallelize]` serializes the test methods inside the class, every `dotnet test` invocation still re-runs the build (and `GenerateRuntimeConfigurationFiles`), and the shared `bin/<tfm>/` outputs were racing with leftover MSBuild / testhost handles across serialized invocations.

### Fix

- Add `EnsureVSTestProjectBuiltAsync(tfm, ct)` on the fixture, gated by a `SemaphoreSlim` + `HashSet<string>` so the VSTest project is built exactly once per TFM. The TFM is only cached after a successful build to avoid poisoning on cancellation/failure.
- Change `VSTest_*` tests to call the pre-build then run `dotnet test ... --no-build --no-restore` so the build/restore targets that write the locked file never run during the actual tests.
- Keep `[DoNotParallelize]` as defense in depth.

### Verification

- Local `dotnet build` of `MSTest.Acceptance.IntegrationTests.csproj` succeeds.
- Functional verification has to happen in CI since this is an intermittent SDK 11 preview race.