### PR TITLE
Migrate string AreEqual overloads to RFC 012 messages

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.InterpolatedStringHandlers.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.InterpolatedStringHandlers.cs
@@ -157,7 +157,7 @@ public sealed partial class Assert
     public readonly struct AssertNonGenericAreEqualInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
-        private readonly Action<string>? _failAction;
+        private readonly Action<string, string, string>? _failAction;
 
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, float expected, float actual, float delta, out bool shouldAppend)
         {
@@ -165,7 +165,8 @@ public sealed partial class Assert
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
-                _failAction = userMessage => ReportAssertAreEqualFailed(expected, actual, delta, userMessage);
+                _failAction = (userMessage, expectedExpression, actualExpression) =>
+                    ReportAssertAreEqualFailed(expected, actual, delta, BuildUserMessageForExpectedExpressionAndActualExpression(userMessage, expectedExpression, actualExpression));
             }
         }
 
@@ -175,7 +176,8 @@ public sealed partial class Assert
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
-                _failAction = userMessage => ReportAssertAreEqualFailed(expected, actual, delta, userMessage);
+                _failAction = (userMessage, expectedExpression, actualExpression) =>
+                    ReportAssertAreEqualFailed(expected, actual, delta, BuildUserMessageForExpectedExpressionAndActualExpression(userMessage, expectedExpression, actualExpression));
             }
         }
 
@@ -185,7 +187,8 @@ public sealed partial class Assert
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
-                _failAction = userMessage => ReportAssertAreEqualFailed(expected, actual, delta, userMessage);
+                _failAction = (userMessage, expectedExpression, actualExpression) =>
+                    ReportAssertAreEqualFailed(expected, actual, delta, BuildUserMessageForExpectedExpressionAndActualExpression(userMessage, expectedExpression, actualExpression));
             }
         }
 
@@ -195,13 +198,20 @@ public sealed partial class Assert
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
-                _failAction = userMessage => ReportAssertAreEqualFailed(expected, actual, delta, userMessage);
+                _failAction = (userMessage, expectedExpression, actualExpression) =>
+                    ReportAssertAreEqualFailed(expected, actual, delta, BuildUserMessageForExpectedExpressionAndActualExpression(userMessage, expectedExpression, actualExpression));
             }
         }
 
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? expected, string? actual, bool ignoreCase, out bool shouldAppend)
-            : this(literalLength, formattedCount, expected, actual, ignoreCase, CultureInfo.InvariantCulture, out shouldAppend)
         {
+            shouldAppend = AreEqualFailing(expected, actual, ignoreCase, CultureInfo.InvariantCulture);
+            if (shouldAppend)
+            {
+                _builder = new StringBuilder(literalLength + formattedCount);
+                _failAction = (userMessage, expectedExpression, actualExpression) =>
+                    ReportAssertAreEqualFailed(expected, actual, ignoreCase, CultureInfo.InvariantCulture, cultureExplicit: false, userMessage, expectedExpression, actualExpression);
+            }
         }
 
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? expected, string? actual, bool ignoreCase, CultureInfo culture, out bool shouldAppend)
@@ -211,18 +221,13 @@ public sealed partial class Assert
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
-                _failAction = userMessage => ReportAssertAreEqualFailed(expected, actual, ignoreCase, culture, userMessage);
+                _failAction = (userMessage, expectedExpression, actualExpression) =>
+                    ReportAssertAreEqualFailed(expected, actual, ignoreCase, culture, cultureExplicit: true, userMessage, expectedExpression, actualExpression);
             }
         }
 
         internal void ComputeAssertion(string expectedExpression, string actualExpression)
-        {
-            if (_failAction is not null)
-            {
-                _builder!.Insert(0, string.Format(CultureInfo.CurrentCulture, FrameworkMessages.CallerArgumentExpressionTwoParametersMessage, "expected", expectedExpression, "actual", actualExpression) + " ");
-                _failAction.Invoke(_builder!.ToString());
-            }
-        }
+            => _failAction?.Invoke(_builder!.ToString(), expectedExpression, actualExpression);
 
         public void AppendLiteral(string value) => _builder!.Append(value);
 
@@ -310,8 +315,14 @@ public sealed partial class Assert
         }
 
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? notExpected, string? actual, bool ignoreCase, out bool shouldAppend)
-            : this(literalLength, formattedCount, notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, out shouldAppend)
         {
+            shouldAppend = AreNotEqualFailing(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture);
+            if (shouldAppend)
+            {
+                _builder = new StringBuilder(literalLength + formattedCount);
+                _failAction = (userMessage, notExpectedExpr, actualExpr) =>
+                    ReportAssertAreNotEqualFailed(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, cultureExplicit: false, userMessage, notExpectedExpr, actualExpr);
+            }
         }
 
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? notExpected, string? actual, bool ignoreCase, CultureInfo culture, out bool shouldAppend)
@@ -321,7 +332,8 @@ public sealed partial class Assert
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
-                _failAction = (userMessage, notExpectedExpr, actualExpr) => ReportAssertAreNotEqualFailed(notExpected, actual, userMessage, notExpectedExpr, actualExpr);
+                _failAction = (userMessage, notExpectedExpr, actualExpr) =>
+                    ReportAssertAreNotEqualFailed(notExpected, actual, ignoreCase, culture, cultureExplicit: true, userMessage, notExpectedExpr, actualExpr);
             }
         }
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.String.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.String.cs
@@ -17,31 +17,130 @@ public sealed partial class Assert
         => CompareInternal(expected, actual, ignoreCase, culture) != 0;
 
     [DoesNotReturn]
-    private static void ReportAssertAreEqualFailed(string? expected, string? actual, bool ignoreCase, CultureInfo culture, string userMessage)
+    private static void ReportAssertAreEqualFailed(string? expected, string? actual, bool ignoreCase, CultureInfo culture, bool cultureExplicit, string? message, string expectedExpression, string actualExpression)
     {
-        string finalMessage;
+        string expectedRendered = AssertionValueRenderer.RenderValue(expected);
+        string actualRendered = AssertionValueRenderer.RenderValue(actual);
 
-        // If the user requested to match case, and the difference between expected/actual is casing only, then we use a different message.
-        if (!ignoreCase && CompareInternal(expected, actual, ignoreCase: true, culture) == 0)
+        StructuredAssertionMessage structured = new(FrameworkMessages.AreEqualStringsFailedSummary);
+        if (!ignoreCase && expected is not null && actual is not null && CompareInternal(expected, actual, ignoreCase: true, culture) == 0)
         {
-            finalMessage = string.Format(
-                CultureInfo.CurrentCulture,
-                FrameworkMessages.AreEqualCaseFailMsg,
-                userMessage,
-                ReplaceNulls(expected),
-                ReplaceNulls(actual));
-        }
-        else
-        {
-            // Use enhanced string comparison for string-specific failures
-            finalMessage = FormatStringComparisonMessage(expected, actual, userMessage);
+            structured.WithAdditionalSummaryLine(FrameworkMessages.AreEqualStringsCaseOnlyDifferenceMsg);
         }
 
-        ReportAssertFailed("Assert.AreEqual", finalMessage);
+        if (expected is not null && actual is not null)
+        {
+            int diffIndex = FindFirstStringDifference(expected, actual, ignoreCase, culture);
+            if (diffIndex >= 0)
+            {
+                AppendStringDiffSummary(structured, expected, actual, diffIndex);
+            }
+        }
+
+        structured.WithUserMessage(message);
+        structured.WithEvidence(CreateStringComparisonEvidence("expected:", expectedRendered, actualRendered, ignoreCase, culture, cultureExplicit));
+        structured.WithExpectedAndActual(expectedRendered, actualRendered);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreEqual", expectedExpression, actualExpression, "<expected>", "<actual>"));
+
+        ReportAssertFailed(structured);
+    }
+
+    [DoesNotReturn]
+    private static void ReportAssertAreNotEqualFailed(string? notExpected, string? actual, bool ignoreCase, CultureInfo culture, bool cultureExplicit, string? message, string notExpectedExpression, string actualExpression)
+    {
+        string notExpectedRendered = AssertionValueRenderer.RenderValue(notExpected);
+        string actualRendered = AssertionValueRenderer.RenderValue(actual);
+
+        StructuredAssertionMessage structured = new(ignoreCase
+            ? FrameworkMessages.AreNotEqualStringsCaseInsensitiveFailedSummary
+            : FrameworkMessages.AreNotEqualStringsFailedSummary);
+        structured.WithUserMessage(message);
+        structured.WithEvidence(CreateStringComparisonEvidence("not expected:", notExpectedRendered, actualRendered, ignoreCase, culture, cultureExplicit));
+        structured.WithExpectedAndActual($"not {notExpectedRendered}", actualRendered);
+        structured.WithCallSiteExpression(FormatCallSiteExpression("Assert.AreNotEqual", notExpectedExpression, actualExpression, "<notExpected>", "<actual>"));
+
+        ReportAssertFailed(structured);
+    }
+
+    private static EvidenceBlock CreateStringComparisonEvidence(string firstLabel, string firstValue, string actualValue, bool ignoreCase, CultureInfo culture, bool cultureExplicit)
+    {
+        EvidenceBlock evidence = EvidenceBlock.Create()
+            .AddLine(firstLabel, firstValue)
+            .AddLine("actual:", actualValue);
+
+        if (ignoreCase)
+        {
+            evidence.AddLine("ignore case:", "true");
+        }
+
+        // Track whether the culture overload was used so explicit CultureInfo.InvariantCulture remains self-describing as culture: "".
+        if (cultureExplicit)
+        {
+            evidence.AddLine("culture:", culture.Name);
+        }
+
+        return evidence;
     }
 
     private static bool AreNotEqualFailing(string? notExpected, string? actual, bool ignoreCase, CultureInfo culture)
         => CompareInternal(notExpected, actual, ignoreCase, culture) == 0;
