### PR TITLE
Enable anti-flicker progress version check in AnsiTerminalTestProgressFrame

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -210,12 +210,14 @@ internal sealed class AnsiTerminalTestProgressFrame
             terminal.AppendLine();
         }
 
-        int i = 0;
+        int i;
         RenderedLines = [with(progress.Length * 2)];
         List<object> progresses = GenerateLinesToRender(progress);
 
-        foreach (object item in progresses)
+        for (i = 0; i < progresses.Count; i++)
         {
+            object item = progresses[i];
+
             if (previousFrame.RenderedLines != null && previousFrame.RenderedLines.Count > i)
             {
                 if (item is TestProgressState progressItem)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -225,7 +225,7 @@ internal sealed class AnsiTerminalTestProgressFrame
 
                     // We have a line that was rendered previously, compare it and decide how to render.
                     RenderedProgressItem previouslyRenderedLine = previousFrame.RenderedLines[i];
-                    if (previouslyRenderedLine.ProgressId == progressItem.Id && false)
+                    if (previouslyRenderedLine.ProgressId == progressItem.Id && previouslyRenderedLine.ProgressVersion == progressItem.Version)
                     {
                         // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
                         string durationString = HumanReadableDurationFormatter.Render(progressItem.Stopwatch.Elapsed);


### PR DESCRIPTION
## Description

In `AnsiTerminalTestProgressFrame.Render` the `TestProgressState` branch had `&& false` hard-coded in the comparison against the previously rendered line, which made the optimization always fall through to the full re-render branch (`CSI K` erase + `AppendTestWorkerProgress`).

The intent of the optimization is documented in the comment that follows the check ("only update the timestamp if possible to avoid flicker") and the parallel `TestDetailState` branch a few lines below already does the correct comparison:

```csharp
if (previouslyRenderedLine.ProgressId == detailItem.Id
    && previouslyRenderedLine.ProgressVersion == detailItem.Version)
```

## Why this is safe

`TestProgressState.Version` is bumped in `TestProgressStateAwareTerminal.UpdateWorker` only when there is new data for that worker:

```csharp
internal void UpdateWorker(int slotIndex)
{
    if (GetShowProgress())
    {
        _counter++;
        TestProgressState? progress = _progressItems[slotIndex];
        progress?.Version = _counter;
    }
}
```

So when no test result has come in between two 500 ms refresh ticks the Id+Version pair matches and we can rewrite just the duration cell at the right of the line instead of erasing and re-rendering the whole counters/assembly-name segment. This is exactly what the comment and the symmetric `TestDetailState` branch describe.

## Risk

Low. `&& false` was introduced as part of the original "Show running tests" change (#4221) and looks like a leftover/oversight that disabled the optimization without ever re-enabling it. With the change, when nothing has happened we now write a much shorter ANSI sequence (just the duration) instead of `CSI K` + re-emitting the counters and assembly name — reducing flicker and bandwidth without changing observable output.

If for some reason the assumption about `Version` accuracy ever fails, the worst-case is a one-tick stale render of the counters; the very next tick that bumps `Version` will trigger a full re-render again.

## Context

Spotted while investigating #6753.