### PR TITLE
[Efficiency Improver] perf: eliminate LINQ closure allocations in TreeNodeFilter hot paths

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.PropertyBagEnumerable.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.PropertyBagEnumerable.cs
@@ -18,7 +18,7 @@ public sealed partial class PropertyBag
         IEnumerator IEnumerable.GetEnumerator() => new PropertyBagEnumerator(_properties, _testNodeStateProperty);
     }
 
-    private struct PropertyBagEnumerator(Property? properties, TestNodeStateProperty? testNodeStateProperty) : IEnumerator<IProperty>
+    internal struct PropertyBagEnumerator(Property? properties, TestNodeStateProperty? testNodeStateProperty) : IEnumerator<IProperty>
     {
         private readonly Property? _properties = properties;
         private readonly TestNodeStateProperty? _testNodeStateProperty = testNodeStateProperty;

--- a/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/PropertyBag.cs
@@ -324,6 +324,12 @@ public sealed partial class PropertyBag
     public IEnumerator<IProperty> GetEnumerator()
         => new PropertyBagEnumerator(_property, _testNodeStateProperty);
 
+    // Returns the struct-based enumerator by value to allow zero-allocation iteration
+    // from inside the assembly (avoids the boxing that happens when the public
+    // GetEnumerator() returns the struct as IEnumerator<IProperty>).
+    internal PropertyBagEnumerator GetStructEnumerator()
+        => new(_property, _testNodeStateProperty);
+
     [DoesNotReturn]
     private static void ThrowDuplicatedPropertyType(IProperty property)
         => throw new InvalidOperationException($"Duplicated property of type '{property}'");

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/OperatorExpression.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/OperatorExpression.cs
@@ -6,7 +6,12 @@ namespace Microsoft.Testing.Platform.Requests;
 // Allows to express an expression A & B or A | B
 internal sealed class OperatorExpression(FilterOperator op, FilterExpression[] subExpressions) : FilterExpression
 {
+    // Stored as an array internally to allow zero-allocation indexed iteration in the
+    // matching hot paths, but exposed as IReadOnlyList<FilterExpression> so callers
+    // cannot mutate the expression tree after construction.
+    private readonly FilterExpression[] _subExpressions = subExpressions;
+
     public FilterOperator Op { get; } = op;
 
-    public FilterExpression[] SubExpressions { get; } = subExpressions;
+    public IReadOnlyList<FilterExpression> SubExpressions => _subExpressions;
 }

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/OperatorExpression.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/OperatorExpression.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.Testing.Platform.Requests;
 
 // Allows to express an expression A & B or A | B
-internal sealed class OperatorExpression(FilterOperator op, IReadOnlyCollection<FilterExpression> subExpressions) : FilterExpression
+internal sealed class OperatorExpression(FilterOperator op, FilterExpression[] subExpressions) : FilterExpression
 {
     public FilterOperator Op { get; } = op;
 
-    public IReadOnlyCollection<FilterExpression> SubExpressions { get; } = subExpressions;
+    public FilterExpression[] SubExpressions { get; } = subExpressions;
 }

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -26,7 +26,17 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
     {
         Filter = filter ?? throw new ArgumentNullException(nameof(filter));
         _filters = ParseFilter(filter);
-        ContainsPropertyFilters = _filters.Any(HasPropertyFilterExpression);
+        bool containsPropertyFilters = false;
+        for (int i = 0; i < _filters.Count; i++)
+        {
+            if (HasPropertyFilterExpression(_filters[i]))
+            {
+                containsPropertyFilters = true;
+                break;
+            }
+        }
+
+        ContainsPropertyFilters = containsPropertyFilters;
     }
 
     /// <summary>
@@ -290,9 +300,9 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
     {
         switch (expr)
         {
-            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprsNot } when subexprsNot.Count != 1:
-            case OperatorExpression { Op: FilterOperator.And, SubExpressions.Count: < 2 }:
-            case OperatorExpression { Op: FilterOperator.Or, SubExpressions.Count: < 2 }:
+            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprsNot } when subexprsNot.Length != 1:
+            case OperatorExpression { Op: FilterOperator.And, SubExpressions.Length: < 2 }:
+            case OperatorExpression { Op: FilterOperator.Or, SubExpressions.Length: < 2 }:
                 throw ApplicationStateGuard.Unreachable();
 
             case OperatorExpression opExpr:
@@ -340,7 +350,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
                     _ => throw ApplicationStateGuard.Unreachable(),
                 };
 
