### PR TITLE
Reuse existing FormatCallSiteExpression helper for AreEqual/AreNotEqual

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -293,7 +293,7 @@ public sealed partial class Assert
         structured.WithUserMessage(message);
         structured.WithEvidence(evidence);
         structured.WithExpectedAndActual(expectedRendered, actualRendered);
-        structured.WithCallSiteExpression(FormatBinaryCallSiteExpression("Assert.AreEqual", expectedExpression, "expected", actualExpression, "actual"));
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreEqual", expectedExpression, actualExpression, "<expected>", "<actual>"));
 
         ReportAssertFailed(structured);
     }
@@ -414,7 +414,7 @@ public sealed partial class Assert
         structured.WithUserMessage(message);
         structured.WithEvidence(evidence);
         structured.WithExpectedAndActual($"not {notExpectedRendered}", actualRendered);
-        structured.WithCallSiteExpression(FormatBinaryCallSiteExpression("Assert.AreNotEqual", notExpectedExpression, "notExpected", actualExpression, "actual"));
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreNotEqual", notExpectedExpression, actualExpression, "<notExpected>", "<actual>"));
 
         ReportAssertFailed(structured);
     }

--- a/src/TestFramework/TestFramework/Assertions/Assert.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.cs
@@ -314,26 +314,6 @@ public sealed partial class Assert
             ? null
             : $"{methodName}({expression})";
 
-    private static readonly char[] LineBreakChars = ['\n', '\r'];
-
-    /// <summary>
-    /// Formats a call-site expression like <c>Assert.MethodName(expression1, expression2)</c>.
-    /// When either expression is empty the call-site is omitted. When an expression contains
-    /// newlines (multiline constant) it is replaced with a <c>&lt;paramName&gt;</c> placeholder.
-    /// </summary>
-    private static string? FormatBinaryCallSiteExpression(string methodName, string expression1, string paramName1, string expression2, string paramName2)
-    {
-        if (string.IsNullOrWhiteSpace(expression1) || string.IsNullOrWhiteSpace(expression2))
-        {
-            return null;
-        }
-
-        string arg1 = expression1.IndexOfAny(LineBreakChars) >= 0 ? $"<{paramName1}>" : expression1;
-        string arg2 = expression2.IndexOfAny(LineBreakChars) >= 0 ? $"<{paramName2}>" : expression2;
-
-        return $"{methodName}({arg1}, {arg2})";
-    }
-
     private static int CompareInternal(string? expected, string? actual, bool ignoreCase, CultureInfo culture)
 #pragma warning disable CA1309 // Use ordinal string comparison
         => string.Compare(expected, actual, ignoreCase, culture);


### PR DESCRIPTION
Follow-up to #8231 addressing https://github.com/microsoft/testfx/pull/8231#discussion_r3257402747.

The new `FormatBinaryCallSiteExpression` helper (plus its `LineBreakChars` field) introduced in #8231 duplicated the existing 2-arg internal `FormatCallSiteExpression` overload and had subtly different semantics:

- It dropped the **entire** call-site line when **either** expression was empty/whitespace, whereas the existing helper only drops it when **both** are empty and otherwise renders a `<placeholder>` for the empty side.
- It carried its own `LineBreakChars`/`IndexOfAny` newline-detection in parallel with the existing `IsMultiline`/`NormalizeCallSitePlaceholder` infrastructure.

This PR:

- Removes `FormatBinaryCallSiteExpression` and the `LineBreakChars` field from `Assert.cs`.
- Routes `Assert.AreEqual` and `Assert.AreNotEqual` failure reporting through the existing `FormatCallSiteExpression(string, string, string, string, string)` overload, matching the call sites already used by `Assert.AreSame`, `Assert.AreNotSame`, `Assert.Contains`, `Assert.AreEquivalent`, `Assert.StartsWith`/`EndsWith`, `Assert.MatchesRegex`, etc.

### Behavioral notes

For the typical case where both `[CallerArgumentExpression]` values are captured normally, the rendered call site is identical (e.g. `Assert.AreEqual(expected, actual)`).

The difference only shows up in the rare edge case where one side's caller-argument expression is empty (e.g. used through reflection / hand-built call) - the call site is now still rendered with `<expected>`/`<actual>` placeholders, consistent with the other binary assertions, instead of being suppressed.

### Validation

- `.\build.cmd -c Release`: succeeded.
- `dotnet test test\UnitTests\TestFramework.UnitTests\TestFramework.UnitTests.csproj -c Release --no-build`: only the same 2 pre-existing `AreAllDistinct_*WithComparer_HasDuplicate_ShouldFail` failures observed on `main` remain (unrelated to this change).
