### PR TITLE
Revert MicroBuild signing plugin pin to 5.4.0

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -101,7 +101,6 @@ extends:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
-          microbuildPluginVersion: '5.4.0'
           enablePublishTestResults: true
           testResultsFormat: 'vstest'
           publishingVersion: 4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      microbuildPluginVersion: '5.4.0'
       enablePublishTestResults: true
       testResultsFormat: 'vstest'
       artifacts:
@@ -314,7 +313,6 @@ stages:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      microbuildPluginVersion: '5.4.0'
       artifacts:
         publish:
           logs:


### PR DESCRIPTION
Pinning `microbuildPluginVersion: '5.4.0'` in `azure-pipelines.yml` and `azure-pipelines-official.yml` (added in #8347) breaks the `Install MicroBuild plugin` pipeline step:

```
Attempting to gather dependency information for package 'MicroBuild.Plugins.Signing.5.4.0' with respect to project 'D:\a\_work\_temp\MicroBuild\MicroBuild\Plugins', targeting 'Any,Version=v0.0'
Package 'MicroBuild.Plugins.Signing 5.4.0' is not found in the following primary source(s): 'https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json'. Please verify all your online package sources are available (OR) package id, version are specified correctly.
##[error]Process 'nuget.exe' exited with code '1'.
```

### Root cause

The `5.4.0` version that `MicroBuildSigningPlugin@4` mentioned in its previous warning (`Please use latest plugin version, version 5.4.0 used instead.`) is an internal fallback inside the task and not an actually published nupkg on the `MicroBuildToolset` feed. Requesting that exact version causes nuget restore to fail.

### Fix

Remove the explicit pin and let the parameter fall back to the Arcade default (`'latest'`). This restores the previously working behavior: the install step succeeds and only emits the cosmetic warning. The long-term fix still needs to happen in `dotnet/arcade`.

### Verification

- `./build.cmd` runs to completion locally (`Build succeeded. 0 Warning(s) 0 Error(s)`) and produces no `.xlf` deltas, so no localization regeneration is needed in this change.