-                expr.Push(new OperatorExpression(filter, subexprs));
+                expr.Push(new OperatorExpression(filter, [.. subexprs]));
                 break;
 
             case OperatorKind.FilterEquals:
@@ -503,7 +513,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
             if (currentFragmentIndex >= _filters.Count)
             {
                 // Note: The regex for ** is .*.*, so we match against such a value expression.
-                FilterExpression lastFilter = _filters.Last();
+                FilterExpression lastFilter = _filters[_filters.Count - 1];
                 if (lastFilter is ValueAndPropertyExpression valueAndPropertyExpression)
                 {
                     lastFilter = valueAndPropertyExpression.Value;
@@ -550,37 +560,88 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
         FilterExpression filterExpression,
         string testNodeFragment,
         PropertyBag properties)
-        => filterExpression switch
+    {
+        switch (filterExpression)
         {
-            ValueExpression vExpr => vExpr.Regex.IsMatch(testNodeFragment),
-            OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subexprs }
-                => subexprs.Any(expr => MatchFilterPattern(expr, testNodeFragment, properties)),
-            OperatorExpression { Op: FilterOperator.And, SubExpressions: var subexprs }
-                => subexprs.All(expr => MatchFilterPattern(expr, testNodeFragment, properties)),
-            OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprs }
-                => !MatchFilterPattern(subexprs.Single(), testNodeFragment, properties),
-            ValueAndPropertyExpression { Value: var valueExpr, Properties: var propExpr }
-                => MatchFilterPattern(valueExpr, testNodeFragment, properties)
-                    && MatchProperties(propExpr, properties),
-            NopExpression => true,
-            _ => throw ApplicationStateGuard.Unreachable(),
-        };
+            case ValueExpression vExpr:
+                return vExpr.Regex.IsMatch(testNodeFragment);
+            case OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subexprs }:
+                for (int i = 0; i < subexprs.Length; i++)
+                {
+                    if (MatchFilterPattern(subexprs[i], testNodeFragment, properties))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case OperatorExpression { Op: FilterOperator.And, SubExpressions: var subexprs }:
+                for (int i = 0; i < subexprs.Length; i++)
+                {
+                    if (!MatchFilterPattern(subexprs[i], testNodeFragment, properties))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprs }:
+                return !MatchFilterPattern(subexprs[0], testNodeFragment, properties);
+            case ValueAndPropertyExpression { Value: var valueExpr, Properties: var propExpr }:
+                return MatchFilterPattern(valueExpr, testNodeFragment, properties)
+                    && MatchProperties(propExpr, properties);
+            case NopExpression:
+                return true;
+            default:
+                throw ApplicationStateGuard.Unreachable();
+        }
+    }
 
     private static bool MatchProperties(
         FilterExpression propertyExpr,
         PropertyBag properties)
