### PR TITLE
Assert.That: capture readable LHS sub-expressions and restore runtime Func/Action filter

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.That.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.That.cs
@@ -112,8 +112,10 @@ public static partial class AssertExtensions
 
         // Compile and invoke ONCE.
         // This intentionally pays the rewrite+compile cost on every Assert.That call (including passing ones)
-        // to guarantee single-pass evaluation for correctness (#6690). If this ever shows up as a hotspot,
-        // we can consider caching the compiled delegate by expression-tree instance.
+        // to guarantee single-pass evaluation for correctness (#6690). Reference-keyed caching of the compiled
+        // delegate would not help the common inline pattern `Assert.That(() => ...)` because each call site
+        // constructs a fresh Expression<Func<bool>> instance at runtime, but could be considered later if a
+        // workload that re-uses the same expression tree across calls demonstrates measurable overhead.
         var lambda = Expression.Lambda<Func<object?[], bool>>(rewrittenBody, arrayParam);
         object?[] values = new object?[context.CaptureNames.Count];
 
@@ -131,8 +133,9 @@ public static partial class AssertExtensions
             return true;
         }
 
-        // Build details using first-occurrence-per-name semantics, filtering out Func/Action values
-        // (matching the historical behavior, using runtime type as the existing code did).
+        // Build details using first-occurrence-per-name semantics. Func/Action-valued captures
+        // are filtered out by runtime type, matching the historical behavior so a member typed
+        // as a delegate whose runtime value is null still shows up as "null" in failure details.
         for (int i = 0; i < context.CaptureNames.Count; i++)
         {
             string name = context.CaptureNames[i];
@@ -196,10 +199,14 @@ public static partial class AssertExtensions
                 AnalyzeArrayIndexExpression(binaryExpr, context);
                 break;
 
-            // Assignment-style binary nodes (=, +=, -=, …) require writable left-hand operands.
-            // CaptureRewriter would replace the LHS with a Block, making it non-writable and
-            // causing the rewritten lambda to fail to compile. Skip these entirely.
+            // Assignment-style binary nodes (=, +=, -=, …) require a writable left-hand operand.
+            // We must not let CaptureRewriter wrap the assignable storage location itself in a Block
+            // (a Block is not a writable LValue), but the readable sub-expressions on the LHS
+            // (e.g., the receiver in `obj.Field = ...` or the array/indices in `arr[i] = ...`) and
+            // the whole RHS subtree are safe to analyze for captures.
             case BinaryExpression binaryExpr when IsAssignmentNodeType(binaryExpr.NodeType):
+                AnalyzeWritableOperand(binaryExpr.Left, context, suppressIntermediateValues);
+                AnalyzeExpression(binaryExpr.Right, context, suppressIntermediateValues);
                 break;
 
             case BinaryExpression binaryExpr:
@@ -224,10 +231,12 @@ public static partial class AssertExtensions
 
                 break;
 
-            // Unary update nodes (++x, x++, --x, x--) require writable operands. CaptureRewriter
-            // would replace the operand with a Block, making it non-writable and causing compilation
-            // of the rewritten lambda to fail. Skip these entirely.
+            // Unary update nodes (++x, x++, --x, x--) require a writable operand. Same constraint
+            // as assignment-style binary nodes above: the writable storage location must not be
+            // wrapped, but its readable sub-expressions are safe to analyze for captures so that
+            // failure details for trees like `++obj.Field` still surface the receiver value.
             case UnaryExpression unaryExpr when IsUnaryUpdateNodeType(unaryExpr.NodeType):
+                AnalyzeWritableOperand(unaryExpr.Operand, context, suppressIntermediateValues);
                 break;
 
             case UnaryExpression unaryExpr:
@@ -305,13 +314,9 @@ public static partial class AssertExtensions
 
     private static void AnalyzeMemberExpression(MemberExpression memberExpr, AnalysisContext context)
     {
-        // Skip Func and Action delegates as they don't provide useful information in assertion failures.
-        // Use the static type so we don't have to evaluate the expression at analysis time.
-        if (IsFuncOrActionType(memberExpr.Type))
-        {
-            return;
-        }
-
+        // Note: We intentionally do NOT skip delegate-typed members here. Filtering happens at
+        // detail-build time based on the runtime value's type (see EvaluateAndCollectDetails),
+        // which preserves the historical behavior of showing `null` for null delegate values.
         string displayName = GetCleanMemberName(memberExpr);
         context.AddCapture(memberExpr, displayName);
 
@@ -320,6 +325,55 @@ public static partial class AssertExtensions
         {
             AnalyzeExpression(memberExpr.Expression, context, suppressIntermediateValues: true);
         }
+    }
+
+    /// <summary>
+    /// Analyzes the writable left-hand operand of an assignment or unary-update expression.
+    /// The writable storage location itself (e.g., a field/property/index access used as
+    /// the target of an assignment) is NOT added as a capture — wrapping it in a Block via
+    /// <see cref="CaptureRewriter"/> would make it non-writable and break compilation of the
+    /// rewritten lambda. However, its readable sub-expressions (the receiver of a member
+    /// access, the array reference and indices of an indexer) ARE analyzed normally so the
+    /// failure-detail message still reports those intermediate values for
+    /// manually-constructed expression trees.
+    /// </summary>
+    private static void AnalyzeWritableOperand(Expression? expr, AnalysisContext context, bool suppressIntermediateValues)
+    {
+        if (expr is null)
+        {
+            return;
+        }
+
+        switch (expr)
+        {
+            // Field/property access used as a write target: traverse the receiver chain for
+            // reads, but don't capture the member itself.
+            case MemberExpression memberExpr when memberExpr.Expression is not null:
+                AnalyzeExpression(memberExpr.Expression, context, suppressIntermediateValues);
+                break;
+
+            // `arr[i] = ...` via the BinaryExpression ArrayIndex form: the array reference and
+            // the index are both reads (assignments to single-dimensional arrays however use
+            // the IndexExpression form below).
+            case BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex:
+                AnalyzeExpression(arrayIndex.Left, context, suppressIntermediateValues);
+                AnalyzeExpression(arrayIndex.Right, context, suppressIntermediateValues);
+                break;
+
+            // Indexer `arr[i] = ...` or `obj[a, b] = ...`: the receiver and all index arguments
+            // are reads.
+            case IndexExpression indexExpr:
+                AnalyzeExpression(indexExpr.Object, context, suppressIntermediateValues);
+                foreach (Expression arg in indexExpr.Arguments)
+                {
+                    AnalyzeExpression(arg, context, suppressIntermediateValues);
+                }
+
+                break;
+        }
+
+        // ParameterExpression (e.g., `++x` on a local) and static field access have no readable
+        // sub-expressions worth analyzing — they fall through the switch above with no-op.
     }
 
     private static void AnalyzeMethodCallExpression(MethodCallExpression callExpr, AnalysisContext context, bool suppressIntermediateValues = false)

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
@@ -1483,6 +1483,94 @@ public partial class AssertTests : TestContainer
         act.Should().NotThrow();
         box.Value.Should().Be(6);
     }
