### PR TITLE
Add Microsoft.Testing.Extensions.Logging bridge to Microsoft.Extensions.Logging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,6 +51,8 @@
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.607501" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="9.10.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.0-preview.1.25513.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/Microsoft.Testing.Platform.slnf
+++ b/Microsoft.Testing.Platform.slnf
@@ -11,6 +11,7 @@
       "src\\Platform\\Microsoft.Testing.Extensions.CrashDump\\Microsoft.Testing.Extensions.CrashDump.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.HangDump\\Microsoft.Testing.Extensions.HangDump.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.HotReload\\Microsoft.Testing.Extensions.HotReload.csproj",
+      "src\\Platform\\Microsoft.Testing.Extensions.Logging\\Microsoft.Testing.Extensions.Logging.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.MSBuild\\Microsoft.Testing.Extensions.MSBuild.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.OpenTelemetry\\Microsoft.Testing.Extensions.OpenTelemetry.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.Retry\\Microsoft.Testing.Extensions.Retry.csproj",

--- a/NonWindowsTests.slnf
+++ b/NonWindowsTests.slnf
@@ -17,6 +17,7 @@
       "src\\Platform\\Microsoft.Testing.Extensions.CrashDump\\Microsoft.Testing.Extensions.CrashDump.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.HangDump\\Microsoft.Testing.Extensions.HangDump.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.HotReload\\Microsoft.Testing.Extensions.HotReload.csproj",
+      "src\\Platform\\Microsoft.Testing.Extensions.Logging\\Microsoft.Testing.Extensions.Logging.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.MSBuild\\Microsoft.Testing.Extensions.MSBuild.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.Retry\\Microsoft.Testing.Extensions.Retry.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.Telemetry\\Microsoft.Testing.Extensions.Telemetry.csproj",

--- a/TestFx.slnx
+++ b/TestFx.slnx
@@ -41,6 +41,7 @@
     <Project Path="src/Platform/Microsoft.Testing.Extensions.CrashDump/Microsoft.Testing.Extensions.CrashDump.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Extensions.HangDump/Microsoft.Testing.Extensions.HangDump.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Extensions.HotReload/Microsoft.Testing.Extensions.HotReload.csproj" />
+    <Project Path="src/Platform/Microsoft.Testing.Extensions.Logging/Microsoft.Testing.Extensions.Logging.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/Microsoft.Testing.Extensions.OpenTelemetry.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj" />