-        => propertyExpr switch
+    {
+        switch (propertyExpr)
         {
-            PropertyExpression { PropertyName: var propExpr, Value: var valueExpr }
-                => properties.AsEnumerable().Any(prop => IsMatchingProperty(prop, propExpr, valueExpr)),
-            OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subExprs }
-                => subExprs.Any(expr => MatchProperties(expr, properties)),
-            OperatorExpression { Op: FilterOperator.And, SubExpressions: var subExprs }
-                => subExprs.All(expr => MatchProperties(expr, properties)),
-            OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subExprs }
-                => !MatchProperties(subExprs.Single(), properties),
-            _ => throw ApplicationStateGuard.Unreachable(),
-        };
+            case PropertyExpression { PropertyName: var propExpr, Value: var valueExpr }:
+                PropertyBag.Property? current = properties._property;
+                while (current is not null)
+                {
+                    if (IsMatchingProperty(current.Current, propExpr, valueExpr))
+                    {
+                        return true;
+                    }
+
+                    current = current.Next;
+                }
+
+                return false;
+            case OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subExprs }:
+                for (int i = 0; i < subExprs.Length; i++)
+                {
+                    if (MatchProperties(subExprs[i], properties))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case OperatorExpression { Op: FilterOperator.And, SubExpressions: var subExprs }:
+                for (int i = 0; i < subExprs.Length; i++)
+                {
+                    if (!MatchProperties(subExprs[i], properties))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subExprs }:
+                return !MatchProperties(subExprs[0], properties);
+            default:
+                throw ApplicationStateGuard.Unreachable();
+        }
+    }
 
     private static bool IsMatchingProperty(IProperty prop, ValueExpression propExpr, ValueExpression valueExpr)
         => prop is TestMetadataProperty testMetadataProperty &&
@@ -588,6 +649,23 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
             valueExpr.Regex.IsMatch(testMetadataProperty.Value);
 
     private static bool HasPropertyFilterExpression(FilterExpression expression)
