### PR TITLE
Pin Nerdbank.MessagePack to fix CVE by @Evangelink in #8096, #8153, #8176 (backport to rel/4.2)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,6 +86,8 @@
     <PackageVersion Include="Polly" Version="8.6.5" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
+    <!-- This comes transitively via StreamJsonRpc, but we want to upgrade it to fix a security vulnerability -->
+    <PackageVersion Include="Nerdbank.MessagePack" Version="1.1.62" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Management" Version="9.0.4" />

--- a/samples/FSharpPlayground/FSharpPlayground.fsproj
+++ b/samples/FSharpPlayground/FSharpPlayground.fsproj
@@ -23,6 +23,8 @@
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="Nerdbank.MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
   </ItemGroup>

--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <PackageReference Include="Nerdbank.MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -26,6 +26,8 @@
   <ItemGroup>
     <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="Nerdbank.MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="Nerdbank.MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 


### PR DESCRIPTION
Backports #8096, #8153 and #8176 to `rel/4.2` to address a security vulnerability in `Nerdbank.MessagePack` (a transitive dependency of `StreamJsonRpc`).

- #8096 — Bumps `Nerdbank.MessagePack` to 1.1.62 in `Directory.Packages.props` and pins it in the MTP / MSTest acceptance integration test projects.
- #8153 — Pins `Nerdbank.MessagePack` in `samples/FSharpPlayground/FSharpPlayground.fsproj`.
- #8176 — Pins `Nerdbank.MessagePack` in `samples/Playground/Playground.csproj`.