### PR TITLE
Stabilize HangDump template-filename tests on macOS

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HangDumpTests.cs
@@ -115,7 +115,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
             new Dictionary<string, string?>
             {
                 ["SLEEPTIMEMS1"] = "4000",
-                ["SLEEPTIMEMS2"] = "20000",
+                ["SLEEPTIMEMS2"] = "600000",
             },
             cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
@@ -148,7 +148,7 @@ public sealed class HangDumpTests : AcceptanceTestBase<HangDumpTests.TestAssetFi
             new Dictionary<string, string?>
             {
                 ["SLEEPTIMEMS1"] = "4000",
-                ["SLEEPTIMEMS2"] = "20000",
+                ["SLEEPTIMEMS2"] = "600000",
             },
             cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);


### PR DESCRIPTION
`HangDump_TemplateFileName_CreateDump` and `HangDump_TemplateFileNameWithSubdirectory_CreateDump` set `SLEEPTIMEMS2=20000` (20 s) while every other hang-triggering test in `HangDumpTests.cs` uses `600000` (10 min).

On macOS, `createdump` writes a full ~5.6 GB core dump that takes ~140 s to flush. When the test host's second sleep is only 20 s, the host completes its run and exits with code 0 **before** `createdump` can kill it, so `AssertExitCodeIs(TestHostProcessExitedNonGracefully)` (expected exit code `7`) fails. The pattern shows up consistently on the macOS Debug leg, e.g.:

```
Hang dump timeout of '00:00:08' expired
...
[createdump] Written 5645312312 bytes (1378250 pages) to core file
[createdump] Target process is alive
Test run summary: Passed!
ExitCode: 0
[createdump] Dump successfully written in 139717ms
```

This is the same class of macOS flake that #7172, #7005, #7028 etc. addressed for sibling tests.

### Fix

Align both tests with the surrounding hang-triggering tests (`HangDump_DefaultSetting_CreateDump`, `HangDump_CustomFileName_CreateDump`, `HangDump_PathWithSpaces_CreateDump`, `HangDump_Formats_CreateDump`, `HangDump_WithDotnetTest_CreateDump`) by using `SLEEPTIMEMS2=600000` so the test host stays alive long enough for `createdump` to terminate it on all platforms.

### Out of scope

`HangDump_TemplateWithPathTraversal_RejectsAndFails` intentionally keeps `SLEEPTIMEMS2=20000` - its `--hangdump-filename` is rejected during option validation before any sleep matters, so it isn't subject to the createdump race.

### Validation

- Local Windows build of `Microsoft.Testing.Platform.Acceptance.IntegrationTests` succeeds.
- The macOS-specific race cannot be reproduced on Windows; the fix is the same well-established mitigation pattern (matching every other hang-triggering test in this file).
