### PR TITLE
Allow duplicate test node UIDs in OpenTelemetry result handler

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
@@ -20,7 +20,7 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
     private readonly IHistogram<double> _totalDuration;
     // Note: we use a queue per Uid because frameworks are allowed (but discouraged) to produce
     // multiple test nodes that share the same Uid (e.g. NUnit's [Values("one", "one")] or
-    // MSTest's "folded" parametrized tests). When that happens we still want to track every
+    // MSTest's "folded" parameterized tests). When that happens we still want to track every
     // in-flight activity and pair them with results in FIFO order, instead of throwing.
     private readonly Dictionary<TestNodeUid, Queue<IPlatformActivity>> _testActivities = [];
     private bool _disposed;

--- a/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
@@ -18,7 +18,11 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
     private readonly ICounter<int> _totalSkippedTests;
     private readonly ICounter<int> _totalUnknownTests;
     private readonly IHistogram<double> _totalDuration;
-    private readonly Dictionary<TestNodeUid, IPlatformActivity> _testActivities = [];
+    // Note: we use a queue per Uid because frameworks are allowed (but discouraged) to produce
+    // multiple test nodes that share the same Uid (e.g. NUnit's [Values("one", "one")] or
+    // MSTest's "folded" parametrized tests). When that happens we still want to track every
+    // in-flight activity and pair them with results in FIFO order, instead of throwing.
+    private readonly Dictionary<TestNodeUid, Queue<IPlatformActivity>> _testActivities = [];
     private bool _disposed;
 
     public OpenTelemetryResultHandler(IPlatformOpenTelemetryService otelService, IEnvironment environment)
@@ -66,7 +70,13 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
 
         if (activity is not null)
         {
-            _testActivities.Add(testNode.Uid, activity);
+            if (!_testActivities.TryGetValue(testNode.Uid, out Queue<IPlatformActivity>? activities))
+            {
+                activities = new Queue<IPlatformActivity>();
+                _testActivities.Add(testNode.Uid, activities);
+            }
+
+            activities.Enqueue(activity);
         }
     }
 
@@ -81,9 +91,12 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
         }
 
         _disposed = true;
-        foreach (IPlatformActivity activity in _testActivities.Values)
+        foreach (Queue<IPlatformActivity> activities in _testActivities.Values)
         {
-            activity.Dispose();
+            foreach (IPlatformActivity activity in activities)
+            {
+                activity.Dispose();
+            }
         }
 
         _testActivities.Clear();
@@ -123,9 +136,15 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
     {
         _totalCompletedTests.Add(1);
 
-        if (!_testActivities.TryGetValue(testNode.Uid, out IPlatformActivity? activity))
+        if (!_testActivities.TryGetValue(testNode.Uid, out Queue<IPlatformActivity>? activities) || activities.Count == 0)
         {
             return;
+        }
+
+        IPlatformActivity activity = activities.Dequeue();
+        if (activities.Count == 0)
+        {
+            _testActivities.Remove(testNode.Uid);
         }
 
         (string result, Exception? exception, TimeSpan? timeoutTime) = stateProperty switch
@@ -183,6 +202,5 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
         }
 
         activity.Dispose();
-        _testActivities.Remove(testNode.Uid);
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
@@ -314,6 +314,94 @@ public sealed class OpenTelemetryResultHandlerTests : IDisposable
         activity.Verify(a => a.SetTag("test.metadataProperty.category", "unit"), Times.Once);
     }
 