+
+    private static int FindFirstStringDifference(string expected, string actual, bool ignoreCase, CultureInfo culture)
+    {
+        if (!ignoreCase && culture.Equals(CultureInfo.InvariantCulture))
+        {
+            return FindFirstStringDifference(expected, actual);
+        }
+
+        int expectedIndex = 0;
+        int actualIndex = 0;
+
+        while (expectedIndex < expected.Length && actualIndex < actual.Length)
+        {
+            if (CompareInternal(expected[expectedIndex].ToString(), actual[actualIndex].ToString(), ignoreCase, culture) == 0)
+            {
+                expectedIndex++;
+                actualIndex++;
+                continue;
+            }
+
+            if (TryAdvanceMatchingWindow(expected, actual, ref expectedIndex, ref actualIndex, ignoreCase, culture))
+            {
+                continue;
+            }
+
+            return Math.Min(expectedIndex, actualIndex);
+        }
+
+        return expectedIndex != expected.Length || actualIndex != actual.Length
+            ? Math.Min(expectedIndex, actualIndex)
+            : -1;
+    }
+
+    private static bool TryAdvanceMatchingWindow(string expected, string actual, ref int expectedIndex, ref int actualIndex, bool ignoreCase, CultureInfo culture)
+    {
+        const int MaxWindowLength = 3;
+
+        for (int expectedWindow = 1; expectedWindow <= MaxWindowLength && expectedIndex + expectedWindow <= expected.Length; expectedWindow++)
+        {
+            for (int actualWindow = 1; actualWindow <= MaxWindowLength && actualIndex + actualWindow <= actual.Length; actualWindow++)
+            {
+                if (expectedWindow == 1 && actualWindow == 1)
+                {
+                    continue;
+                }
+
+                if (CompareInternal(expected.Substring(expectedIndex, expectedWindow), actual.Substring(actualIndex, actualWindow), ignoreCase, culture) == 0)
+                {
+                    expectedIndex += expectedWindow;
+                    actualIndex += actualWindow;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Tests whether the specified strings are equal and throws an exception
@@ -74,7 +173,16 @@ public sealed partial class Assert
     /// Thrown if <paramref name="expected"/> is not equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreEqual(string? expected, string? actual, bool ignoreCase, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
-        => AreEqual(expected, actual, ignoreCase, CultureInfo.InvariantCulture, message, expectedExpression, actualExpression);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.AreEqual");
+
+        if (!AreEqualFailing(expected, actual, ignoreCase, CultureInfo.InvariantCulture))
+        {
+            return;
+        }
+
+        ReportAssertAreEqualFailed(expected, actual, ignoreCase, CultureInfo.InvariantCulture, cultureExplicit: false, message, expectedExpression, actualExpression);
+    }
 
     /// <inheritdoc cref="AreEqual(string?, string?, bool, string, string, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -139,8 +247,7 @@ public sealed partial class Assert
             return;
         }
 
-        string userMessage = BuildUserMessageForExpectedExpressionAndActualExpression(message, expectedExpression, actualExpression);
-        ReportAssertAreEqualFailed(expected, actual, ignoreCase, culture, userMessage);
+        ReportAssertAreEqualFailed(expected, actual, ignoreCase, culture, cultureExplicit: true, message, expectedExpression, actualExpression);
     }
 
     /// <summary>
@@ -175,7 +282,16 @@ public sealed partial class Assert
     /// Thrown if <paramref name="notExpected"/> is equal to <paramref name="actual"/>.
     /// </exception>
     public static void AreNotEqual(string? notExpected, string? actual, bool ignoreCase, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
-        => AreNotEqual(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, message, notExpectedExpression, actualExpression);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.AreNotEqual");
+
+        if (!AreNotEqualFailing(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture))
+        {
+            return;
+        }
+
+        ReportAssertAreNotEqualFailed(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture, cultureExplicit: false, message, notExpectedExpression, actualExpression);
+    }
 
     /// <inheritdoc cref="AreNotEqual(string?, string?, bool, string, string, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578
@@ -235,140 +351,15 @@ public sealed partial class Assert
     {
         TelemetryCollector.TrackAssertionCall("Assert.AreNotEqual");
 
-        CheckParameterNotNull(culture, "Assert.AreNotEqual", "culture");
+        CheckParameterNotNull(culture, "Assert.AreNotEqual", nameof(culture));
         if (!AreNotEqualFailing(notExpected, actual, ignoreCase, culture))
         {
             return;
         }
 
-        ReportAssertAreNotEqualFailed(notExpected, actual, message, notExpectedExpression, actualExpression);
+        ReportAssertAreNotEqualFailed(notExpected, actual, ignoreCase, culture, cultureExplicit: true, message, notExpectedExpression, actualExpression);
     }
 
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
-}
-
-internal static class StringPreviewHelper
-{
-    public static Tuple<string, string, int> CreateStringPreviews(string expected, string actual, int diffIndex, int fullPreviewLength)
-    {
-        int ellipsisLength = 3; // Length of the ellipsis "..."
-
-        if (fullPreviewLength % 2 == 0)
-        {
-            // Being odd makes it easier to calculate the context length, and center the marker, this is not user customizable.
-            throw new ArgumentException($"{nameof(fullPreviewLength)} must be odd, but it was even.");
-        }
-
-        // This is arbitrary number that is 2 times the size of the ellipsis,
-        // plus 3 chars to make it easier to check the tests are correct when part of string is masked.
-        // Preview length is not user customizable, just makes it harder to break the tests, and avoids few ifs we would need to write otherwise.
-        if (fullPreviewLength < 9)
-        {
-            throw new ArgumentException($"{nameof(fullPreviewLength)} cannot be shorter than 9.");
-        }
-
-        // In case we want to instead count runes or text elements we can change it just here.
-        int expectedLength = expected.Length;
-        int actualLength = actual.Length;
-
-        if (diffIndex < 0 || diffIndex > Math.Min(expectedLength, actualLength)) // Not -1 here because the difference can be right after the end of the shorter string.
-        {
-            throw new ArgumentOutOfRangeException(nameof(diffIndex), "diffIndex must be within the bounds of both strings.");
-        }
-
-        int contextLength = (fullPreviewLength - 1) / 2;
-
-        // Diff index must point into the string, the start of the strings will always be shortened the same amount,
-        // because otherwise the diff would happen at the beginning of the string.
-        // So we just care about how far we are from the end of the string, so we can show the maximum amount of info to the user
-        // when diff is really close to the end.
-        string shorterString = expectedLength < actualLength ? expected : actual;
-        string longerString = expectedLength < actualLength ? actual : expected;
-        bool expectedIsShorter = expectedLength < actualLength;
-
-        int shorterStringLength = shorterString.Length;
-        int longerStringLength = longerString.Length;
-
-        // End marker will point to the end of the shorter string, but the end of the longer string will be replaced by ... when it reaches the end of the preview.
-        // Make sure we don't point at the dots. To do this we need to make sure the strings are cut at the beginning, rather than preferring the maximum context shown.
-        //
-        // Marker needs to point where ellipsis would be when we shorten the longer string.
-        bool markerPointsAtTheEnd = shorterStringLength - diffIndex <= ellipsisLength;
-        // Strings need to have different lengths, for same length strings we don't add ellipsis.
-        bool stringsHaveDifferentLength = longerStringLength > shorterStringLength;
-        // Shorter string needs to be long enough to fill the preview window to the point where ellipsis shows up (last 3 chars).
-        bool shorterStringIsLongEnoughToFillPreviewWindow = shorterStringLength >= fullPreviewLength - ellipsisLength;
-        bool markerPointsAtEllipsis = markerPointsAtTheEnd && stringsHaveDifferentLength && shorterStringIsLongEnoughToFillPreviewWindow;
-        int ellipsisSpaceOrZero = markerPointsAtEllipsis ? ellipsisLength + 2 : 0;
-
-        // Find the end of the string that we will show, either the end of the shorter string, or the end of the preview window.
-        int endOfString = Math.Min(diffIndex + contextLength, shorterStringLength);
-
-        // Then calculate the start of the preview from that. This makes sure that if diff is close end of the string we show as much as we can.
-        int start = endOfString - fullPreviewLength + ellipsisSpaceOrZero;
-
-        // If the string is shorter than the preview, start cutting from 0, otherwise start cutting from the calculated start.
-        int cutStart = Math.Max(0, start);
-        // From here we need to handle longer and shorter string separately, because one of the can be shorter,
-        // and we want to show the maximum we can that fits in the preview window.
-        int cutEndShort = Math.Min(cutStart + fullPreviewLength, shorterStringLength);
-        int cutEndLong = Math.Min(cutStart + fullPreviewLength, longerStringLength);
-
-        string shorterStringPreview = shorterString.Substring(cutStart, cutEndShort - cutStart);
-        string longerStringPreview = longerString.Substring(cutStart, cutEndLong - cutStart);
-
-        // We cut something from the start of the string, so we need to add ellipsis there.
-        // We know if one string is cut then both must be cut, otherwise the diff would be at the beginning of the string.
-        if (cutStart > 0)
-        {
-            shorterStringPreview = EllipsisStart(shorterStringPreview);
-            longerStringPreview = EllipsisStart(longerStringPreview);
-        }
-
-        // We cut something from the end of the string, so we need to add ellipsis there.
-        // We don't know if both strings are cut, so we need to check them separately.
-        if (cutEndShort < shorterStringLength)
-        {
-            shorterStringPreview = EllipsisEnd(shorterStringPreview);
-        }
-
-        // We cut something from the end of the string, so we need to add ellipsis there.
-        if (cutEndLong < longerStringLength)
-        {
-            longerStringPreview = EllipsisEnd(longerStringPreview);
-        }
-
-        string escapedShorterStringPreview = MakeControlCharactersVisible(shorterStringPreview);
-        string escapedLongerStringPreview = MakeControlCharactersVisible(longerStringPreview);
-
-        return new Tuple<string, string, int>(
-            expectedIsShorter ? escapedShorterStringPreview : escapedLongerStringPreview,
-            expectedIsShorter ? escapedLongerStringPreview : escapedShorterStringPreview,
-            diffIndex - cutStart);
-    }
-
-    private static string EllipsisEnd(string text)
-        => $"{text.Substring(0, text.Length - 3)}...";
-
-    private static string EllipsisStart(string text)
-        => $"...{text.Substring(3)}";
-
-    private static string MakeControlCharactersVisible(string text)
-    {
-        var stringBuilder = new StringBuilder(text.Length);
-        foreach (char ch in text)
-        {
-            if (char.IsControl(ch))
-            {
-                stringBuilder.Append((char)(0x2400 + ch));
-            }
-            else
-            {
-                stringBuilder.Append(ch);
-            }
-        }
-
-        return stringBuilder.ToString();
-    }
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs
@@ -145,40 +145,21 @@ public sealed partial class Assert
     private static bool AreEqualFailing<T>(T? expected, T? actual, IEqualityComparer<T>? comparer)
         => !(comparer ?? EqualityComparer<T>.Default).Equals(expected!, actual!);
 
-    private static string FormatStringComparisonMessage(string? expected, string? actual, string userMessage)
+    private static void AppendStringDiffSummary(StructuredAssertionMessage structured, string expected, string actual)
+        => AppendStringDiffSummary(structured, expected, actual, FindFirstStringDifference(expected, actual));
+
+    private static void AppendStringDiffSummary(StructuredAssertionMessage structured, string expected, string actual, int diffIndex)
     {
-        // Handle null cases
-        if (expected is null && actual is null)
-        {
-            return string.Format(
-                CultureInfo.CurrentCulture,
-                FrameworkMessages.AreEqualFailMsg,
-                userMessage,
-                ReplaceNulls(expected),
-                ReplaceNulls(actual));
-        }
-
-        if (expected is null || actual is null)
-        {
-            return string.Format(
-                CultureInfo.CurrentCulture,
-                FrameworkMessages.AreEqualFailMsg,
-                userMessage,
-                ReplaceNulls(expected),
-                ReplaceNulls(actual));
-        }
-
-        // Find the first difference
-        int diffIndex = FindFirstStringDifference(expected, actual);
-
         if (diffIndex == -1)
         {
-            // Strings are equal - should not happen in practice, we call this method only when they are not equal.
             throw ApplicationStateGuard.Unreachable();
         }
 
-        // Format the enhanced string comparison message
-        return FormatStringDifferenceMessage(expected, actual, diffIndex, userMessage);
+        string diffSummary = expected.Length == actual.Length
+            ? string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEqualStringDiffLengthBothMsg, expected.Length, diffIndex)
+            : string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEqualStringDiffLengthDifferentMsg, expected.Length, actual.Length, diffIndex);
+
+        structured.WithAdditionalSummaryLine(diffSummary);
     }
 
     private static int FindFirstStringDifference(string expected, string actual)