-        => expression is ValueAndPropertyExpression ||
-           (expression is OperatorExpression op && op.SubExpressions.Any(HasPropertyFilterExpression));
+    {
+        if (expression is ValueAndPropertyExpression)
+        {
+            return true;
+        }
+
+        if (expression is OperatorExpression op)
+        {
+            for (int i = 0; i < op.SubExpressions.Length; i++)
+            {
+                if (HasPropertyFilterExpression(op.SubExpressions[i]))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -300,9 +300,9 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
     {
         switch (expr)
         {
-            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprsNot } when subexprsNot.Length != 1:
-            case OperatorExpression { Op: FilterOperator.And, SubExpressions.Length: < 2 }:
-            case OperatorExpression { Op: FilterOperator.Or, SubExpressions.Length: < 2 }:
+            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprsNot } when subexprsNot.Count != 1:
+            case OperatorExpression { Op: FilterOperator.And, SubExpressions.Count: < 2 }:
+            case OperatorExpression { Op: FilterOperator.Or, SubExpressions.Count: < 2 }:
                 throw ApplicationStateGuard.Unreachable();
 
             case OperatorExpression opExpr:
@@ -350,7 +350,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
                     _ => throw ApplicationStateGuard.Unreachable(),
                 };
 
-                expr.Push(new OperatorExpression(filter, [.. subexprs]));
+                expr.Push(new OperatorExpression(filter, subexprs.ToArray()));
                 break;
 
             case OperatorKind.FilterEquals:
@@ -513,7 +513,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
             if (currentFragmentIndex >= _filters.Count)
             {
                 // Note: The regex for ** is .*.*, so we match against such a value expression.
-                FilterExpression lastFilter = _filters[_filters.Count - 1];
+                FilterExpression lastFilter = _filters[^1];
                 if (lastFilter is ValueAndPropertyExpression valueAndPropertyExpression)
                 {
                     lastFilter = valueAndPropertyExpression.Value;
@@ -566,7 +566,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
             case ValueExpression vExpr:
                 return vExpr.Regex.IsMatch(testNodeFragment);
             case OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subexprs }:
-                for (int i = 0; i < subexprs.Length; i++)
+                for (int i = 0; i < subexprs.Count; i++)
                 {
                     if (MatchFilterPattern(subexprs[i], testNodeFragment, properties))
                     {
@@ -576,7 +576,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
 
                 return false;
             case OperatorExpression { Op: FilterOperator.And, SubExpressions: var subexprs }:
-                for (int i = 0; i < subexprs.Length; i++)
+                for (int i = 0; i < subexprs.Count; i++)
                 {
                     if (!MatchFilterPattern(subexprs[i], testNodeFragment, properties))
                     {
@@ -585,8 +585,8 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
                 }
 
                 return true;
-            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subexprs }:
-                return !MatchFilterPattern(subexprs[0], testNodeFragment, properties);
+            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: [var singleSubExpr] }:
+                return !MatchFilterPattern(singleSubExpr, testNodeFragment, properties);
             case ValueAndPropertyExpression { Value: var valueExpr, Properties: var propExpr }:
                 return MatchFilterPattern(valueExpr, testNodeFragment, properties)
                     && MatchProperties(propExpr, properties);
@@ -604,20 +604,21 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
         switch (propertyExpr)
         {
             case PropertyExpression { PropertyName: var propExpr, Value: var valueExpr }:
-                PropertyBag.Property? current = properties._property;
-                while (current is not null)
+                // Use the struct-based enumerator on PropertyBag to iterate every property
+                // (including TestNodeStateProperty) without allocating, while keeping
+                // TreeNodeFilter decoupled from PropertyBag's internal storage layout.
+                PropertyBag.PropertyBagEnumerator enumerator = properties.GetStructEnumerator();
+                while (enumerator.MoveNext())
                 {
-                    if (IsMatchingProperty(current.Current, propExpr, valueExpr))
+                    if (IsMatchingProperty(enumerator.Current, propExpr, valueExpr))
                     {
                         return true;
                     }
-
-                    current = current.Next;
                 }
 
                 return false;
             case OperatorExpression { Op: FilterOperator.Or, SubExpressions: var subExprs }:
-                for (int i = 0; i < subExprs.Length; i++)
+                for (int i = 0; i < subExprs.Count; i++)
                 {
                     if (MatchProperties(subExprs[i], properties))
                     {
@@ -627,7 +628,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
 
                 return false;
             case OperatorExpression { Op: FilterOperator.And, SubExpressions: var subExprs }:
-                for (int i = 0; i < subExprs.Length; i++)
+                for (int i = 0; i < subExprs.Count; i++)
                 {
                     if (!MatchProperties(subExprs[i], properties))
                     {
@@ -636,8 +637,8 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
                 }
 
                 return true;
-            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: var subExprs }:
-                return !MatchProperties(subExprs[0], properties);
+            case OperatorExpression { Op: FilterOperator.Not, SubExpressions: [var singleSubExpr] }:
+                return !MatchProperties(singleSubExpr, properties);
             default:
                 throw ApplicationStateGuard.Unreachable();
         }
@@ -657,7 +658,7 @@ public sealed class TreeNodeFilter : ITestExecutionFilter
 
         if (expression is OperatorExpression op)
         {
-            for (int i = 0; i < op.SubExpressions.Length; i++)
+            for (int i = 0; i < op.SubExpressions.Count; i++)
             {
                 if (HasPropertyFilterExpression(op.SubExpressions[i]))
                 {


### PR DESCRIPTION
OperatorExpression.SubExpressions changed from IReadOnlyCollection<FilterExpression>
to FilterExpression[] so callers can iterate with zero-allocation index loops.

MatchFilterPattern and MatchProperties converted from switch expressions with
LINQ lambda closures to switch statements with explicit for loops:
- Eliminates one closure + one IEnumerator<T> allocation per Or/And branch per node
- MatchProperties additionally walks PropertyBag._property linked list directly,
  eliminating the AsEnumerable() call and Any() closure per property expression

HasPropertyFilterExpression and ContainsPropertyFilters initializer converted
from LINQ Any(method group) to explicit index loops.

_filters.Last() replaced with _filters[_filters.Count - 1].

These paths are called once per filter segment per test node during test
filtering; eliminating per-call allocations reduces GC pressure proportional
to test-suite size.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #8305