--- a/docs/RFCs/013-Microsoft-Extensions-Bridges.md
+++ b/docs/RFCs/013-Microsoft-Extensions-Bridges.md
@@ -1,0 +1,153 @@
+# RFC 013 - Microsoft.Extensions.* Bridges for Microsoft.Testing.Platform
+
+- [x] Approved in principle
+- [ ] Under discussion
+- [x] Implementation (Logging bridge)
+- [ ] Shipped
+
+## Summary
+
+Microsoft.Testing.Platform (MTP) intentionally ships zero-dependency abstractions for logging, configuration, dependency injection, and hosting. This RFC defines an architectural pattern and the first concrete deliverable for **opt-in side-package bridges** that let users interoperate with the `Microsoft.Extensions.*` ecosystem (`Microsoft.Extensions.Logging`, `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`).
+
+The first bridge delivered with this RFC is `Microsoft.Testing.Extensions.Logging`, which forwards MTP's diagnostic logs to any `Microsoft.Extensions.Logging` provider (Console, Debug, Serilog, Application Insights, OpenTelemetry, etc.).
+
+## Motivation
+
+MTP today ships its own slim implementations of:
+
+| Concern | MTP namespace | Equivalent in BCL ecosystem |
+|---|---|---|
+| Logging | `Microsoft.Testing.Platform.Logging` | `Microsoft.Extensions.Logging` |
+| Configuration | `Microsoft.Testing.Platform.Configurations` | `Microsoft.Extensions.Configuration` |
+| Service location | `Microsoft.Testing.Platform.Services.ServiceProvider` | `Microsoft.Extensions.DependencyInjection` |
+| Host lifecycle | `Microsoft.Testing.Platform.Hosts` | `Microsoft.Extensions.Hosting` |
+
+This is deliberate: MTP must remain trim/AOT-friendly, must target `netstandard2.0`, and must not impose a particular DI/logging stack on test authors or extension authors. A test framework or test app must be able to use Microsoft.Testing.Platform without pulling any `Microsoft.Extensions.*` package into the closure of its dependencies.
+
+However, real-world test apps frequently want to:
+
+- Stream MTP's diagnostic output through an existing logging pipeline (Serilog/Seq, Application Insights, OTLP, the in-IDE Debug window, a custom in-memory sink in a test).
+- Reuse the same `IConfiguration` they already build for the system under test.
+- Plug an `IHostedService` into the test session lifecycle (similar to `WebApplicationFactory`).
+- Consume `Microsoft.Extensions.Logging.ILogger<T>` from inside their fixtures.
+
+The current "homegrown core + opt-in bridge extensions" pattern satisfies both constraints.
+
+## Design principles
+
+1. **Core stays dep-free.** `Microsoft.Testing.Platform` and the existing extensions (`Microsoft.Testing.Extensions.TrxReport`, `…CrashDump`, `…HangDump`, `…Telemetry`, `…HotReload`, `…Retry`, `…OpenTelemetry`, etc.) do not take a `PackageReference` on any `Microsoft.Extensions.*` package as a side effect of a bridge existing.
+2. **Bridges are additive.** A bridge package never replaces a homegrown subsystem. Example: a future Configuration bridge does not replace MTP's vendored `JsonConfigurationFileParser`; it provides an additional `IConfigurationSource` on top of it.
+3. **Bridges are end-user surface.** They are referenced only by application code (the test host `Program.cs` or a test framework that explicitly chooses the dependency). They are never transitive prerequisites of any existing MTP package.
+4. **Bridges follow the established extension shape.** Same project layout, `BannedSymbols.txt`, `PublicAPI/*.txt`, `PACKAGE.md`, and `[TPEXP]` annotation as `Microsoft.Testing.Extensions.OpenTelemetry`.
+5. **Honest about gaps.** Where the BCL contract is richer than the MTP contract (e.g. `EventId`, `BeginScope`, async logging), the bridge documents the mapping rather than inventing capability.
+
+## Phasing
+
+| Phase | Package | Status |
+|---|---|---|
+| 1 | `Microsoft.Testing.Extensions.Logging` | This RFC |
+| 2 | `Microsoft.Testing.Extensions.Configuration` | Future |
+| 3 | `Microsoft.Testing.Extensions.DependencyInjection` | Future |
+| 4 | `Microsoft.Testing.Extensions.Hosting` | Future |
+
+## Detailed design — `Microsoft.Testing.Extensions.Logging`
+
+### Goal
+
+Let a user write something like:
+
+```csharp
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
+
+builder.AddMicrosoftExtensionsLogging(logging =>
+{
+    logging.AddConsole();          // any Microsoft.Extensions.Logging provider
+    logging.AddDebug();
+    // logging.AddSerilog(...);
+    // logging.AddApplicationInsights(...);
+});
+```
+
+…and have every diagnostic message that MTP and its extensions write flow through those providers, in addition to (not in place of) MTP's own `--diagnostic` file logger.
+
+### API
+
+The extension surface is a single `[TPEXP]` static class with two extension methods on `ITestApplicationBuilder`:
+
+```csharp
+namespace Microsoft.Testing.Extensions;
+
+[Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
+public static class MicrosoftExtensionsLoggingBuilderExtensions
+{
+    // Builds and owns a new MEL LoggerFactory.
+    public static ITestApplicationBuilder AddMicrosoftExtensionsLogging(
+        this ITestApplicationBuilder builder,
+        Action<Microsoft.Extensions.Logging.ILoggingBuilder> configure);
+
+    // Forwards to a caller-owned LoggerFactory.
+    public static ITestApplicationBuilder AddMicrosoftExtensionsLogging(
+        this ITestApplicationBuilder builder,
+        Microsoft.Extensions.Logging.ILoggerFactory loggerFactory);
+}
+```
+
+### Adapter pipeline
+
+Internally:
+
+```
+MTP ILoggingManager.AddProvider(factoryFunc)
+        │
+        ▼
+MicrosoftExtensionsLoggingProvider : MTP.ILoggerProvider, IDisposable
+        │     (wraps a MEL.ILoggerFactory)
+        ▼
+MicrosoftExtensionsLoggerAdapter : MTP.ILogger
+        │     (wraps a MEL.ILogger)
+        ▼
+Microsoft.Extensions.Logging.LoggerFactory → user's MEL providers
+```
+
+### Semantic mapping
+
+| MTP concept | Mapped MEL concept | Notes |
+|---|---|---|
+| `LogLevel.Trace…Critical/None` (0..6) | `Microsoft.Extensions.Logging.LogLevel.Trace…Critical/None` | Same numeric values; mapped via explicit `switch` for safety/AOT |
+| `ILogger.Log<TState>(level, state, ex, formatter)` | `ILogger.Log<TState>(level, EventId.None, state, ex, formatter)` | `EventId` defaults to `None` |
+| `ILogger.LogAsync<TState>(...)` | Synchronous `Log` + `Task.CompletedTask` | MEL has no async API |
+| `ILogger.IsEnabled(level)` | `ILogger.IsEnabled(level)` | Forwards; MEL's per-category filter still applies |
+| Category name | Category name | Pass-through string |
+| Provider disposal | `LoggerFactory.Dispose()` | Owned factories disposed; caller-owned ones not |
+
+### Filtering interaction
+
+MTP's `Logger.Log` already calls `logger.IsEnabled(level)` per child provider in `Logger.cs:18` before forwarding. The MEL adapter forwards `IsEnabled` to the underlying MEL logger, so MEL's per-category filter rules continue to apply on top of MTP's coarse global level. There is **no double-filter bug**.
+
+### What is intentionally not done
+
+- **No new CLI options.** Configuration is purely programmatic.
+- **No replacement of the built-in file logger.** `--diagnostic` continues to produce its `.diag` file when the user enables it; the bridge adds *additional* sinks.
+- **No MTP-side `ILogger` exposure as a MEL `ILogger`.** Direction B (test code consuming `Microsoft.Extensions.Logging.ILogger<T>` and having it write through MTP) is omitted from the v1 shipment. It will be added once we have a concrete consumer scenario, to avoid speculative public API.
+- **No MSBuild auto-registration hook.** The user must opt in with a `configure` delegate, so the MSBuild-based `TestingPlatformBuilderHook` pattern (used by `…HotReload`) does not apply.
+
+### Package metadata
+
+- **TFMs**: `netstandard2.0;net8.0;net9.0` (matches `$(SupportedNetFrameworks)`).
+- **Version**: `1.0.0-alpha.*` (mirrors `Microsoft.Testing.Extensions.OpenTelemetry`).
+- **Dependencies**: `Microsoft.Extensions.Logging` (drags `Microsoft.Extensions.Logging.Abstractions` transitively).
+- **Trim/AOT**: `IsTrimmable=true`, `IsAotCompatible=true` (inherited).
+
+### Risks
+
+1. The bridge depends on the still-`[TPEXP]` `ILoggingManager` API. Acceptable: the bridge is itself `[TPEXP]`.
+2. `EventId` is dropped. Users who rely on `EventId`-based filtering downstream of the bridge will lose that fidelity; documented.
+3. `LogAsync` becomes synchronous when going through a MEL provider that performs blocking I/O (Console, plain file). MEL has no async API; this is a known and intrinsic limitation.
+
+## Future work (not in this RFC's deliverable)
+
+- **Direction B** adapter (MTP `ILoggerFactory` exposed as `Microsoft.Extensions.Logging.ILoggerFactory`).
+- **`Microsoft.Testing.Extensions.Configuration`** — wrap `Microsoft.Extensions.Configuration.IConfiguration` as an MTP `IConfigurationSource`. Additive; does not retire the vendored `JsonConfigurationFileParser`.
+- **`Microsoft.Testing.Extensions.DependencyInjection`** — expose MTP services in an `IServiceCollection`/`IServiceProvider`.
+- **`Microsoft.Testing.Extensions.Hosting`** — `IHostedService` lifecycle bound to the test session.

--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -32,6 +32,8 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.CrashDump\Microsoft.Testing.Extensions.CrashDump.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.OpenTelemetry\Microsoft.Testing.Extensions.OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Logging\Microsoft.Testing.Extensions.Logging.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Playground/Program.cs
+++ b/samples/Playground/Program.cs
@@ -67,6 +67,19 @@ public class Program
             //         metrics.AddTestingPlatformInstrumentation();
             //         metrics.AddOtlpExporter();
             //     });