@@ -197,97 +178,40 @@ public sealed partial class Assert
         return expected.Length != actual.Length ? minLength : -1;
     }
 
-    private static string FormatStringDifferenceMessage(string expected, string actual, int diffIndex, string userMessage)
-    {
-        string lengthInfo = expected.Length == actual.Length
-            ? string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEqualStringDiffLengthBothMsg, expected.Length, diffIndex)
-            : string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEqualStringDiffLengthDifferentMsg, expected.Length, actual.Length);
-
-        // Create contextual preview around the difference
-        const int contextLength = 41; // Show up to 20 characters of context on each side
-        Tuple<string, string, int> tuple = StringPreviewHelper.CreateStringPreviews(expected, actual, diffIndex, contextLength);
-        string expectedPreview = tuple.Item1;
-        string actualPreview = tuple.Item2;
-        int caretPosition = tuple.Item3;
-
-        // Get localized prefixes
-        string expectedPrefix = FrameworkMessages.AreEqualStringDiffExpectedPrefix;
-        string actualPrefix = FrameworkMessages.AreEqualStringDiffActualPrefix;
-
-        // Calculate the maximum prefix length to align the caret properly
-        int maxPrefixLength = Math.Max(expectedPrefix.Length, actualPrefix.Length);
-
-        // Pad shorter prefix to match the longer one for proper alignment
-        string paddedExpectedPrefix = expectedPrefix.PadRight(maxPrefixLength);
-        string paddedActualPrefix = actualPrefix.PadRight(maxPrefixLength);
-
-        // Build the formatted lines with proper alignment
-        string expectedLine = paddedExpectedPrefix + $"\"{expectedPreview}\"";
-        string actualLine = paddedActualPrefix + $"\"{actualPreview}\"";
-
-        // The caret should align under the difference in the string content
-        // For localized prefixes with different lengths, we need to account for the longer prefix
-        // to ensure proper alignment. But the caret position is relative to the string content.
-        int adjustedCaretPosition = maxPrefixLength + 1 + caretPosition; // +1 for the opening quote
-
-        // Format user message properly - add leading space if not empty, otherwise no extra formatting
-        string formattedUserMessage = string.IsNullOrEmpty(userMessage) ? string.Empty : $" {userMessage}";
-
-        return string.Format(
-            CultureInfo.CurrentCulture,
-            FrameworkMessages.AreEqualStringDiffFailMsg,
-            lengthInfo,
-            formattedUserMessage,
-            expectedLine,
-            actualLine,
-            new string('-', adjustedCaretPosition) + "^");
-    }
-
     [DoesNotReturn]
     private static void ReportAssertAreEqualFailed(object? expected, object? actual, string? message, string expectedExpression, string actualExpression)
     {
         string expectedRendered = AssertionValueRenderer.RenderValue(expected);
         string actualRendered = AssertionValueRenderer.RenderValue(actual);
 
-        string summary;
         EvidenceBlock evidence;
-        string? additionalSummaryLine = null;
+        StructuredAssertionMessage structured;
 
         if (actual is not null && expected is not null && !actual.GetType().Equals(expected.GetType()))
         {
             Type expectedType = expected.GetType();
             Type actualType = actual.GetType();
-            summary = FrameworkMessages.AreEqualDifferentTypesFailedSummary;
             evidence = EvidenceBlock.Create()
                 .AddLine("expected:", expectedRendered)
                 .AddLine("expected type:", expectedType.FullName ?? expectedType.Name)
                 .AddLine("actual:", actualRendered)
                 .AddLine("actual type:", actualType.FullName ?? actualType.Name);
+            structured = new(FrameworkMessages.AreEqualDifferentTypesFailedSummary);
         }
         else if (expected is string expectedString && actual is string actualString)
         {
-            summary = FrameworkMessages.AreEqualStringsFailedSummary;
-            int diffIndex = FindFirstStringDifference(expectedString, actualString);
-            additionalSummaryLine = expectedString.Length == actualString.Length
-                ? string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEqualStringDiffLengthBothMsg, expectedString.Length, diffIndex)
-                : string.Format(CultureInfo.CurrentCulture, FrameworkMessages.AreEqualStringDiffLengthDifferentMsg, expectedString.Length, actualString.Length);
-
             evidence = EvidenceBlock.Create()
                 .AddLine("expected:", expectedRendered)
                 .AddLine("actual:", actualRendered);
+            structured = new(FrameworkMessages.AreEqualStringsFailedSummary);
+            AppendStringDiffSummary(structured, expectedString, actualString);
         }
         else
         {
-            summary = FrameworkMessages.AreEqualFailedSummary;
             evidence = EvidenceBlock.Create()
                 .AddLine("expected:", expectedRendered)
                 .AddLine("actual:", actualRendered);
-        }
-
-        StructuredAssertionMessage structured = new(summary);
-        if (additionalSummaryLine is not null)
-        {
-            structured.WithAdditionalSummaryLine(additionalSummaryLine);
+            structured = new(FrameworkMessages.AreEqualFailedSummary);
         }
 
         structured.WithUserMessage(message);

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -151,10 +151,10 @@
     <value>But was:  </value>
   </data>
   <data name="AreEqualStringDiffLengthBothMsg" xml:space="preserve">
