### PR TITLE
Work around MSB4216 in CodeQL pipeline (x86 .NET task host)

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -1,0 +1,33 @@
+<Project>
+
+  <!--
+    Workaround for https://github.com/dotnet/msbuild/issues/13739.
+
+    The Arcade SDK version this repository consumes (11.0.0-beta.26156.2) declares
+    InstallDotNetCore (and other build tasks) with Runtime="NET" but no Architecture
+    attribute in tools\BuildTasks.props. When the host MSBuild is x86 .NET Framework
+    (e.g. the default MSBuild.exe shipped with VS 2026 Insiders / Preview, which is
+    what the CodeQL pipeline uses), MSBuild tries to spin up an x86 .NET task host.
+    The .NET SDK only ships x64/arm64 MSBuild binaries, so there is no x86 MSBuild.exe
+    under .dotnet\sdk\<version>\, producing:
+
+      error MSB4216: Could not run the "InstallDotNetCore" task because MSBuild could
+      not create or connect to a task host with runtime "NET" and architecture "x86".
+
+    Architecture="*" lets MSBuild use any available .NET task host architecture.
+    This was fixed centrally in dotnet/arcade#16790 (merged 2026-05-12); remove this
+    workaround once Arcade flows that fix into this repository.
+
+    eng\Tools.props is imported by Arcade's Tools.proj
+    (artifacts\toolset\<version>\Tools.proj) right before it imports
+    InstallDotNetCore.targets, making this the correct place to override the
+    UsingTask registration that comes from Sdk.props -> BuildTasks.props.
+  -->
+  <UsingTask Condition="'$(ArcadeSdkBuildTasksAssembly)' != ''"
+             TaskName="Microsoft.DotNet.Arcade.Sdk.InstallDotNetCore"
+             AssemblyFile="$(ArcadeSdkBuildTasksAssembly)"
+             Runtime="NET"
+             Architecture="*"
+             Override="true" />
+
+</Project>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -3,9 +3,9 @@
   <!--
     Workaround for https://github.com/dotnet/msbuild/issues/13739.
 
-    The Arcade SDK version this repository consumes (11.0.0-beta.26156.2) declares
-    InstallDotNetCore (and other build tasks) with Runtime="NET" but no Architecture
-    attribute in tools\BuildTasks.props. When the host MSBuild is x86 .NET Framework
+    The Arcade SDK this repository consumes declares InstallDotNetCore (and other
+    build tasks) with Runtime="NET" but no Architecture attribute in
+    tools\BuildTasks.props. When the host MSBuild is x86 .NET Framework
     (e.g. the default MSBuild.exe shipped with VS 2026 Insiders / Preview, which is
     what the CodeQL pipeline uses), MSBuild tries to spin up an x86 .NET task host.
     The .NET SDK only ships x64/arm64 MSBuild binaries, so there is no x86 MSBuild.exe


### PR DESCRIPTION
## Problem

The CodeQL pipeline's `Windows Build` step has been failing for ~2 weeks with:

```
artifacts\toolset\<ver>\InstallDotNetCore.targets(17,5): error MSB4216:
  (NETCORE_ENGINEERING_TELEMETRY=Restore) Could not run the "InstallDotNetCore"
  task because MSBuild could not create or connect to a task host with runtime
  "NET" and architecture "x86". Please ensure that (1) the requested runtime
  and/or architecture are available on the machine, and (2) that the required
  executable "D:\a\_work\1\s\.dotnet\sdk\<ver>\MSBuild.exe" exists and can be run.
```

## Root cause

The Arcade SDK version this repo consumes (`11.0.0-beta.26156.2`) declares `InstallDotNetCore` in `BuildTasks.props` with `Runtime="NET"` but no `Architecture` attribute. When the host MSBuild is x86 .NET Framework (the default `MSBuild.exe` shipped in VS 2026 Insiders / Preview — which is what the CodeQL image uses), MSBuild tries to spin up an **x86 .NET task host**. The .NET SDK only ships x64/arm64 binaries, so there is no x86 `MSBuild.exe` under `.dotnet\sdk\<ver>\` and MSB4216 is raised.

Tracked centrally in [dotnet/msbuild#13739](https://github.com/dotnet/msbuild/issues/13739) and fixed in [dotnet/arcade#16790](https://github.com/dotnet/arcade/pull/16790) (merged 2026-05-12) by adding `Architecture="*"` to every `Runtime="NET"` `UsingTask` declaration in Arcade's `BuildTasks.props`. The fix has not yet flowed into testfx via Maestro.

## Fix

Add `eng/Tools.props` that overrides the `InstallDotNetCore` `UsingTask` with `Architecture="*"` and `Override="true"`. Arcade's `Tools.proj` (in `artifacts\toolset\<ver>\`) explicitly imports `$(RepositoryEngineeringDir)Tools.props` **right before** importing `InstallDotNetCore.targets`, so this is the correct extension point: the override registers after the original (which arrives via `Sdk.props` → `BuildTasks.props`) and before the task is invoked. `Override="true"` ensures the new registration wins regardless of declaration order.

Only `InstallDotNetCore` is patched because it is the only task that has been observed failing (it runs `AfterTargets="Restore"` on `Tools.proj`, before any other Arcade task is invoked).

Remove this file once the upstream Arcade fix flows into the repo.
