### PR TITLE
Fix AreAllDistinct tests to expect short comparer type name

### DIFF
--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreAll.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreAll.cs
@@ -214,7 +214,7 @@ public partial class AssertTests : TestContainer
 
     public void AreAllDistinct_Generic_WithComparer_HasDuplicate_ShouldFail()
     {
-        string comparerTypeName = typeof(CaseInsensitiveStringComparer).FullName!;
+        string comparerTypeName = nameof(CaseInsensitiveStringComparer);
         string expectedMessage = """
             Assertion failed. Expected all items in collection to be distinct.
 
@@ -267,7 +267,7 @@ public partial class AssertTests : TestContainer
 
     public void AreAllDistinct_NonGeneric_WithComparer_HasDuplicate_ShouldFail()
     {
-        string comparerTypeName = typeof(CaseInsensitiveStringComparer).FullName!;
+        string comparerTypeName = nameof(CaseInsensitiveStringComparer);
         string expectedMessage = """
             Assertion failed. Expected all items in collection to be distinct.
 


### PR DESCRIPTION
Fixes test breakage introduced by #8311.

#8311 changed `Assert.AreAllDistinct` failure messages to render the comparer's short type name (`comparer.GetType().Name`) instead of the full name, but it didn't update the corresponding unit tests. The tests in `AssertTests.AreAll.cs` still computed their expected message from `typeof(CaseInsensitiveStringComparer).FullName`, so on every PR build the following two tests fail:

- `AreAllDistinct_Generic_WithComparer_HasDuplicate_ShouldFail`
- `AreAllDistinct_NonGeneric_WithComparer_HasDuplicate_ShouldFail`

This PR switches the expected `comparer:` line in both tests to use `nameof(CaseInsensitiveStringComparer)`, matching what `Assert.AreAllDistinct` actually renders.

### Validation

`dotnet test test\UnitTests\TestFramework.UnitTests\TestFramework.UnitTests.csproj -c Release --no-build --framework net9.0` -> `succeeded: 1045 / failed: 0` (previously `succeeded: 1043 / failed: 2`).
