### PR TITLE
[code-simplifier] Simplify TestDataConnectionSql partial modules

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Helpers.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Helpers.cs
@@ -34,22 +34,7 @@ internal partial class TestDataConnectionSql
     /// <param name="values">An array of values.</param>
     /// <returns>True if string exists in array.</returns>
     private static bool IsInArray(string? candidate, string[]? values)
-    {
-        if (values == null)
-        {
-            return false;
-        }
-
-        foreach (string value in values)
-        {
-            if (string.Equals(value, candidate, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => values is not null && Array.Exists(values, v => string.Equals(v, candidate, StringComparison.OrdinalIgnoreCase));
 
     #endregion
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Names.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Names.cs
@@ -19,16 +19,10 @@ internal partial class TestDataConnectionSql
     {
         string[]? parts = SplitName(tableName);
 
-        if (parts is { Length: > 0 })
-        {
-            // Seems to be well formed, so make sure we end up fully quoted
-            return JoinAndQuoteName(parts, true);
-        }
-        else
-        {
-            // Just use what they gave us, literally, since we do not really understand the format
-            return tableName;
-        }
+        // Seems to be well formed, so make sure we end up fully quoted; otherwise use as-is
+        return parts is { Length: > 0 }
+            ? JoinAndQuoteName(parts, true)
+            : tableName;
     }
 
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Schema.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Schema.cs
@@ -111,8 +111,7 @@ internal partial class TestDataConnectionSql
                     WriteDiagnostics("Table {0}{1} found", tableSchema != null ? tableSchema + "." : string.Empty, tableName);
 
                     // If schema is defined and is not equal to default, prepend table schema in front of the table.
-                    string? qualifiedTableName = tableName;
-                    qualifiedTableName = isDefaultSchema
+                    string qualifiedTableName = isDefaultSchema
                         ? FormatTableNameForDisplay(null, tableName)
                         : FormatTableNameForDisplay(tableSchema, tableName);
 
@@ -162,7 +161,7 @@ internal partial class TestDataConnectionSql
                 WriteDiagnostics("GetColumns for {0} failed to get column metadata, exception {1}", tableName, e);
             }
 
-            if (columns != null)
+            if (columns is not null)
             {
                 List<string> result = [];
 
@@ -177,10 +176,8 @@ internal partial class TestDataConnectionSql
                 // must be found in a single metadata collection
                 return result;
             }
-            else
-            {
-                WriteDiagnostics("Column metadata is null");
-            }
+
+            WriteDiagnostics("Column metadata is null");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
- Replace verbose IsInArray loop with Array.Exists expression
- Simplify PrepareNameForSql to a single ternary return
- Remove redundant dead assignment in GetDataTablesAndViews
- Use 'is not null' pattern and remove redundant else block in GetColumns

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fix #8303
