### PR TITLE
Sanitize ODBC sample connection string to unblock dnceng mirror

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Helpers.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnectionSql.Helpers.cs
@@ -104,7 +104,7 @@ internal partial class TestDataConnectionSql
     /// </summary>
     /// <remarks>
     /// sqlsrv32.dll: Driver={SQL Server};Server=SqlServer;Database=DatabaseName;Trusted_Connection=yes
-    /// msorcl32.dll: Driver={Microsoft ODBC for Oracle};Server=OracleServer;Uid=user;Pwd=password.
+    /// msorcl32.dll: Driver={Microsoft ODBC for Oracle};Server=OracleServer;Uid=&lt;user&gt;;Pwd=&lt;password&gt;.
     /// </remarks>
     protected static class KnownOdbcDrivers
     {


### PR DESCRIPTION
Fixes #8291.

## Root cause

PR #8270 (`Refactor `TestDataConnectionSql` into focused partial modules`) moved a long-standing doc comment containing a sample ODBC connection string into a brand-new file `TestDataConnectionSql.Helpers.cs`. That comment contains the literal substring `Pwd=password`, which Azure DevOps push protection flags as an embedded credential (**VS403654** — *ODBC connection string with credentials*) and rejects the fast-forward mirror push from GitHub to `dev.azure.com/dnceng/internal/_git/microsoft-testfx`.

The same comment lived in `TestDataConnectionSql.cs` since the 2016 initial commit and had already been mirrored long before push protection was enabled, so the original location is grandfathered in. The refactor re-introduced the pattern in a new file, which now trips the scanner on every subsequent push.

Timing matches:

| Event | Time (UTC) |
|---|---|
| Commit `037e9b09e` pushed | 2026-05-16 14:22 |
| dnceng-bot opens #8291 | 2026-05-16 14:28 |

## Fix

Replace `Uid=user;Pwd=password` with `Uid=<user>;Pwd=<password>` (XML-encoded as `&lt;user&gt;`/`&lt;password&gt;` so the doc-comment XML stays valid). The example remains useful and self-explanatory but no longer matches the connection-string-with-credentials detector.