+    [TestMethod]
+    public void NotifyInProgress_WithDuplicateUid_DoesNotThrow()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/7442.
+        // Some test frameworks (e.g. NUnit with [Values("one", "one")] or MSTest with folded
+        // parametrized tests) can emit multiple test nodes that share the same Uid. Starting
+        // activities for them used to throw because the underlying dictionary did not tolerate
+        // duplicate keys.
+        Mock<IPlatformActivity> activity1 = new();
+        Mock<IPlatformActivity> activity2 = new();
+        _otelService.SetupSequence(s => s.StartActivity(
+            It.IsAny<string>(),
+            It.IsAny<IEnumerable<KeyValuePair<string, object?>>?>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTimeOffset>()))
+            .Returns(activity1.Object)
+            .Returns(activity2.Object);
+
+        TestNode testNode = CreateTestNode("duplicate-uid");
+
+        _handler.NotifyInProgress(testNode, null);
+        _handler.NotifyInProgress(testNode, null);
+
+        Assert.AreEqual(2, _startedCounter.Value);
+    }
+
+    [TestMethod]
+    public void HandleTestResult_WithDuplicateUid_PairsActivitiesInFifoOrder()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/7442.
+        // When two in-flight activities share the same Uid, results must be paired with them
+        // in FIFO order and each activity must be disposed exactly once.
+        Mock<IPlatformActivity> activity1 = new();
+        activity1.Setup(a => a.SetTag(It.IsAny<string>(), It.IsAny<object?>())).Returns(activity1.Object);
+        Mock<IPlatformActivity> activity2 = new();
+        activity2.Setup(a => a.SetTag(It.IsAny<string>(), It.IsAny<object?>())).Returns(activity2.Object);
+
+        _otelService.SetupSequence(s => s.StartActivity(
+            It.IsAny<string>(),
+            It.IsAny<IEnumerable<KeyValuePair<string, object?>>?>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTimeOffset>()))
+            .Returns(activity1.Object)
+            .Returns(activity2.Object);
+
+        TestNode testNode = CreateTestNode("duplicate-uid");
+
+        _handler.NotifyInProgress(testNode, null);
+        _handler.NotifyInProgress(testNode, null);
+        _handler.NotifyPassed(testNode, PassedTestNodeStateProperty.CachedInstance);
+        _handler.NotifyFailed(testNode, new FailedTestNodeStateProperty());
+
+        activity1.Verify(a => a.SetTag("test.result", "passed"), Times.Once);
+        activity1.Verify(a => a.SetTag("test.result", "failed"), Times.Never);
+        activity1.Verify(a => a.Dispose(), Times.Once);
+
+        activity2.Verify(a => a.SetTag("test.result", "failed"), Times.Once);
+        activity2.Verify(a => a.SetTag("test.result", "passed"), Times.Never);
+        activity2.Verify(a => a.Dispose(), Times.Once);
+
+        Assert.AreEqual(2, _completedCounter.Value);
+    }
+
+    [TestMethod]
+    public void Dispose_WithMultipleActivitiesSharingUid_DisposesAllOfThem()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/7442.
+        // Orphaned activities sharing the same Uid must all be disposed.
+        Mock<IPlatformActivity> activity1 = new();
+        Mock<IPlatformActivity> activity2 = new();
+        _otelService.SetupSequence(s => s.StartActivity(
+            It.IsAny<string>(),
+            It.IsAny<IEnumerable<KeyValuePair<string, object?>>?>(),
+            It.IsAny<string?>(),
+            It.IsAny<DateTimeOffset>()))
+            .Returns(activity1.Object)
+            .Returns(activity2.Object);
+
+        TestNode testNode = CreateTestNode("orphan-duplicate-uid");
+        _handler.NotifyInProgress(testNode, null);
+        _handler.NotifyInProgress(testNode, null);
+
+        _handler.Dispose();
+
+        activity1.Verify(a => a.Dispose(), Times.Once);
+        activity2.Verify(a => a.Dispose(), Times.Once);
+    }
+
     public void Dispose()
         => _handler.Dispose();
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
@@ -319,7 +319,7 @@ public sealed class OpenTelemetryResultHandlerTests : IDisposable
     {
         // Regression test for https://github.com/microsoft/testfx/issues/7442.
         // Some test frameworks (e.g. NUnit with [Values("one", "one")] or MSTest with folded
-        // parametrized tests) can emit multiple test nodes that share the same Uid. Starting
+        // parameterized tests) can emit multiple test nodes that share the same Uid. Starting
         // activities for them used to throw because the underlying dictionary did not tolerate
         // duplicate keys.
         Mock<IPlatformActivity> activity1 = new();


### PR DESCRIPTION
Fixes #7442.

Some test frameworks emit multiple in-flight test nodes that share the same `TestNodeUid` (e.g. NUnit's `[Values(\"one\", \"one\")]` or MSTest's folded parametrized tests). The OpenTelemetry result handler used to track activities in a `Dictionary<TestNodeUid, IPlatformActivity>`, which threw `An item with the same key has already been added` when two such tests were in progress at the same time, crashing the test run as soon as `Microsoft.Testing.Extensions.OpenTelemetry` was referenced.

## Change

Switch `_testActivities` to a `Dictionary<TestNodeUid, Queue<IPlatformActivity>>`:

* `NotifyInProgress` enqueues the newly started activity for the Uid (instead of `Add` which throws on duplicate keys).
* `HandleTestResult` dequeues the oldest in-flight activity for the Uid and applies the result tags to it. This preserves FIFO pairing, which is the best we can do when the framework gives us no other way to disambiguate two concurrent test executions with the same Uid.
* `Dispose` walks every queue and disposes any remaining orphaned activities.

## Tests

Added regression tests in `OpenTelemetryResultHandlerTests`:

* `NotifyInProgress_WithDuplicateUid_DoesNotThrow` — two `NotifyInProgress` calls for the same Uid no longer throw.
* `HandleTestResult_WithDuplicateUid_PairsActivitiesInFifoOrder` — when two activities share a Uid, the first result goes to the first activity and the second result goes to the second activity, and each activity is disposed exactly once.
* `Dispose_WithMultipleActivitiesSharingUid_DisposesAllOfThem` — orphaned activities sharing a Uid are all disposed on shutdown.