### PR TITLE
Bump OTel by @Evangelink in #8099 (backport to rel/4.2)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
-    <PackageVersion Include="OpenTelemetry" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="Polyfill" Version="9.7.3" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>

--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" VersionOverride="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" VersionOverride="1.15.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backports #8099 to `rel/4.2` to address a security vulnerability in OpenTelemetry.

- Bumps `OpenTelemetry` from 1.14.0 to 1.15.3 in `Directory.Packages.props`.
- Bumps `OpenTelemetry.Exporter.OpenTelemetryProtocol` from 1.14.0 to 1.15.3 in `samples/Playground/Playground.csproj`.