### PR TITLE
Fix CA1305 in Assert.That test (int.ToString() needs IFormatProvider)

### DIFF
--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
@@ -1157,7 +1157,7 @@ public partial class AssertTests : TestContainer
         string? value = "hello";
 
         // Non-null value short-circuits the null-coalescing operator; counter.Increment() must NOT run.
-        Action act = () => Assert.That(() => (value ?? counter.Increment().ToString()) == "hello");
+        Action act = () => Assert.That(() => (value ?? counter.Increment().ToString(CultureInfo.InvariantCulture)) == "hello");
 
         act.Should().NotThrow();
         counter.Count.Should().Be(0);


### PR DESCRIPTION
The Windows build is failing with CA1305 in `That_Coalesce_ShortCircuit_PassingAssertion_DoesNotInvokeRight` because `int.ToString()` is called without a format provider. This blocks PR #8348 (and any other PR built against `main`).

Fix: pass `CultureInfo.InvariantCulture` to `int.ToString`.

The bug was introduced in #8307 / #8306.