+
+    private sealed class MutableContainer
+    {
+#pragma warning disable SA1401 // Fields should be private - intentional: this type tests Expression.Assign on nested members.
+        public MutableBox Inner = new() { Value = 0 };
+#pragma warning restore SA1401
+    }
+
+    public void That_ManuallyConstructedAssignExpression_AnalyzesReceiverChainAndRhs()
+    {
+        // Construct: (container.Inner.Value = ComputeValue()) < 0   — fails, so message must
+        // include both the readable receiver chain (container.Inner) AND the RHS computation
+        // result captured from the sole evaluation of the assignment (#6690 single-pass guarantee).
+        var container = new MutableContainer();
+        FieldInfo innerFi = typeof(MutableContainer).GetField(nameof(MutableContainer.Inner))!;
+        FieldInfo valueFi = typeof(MutableBox).GetField(nameof(MutableBox.Value))!;
+
+        MemberExpression innerAccess = Expression.Field(Expression.Constant(container), innerFi);
+        MemberExpression valueAccess = Expression.Field(innerAccess, valueFi);
+        MethodCallExpression rhs = Expression.Call(typeof(MutableBoxHelper).GetMethod(nameof(MutableBoxHelper.ComputeValue))!);
+        BinaryExpression assign = Expression.Assign(valueAccess, rhs);
+        BinaryExpression body = Expression.LessThan(assign, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+
+        // Failure message should reflect that the readable receiver and RHS were both captured
+        // during the single evaluation of the assignment (i.e., neither the LHS subtree nor the
+        // RHS was skipped wholesale by the analyzer).
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("ComputeValue()");
+        // The Inner member of the writable LHS receiver chain was captured as a read-side
+        // sub-expression (rather than the whole assignment being skipped wholesale).
+        ex.Message.Should().Contain("Inner");
+        // The assignment side-effect must still apply since the lambda is evaluated exactly once.
+        container.Inner.Value.Should().Be(42);
+    }
+
+    public void That_ManuallyConstructedPreIncrementExpression_AnalyzesReceiverChain()
+    {
+        // Construct: --container.Inner.Value > 0   — fails (0 - 1 = -1 is not > 0).
+        // The readable receiver chain (container.Inner) must still be captured even though the
+        // writable storage location (container.Inner.Value) is not.
+        var container = new MutableContainer { Inner = new MutableBox { Value = 0 } };
+        FieldInfo innerFi = typeof(MutableContainer).GetField(nameof(MutableContainer.Inner))!;
+        FieldInfo valueFi = typeof(MutableBox).GetField(nameof(MutableBox.Value))!;
+
+        MemberExpression innerAccess = Expression.Field(Expression.Constant(container), innerFi);
+        MemberExpression valueAccess = Expression.Field(innerAccess, valueFi);
+        UnaryExpression preDec = Expression.PreDecrementAssign(valueAccess);
+        BinaryExpression body = Expression.GreaterThan(preDec, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        // The Inner member of the writable LHS receiver chain was captured as a read-side
+        // sub-expression even though the writable target (Inner.Value) is not captured.
+        ex.Message.Should().Contain("Inner");
+        // Side effect of the single root evaluation applied.
+        container.Inner.Value.Should().Be(-1);
+    }
+
+    // Regression: a member whose static type is Func/Action but whose runtime value is null should
+    // still appear in the failure details, matching pre-PR behavior. Filtering must remain
+    // runtime-typed at detail-build time rather than static-typed at analysis time.
+    private sealed class HolderWithFuncField
+    {
+#pragma warning disable SA1401 // Fields should be private - intentional: test fixture exposing a delegate-typed field.
+        public Func<int>? Callback;
+#pragma warning restore SA1401
+    }
+
+    public void That_NullDelegateTypedMember_StillAppearsInDetails()
+    {
+        var holder = new HolderWithFuncField { Callback = null };
+
+        Action act = () => Assert.That(() => holder.Callback != null);
+
+        AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+        ex.Message.Should().Contain("Callback");
+        ex.Message.Should().Contain("null");
+    }
+}
+
+internal static class MutableBoxHelper
+{
+    public static int ComputeValue() => 42;
 }
 
 internal static class AssertTestsExtensions


### PR DESCRIPTION
Follow-up to #8306 (merged) addressing the remaining unresolved review comments on `Assert.That(Expression<Func<bool>>)`.

## Summary of review comments addressed

### 1. Capture readable LHS sub-expressions of assignment / unary-update nodes (review comments [3264506474](https://github.com/microsoft/testfx/pull/8306#discussion_r3264506474), [3264506501](https://github.com/microsoft/testfx/pull/8306#discussion_r3264506501))

The previous behavior was to skip assignment-style `BinaryExpression` and unary-update `UnaryExpression` nodes entirely in `AnalyzeExpression`, which avoided the writable-LHS-wrapped-in-Block compile issue but also dropped diagnostic information for manually-constructed expression trees.

`AnalyzeWritableOperand` now recurses into the readable sub-expressions of the writable LHS (member receiver, index target and arguments) while leaving the writable storage location itself uncaptured. The RHS of assignments is now analyzed normally as well. Empirically verified that `MemberExpression(Block(...), Field) = value` and `Expression.PreIncrementAssign(MemberExpression(Block(...), Field))` both compile and assign correctly via the .NET Expression API.

### 2. Restore runtime-typed Func/Action filter (review comment [3264506519](https://github.com/microsoft/testfx/pull/8306#discussion_r3264506519))

`AnalyzeMemberExpression` previously skipped captures for members whose static type was `Func`/`Action`. This was inconsistent with the comment at the detail-build loop ("matching the historical behavior, using runtime type as the existing code did") and dropped null delegate-typed members from failure details, which previously surfaced as `null`.

The static-type skip is removed; filtering is now applied uniformly at detail-build time using the runtime value's type. A regression test (`That_NullDelegateTypedMember_StillAppearsInDetails`) locks in the restored behavior.

### 3. Caching trade-off comment refresh (review comment [3264506539](https://github.com/microsoft/testfx/pull/8306#discussion_r3264506539))

The existing perf trade-off comment near the `Compile()` site is updated to be more precise: reference-keyed plan caching would not help the common inline `Assert.That(() => ...)` pattern because each call site constructs a fresh `Expression<Func<bool>>` instance at runtime, but it could be considered later if a workload that re-uses the same expression tree across calls demonstrates measurable overhead. No caching is implemented in this PR.

## Tests

Three new unit tests in `AssertTests.That.cs`:

- `That_ManuallyConstructedAssignExpression_AnalyzesReceiverChainAndRhs` — verifies the readable LHS receiver chain and the RHS computation result both appear in failure details for a manually-constructed `(container.Inner.Value = ComputeValue()) < 0` tree.
- `That_ManuallyConstructedPreIncrementExpression_AnalyzesReceiverChain` — verifies the readable LHS receiver chain appears in failure details for `--container.Inner.Value > 0` and that the side effect still applies (single-pass).
- `That_NullDelegateTypedMember_StillAppearsInDetails` — locks in the restored runtime-typed Func/Action filter so a `null` `Func<int>` field still surfaces as `null` in the details.

All 882 `AssertTests` pass on `net9.0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