-    <value>String lengths are both {0} but differ at index {1}.</value>
+    <value>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</value>
   </data>
   <data name="AreEqualStringDiffLengthDifferentMsg" xml:space="preserve">
-    <value>Expected string length {0} but was {1}.</value>
+    <value>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</value>
   </data>
   <data name="AreEquivalentFailedSummary" xml:space="preserve">
     <value>Expected values to be structurally equivalent.</value>
@@ -491,11 +491,20 @@ Actual: {2}</value>
   <data name="AreEqualDifferentTypesFailedSummary" xml:space="preserve">
     <value>Expected values to be equal, but they are of different types.</value>
   </data>
+  <data name="AreEqualStringsCaseOnlyDifferenceMsg" xml:space="preserve">
+    <value>Strings differ only in case.</value>
+  </data>
   <data name="AreEqualStringsFailedSummary" xml:space="preserve">
     <value>Expected strings to be equal.</value>
   </data>
   <data name="AreNotEqualFailedSummary" xml:space="preserve">
     <value>Expected values to not be equal.</value>
+  </data>
+  <data name="AreNotEqualStringsCaseInsensitiveFailedSummary" xml:space="preserve">
+    <value>Expected strings to differ (case-insensitive).</value>
+  </data>
+  <data name="AreNotEqualStringsFailedSummary" xml:space="preserve">
+    <value>Expected strings to differ.</value>
   </data>
   <data name="AreAllNotNullFailedSummary" xml:space="preserve">
     <value>Expected all items in collection to be non-null.</value>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Očekáváno:&lt;{1}&gt;. Aktuálně:&lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Očekáván rozdíl, který není větší jak &lt;{3}&gt; mezi očekávanou hodnotou &lt;{1}&gt; a aktuální hodnotou &lt;{2}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Očekáváno:&lt;{1}&gt;. Případ je rozdílný pro aktuální hodnotu:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Očekáváno:&lt;{1} ({2})&gt;. Aktuálně:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Očekáváno: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Ale bylo:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Délky obou řetězců jsou {0}, ale liší se na indexu {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Délky obou řetězců jsou {0}, ale liší se na indexu {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Očekávaná délka řetězce je {0}, ale byla {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Nebyla očekávána žádná hodnota kromě:&lt;{1}&gt;. Aktuálně:&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Očekáván rozdíl, který je větší jak &lt;{3}&gt; mezi očekávanou hodnotou &lt;{1}&gt; a aktuální hodnotou &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Erwartet:&lt;{1}&gt;. Tatsächlich:&lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Es wurde eine Differenz nicht größer als &lt;{3}&gt; zwischen dem erwarteten Wert &lt;{1}&gt; und dem tatsächlichen Wert &lt;{2}&gt; erwartet. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Erwartet:&lt;{1}&gt;. Die Großschreibung des tatsächlichen Werts weicht davon ab:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Erwartet:&lt;{1} ({2})&gt;. Tatsächlich:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Erwartet: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">War aber:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Die Zeichenfolgenlängen sind beide {0}, unterscheiden sich jedoch bei Index {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Die Zeichenfolgenlängen sind beide {0}, unterscheiden sich jedoch bei Index {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Die erwartete Länge der Zeichenfolge ist {0}, war aber {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Es wurde ein beliebiger Wert erwartet außer:&lt;{1}&gt;. Tatsächlich:&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Es wurde eine Differenz größer als &lt;{3}&gt; zwischen dem erwarteten Wert &lt;{1}&gt; und dem tatsächlichen Wert &lt;{2}&gt; erwartet. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Se esperaba &lt;{1}&gt;, pero es &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Se esperaba una diferencia no superior a &lt;{3}&gt; entre el valor esperado &lt;{1}&gt; y el valor actual &lt;{2}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Se esperaba:&lt;{1}&gt;. La caja es diferente para el valor actual:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Se esperaba:&lt;{1} ({2})&gt;, pero es:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Se esperaba: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Pero fue:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Las longitudes de las cadenas son {0} pero difieren en el índice {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Las longitudes de las cadenas son {0} pero difieren en el índice {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Se esperaba una longitud de cadena {0} pero fue {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Se esperaba cualquier valor excepto &lt;{1}&gt;, pero es &lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Se esperaba una diferencia mayor que &lt;{3}&gt; entre el valor esperado &lt;{1}&gt; y el valor actual &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Attendu : &lt;{1}&gt;, Réel : &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Différence attendue non supérieure à &lt;{3}&gt; comprise entre la valeur attendue &lt;{1}&gt; et la valeur réelle &lt;{2}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Attendu :&lt;{1}&gt;. La casse est différente pour la valeur réelle :&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Attendu : &lt;{1} ({2})&gt;, Réel : &lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Attendu : </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Mais c'était :  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Les longueurs de chaîne sont toutes les deux {0} mais diffèrent à l’index {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Les longueurs de chaîne sont toutes les deux {0} mais diffèrent à l’index {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">La longueur de chaîne attendue {0} mais était {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Toute valeur attendue sauf :&lt;{1}&gt;. Réel :&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Différence attendue supérieure à &lt;{3}&gt; comprise entre la valeur attendue &lt;{1}&gt; et la valeur réelle &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Previsto:&lt;{1}&gt;. Effettivo:&lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Prevista una differenza non maggiore di &lt;{3}&gt; tra il valore previsto &lt;{1}&gt; e il valore effettivo &lt;{2}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Previsto:&lt;{1}&gt;. La combinazione di maiuscole e minuscole è diversa per il valore effettivo:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Previsto:&lt;{1} ({2})&gt;. Effettivo:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Previsto: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Ma era:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Le lunghezze delle stringhe sono entrambe {0} ma differiscono all'indice {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Le lunghezze delle stringhe sono entrambe {0} ma differiscono all'indice {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">La lunghezza della stringa prevista è {0} ma era {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Previsto qualsiasi valore tranne:&lt;{1}&gt;. Effettivo:&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Prevista una differenza maggiore di &lt;{3}&gt; tra il valore previsto &lt;{1}&gt; e il valore effettivo &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">&lt;{1}&gt; が必要ですが、&lt;{2}&gt; が指定されました。{0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">指定する値 &lt;{1}&gt; と実際の値 &lt;{2}&gt; との間には &lt;{3}&gt; 以内の差が必要です。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">&lt;{1}&gt; が必要です。実際の値: &lt;{2}&gt; では大文字と小文字が異なります。{0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">&lt;{1} ({2})&gt; が必要ですが、&lt;{3} ({4})&gt; が指定されました。{0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">期待値:</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">しかし、次でした: </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">文字列の長さは両方とも {0} ですが、インデックス {1} で異なります。</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">文字列の長さは両方とも {0} ですが、インデックス {1} で異なります。</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">期待される文字列の長さは {0} ですが、実際は {1} でした。</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">&lt;{1}&gt; 以外の任意の値が必要ですが、&lt;{2}&gt; が指定されています。{0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">指定する値 &lt;{1}&gt; と実際の値 &lt;{2}&gt; との間には、&lt;{3}&gt; を超える差が必要です。{0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">예상 값: &lt;{1}&gt;. 실제 값: &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">예상 값 &lt;{1}&gt;과(와) 실제 값 &lt;{2}&gt;의 차이가 &lt;{3}&gt;보다 크지 않아야 합니다. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">예상 값: &lt;{1}&gt;. 대/소문자가 다른 실제 값: &lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">예상 값: &lt;{1} ({2})&gt;. 실제 값: &lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">예상: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">그러나 다음과 같습니다.  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">문자열 길이는 둘 다 {0} 이지만 인덱스 {1}에서 다릅니다.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">문자열 길이는 둘 다 {0} 이지만 인덱스 {1}에서 다릅니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">문자열 길이 {0}(을)를 예상했지만 {1}입니다.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">예상 값: &lt;{1}&gt;을(를) 제외한 모든 값. 실제 값: &lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">예상 값 &lt;{1}&gt;과(와) 실제 값 &lt;{2}&gt;의 차이가 &lt;{3}&gt;보다 커야 합니다. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Oczekiwana:&lt;{1}&gt;. Rzeczywista:&lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Oczekiwano różnicy nie większej niż &lt;{3}&gt; pomiędzy oczekiwaną wartością &lt;{1}&gt; a rzeczywistą wartością &lt;{2}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Oczekiwano:&lt;{1}&gt;. Przypadek różni się od rzeczywistej wartości:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Oczekiwana:&lt;{1} ({2})&gt;. Rzeczywista:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Oczekiwane: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Ale było:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Długości ciągów są {0}, ale różnią się w indeksie {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Długości ciągów są {0}, ale różnią się w indeksie {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Oczekiwano ciągu o długości {0}, ale miał wartość {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Oczekiwano dowolnej wartości za wyjątkiem:&lt;{1}&gt;. Rzeczywista:&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Oczekiwano różnicy większej niż &lt;{3}&gt; pomiędzy oczekiwaną wartością &lt;{1}&gt; a rzeczywistą wartością &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Esperado:&lt;{1}&gt;. Real:&lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Esperada uma diferença não maior que &lt;{3}&gt; entre o valor esperado &lt;{1}&gt; e o valor real &lt;{2}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Esperado:&lt;{1}&gt;. Capitalização é diferente para o valor real:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Esperado:&lt;{1} ({2})&gt;. Real:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Esperado: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Mas foi:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Os comprimentos de cadeia de caracteres são ambos {0}, mas diferem no índice {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Os comprimentos de cadeia de caracteres são ambos {0}, mas diferem no índice {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Comprimento esperado da cadeia de caracteres {0}, mas foi {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Esperado qualquer valor exceto:&lt;{1}&gt;. Real:&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Esperada uma diferença maior que &lt;{3}&gt; entre o valor esperado &lt;{1}&gt; e o valor real &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Ожидается: &lt;{1}&gt;. Фактически: &lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Между ожидаемым значением &lt;{1}&gt; и фактическим значением &lt;{2}&gt; требуется разница не более чем &lt;{3}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Ожидается: &lt;{1}&gt;. Отличается на фактическое значение: &lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Ожидается: &lt;{1} ({2})&gt;. Фактически: &lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Ожидалось: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Было:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Длины строк равны {0}, но различаются по индексу {1}.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Длины строк равны {0}, но различаются по индексу {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Ожидалась длина строки: {0}, фактическая длина строки: {1}.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Ожидается любое значение, кроме: &lt;{1}&gt;. Фактически: &lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Между ожидаемым значением &lt;{1}&gt; и фактическим значением &lt;{2}&gt; требуется разница более чем &lt;{3}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Beklenen:&lt;{1}&gt;. Gerçek:&lt;{2}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Beklenen değer &lt;{1}&gt; ile gerçek değer &lt;{2}&gt; arasında, şundan büyük olmayan fark bekleniyor: &lt;{3}&gt;. {0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">Beklenen:&lt;{1}&gt;. Durum, gerçek değer için farklı:&lt;{2}&gt;. {0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">Beklenen:&lt;{1} ({2})&gt;. Gerçek:&lt;{3} ({4})&gt;. {0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">Beklenen: </target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">Ancak:  </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">Dize uzunlukları her ikisi de {0} ama dizin {1} üzerinde farklılık gösterir.</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">Dize uzunlukları her ikisi de {0} ama dizin {1} üzerinde farklılık gösterir.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">Beklenen dize uzunluğu {0} idi, ancak dize uzunluğu {1} oldu.</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">Şunun dışında bir değer bekleniyor:&lt;{1}&gt;. Gerçek:&lt;{2}&gt;. {0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">Beklenen değer &lt;{1}&gt; ile gerçek değer &lt;{2}&gt; arasında, şundan büyük olan fark bekleniyor: &lt;{3}&gt;. {0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">应为: &lt;{1}&gt;，实际为: &lt;{2}&gt;。{0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">预期值 &lt;{1}&gt; 和实际值 &lt;{2}&gt; 之间的差不应大于 &lt;{3}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">应为: &lt;{1}&gt;。实际值的大小写有所不同: &lt;{2}&gt;。{0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">应为: &lt;{1} ({2})&gt;，实际为: &lt;{3} ({4})&gt;。{0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">应为:</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">但却是: </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">字符串长度均为 {0}，但在索引 {1} 处有所不同。</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">字符串长度均为 {0}，但在索引 {1} 处有所不同。</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">字符串长度应为 {0}，但为 {1}。</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">应为: &lt;{1}&gt; 以外的任意值，实际为: &lt;{2}&gt;。{0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">预期值 &lt;{1}&gt; 和实际值 &lt;{2}&gt; 之间的差应大于 &lt;{3}&gt;。{0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -32,56 +32,61 @@
         <target state="new">Expected all items in collection to be of the specified type.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualFailMsg">
-        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
-        <target state="translated">預期: &lt;{1}&gt;。實際: &lt;{2}&gt;。{0}</target>
-        <note></note>
+      <trans-unit id="AreEqualCaseFailMsg">
+        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDeltaFailMsg">
         <source>Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">預期值 &lt;{1}&gt; 和實際值 &lt;{2}&gt; 之間的預期差異沒有大於 &lt;{3}&gt;。{0}</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualCaseFailMsg">
-        <source>Expected:&lt;{1}&gt;. Case is different for actual value:&lt;{2}&gt;. {0}</source>
-        <target state="translated">預期: &lt;{1}&gt;。大小寫與下列實際值不同: &lt;{2}&gt;。{0}</target>
-        <note></note>
+        <target state="new">Expected a difference no greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEqualDifferentTypesFailMsg">
         <source>Expected:&lt;{1} ({2})&gt;. Actual:&lt;{3} ({4})&gt;. {0}</source>
         <target state="translated">預期: &lt;{1} ({2})&gt;。實際: &lt;{3} ({4})&gt;。{0}</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="AreEqualFailMsg">
+        <source>Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
+        <target state="new">Expected:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffActualPrefix">
+        <source>But was:  </source>
+        <target state="new">But was:  </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringDiffExpectedPrefix">
+        <source>Expected: </source>
+        <target state="new">Expected: </target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreEqualStringDiffFailMsg">
         <source>{0}{1}
 {2}
 {3}
 {4}</source>
-        <target state="translated">{0}{1}
+        <target state="new">{0}{1}
 {2}
 {3}
 {4}</target>
         <note />
       </trans-unit>
-      <trans-unit id="AreEqualStringDiffExpectedPrefix">
-        <source>Expected: </source>
-        <target state="translated">預期為:</target>
-        <note></note>
-      </trans-unit>
-      <trans-unit id="AreEqualStringDiffActualPrefix">
-        <source>But was:  </source>
-        <target state="translated">但為: </target>
-        <note></note>
-      </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthBothMsg">
-        <source>String lengths are both {0} but differ at index {1}.</source>
-        <target state="translated">字串長度兩者都是 {0}，但索引 {1} 不同。</target>
+        <source>Strings have same length ({0}) and differ at 1 location(s). First difference at index {1}.</source>
+        <target state="needs-review-translation">字串長度兩者都是 {0}，但索引 {1} 不同。</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringDiffLengthDifferentMsg">
-        <source>Expected string length {0} but was {1}.</source>
-        <target state="translated">預期的字串長度為 {0}，但為 {1}。</target>
-        <note></note>
+        <source>Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</source>
+        <target state="new">Strings have different lengths (expected: {0}, actual: {1}) and differ at 1 location(s). First difference at index {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreEqualStringsCaseOnlyDifferenceMsg">
+        <source>Strings differ only in case.</source>
+        <target state="new">Strings differ only in case.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreEquivalentFailedSummary">
         <source>Expected values to be structurally equivalent.</source>
@@ -188,15 +193,25 @@
         <target state="new">&lt;root&gt;</target>
         <note>Placeholder used in equivalence-mismatch messages when the difference is at the top of the object graph.</note>
       </trans-unit>
+      <trans-unit id="AreNotEqualDeltaFailMsg">
+        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
+        <target state="new">Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AreNotEqualFailMsg">
         <source>Expected any value except:&lt;{1}&gt;. Actual:&lt;{2}&gt;. {0}</source>
         <target state="translated">預期任何值 (&lt;{1}&gt; 除外)。實際: &lt;{2}&gt;。{0}</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="AreNotEqualDeltaFailMsg">
-        <source>Expected a difference greater than &lt;{3}&gt; between expected value &lt;{1}&gt; and actual value &lt;{2}&gt;. {0}</source>
-        <target state="translated">預期值 &lt;{1}&gt; 和實際值 &lt;{2}&gt; 之間的預期差異大於 &lt;{3}&gt;。{0}</target>
-        <note></note>
+      <trans-unit id="AreNotEqualStringsCaseInsensitiveFailedSummary">
+        <source>Expected strings to differ (case-insensitive).</source>
+        <target state="new">Expected strings to differ (case-insensitive).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AreNotEqualStringsFailedSummary">
+        <source>Expected strings to differ.</source>
+        <target state="new">Expected strings to differ.</target>
+        <note />
       </trans-unit>
       <trans-unit id="AreNotEquivalentComparisonFailedSummary">
         <source>Could not complete structural comparison.</source>

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -173,8 +173,19 @@ public partial class AssertTests : TestContainer
 
         // Won't ignore case.
         Action action = () => Assert.AreEqual(expected, actual, false, englishCulture);
-        action.Should().Throw<Exception>()
-            .WithMessage("Assert.AreEqual failed. Expected:<i>. Case is different for actual value:<I>. 'expected' expression: 'expected', 'actual' expression: 'actual'.");
+        action.Should().Throw<AssertFailedException>()
+            .Which.Message.Should().Be(
+                """
+                Assertion failed. Expected strings to be equal.
+                Strings differ only in case.
+                Strings have same length (1) and differ at 1 location(s). First difference at index 0.
+
+                expected: "i"
+                actual:   "I"
+                culture:  en-EN
+
+                Assert.AreEqual(expected, actual)
+                """);
     }
 
     public void AreEqual_WithTurkishCultureAndDoesNotIgnoreCase_Throws()
@@ -1503,7 +1514,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                String lengths are both 4 but differ at index 0.
+                Strings have same length (4) and differ at 1 location(s). First difference at index 0.
 
                 expected: "baaa"
                 actual:   "aaaa"
@@ -1519,7 +1530,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                String lengths are both 4 but differ at index 3.
+                Strings have same length (4) and differ at 1 location(s). First difference at index 3.
 
                 expected: "aaaa"
                 actual:   "aaab"
@@ -1531,17 +1542,12 @@ public partial class AssertTests : TestContainer
     public void AreEqualStringWithSpecialCharactersShouldEscape()
     {
         Action action = () => Assert.AreEqual("aa\ta", "aa a");
-        action.Should().Throw<AssertFailedException>()
-            .Which.Message.Should().Be(
-                """
-                Assertion failed. Expected strings to be equal.
-                String lengths are both 4 but differ at index 2.
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>().Which;
 
-                expected: "aa\ta"
-                actual:   "aa a"
-
-                Assert.AreEqual("aa\ta", "aa a")
-                """);
+        ex.Message.Should().Contain("Strings have same length (4) and differ at 1 location(s). First difference at index 2.");
+        ex.Message.Should().Contain("expected: \"aa\\ta\"");
+        ex.Message.Should().Contain("actual:   \"aa a\"");
+        ex.Message.Should().Contain("Assert.AreEqual(\"aa\\ta\", \"aa a\")");
     }
 
     // Long-string truncation is intentionally not yet implemented; documents the current full-string render.
@@ -1555,7 +1561,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                String lengths are both 201 but differ at index 100.
+                Strings have same length (201) and differ at 1 location(s). First difference at index 100.
 
                 expected: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                 actual:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -1567,12 +1573,21 @@ public partial class AssertTests : TestContainer
     public void AreEqualStringWithCultureShouldUseEnhancedMessage()
     {
         Action action = () => Assert.AreEqual("aaaa", "aaab", false, CultureInfo.InvariantCulture);
-        action.Should().Throw<Exception>()
-            .WithMessage("""
-            Assert.AreEqual failed. String lengths are both 4 but differ at index 3. 'expected' expression: '"aaaa"', 'actual' expression: '"aaab"'.
-            Expected: "aaaa"
-            But was:  "aaab"
-            --------------^
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>().Which;
+
+        ex.Message.Should().StartWith(
+            """
+            Assertion failed. Expected strings to be equal.
+            Strings have same length (4) and differ at 1 location(s). First difference at index 3.
+
+            expected: "aaaa"
+            actual:   "aaab"
+            """);
+        ex.Message.Should().Contain($"{Environment.NewLine}culture:");
+        ex.Message.Should().EndWith(
+            """
+
+            Assert.AreEqual("aaaa", "aaab")
             """);
     }
 
@@ -1583,7 +1598,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                Expected string length 4 but was 3.
+                Strings have different lengths (expected: 4, actual: 3) and differ at 1 location(s). First difference at index 3.
 
                 expected: "aaaa"
                 actual:   "aaa"
@@ -1599,7 +1614,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                Expected string length 3 but was 4.
+                Strings have different lengths (expected: 3, actual: 4) and differ at 1 location(s). First difference at index 3.
 
                 expected: "aaa"
                 actual:   "aaab"
@@ -1615,7 +1630,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                String lengths are both 4 but differ at index 3.
+                Strings have same length (4) and differ at 1 location(s). First difference at index 3.
                 My custom message
 
                 expected: "aaaa"
@@ -1632,7 +1647,7 @@ public partial class AssertTests : TestContainer
             .Which.Message.Should().Be(
                 """
                 Assertion failed. Expected strings to be equal.
-                Expected string length 2 but was 4.
+                Strings have different lengths (expected: 2, actual: 4) and differ at 1 location(s). First difference at index 0.
 
                 expected: "🥰"
                 actual:   "aaab"
@@ -1641,208 +1656,117 @@ public partial class AssertTests : TestContainer
                 """);
     }
 
-    public void CreateStringPreviews_DiffPointsToCorrectPlaceInNonShortenedString()
+    public void AreEqualStringSpecificWithIgnoreCaseAndCultureUsesComparisonAwareDiffIndex()
     {
-        int preview = 9;
-        int length = 1;
-        int diffIndex = 0;
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(length, diffIndex), DigitString(length, diffIndex), diffIndex, preview));
-        StringPreviewsAreEqual(
-            """
-            "X"
-            "X"
-            _^
-            """,
-            stringPreview);
-    }
+        Action action = () => Assert.AreEqual("straße", "STRAẞE!", true, new CultureInfo("de-DE"));
+        action.Should().Throw<AssertFailedException>()
+            .Which.Message.Should().Be(
+                """
+                Assertion failed. Expected strings to be equal.
+                Strings have different lengths (expected: 6, actual: 7) and differ at 1 location(s). First difference at index 6.
 
-    public void CreateStringPreviews_DiffPointsToCorrectPlaceInShortenedStringWithEndCut()
-    {
-        int preview = 9;
-        int length = preview + 10;
-        int diffIndex = 0;
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(length, diffIndex), DigitString(length, diffIndex), diffIndex, preview));
-        StringPreviewsAreEqual(
-            """
-            "X12345..."
-            "X12345..."
-            _^
-            """, stringPreview);
-    }
+                expected:    "straße"
+                actual:      "STRAẞE!"
+                ignore case: true
+                culture:     de-DE
 
-    public void CreateStringPreviews_DiffPointsToCorrectPlaceInShortenedStringWithStartCut()
-    {
-        int preview = 9;
-        int length = 10;
-        int diffIndex = 9;
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(length, diffIndex), DigitString(length, diffIndex), diffIndex: diffIndex, preview));
-        StringPreviewsAreEqual(
-            """
-            "...45678X"
-            "...45678X"
-            _________^
-            """,
-            stringPreview);
-    }
-
-    public void CreateStringPreviews_ShowWholeStringWhenDifferenceIsAtTheEndAndJustOneStringDoesNotFit()
-    {
-        int preview = 21;
-        int length = 50;
-        int diffIndex = 16;
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(preview, diffIndex), DigitString(length, diffIndex), diffIndex: diffIndex, preview));
-        StringPreviewsAreEqual(
-            """
-            "0123456789012345X7890"
-            "0123456789012345X7..."
-            _________________^
-            """,
-            stringPreview);
-    }
-
-    public void CreateStringPreviews_MakeSureWeDontPointToEndEllipsis()
-    {
-        // We will mask last 3 chars of the string, so we need to make sure that the diff index is not pointing to the end ellipsis.
-        int preview = 25;
-        int length = 50;
-        int diffIndex = 24;
-
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(preview, diffIndex), DigitString(length, diffIndex), diffIndex: diffIndex, preview));
-        StringPreviewsAreEqual(
-            """
-            "...8901234567890123X"
-            "...8901234567890123X56..."
-            ____________________^
-            """,
-            stringPreview);
-    }
-
-    public void CreateStringPreviews_MakeSureWeDontPointToEndEllipsis_WhenLongerStringOneCharLargerThanPreviewWindow()
-    {
-        // We will mask last 3 chars of the string, so we need to make sure that the diff index is not pointing to the end ellipsis.
-        int preview = 15;
-        int diffIndex = preview - 1;
-
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(preview, diffIndex), DigitString(preview + 1, diffIndex), diffIndex: diffIndex, preview));
-        StringPreviewsAreEqual(
-            """
-            "...890123X"
-            "...890123X5"
-            __________^
-            """,
-            stringPreview);
-    }
-
-    public void CreateStringPreviews_MakeSureWeDontPointToEndEllipsis_WhenLongerStringIsBarelyLonger()
-    {
-        // We will mask last 3 chars of the string, so we need to make sure that the diff index is not pointing to the end ellipsis.
-        int preview = 25;
-
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews("01234567890123456789012345678901234567890123X", "01234567890123456789012345678901234567890123X56", diffIndex: 44, preview));
-        StringPreviewsAreEqual(
-            """
-            "...8901234567890123X"
-            "...8901234567890123X56"
-            ____________________^
-            """,
-            stringPreview);
-    }
-
-    public void CreateStringPreviews_DiffPointsAfterLastCharacterWhenStringsAreAllTheSameCharactersUntilTheEndOfTheShorterOne()
-    {
-        int preview = 9;
-        int diffIndex = 3;
-        string stringPreview = FormatStringPreview(StringPreviewHelper.CreateStringPreviews("aaa", "aaaX", diffIndex, preview));
-        stringPreview.Should().Be("""
-            "aaa"
-            "aaaX"
-            ____^
-            """);
-    }
-
-    public void CreateStringPreviews_DiffNeverPointsAtEllipsis_Generated()
-    {
-        // Generate all combinations of string lengths and diff to see if in any of them we point to ellipsis.
-        StringBuilder s = new();
-        foreach (int a in Enumerable.Range(1, 20))
-        {
-            foreach (int e in Enumerable.Range(1, 20))
-            {
-                foreach (int d in Enumerable.Range(1, Math.Min(a, e)))
-                {
-                    string p = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString(e, d), DigitString(a, d), diffIndex: d, 11));
-
-                    string[] lines = p.Split('\n');
-                    int diffIndicator = lines[2].IndexOf('^');
-                    bool line0PointsOnEllipsis = lines[0].Length > diffIndicator && lines[0][diffIndicator] == '.';
-                    bool line1PointsOnEllipsis = lines[1].Length > diffIndicator && lines[1][diffIndicator] == '.';
-
-                    if (line0PointsOnEllipsis || line1PointsOnEllipsis)
-                    {
-                        string text = $"""
-                            Failed for:
-                            Expected={e}, Actual={a}, DiffIndex={d}
-                            string result = FormatStringPreview(StringPreviewHelper.CreateStringPreviews(DigitString({e}, {d}), DigitString({a}, {d}), diffIndex: {d}, 11));
-                            {p}
-                            """;
-
-                        s.AppendLine(text);
-                        s.AppendLine();
-                    }
-                }
-            }
-        }
-
-        if (s.Length > 0)
-        {
-            throw new InvalidOperationException($"Some combinations pointed to ellipsis:\n{s}");
-        }
-    }
-
-    private string FormatStringPreview(Tuple<string, string, int> tuple)
-        => $"""
-            "{tuple.Item1}"
-            "{tuple.Item2}"
-            {new string('_', tuple.Item3 + 1)}{'^'}
-            """;
-
-    private static string DigitString(int length, int diffIndex)
-    {
-        const string digits = "0123456789";
-        if (length <= 0)
-        {
-            return string.Empty;
-        }
-
-        var result = new StringBuilder(length);
-        for (int i = 0; i < length; i++)
-        {
-            if (i == diffIndex)
-            {
-                // Use 'X' to indicate a difference should be at this index.
-                // To make it easier to see where the arrow should point, even though both strings are the same (we provide the diff index externally).
-                result.Append('X');
-                continue;
-            }
-
-            result.Append(digits[i % digits.Length]);
-        }
-
-        return result.ToString();
-    }
-
-    private void StringPreviewsAreEqual(string expected, string actual)
-    {
-        if (expected != actual)
-        {
-            throw new InvalidOperationException(
-                $"""
-                Actual:
-                {actual}
-
-                Expected:
-                {expected}
+                Assert.AreEqual("straße", "STRAẞE!")
                 """);
-        }
     }
+
+    public void AreEqualStringSpecificWithNullExpectedUsesStructuredMessage()
+    {
+        string? expected = null;
+        string actual = "string";
+
+        Action action = () => Assert.AreEqual(expected, actual, false);
+        action.Should().Throw<AssertFailedException>()
+            .Which.Message.Should().Be(
+                """
+                Assertion failed. Expected strings to be equal.
+
+                expected: null
+                actual:   "string"
+
+                Assert.AreEqual(expected, actual)
+                """);
+    }
+
+    public void AreEqualStringSpecificWithMultilineStringsUsesStructuredMessage()
+    {
+        string expected = "line one\nline two\nline three";
+        string actual = "line one\nLINE TWO\nline three";
+
+        Action action = () => Assert.AreEqual(expected, actual, false);
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>().Which;
+
+        ex.Message.Should().Contain("Assertion failed. Expected strings to be equal.");
+        ex.Message.Should().Contain("line one");
+        ex.Message.Should().Contain("LINE TWO");
+        ex.Message.Should().Contain("Assert.AreEqual(expected, actual)");
+    }
+
+    public void AreEqualStringSpecificWhenEqualDoesNotThrow()
+        => FluentActions.Invoking(() => Assert.AreEqual("Straße", "STRAẞE", true, new CultureInfo("de-DE"))).Should().NotThrow();
+
+    public void AreNotEqualStringSpecificShowsStructuredMessage()
+    {
+        string notExpected = "A";
+        string actual = "A";
+
+        Action action = () => Assert.AreNotEqual(notExpected, actual, false);
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>().Which;
+
+        ex.Message.Should().Be(
+            """
+            Assertion failed. Expected strings to differ.
+
+            not expected: "A"
+            actual:       "A"
+
+            Assert.AreNotEqual(notExpected, actual)
+            """);
+        ex.ExpectedText.Should().Be("not \"A\"");
+        ex.ActualText.Should().Be("\"A\"");
+        ex.Data["assert.expected"].Should().Be("not \"A\"");
+        ex.Data["assert.actual"].Should().Be("\"A\"");
+    }
+
+    public void AreNotEqualStringSpecificWithIgnoreCaseAndCultureShowsEvidence()
+    {
+        Action action = () => Assert.AreNotEqual("Straße", "STRAẞE", true, new CultureInfo("de-DE"));
+        action.Should().Throw<AssertFailedException>()
+            .Which.Message.Should().Be(
+                """
+                Assertion failed. Expected strings to differ (case-insensitive).
+
+                not expected: "Straße"
+                actual:       "STRAẞE"
+                ignore case:  true
+                culture:      de-DE
+
+                Assert.AreNotEqual("Straße", "STRAẞE")
+                """);
+    }
+
+    public void AreNotEqualStringSpecificWithBothNullShowsStructuredMessage()
+    {
+        string? notExpected = null;
+        string? actual = null;
+
+        Action action = () => Assert.AreNotEqual(notExpected, actual, false);
+        action.Should().Throw<AssertFailedException>()
+            .Which.Message.Should().Be(
+                """
+                Assertion failed. Expected strings to differ.
+
+                not expected: null
+                actual:       null
+
+                Assert.AreNotEqual(notExpected, actual)
+                """);
+    }
+
+    public void AreNotEqualStringSpecificWhenDifferentDoesNotThrow()
+        => FluentActions.Invoking(() => Assert.AreNotEqual("Straße", "STRASSE!", true, new CultureInfo("de-DE"))).Should().NotThrow();
 }


### PR DESCRIPTION
## Summary
- migrate the string-specific `Assert.AreEqual` / `Assert.AreNotEqual` failure paths to RFC 012 structured assertion messages
- share string diff-summary formatting with the generic `Assert.AreEqual` path and update string interpolated handlers
- refresh string assertion tests and regenerated XLF resources for the new messages

## Validation
- `dotnet build src\TestFramework\TestFramework\TestFramework.csproj -c Release --nologo -v:minimal`
- `dotnet msbuild test\UnitTests\TestFramework.UnitTests\TestFramework.UnitTests.csproj /restore /t:Build /p:Configuration=Release /p:TargetFramework=net9.0 /m:1 /v:m /nologo`
- `artifacts\bin\TestFramework.UnitTests\Release\net9.0\Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.exe --no-progress --output Normal --treenode-filter "/*/*/AssertTests/*AreEqual*"`
- `artifacts\bin\TestFramework.UnitTests\Release\net9.0\Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.exe --no-progress --output Normal --treenode-filter "/*/*/AssertTests/*AreNotEqual*"`