### PR TITLE
Pin MicroBuild signing plugin to 5.4.0

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -101,6 +101,7 @@ extends:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
+          microbuildPluginVersion: '5.4.0'
           enablePublishTestResults: true
           testResultsFormat: 'vstest'
           publishingVersion: 4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,7 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
+      microbuildPluginVersion: '5.4.0'
       enablePublishTestResults: true
       testResultsFormat: 'vstest'
       artifacts:
@@ -313,6 +314,7 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
+      microbuildPluginVersion: '5.4.0'
       artifacts:
         publish:
           logs:


### PR DESCRIPTION
Fixes a pipeline warning emitted by the `Install MicroBuild plugin` step:

> ##[warning]Please use latest plugin version, version 5.4.0 used instead.

### Root cause
`eng/common/core-templates/steps/install-microbuild.yml` defaults `microbuildPluginVersion` to `'latest'`, which is then passed as the `version` input to `MicroBuildSigningPlugin@4`. The task warns when `latest` is used and falls back to `5.4.0`.

### Fix
`eng/common` is owned by Arcade and local edits would be overwritten by automation, so the fix overrides `microbuildPluginVersion: '5.4.0'` from the calling pipeline templates instead.

### Changes
- `azure-pipelines.yml` – both `jobs.yml` invocations (main build and `WindowsSamples`)
- `azure-pipelines-official.yml` – the `templates-official/jobs/jobs.yml` invocation

### Follow-up
If we want this fix to benefit every Arcade consumer, the long-term solution is a PR to `dotnet/arcade` to either bump the default or drop the `version: latest` input.
