### PR TITLE
Stop forcing verbose createdump diagnostics in CrashDump extension

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs
@@ -16,8 +16,6 @@ internal sealed class CrashDumpEnvironmentVariableProvider : ITestHostEnvironmen
     private const string EnableMiniDumpVariable = "DbgEnableMiniDump";
     private const string MiniDumpTypeVariable = "DbgMiniDumpType";
     private const string MiniDumpNameVariable = "DbgMiniDumpName";
-    private const string CreateDumpDiagnosticsVariable = "CreateDumpDiagnostics";
-    private const string CreateDumpVerboseDiagnosticsVariable = "CreateDumpVerboseDiagnostics";
     private const string EnableCrashReportVariable = "EnableCrashReport";
     private const string EnableCrashReportOnlyVariable = "EnableCrashReportOnly";
     private const string EnabledValue = "1";
@@ -69,8 +67,6 @@ internal sealed class CrashDumpEnvironmentVariableProvider : ITestHostEnvironmen
         foreach (string prefix in Prefixes)
         {
             environmentVariables.SetVariable(new($"{prefix}{EnableMiniDumpVariable}", EnabledValue, false, true));
-            environmentVariables.SetVariable(new($"{prefix}{CreateDumpDiagnosticsVariable}", EnabledValue, false, true));
-            environmentVariables.SetVariable(new($"{prefix}{CreateDumpVerboseDiagnosticsVariable}", EnabledValue, false, true));
         }
 
         if (crashReportEnabled)
@@ -159,8 +155,6 @@ internal sealed class CrashDumpEnvironmentVariableProvider : ITestHostEnvironmen
         bool crashReportEnabled = _commandLineOptions.IsOptionSet(CrashDumpCommandLineOptions.CrashReportOptionName);
 
         ValidateBothPrefixes(EnableMiniDumpVariable, EnabledValue);
-        ValidateBothPrefixes(CreateDumpDiagnosticsVariable, EnabledValue);
-        ValidateBothPrefixes(CreateDumpVerboseDiagnosticsVariable, EnabledValue);
 
         if (crashReportEnabled)
         {

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
@@ -25,6 +25,11 @@ public static class WellKnownEnvironmentVariables
         "COMPlus_DbgEnableElfDumpOnMacOS",
         "COMPlus_DbgMiniDumpName",
         "COMPlus_DbgMiniDumpType",
+        "COMPlus_CreateDumpDiagnostics",
+        "COMPlus_CreateDumpVerboseDiagnostics",
+        "COMPlus_CreateDumpLogToFile",
+        "COMPlus_EnableCrashReport",
+        "COMPlus_EnableCrashReportOnly",
 
         // Hot reload mode
         "TESTINGPLATFORM_HOTRELOAD_ENABLED",


### PR DESCRIPTION
Fixes #7045

## Problem

When the `Microsoft.Testing.Extensions.CrashDump` extension is enabled in MTP, the runtime's `createdump` emits megabytes of `[createdump]` diagnostics (thread RIPs, AUXV, module mappings, ...) to stdout on Linux/macOS whenever a testhost crashes. In the reporter's case (#7045) this produced a **160 MB** log for a single crashed test, large enough to make the GitHub Actions UI unresponsive.

The cause is that `CrashDumpEnvironmentVariableProvider` unconditionally set `DOTNET_CreateDumpDiagnostics` and `DOTNET_CreateDumpVerboseDiagnostics` (and the `COMPlus_` twins) to `""1""`, which turns on the runtime's verbose `createdump` logging. VSTest does not enable these. `HangDump` already does the right thing by calling `WriteDump(..., logDumpGeneration: false)`. So this extension was the odd one out.

## Fix

- Stop setting `CreateDumpDiagnostics` / `CreateDumpVerboseDiagnostics` (both `DOTNET_` and `COMPlus_`) in `CrashDumpEnvironmentVariableProvider`. Drop the corresponding `ValidateBothPrefixes` calls and the now-unused private const fields.
- Add the missing `COMPlus_` twins of the createdump / crash-report environment variables to the test infrastructure `WellKnownEnvironmentVariables.ToSkipEnvironmentVariables` list (the `DOTNET_` ones were already there - flagged by @nohwnd in the issue).

## Opt back in

Anyone who actually wanted the verbose `createdump` output (e.g. when filing a runtime issue) can opt in by setting `DOTNET_CreateDumpDiagnostics=1` (and/or `DOTNET_CreateDumpVerboseDiagnostics=1`) in the parent process environment - the platform no longer overrides or locks those variables.

## Out of scope (tracked separately / referred to other repos)

- Lowering the default `--crashdump-type` from `Full` to `Mini` to match VSTest (would change dump file size; deserves its own RFC).
- Spurious *""A test session start event was received without a corresponding test session end""* - fixed by dotnet/sdk#51857.
- macOS dump hang when `UseAppHost` is the default - xunit/xunit#3432 (entitlements workaround documented in MTP docs).
- Dump tooling not surfacing the recursive frame in VS / dotnet dump analyze - runtime/diagnostics issue.