+
+            // Forward Microsoft.Testing.Platform diagnostic logs to Microsoft.Extensions.Logging
+            // providers (Console, Debug, Serilog, Application Insights, ...). This pulls in any
+            // logging stack from the BCL ecosystem without modifying the platform.
+            // Run with --diagnostic to see entries appear on stdout alongside the .diag file.
+            // testApplicationBuilder.AddMicrosoftExtensionsLogging(logging =>
+            // {
+            //     logging.AddSimpleConsole(options =>
+            //     {
+            //         options.SingleLine = true;
+            //         options.TimestampFormat = "HH:mm:ss.fff ";
+            //     });
+            // });
             using ITestApplication testApplication = await testApplicationBuilder.BuildAsync();
             return await testApplication.RunAsync();
         }

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/BannedSymbols.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/BannedSymbols.txt
@@ -1,0 +1,4 @@
+﻿M:System.String.IsNullOrEmpty(System.String); Use 'TAString.IsNullOrEmpty' instead
+M:System.String.IsNullOrWhiteSpace(System.String); Use 'TAString.IsNullOrWhiteSpace' instead
+M:System.Diagnostics.Debug.Assert(System.Boolean); Use 'RoslynDebug.Assert' instead
+M:System.Diagnostics.Debug.Assert(System.Boolean,System.String); Use 'RoslynDebug.Assert' instead

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/LogLevelMapper.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/LogLevelMapper.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MelLogLevel = Microsoft.Extensions.Logging.LogLevel;
+using MtpLogLevel = Microsoft.Testing.Platform.Logging.LogLevel;
+
+namespace Microsoft.Testing.Extensions.Logging;
+
+internal static class LogLevelMapper
+{
+    public static MelLogLevel ToMicrosoftExtensions(MtpLogLevel level)
+        => level switch
+        {
+            MtpLogLevel.Trace => MelLogLevel.Trace,
+            MtpLogLevel.Debug => MelLogLevel.Debug,
+            MtpLogLevel.Information => MelLogLevel.Information,
+            MtpLogLevel.Warning => MelLogLevel.Warning,
+            MtpLogLevel.Error => MelLogLevel.Error,
+            MtpLogLevel.Critical => MelLogLevel.Critical,
+            MtpLogLevel.None => MelLogLevel.None,
+            _ => MelLogLevel.None,
+        };
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/Microsoft.Testing.Extensions.Logging.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/Microsoft.Testing.Extensions.Logging.csproj
@@ -1,0 +1,44 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;$(SupportedNetFrameworks)</TargetFrameworks>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <GenerateBuildInfo>true</GenerateBuildInfo>
+    <BuildInfoTemplateFile>$(RepoRoot)src\Platform\SharedExtensionHelpers\BuildInfo.cs.template</BuildInfoTemplateFile>
+  </PropertyGroup>
+
+  <!-- NuGet properties -->
+  <PropertyGroup>
+    <PackageDescription>
+      <![CDATA[Microsoft Testing is a set of platform, framework and protocol intended to make it possible to run any test on any target or device.
+
+This package provides a Microsoft.Extensions.Logging bridge for the platform, allowing diagnostic log messages produced by Microsoft.Testing.Platform and its extensions to flow through any Microsoft.Extensions.Logging provider (Console, Debug, Serilog, OpenTelemetry, Application Insights, ...).]]>
+    </PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+    <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)src/Polyfills/**/*.cs" Link="Polyfills\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggerAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggerAdapter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MelILogger = Microsoft.Extensions.Logging.ILogger;
+using MtpILogger = Microsoft.Testing.Platform.Logging.ILogger;
+using MtpLogLevel = Microsoft.Testing.Platform.Logging.LogLevel;
+
+namespace Microsoft.Testing.Extensions.Logging;
+
+/// <summary>
+/// Adapter that exposes a <see cref="MelILogger"/> as an <see cref="MtpILogger"/>.
+/// </summary>
+internal sealed class MicrosoftExtensionsLoggerAdapter : MtpILogger
+{
+    private readonly MelILogger _inner;
+
+    public MicrosoftExtensionsLoggerAdapter(MelILogger inner)
+        => _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+
+    public bool IsEnabled(MtpLogLevel logLevel)
+        => _inner.IsEnabled(LogLevelMapper.ToMicrosoftExtensions(logLevel));
+
+    public void Log<TState>(MtpLogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => _inner.Log(LogLevelMapper.ToMicrosoftExtensions(logLevel), default, state, exception, formatter);
+
+    public Task LogAsync<TState>(MtpLogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        // Microsoft.Extensions.Logging has no async API; forward synchronously and complete.
+        Log(logLevel, state, exception, formatter);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingBuilderExtensions.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Testing.Extensions.Logging;
+using Microsoft.Testing.Platform.Builder;
+
+using MelILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using MelLoggerFactory = Microsoft.Extensions.Logging.LoggerFactory;
+
+namespace Microsoft.Testing.Extensions;
+
+/// <summary>
+/// Extension methods on <see cref="ITestApplicationBuilder"/> for forwarding the
+/// Microsoft Testing Platform diagnostic logs to <c>Microsoft.Extensions.Logging</c> providers.
+/// </summary>
+[Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
+public static class MicrosoftExtensionsLoggingBuilderExtensions
+{
+    /// <summary>
+    /// Forwards every diagnostic log message produced by Microsoft Testing Platform and its
+    /// extensions to <c>Microsoft.Extensions.Logging</c> providers configured by the supplied delegate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A new <see cref="MelILoggerFactory"/> is created internally for each call and disposed when the
+    /// test application terminates. The minimum level is initialized from the platform's effective
+    /// diagnostic level so log volume is bounded by the platform configuration; per-category filters in
+    /// the <see cref="ILoggingBuilder"/> can only narrow this set, never widen it.
+    /// </para>
+    /// <para>
+    /// When the platform's effective level is <see cref="Microsoft.Testing.Platform.Logging.LogLevel.None"/>
+    /// (the default when <c>--diagnostic</c> is not enabled), the supplied <paramref name="configure"/>
+    /// delegate is not invoked and no <see cref="MelILoggerFactory"/> is created, so expensive sinks
+    /// (network, file, gRPC) are not initialized for runs that will never emit a log.
+    /// </para>
+    /// <para>
+    /// Microsoft Testing Platform's <see cref="Microsoft.Testing.Platform.Logging.ILogger"/> has no notion
+    /// of <see cref="Microsoft.Extensions.Logging.EventId"/>; messages forwarded through this bridge are
+    /// logged with <c>EventId.None</c>.
+    /// </para>
+    /// <para>
+    /// This extension is additive: it does not replace the platform's built-in <c>--diagnostic</c>
+    /// file logger. When <c>--diagnostic</c> is enabled, messages are written to both the diagnostic
+    /// file and the configured <c>Microsoft.Extensions.Logging</c> providers.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The test application builder.</param>
+    /// <param name="configure">A delegate that configures the <see cref="ILoggingBuilder"/>.</param>
+    /// <returns>The same <see cref="ITestApplicationBuilder"/> for chaining.</returns>
+    public static ITestApplicationBuilder AddMicrosoftExtensionsLogging(
+        this ITestApplicationBuilder builder,
+        Action<ILoggingBuilder> configure)
+    {
+        _ = builder ?? throw new ArgumentNullException(nameof(builder));
+        _ = configure ?? throw new ArgumentNullException(nameof(configure));
+
+        builder.Logging.AddProvider((mtpLevel, _) =>
+        {
+            if (mtpLevel == Microsoft.Testing.Platform.Logging.LogLevel.None)
+            {
+                // No log message will ever flow; avoid constructing the user's logging pipeline.
+                return NopLoggerProvider.Instance;
+            }
+
+            MelILoggerFactory factory = MelLoggerFactory.Create(loggingBuilder =>
+            {
+                loggingBuilder.SetMinimumLevel(LogLevelMapper.ToMicrosoftExtensions(mtpLevel));
+                configure(loggingBuilder);
+            });
+            return new MicrosoftExtensionsLoggingProvider(factory, ownsFactory: true);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Forwards every diagnostic log message produced by Microsoft Testing Platform and its
+    /// extensions to a caller-owned <see cref="MelILoggerFactory"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The factory's lifetime is owned by the caller; the bridge will not dispose it.
+    /// This overload is intended for scenarios where the same <see cref="MelILoggerFactory"/>
+    /// instance is shared with other components, such as the system under test.
+    /// </para>
+    /// <para>
+    /// When the platform's effective level is <see cref="Microsoft.Testing.Platform.Logging.LogLevel.None"/>,
+    /// the bridge becomes a no-op and no calls are made on <paramref name="loggerFactory"/>.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The test application builder.</param>
+    /// <param name="loggerFactory">A <see cref="MelILoggerFactory"/> that the platform should forward logs to.</param>
+    /// <returns>The same <see cref="ITestApplicationBuilder"/> for chaining.</returns>
+    public static ITestApplicationBuilder AddMicrosoftExtensionsLogging(
+        this ITestApplicationBuilder builder,
+        MelILoggerFactory loggerFactory)
+    {
+        _ = builder ?? throw new ArgumentNullException(nameof(builder));
+        _ = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
+        builder.Logging.AddProvider((mtpLevel, _) => mtpLevel == Microsoft.Testing.Platform.Logging.LogLevel.None
+            ? NopLoggerProvider.Instance
+            : new MicrosoftExtensionsLoggingProvider(loggerFactory, ownsFactory: false));
+
+        return builder;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingProvider.cs
@@ -29,7 +29,9 @@ internal sealed class MicrosoftExtensionsLoggingProvider : MtpILoggerProvider, I
     }
 
     public MtpILogger CreateLogger(string categoryName)
-        => new MicrosoftExtensionsLoggerAdapter(_loggerFactory.CreateLogger(categoryName));
+        => Volatile.Read(ref _disposed) != 0
+            ? throw new ObjectDisposedException(nameof(MicrosoftExtensionsLoggingProvider))
+            : new MicrosoftExtensionsLoggerAdapter(_loggerFactory.CreateLogger(categoryName));
 
     public void Dispose()
     {

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingProvider.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MelILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
+using MtpILogger = Microsoft.Testing.Platform.Logging.ILogger;
+using MtpILoggerProvider = Microsoft.Testing.Platform.Logging.ILoggerProvider;
+
+namespace Microsoft.Testing.Extensions.Logging;
+
+/// <summary>
+/// Microsoft.Testing.Platform logger provider that forwards every log message produced by the
+/// platform and its extensions to a <see cref="MelILoggerFactory"/>.
+/// </summary>
+internal sealed class MicrosoftExtensionsLoggingProvider : MtpILoggerProvider, IDisposable
+#if NETCOREAPP
+#pragma warning disable SA1001 // Commas should be spaced correctly
+    , IAsyncDisposable
+#pragma warning restore SA1001 // Commas should be spaced correctly
+#endif
+{
+    private readonly MelILoggerFactory _loggerFactory;
+    private readonly bool _ownsFactory;
+    private int _disposed;
+
+    public MicrosoftExtensionsLoggingProvider(MelILoggerFactory loggerFactory, bool ownsFactory)
+    {
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _ownsFactory = ownsFactory;
+    }
+
+    public MtpILogger CreateLogger(string categoryName)
+        => new MicrosoftExtensionsLoggerAdapter(_loggerFactory.CreateLogger(categoryName));
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (_ownsFactory && _loggerFactory is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+#if NETCOREAPP
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (!_ownsFactory)
+        {
+            return;
+        }
+
+        // Prefer the async path so that buffered/network-backed MEL providers (Serilog, OpenTelemetry,
+        // Application Insights) can flush gracefully without blocking the synchronous Dispose() call.
+        if (_loggerFactory is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else if (_loggerFactory is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+#endif
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/NopLoggerProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/NopLoggerProvider.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MtpILogger = Microsoft.Testing.Platform.Logging.ILogger;
+using MtpILoggerProvider = Microsoft.Testing.Platform.Logging.ILoggerProvider;
+using MtpLogLevel = Microsoft.Testing.Platform.Logging.LogLevel;
+
+namespace Microsoft.Testing.Extensions.Logging;
+
+/// <summary>
+/// Singleton no-op <see cref="MtpILoggerProvider"/> used when the platform's effective
+/// <see cref="MtpLogLevel"/> is <see cref="MtpLogLevel.None"/>, so that no Microsoft.Extensions.Logging
+/// pipeline is constructed for runs that will never emit a log.
+/// </summary>
+internal sealed class NopLoggerProvider : MtpILoggerProvider
+{
+    public static NopLoggerProvider Instance { get; } = new();
+
+    private NopLoggerProvider()
+    {
+    }
+
+    public MtpILogger CreateLogger(string categoryName) => NopLogger.Instance;
+
+    private sealed class NopLogger : MtpILogger
+    {
+        public static NopLogger Instance { get; } = new();
+
+        private NopLogger()
+        {
+        }
+
+        public bool IsEnabled(MtpLogLevel logLevel) => false;
+
+        public void Log<TState>(MtpLogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+
+        public Task LogAsync<TState>(MtpLogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Task.CompletedTask;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/PACKAGE.md
@@ -1,0 +1,61 @@
+# Microsoft.Testing.Extensions.Logging
+
+`Microsoft.Testing.Extensions.Logging` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that bridges the platform's logging pipeline with [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging), so diagnostic messages produced by the platform and its extensions can flow through any `Microsoft.Extensions.Logging` provider — Console, Debug, Serilog, Application Insights, OpenTelemetry, custom sinks, and more.
+
+Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.Logging` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
+
+## Install the package
+
+```dotnetcli
+dotnet add package Microsoft.Testing.Extensions.Logging
+```
+
+You will typically also add a `Microsoft.Extensions.Logging` provider package, e.g.:
+
+```dotnetcli
+dotnet add package Microsoft.Extensions.Logging.Console
+```
+
+## Usage
+
+```csharp
+using Microsoft.Extensions.Logging;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+
+builder.AddMicrosoftExtensionsLogging(logging =>
+{
+    logging.AddConsole();
+    logging.AddDebug();
+});
+
+using ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();
+```
+
+## About
+
+This package extends Microsoft.Testing.Platform with:
+
+- **Bridge to `Microsoft.Extensions.Logging`**: any MTP diagnostic log message is forwarded to the configured `Microsoft.Extensions.Logging` providers in addition to the platform's built-in `--diagnostic` file logger.
+- **Reuse existing logging stacks**: plug Serilog, OpenTelemetry logs, Application Insights, or your own custom `ILoggerProvider` into the testing platform without writing a custom MTP logger provider.
+
+The bridge maps `Microsoft.Testing.Platform.Logging.LogLevel` to `Microsoft.Extensions.Logging.LogLevel`, forwards the same `state`, `exception`, and formatter through to `Microsoft.Extensions.Logging.ILogger.Log`, and respects per-category filter rules defined in the `ILoggingBuilder`.
+
+### Notes and limitations
+
+- **`EventId` is not propagated.** Microsoft.Testing.Platform's `ILogger` has no notion of `EventId`; every forwarded log entry is written with `EventId.None`. Consumers that rely on `EventId`-based filtering downstream of the bridge will not see distinct IDs.
+- **Per-category filters can only narrow, never widen.** The bridge initializes the `ILoggingBuilder` with the platform's effective diagnostic level, and the platform itself filters messages before they reach any provider. Setting a more verbose minimum level inside `configure` has no effect.
+- **No-op when `--diagnostic` is off.** When the platform's effective `LogLevel` is `None` (the default), the `configure` delegate is not invoked and no `Microsoft.Extensions.Logging.LoggerFactory` is created, so expensive sinks (network, file, gRPC) are not initialized for runs that will never emit a log.
+- **`LogAsync` is forwarded synchronously.** `Microsoft.Extensions.Logging` has no async logging API; `ILogger.LogAsync` is forwarded to `ILogger.Log` and returns `Task.CompletedTask`.
+- **Owned vs. caller-owned factories.** The `Action<ILoggingBuilder>` overload creates and disposes its own `ILoggerFactory`. The `ILoggerFactory` overload never disposes the caller-supplied instance.
+
+## Documentation
+
+For comprehensive documentation, see <https://aka.ms/testingplatform>.
+
+## Feedback & contributing
+
+Microsoft.Testing.Platform is an open source project. Provide feedback or report issues in the [microsoft/testfx](https://github.com/microsoft/testfx/issues) GitHub repository.

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/PublicAPI/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+[TPEXP]Microsoft.Testing.Extensions.MicrosoftExtensionsLoggingBuilderExtensions
+[TPEXP]static Microsoft.Testing.Extensions.MicrosoftExtensionsLoggingBuilderExtensions.AddMicrosoftExtensionsLogging(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!
+[TPEXP]static Microsoft.Testing.Extensions.MicrosoftExtensionsLoggingBuilderExtensions.AddMicrosoftExtensionsLogging(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder, System.Action<Microsoft.Extensions.Logging.ILoggingBuilder!>! configure) -> Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -81,6 +81,13 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 
             await DisposeServiceProviderAsync(ServiceProvider, alreadyDisposed: alreadyDisposed, isProcessShutdown: true).ConfigureAwait(false);
             await DisposeHelper.DisposeAsync(ServiceProvider.GetService<FileLoggerProvider>()).ConfigureAwait(false);
+
+            // Dispose the LoggerFactoryProxy last so that all user-registered logger providers
+            // (e.g., Microsoft.Extensions.Logging providers added via the Microsoft.Testing.Extensions.Logging
+            // bridge such as Serilog, Application Insights, OpenTelemetry) get a chance to flush their buffers.
+            // The proxy is skipped by DisposeServiceProviderAsync for ordering reasons.
+            await DisposeHelper.DisposeAsync(ServiceProvider.GetService<LoggerFactoryProxy>()).ConfigureAwait(false);
+
             if (PushOnlyProtocol is not null && !alreadyDisposed.Contains(PushOnlyProtocol))
             {
                 await DisposeHelper.DisposeAsync(PushOnlyProtocol).ConfigureAwait(false);
@@ -311,6 +318,14 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
             // Logger is the most special service and we dispose it manually as last one, we want to be able to
             // collect logs till the end of the process.
             if (service is FileLoggerProvider)
+            {
+                continue;
+            }
+
+            // The LoggerFactoryProxy owns the real ILoggerFactory and is disposed manually after the rest of
+            // the services so that providers registered through it (including bridges to
+            // Microsoft.Extensions.Logging) can flush at the very end of the process.
+            if (service is LoggerFactoryProxy)
             {
                 continue;
             }

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactory.cs
@@ -46,6 +46,12 @@ internal sealed class LoggerFactory(ILoggerProvider[] loggerProviders, LogLevel 
 
     public void Dispose()
     {
+        // NOTE: Reachable through the explicit LoggerFactoryProxy disposal at the end of
+        // CommonHost.RunAsync's finally block. Before that change, this method was never
+        // executed at runtime, so anything that becomes externally observable here (provider
+        // ordering, exceptions, side effects) must be considered against the live shutdown path.
+        // FileLoggerProvider is intentionally skipped because CommonHost disposes it explicitly
+        // on the preceding line.
         foreach (IDisposable disposable in _loggerProviders.OfType<IDisposable>())
         {
             // FileLoggerProvider is special and needs to be disposed manually.

--- a/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryProxy.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryProxy.cs
@@ -3,14 +3,55 @@
 
 namespace Microsoft.Testing.Platform.Logging;
 
-internal sealed class LoggerFactoryProxy : ILoggerFactory
+internal sealed class LoggerFactoryProxy : ILoggerFactory, IDisposable
+#if NETCOREAPP
+#pragma warning disable SA1001 // Commas should be spaced correctly
+    , IAsyncDisposable
+#pragma warning restore SA1001 // Commas should be spaced correctly
+#endif
 {
     private ILoggerFactory? _loggerFactory;
+    private int _disposed;
 
-    public ILogger CreateLogger(string categoryName) => _loggerFactory is null
-            ? throw new InvalidOperationException(Resources.PlatformResources.LoggerFactoryNotReady)
-            : _loggerFactory.CreateLogger(categoryName);
+    public ILogger CreateLogger(string categoryName)
+        => Volatile.Read(ref _disposed) != 0
+            ? throw new ObjectDisposedException(nameof(LoggerFactoryProxy))
+            : _loggerFactory is null
+                ? throw new InvalidOperationException(Resources.PlatformResources.LoggerFactoryNotReady)
+                : _loggerFactory.CreateLogger(categoryName);
 
     public void SetLoggerFactory(ILoggerFactory loggerFactory)
         => _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (_loggerFactory is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+#if NETCOREAPP
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (_loggerFactory is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else if (_loggerFactory is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+#endif
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -15,6 +15,7 @@ public abstract class AcceptanceTestBase
         MSTestVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "MSTest.TestFramework.");
         MicrosoftTestingPlatformVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "Microsoft.Testing.Platform.");
         MSTestEngineVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "MSTest.Engine.");
+        MicrosoftTestingExtensionsLoggingVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "Microsoft.Testing.Extensions.Logging.");
     }
 
     internal static string RID { get; }
@@ -33,6 +34,8 @@ public abstract class AcceptanceTestBase
     public static string MicrosoftNETTestSdkVersion { get; private set; }
 
     public static string MicrosoftTestingPlatformVersion { get; private set; }
+
+    public static string MicrosoftTestingExtensionsLoggingVersion { get; private set; }
 
     private static string ExtractVersionFromPackage(string rootFolder, string packagePrefixName)
     {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MicrosoftExtensionsLoggingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MicrosoftExtensionsLoggingTests.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestClass]
+public class MicrosoftExtensionsLoggingTests : AcceptanceTestBase<MicrosoftExtensionsLoggingTests.TestAssetFixture>
+{
+    private const string AssetName = "MicrosoftExtensionsLoggingTest";
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task MELBridge_WhenEnabled_ForwardsPlatformDiagnosticLogsToMELProvider(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--diagnostic --diagnostic-verbosity Trace",
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
+
+        // The test asset registers a custom Microsoft.Extensions.Logging provider that prefixes every
+        // log line with "[MEL]" and writes it to stdout. If the bridge is wired correctly, MTP's own
+        // diagnostic messages (which start being emitted very early in startup) must appear with that
+        // prefix on stdout, in addition to being written to the --diagnostic file.
+        testHostResult.AssertOutputContains("[MEL]");
+        testHostResult.AssertOutputContains("Microsoft.Testing.Platform");
+
+        // The provider writes "[MEL-FLUSH]" to stdout from its Dispose method. Asserting on it locks in
+        // the fact that the bridge-owned LoggerFactory is disposed at shutdown — without that, buffered
+        // MEL providers (Serilog, Application Insights, OpenTelemetry, ...) would never flush.
+        testHostResult.AssertOutputContains("[MEL-FLUSH]");
+    }
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task MELBridge_WhenDiagnosticIsOff_ConfigureDelegateIsNotInvokedAndNoLogsAreForwarded(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+
+        // Without --diagnostic, MTP's log level defaults to None. The bridge short-circuits and never
+        // invokes the user's configure delegate, so no MEL pipeline is constructed and no logs are forwarded.
+        TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
+        testHostResult.AssertOutputDoesNotContain("[MEL]");
+        testHostResult.AssertOutputDoesNotContain("[MEL-FLUSH]");
+        testHostResult.AssertOutputDoesNotContain("[MEL-CONFIGURE-INVOKED]");
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string TestCode = """
+#file MicrosoftExtensionsLoggingTest.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <UseAppHost>true</UseAppHost>
+        <LangVersion>preview</LangVersion>
+        <NoWarn>$(NoWarn);TPEXP</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="Microsoft.Testing.Extensions.Logging" Version="$MicrosoftTestingExtensionsLoggingVersion$" />
+    </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(
+            sp => new TestFrameworkCapabilities(),
+            (_, __) => new DummyTestFramework());
+
+        // Forward MTP diagnostic logs to a custom MEL provider that prefixes every message
+        // with "[MEL]" so the acceptance test can assert on stdout that the bridge is wired up.
+        // Register the provider as a type so the MEL ServiceProvider owns its lifetime and disposes
+        // it on shutdown (this is how Console/Debug/Serilog providers are registered, and matches
+        // real-world consumer usage).
+        // The marker "[MEL-CONFIGURE-INVOKED]" lets the no-diagnostic test assert that this delegate
+        // is *not* invoked when MTP's log level resolves to None.
+        builder.AddMicrosoftExtensionsLogging(logging =>
+        {
+            Console.WriteLine("[MEL-CONFIGURE-INVOKED]");
+            logging.Services.AddSingleton<ILoggerProvider, MarkerLoggerProvider>();
+        });
+
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public sealed class MarkerLoggerProvider : ILoggerProvider
+{
+    private bool _disposed;
+
+    public ILogger CreateLogger(string categoryName) => new MarkerLogger(categoryName);
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // Marker used by the acceptance test to verify the bridge-owned LoggerFactory is disposed
+        // at shutdown so buffered MEL providers get a chance to flush.
+        Console.WriteLine("[MEL-FLUSH]");
+    }
+}
+
+public sealed class MarkerLogger(string categoryName) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    public bool IsEnabled(LogLevel logLevel) => true;
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        // Print to stdout with the [MEL] marker the acceptance test will look for.
+        Console.WriteLine($"[MEL] {logLevel} {categoryName}: {formatter(state, exception)}");
+    }
+}
+
+public class DummyTestFramework : ITestFramework
+{
+    public string Uid => nameof(DummyTestFramework);
+    public string Version => "2.0.0";
+    public string DisplayName => nameof(DummyTestFramework);
+    public string Description => nameof(DummyTestFramework);
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+    public Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        context.Complete();
+        return Task.CompletedTask;
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            TestCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsLoggingVersion$", MicrosoftTestingExtensionsLoggingVersion));
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/LogLevelMapperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/LogLevelMapperTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.Logging;
+
+using MelLogLevel = Microsoft.Extensions.Logging.LogLevel;
+using MtpLogLevel = Microsoft.Testing.Platform.Logging.LogLevel;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class LogLevelMapperTests
+{
+    [DataRow(MtpLogLevel.Trace, MelLogLevel.Trace)]
+    [DataRow(MtpLogLevel.Debug, MelLogLevel.Debug)]
+    [DataRow(MtpLogLevel.Information, MelLogLevel.Information)]
+    [DataRow(MtpLogLevel.Warning, MelLogLevel.Warning)]
+    [DataRow(MtpLogLevel.Error, MelLogLevel.Error)]
+    [DataRow(MtpLogLevel.Critical, MelLogLevel.Critical)]
+    [DataRow(MtpLogLevel.None, MelLogLevel.None)]
+    [TestMethod]
+    public void ToMicrosoftExtensions_MapsEveryDefinedMtpLevelToMatchingMelLevel(MtpLogLevel input, MelLogLevel expected)
+        => Assert.AreEqual(expected, LogLevelMapper.ToMicrosoftExtensions(input));
+
+    [TestMethod]
+    public void ToMicrosoftExtensions_EveryEnumValueHasAnExplicitMapping()
+    {
+        // Locks in coverage: if a new MTP LogLevel value is added in the future without updating the mapper,
+        // this test catches the silent fallback to None before it ships.
+        foreach (MtpLogLevel value in (MtpLogLevel[])Enum.GetValues(typeof(MtpLogLevel)))
+        {
+            MelLogLevel mapped = LogLevelMapper.ToMicrosoftExtensions(value);
+            Assert.AreEqual(
+                value.ToString(),
+                mapped.ToString(),
+                $"LogLevelMapper.ToMicrosoftExtensions(LogLevel.{value}) returned {mapped}; expected a same-named MEL level. Update LogLevelMapper when adding new MTP LogLevel values.");
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj
@@ -36,6 +36,9 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj">
       <SetTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETCoreApp'">TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Logging\Microsoft.Testing.Extensions.Logging.csproj">
+      <SetTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETCoreApp'">TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggerFactoryProxyTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LoggerFactoryProxyTests.cs
@@ -41,4 +41,84 @@ public sealed class LoggerFactoryProxyTests
         Assert.AreSame(mockLogger.Object, result);
         mockFactory.Verify(f => f.CreateLogger("category"), Times.Once);
     }
+
+    [TestMethod]
+    public void Dispose_WhenNoInnerFactorySet_DoesNotThrow()
+    {
+        LoggerFactoryProxy proxy = new();
+
+        // Should be a no-op rather than NRE — host shutdown paths call this defensively.
+        proxy.Dispose();
+    }
+
+    [TestMethod]
+    public void Dispose_WhenInnerFactoryIsDisposable_DisposesInnerFactory()
+    {
+        Mock<ILoggerFactory> mockFactory = new();
+        Mock<IDisposable> mockDisposable = mockFactory.As<IDisposable>();
+
+        LoggerFactoryProxy proxy = new();
+        proxy.SetLoggerFactory(mockFactory.Object);
+
+        proxy.Dispose();
+
+        mockDisposable.Verify(d => d.Dispose(), Times.Once);
+    }
+
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_DisposesInnerFactoryOnlyOnce()
+    {
+        Mock<ILoggerFactory> mockFactory = new();
+        Mock<IDisposable> mockDisposable = mockFactory.As<IDisposable>();
+
+        LoggerFactoryProxy proxy = new();
+        proxy.SetLoggerFactory(mockFactory.Object);
+
+        proxy.Dispose();
+        proxy.Dispose();
+
+        mockDisposable.Verify(d => d.Dispose(), Times.Once);
+    }
+
+    [TestMethod]
+    public void CreateLogger_AfterDispose_ThrowsObjectDisposedException()
+    {
+        LoggerFactoryProxy proxy = new();
+        proxy.SetLoggerFactory(Mock.Of<ILoggerFactory>());
+
+        proxy.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => proxy.CreateLogger("category"));
+    }
+
+#if NETCOREAPP
+    [TestMethod]
+    public async Task DisposeAsync_WhenInnerFactoryIsAsyncDisposable_DisposesAsync()
+    {
+        Mock<ILoggerFactory> mockFactory = new();
+        Mock<IAsyncDisposable> mockAsyncDisposable = mockFactory.As<IAsyncDisposable>();
+        mockAsyncDisposable.Setup(d => d.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        LoggerFactoryProxy proxy = new();
+        proxy.SetLoggerFactory(mockFactory.Object);
+
+        await proxy.DisposeAsync();
+
+        mockAsyncDisposable.Verify(d => d.DisposeAsync(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_WhenInnerFactoryIsOnlyDisposable_FallsBackToSyncDispose()
+    {
+        Mock<ILoggerFactory> mockFactory = new();
+        Mock<IDisposable> mockDisposable = mockFactory.As<IDisposable>();
+
+        LoggerFactoryProxy proxy = new();
+        proxy.SetLoggerFactory(mockFactory.Object);
+
+        await proxy.DisposeAsync();
+
+        mockDisposable.Verify(d => d.Dispose(), Times.Once);
+    }
+#endif
 }


### PR DESCRIPTION
Adds a new opt-in side-package, **`Microsoft.Testing.Extensions.Logging`**, that lets users forward Microsoft.Testing.Platform's diagnostic log messages to any `Microsoft.Extensions.Logging` provider — Console, Debug, Serilog, OpenTelemetry, Application Insights, custom sinks, and so on. MTP's homegrown `Microsoft.Testing.Platform.Logging` stays in core (zero dependencies, AOT-friendly, netstandard2.0); the bridge is purely additive and is **never** referenced by core or by any existing extension.

This is phase 1 of the policy laid out in the new **[RFC 013 — Microsoft.Extensions.* Bridges](./docs/RFCs/013-Microsoft-Extensions-Bridges.md)**. Future phases (Configuration, DI, Hosting) will follow the same shape.

## Public API ([TPEXP])

```csharp
namespace Microsoft.Testing.Extensions;

[Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
public static class MicrosoftExtensionsLoggingBuilderExtensions
{
    public static ITestApplicationBuilder AddMicrosoftExtensionsLogging(
        this ITestApplicationBuilder builder,
        Action<Microsoft.Extensions.Logging.ILoggingBuilder> configure);

    public static ITestApplicationBuilder AddMicrosoftExtensionsLogging(
        this ITestApplicationBuilder builder,
        Microsoft.Extensions.Logging.ILoggerFactory loggerFactory);
}
```

The first overload **owns** and disposes the MEL `LoggerFactory`; the second forwards to a caller-owned factory. Both **short-circuit to a no-op** when MTP's effective `LogLevel` is `None` (no `--diagnostic`), so expensive sinks (Application Insights connection setup, Serilog file sinks, OTLP exporters, …) are not constructed for runs that will never emit a log.

Usage:

```csharp
ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);

builder.AddMicrosoftExtensionsLogging(logging =>
{
    logging.AddConsole();
    // logging.AddSerilog(...);
    // logging.AddApplicationInsights(...);
});

using ITestApplication app = await builder.BuildAsync();
return await app.RunAsync();
```

## Semantic mapping

| MTP concept | Mapped MEL concept | Notes |
|---|---|---|
| `LogLevel.Trace…Critical/None` (0..6) | `Microsoft.Extensions.Logging.LogLevel` | Same numeric values; mapped via explicit `switch` for safety/AOT |
| `Log<TState>(level, state, ex, formatter)` | `Log<TState>(level, EventId.None, state, ex, formatter)` | `EventId` defaults to `None` |
| `LogAsync<TState>(...)` | Synchronous `Log` + `Task.CompletedTask` | MEL has no async API |
| `IsEnabled(level)` | Forwards to MEL | Per-category filters can only **narrow**, never widen |
| Disposal | `LoggerFactory.Dispose`/`DisposeAsync` | Owned factories disposed; caller-owned ones are not |

## Tightly coupled platform fix

Discovered via the rubber-duck and expert-reviewer passes: MTP's `LoggerFactory` was **never disposed** during host shutdown, so user-registered MEL providers like Serilog / Application Insights / OpenTelemetry would silently lose their final flush. The fix:

- `LoggerFactoryProxy` now implements `IDisposable` (+ `IAsyncDisposable` on `NETCOREAPP`), forwarding to the wrapped factory with thread-safe idempotency (`Interlocked.Exchange` on `_disposed`). `CreateLogger` after `Dispose` throws `ObjectDisposedException` instead of silently dispatching.
- `CommonHost.RunAsync`'s `finally` block now disposes the proxy explicitly, **after** the explicit `FileLoggerProvider` disposal, so user-registered logger providers flush last. The proxy is skipped by the standard `DisposeServiceProviderAsync` loop (same pattern as `FileLoggerProvider`) so ordering is preserved.
- `LoggerFactory.Dispose` got a `// NOTE:` comment flagging that, post-PR, this method is now reachable at runtime so future authors notice when adding new shared `ILoggerProvider` registrations.

## Tests (all passing)

- **6 acceptance tests** (`MicrosoftExtensionsLoggingTests`, 2 × 3 TFMs): forwarding works, short-circuit works (asserts the configure delegate is **not** invoked when `--diagnostic` is off), and the bridge-owned `LoggerFactory` is disposed at end of process so buffered MEL providers flush.
- **6 new unit tests** for `LoggerFactoryProxy`'s disposal surface: idempotency, `ObjectDisposedException` post-dispose, `IAsyncDisposable` preference. 25/25 pass on net8/net9/net462.
- **8 new unit tests** for `LogLevelMapper`: exhaustive `DataRow` over all 7 levels + a future-proofing `Enum.GetValues` test that catches silent fallback to `None` if a new MTP `LogLevel` is ever added without updating the mapper. 32/32 pass on net8/net9/net462/net472.
- **No regressions**: 36 `DiagnosticTests` still green (`FileLoggerProvider` lifecycle preserved).

## Review

- **Rubber-duck** review identified the missing `LoggerFactory` disposal before any code was committed, driving the platform-side fix.
- **3 rounds of expert-reviewer** (21 dimensions): all major and minor findings addressed.
- `Build.cmd -pack` succeeds with **0 warnings, 0 errors**. All 23 NuGet packages produced and content-validated, including the new `Microsoft.Testing.Extensions.Logging.1.0.0-dev.nupkg`.

## Intentional non-goals (deferred to future phases)

- **Direction B** (MTP `ILoggerFactory` exposed as `Microsoft.Extensions.Logging.ILoggerFactory`) — omitted from v1 to avoid speculative public API.
- **No new CLI options.** Configuration is purely programmatic.
- **Does not replace** the built-in `--diagnostic` file logger; both run together when `--diagnostic` is enabled.
- **No MSBuild auto-registration hook** — the user must opt in with `configure`, so the `TestingPlatformBuilderHook` pattern does not apply.

## Files

**New:**
- `docs/RFCs/013-Microsoft-Extensions-Bridges.md`
- `src/Platform/Microsoft.Testing.Extensions.Logging/` (csproj, BannedSymbols, PACKAGE.md, PublicAPI, 4 internal classes + 2 public extension methods)
- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MicrosoftExtensionsLoggingTests.cs`
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/LogLevelMapperTests.cs`

**Modified:**
- `Directory.Packages.props` — added `Microsoft.Extensions.Logging` + `Microsoft.Extensions.Logging.Console` (the latter only consumed by `samples/Playground`).
- `TestFx.slnx`, `Microsoft.Testing.Platform.slnf` — registered the new project.
- `samples/Playground/*` — opt-in example wiring the bridge with `AddSimpleConsole`.
- `src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactoryProxy.cs` — disposable + thread-safe idempotency.
- `src/Platform/Microsoft.Testing.Platform/Logging/LoggerFactory.cs` — documentation note flagging new reachability.
- `src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs` — explicit proxy disposal.
- `test/IntegrationTests/.../Helpers/AcceptanceTestBase.cs` — extracts the new extension's alpha version.
- `test/UnitTests/.../LoggerFactoryProxyTests.cs` — +4 tests covering new disposal surface.
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj` — references the bridge for unit testing.
