### PR TITLE
Update generic-crash banner to flag missing diagnostic artifacts (#8191 follow-up)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
@@ -148,7 +148,7 @@
     <value>[net6.0+ only] Generate a dump file if the test process crashes</value>
   </data>
   <data name="CrashDumpProcessCrashed" xml:space="preserve">
-    <value>Test host process with PID '{0}' crashed</value>
+    <value>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</value>
   </data>
   <data name="CrashDumpProcessCrashedDumpAndReportFileCreated" xml:space="preserve">
     <value>Test host process with PID '{0}' crashed, a dump file and crash report were generated</value>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
@@ -148,7 +148,7 @@
     <value>[net6.0+ only] Generate a dump file if the test process crashes</value>
   </data>
   <data name="CrashDumpProcessCrashed" xml:space="preserve">
-    <value>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</value>
+    <value>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</value>
   </data>
   <data name="CrashDumpProcessCrashedDumpAndReportFileCreated" xml:space="preserve">
     <value>Test host process with PID '{0}' crashed, a dump file and crash report were generated</value>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed</source>
-        <target state="new">Test host process with PID '{0}' crashed</target>
+        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashed">
-        <source>Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</source>
-        <target state="new">Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced</target>
+        <source>Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</source>
+        <target state="new">Test host process with PID '{0}' crashed, but the expected diagnostic artifact(s) were not produced</target>
         <note />
       </trans-unit>
       <trans-unit id="CrashDumpProcessCrashedDumpAndReportFileCreated">


### PR DESCRIPTION
Follow-up to #8191 addressing the one remaining review item that genuinely needed a code change.

### Background

[Discussion r3258181945](https://github.com/microsoft/testfx/pull/8191#discussion_r3258181945) pointed out that when `--crashdump` or `--crash-report` is requested but the expected artifact does not appear on disk, `OnTestHostProcessExitedAsync` falls through to the `(false, false)` branch of the new banner switch and emits the generic `CrashDumpProcessCrashed` message (`Test host process with PID 'X' crashed`). The per-artifact `CannotFindExpected*` messages are still printed below, but a quick skim of the output gave no banner-level signal that an expected diagnostic artifact was missing.

### Change

`IsEnabledAsync` guarantees at least one of `--crashdump` / `--crash-report` is set whenever the handler runs, so reaching the `(false, false)` branch always means an expected artifact was not produced. Update `CrashDumpProcessCrashed` to reflect that explicitly:

> Test host process with PID '{0}' crashed but the expected diagnostic artifact(s) were not produced

No code-side changes — only the resource value and the regenerated XLF files. The `(false, false)` branch already uses `CrashDumpProcessCrashed`, so the new wording flows through automatically.

### Other PR review items

All other open review comments on #8191 (10 of them) were already addressed in the merge — replies sent on each thread acknowledging the existing fix with file:line citations. The two remaining "discussion-only" items (option naming and `--help`/`--info` release-notes mention) were replied to in-thread explaining the rationale.

### Validation

`.\build.cmd -c Release` — **0 warnings, 0 errors**.
