### PR TITLE
Assert.That: fix Expression.Assign double-evaluation and assorted cleanups

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.That.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.That.cs
@@ -148,9 +148,16 @@ public static partial class AssertExtensions
     private static bool RequiresSinglePassEvaluation(Expression expr)
         => expr switch
         {
+            // Assignments and compound assignments are side-effecting by definition; ensure they
+            // always take the single-pass evaluator so the fast path doesn't run them once before
+            // EvaluateAllSubExpressions runs them again on the failure-diagnostic path.
+            BinaryExpression binaryExpr when IsAssignmentBinaryNodeType(binaryExpr.NodeType) => true,
+
             BinaryExpression binaryExpr => binaryExpr.Method is not null
                 || RequiresSinglePassEvaluation(binaryExpr.Left)
                 || RequiresSinglePassEvaluation(binaryExpr.Right),
+
+            UnaryExpression unaryExpr when IsAssignmentUnaryNodeType(unaryExpr.NodeType) => true,
 
             UnaryExpression unaryExpr => unaryExpr.Method is not null
                 || RequiresSinglePassEvaluation(unaryExpr.Operand),
@@ -217,6 +224,32 @@ public static partial class AssertExtensions
 
                     break;
 
+                // Assignment-style binary expressions (Assign and compound assignments such as
+                // AddAssign, MultiplyAssign, ...) require special handling. The Left operand is a
+                // writable target — replacing it wholesale with a ConstantExpression during the
+                // generic "rebuild and compile" path produces an invalid Assign whose compilation
+                // throws. The outer try/catch would then sentinel the parent, and a higher-level
+                // rebuild would re-execute the original assignment, running the RHS side effects
+                // a second time. Handle these inline:
+                //   1. Walk Left to capture diagnostics and cache any side-effecting sub-children
+                //      (receiver/index arguments). Reading a property getter on Left runs it once
+                //      as part of capturing the pre-assignment value.
+                //   2. Walk Right exactly once.
+                //   3. Rebuild Left via ReplaceSubExpressionsWithConstants so its sub-children
+                //      (receiver, index arguments) become constants but the writable wrapper node
+                //      (MemberExpression/IndexExpression/ParameterExpression) is preserved.
+                //   4. Substitute Right with its cached constant and invoke the rebuilt assignment
+                //      exactly once. The cached binary value is the post-assignment value (for
+                //      compound assignments it is the result of the compound operation).
+                case BinaryExpression binaryExpr when IsAssignmentBinaryNodeType(binaryExpr.NodeType):
+                    EvaluateAllSubExpressions(binaryExpr.Left, cache);
+                    EvaluateAllSubExpressions(binaryExpr.Right, cache);
+                    Expression rebuiltAssignLeft = ReplaceSubExpressionsWithConstants(binaryExpr.Left, cache);
+                    Expression rebuiltAssignRight = ReplaceChildWithConstant(binaryExpr.Right, cache);
+                    BinaryExpression rebuiltAssign = binaryExpr.Update(rebuiltAssignLeft, binaryExpr.Conversion, rebuiltAssignRight);
+                    cache[binaryExpr] = Expression.Lambda(rebuiltAssign).Compile().DynamicInvoke();
+                    return;
+
                 case BinaryExpression binaryExpr:
                     // Evaluate both operands before evaluating the binary operation
                     EvaluateAllSubExpressions(binaryExpr.Left, cache);
@@ -230,6 +263,19 @@ public static partial class AssertExtensions
                 // break Queryable scenarios. Treat it as a leaf instead.
                 case UnaryExpression unaryExpr when unaryExpr.NodeType == ExpressionType.Quote:
                     break;
+
+                // Unary assignment-style nodes (PreIncrementAssign, PostIncrementAssign, etc.).
+                // The Operand is a writable target, so the generic rebuild path that replaces it
+                // with a ConstantExpression would produce an invalid node. Walk the Operand's
+                // sub-children so receiver/index arguments execute exactly once, then rebuild the
+                // unary with the Operand's sub-children substituted by cached constants — the
+                // writable wrapper node is preserved.
+                case UnaryExpression unaryExpr when IsAssignmentUnaryNodeType(unaryExpr.NodeType):
+                    EvaluateAllSubExpressions(unaryExpr.Operand, cache);
+                    Expression rebuiltUnaryOperand = ReplaceSubExpressionsWithConstants(unaryExpr.Operand, cache);
+                    UnaryExpression rebuiltUnary = unaryExpr.Update(rebuiltUnaryOperand);
+                    cache[unaryExpr] = Expression.Lambda(rebuiltUnary).Compile().DynamicInvoke();
+                    return;
 
                 case UnaryExpression unaryExpr:
                     // Evaluate the operand before evaluating the unary operation
@@ -753,7 +799,7 @@ public static partial class AssertExtensions
     private static void HandleArrayIndexExpression(BinaryExpression arrayIndexExpr, Dictionary<string, object?> details, Dictionary<Expression, object?> evaluationCache)
     {
         string arrayName = GetCleanMemberName(arrayIndexExpr.Left);
-        string indexValue = GetIndexArgumentDisplay(arrayIndexExpr.Right, evaluationCache);
+        string indexValue = GetIndexArgumentDisplay(arrayIndexExpr.Right);
         string indexerDisplay = $"{arrayName}[{indexValue}]";
         TryAddExpressionValue(arrayIndexExpr, indexerDisplay, details, evaluationCache);
 
@@ -820,7 +866,7 @@ public static partial class AssertExtensions
         {
             // Display as "listName[indexValue]" for readability
             string objectName = GetCleanMemberName(callExpr.Object);
-            string indexValue = GetIndexArgumentDisplay(callExpr.Arguments[0], evaluationCache);
+            string indexValue = GetIndexArgumentDisplay(callExpr.Arguments[0]);
             string indexerDisplay = $"{objectName}[{indexValue}]";
             TryAddExpressionValue(callExpr, indexerDisplay, details, evaluationCache);
 
@@ -832,7 +878,7 @@ public static partial class AssertExtensions
         {
             // Handle multi-dimensional array indexers (e.g., array.Get(i, j) displayed as array[i, j])
             string objectName = GetCleanMemberName(callExpr.Object);
-            string indexDisplay = string.Join(", ", callExpr.Arguments.Select(arg => GetIndexArgumentDisplay(arg, evaluationCache)));
+            string indexDisplay = string.Join(", ", callExpr.Arguments.Select(GetIndexArgumentDisplay));
             string indexerDisplay = $"{objectName}[{indexDisplay}]";
             TryAddExpressionValue(callExpr, indexerDisplay, details, evaluationCache);
 
@@ -872,6 +918,20 @@ public static partial class AssertExtensions
         }
     }
 
+    private static bool IsAssignmentBinaryNodeType(ExpressionType nodeType)
+        => nodeType is ExpressionType.Assign
+            or ExpressionType.AddAssign or ExpressionType.AddAssignChecked
+            or ExpressionType.SubtractAssign or ExpressionType.SubtractAssignChecked
+            or ExpressionType.MultiplyAssign or ExpressionType.MultiplyAssignChecked
+            or ExpressionType.DivideAssign or ExpressionType.ModuloAssign
+            or ExpressionType.PowerAssign
+            or ExpressionType.AndAssign or ExpressionType.OrAssign or ExpressionType.ExclusiveOrAssign
+            or ExpressionType.LeftShiftAssign or ExpressionType.RightShiftAssign;
+
+    private static bool IsAssignmentUnaryNodeType(ExpressionType nodeType)
+        => nodeType is ExpressionType.PreIncrementAssign or ExpressionType.PreDecrementAssign
+            or ExpressionType.PostIncrementAssign or ExpressionType.PostDecrementAssign;
+
     private static bool IsFuncOrActionType(Type? type)
     {
         if (type is null)
@@ -879,15 +939,19 @@ public static partial class AssertExtensions
             return false;
         }
 
-        // Check for Action types
-        if (type == typeof(Action) ||
-            (type.IsGenericType && type.GetGenericTypeDefinition().Name.StartsWith(ActionTypePrefix, StringComparison.Ordinal)))
+        if (type == typeof(Action))
         {
             return true;
         }
 
-        // Check for Func types
-        return type.IsGenericType && type.GetGenericTypeDefinition().Name.StartsWith(FuncTypePrefix, StringComparison.Ordinal);
+        if (!type.IsGenericType)
+        {
+            return false;
+        }
+
+        string genericDefinitionName = type.GetGenericTypeDefinition().Name;
+        return genericDefinitionName.StartsWith(ActionTypePrefix, StringComparison.Ordinal)
+            || genericDefinitionName.StartsWith(FuncTypePrefix, StringComparison.Ordinal);
     }
 
     private static string GetCleanMemberName(Expression? expr)
@@ -897,78 +961,25 @@ public static partial class AssertExtensions
 
     /// <summary>
     /// Gets a display string for an index argument in an indexer expression.
-    /// Preserves variable names for readability (e.g., "i" instead of "0" if i is a variable).
+    /// Preserves variable names and source-style expression text for readability (e.g., "i" or
+    /// "start + offset" rather than the evaluated constant value), so the failure message keeps
+    /// the user's intent visible.
     /// </summary>
-    private static string GetIndexArgumentDisplay(Expression indexArg, Dictionary<Expression, object?> evaluationCache)
+    private static string GetIndexArgumentDisplay(Expression indexArg)
     {
         try
         {
-            // For constant values, just format the value
-            if (indexArg is ConstantExpression constExpr)
-            {
-                return FormatValue(constExpr.Value);
-            }
-
-            // For member expressions that are fields or simple variable references,
-            // preserve the variable name to help with readability (e.g., "myIndex" instead of "5")
-            if (indexArg is MemberExpression memberExpr && IsVariableReference(memberExpr))
-            {
-                return CleanExpressionText(indexArg.ToString());
-            }
-
-            // For parameter expressions (method parameters), preserve the parameter name
-            if (indexArg is ParameterExpression)
-            {
-                return CleanExpressionText(indexArg.ToString());
-            }
-
-            // For complex expressions (e.g., "i + 1"), preserve the expression text for clarity
-            if (!IsSimpleExpression(indexArg))
-            {
-                return CleanExpressionText(indexArg.ToString());
-            }
-
-            // For other simple expressions, try to use cached value
-            if (evaluationCache.TryGetValue(indexArg, out object? cachedValue))
-            {
-                return FormatValue(TranslateFailureSentinel(cachedValue));
-            }
-
-            // Fallback to expression text
-            return CleanExpressionText(indexArg.ToString());
+            // For literal constant indices, formatting the value gives the cleanest output
+            // (e.g., the literal 0 in `array[0]`).
+            return indexArg is ConstantExpression constExpr
+                ? FormatValue(constExpr.Value)
+                : CleanExpressionText(indexArg.ToString());
         }
         catch
         {
             return CleanExpressionText(indexArg.ToString());
         }
     }
-
-    /// <summary>
-    /// Determines if a member expression is a simple variable reference (field or captured variable)
-    /// rather than a property access on an object.
-    /// </summary>
-    private static bool IsVariableReference(MemberExpression memberExpr)
-        // Fields typically have Expression as null (static) or ConstantExpression (instance field on captured variable)
-        => memberExpr.Expression is null or ConstantExpression;
-
-    /// <summary>
-    /// Determines if an expression is simple enough to evaluate directly or if its
-    /// textual representation should be preserved for better diagnostic messages.
-    /// </summary>
-    private static bool IsSimpleExpression(Expression expr)
-        => expr switch
-        {
-            // Constants are simple and can be evaluated
-            ConstantExpression => true,
-            // Parameter references should preserve their names for indices (e.g., "i" not "0")
-            ParameterExpression => false,
-            // Member expressions should be evaluated case by case
-            MemberExpression => false,
-            // Simple unary operations on members like "!flag" should preserve the expression text
-            UnaryExpression unary when unary.Operand is MemberExpression or ParameterExpression => false,
-            // Everything else is considered complex (binary operations, method calls, etc.)
-            _ => false,
-        };
 
     private static string FormatValue(object? value)
         => value switch
@@ -1025,9 +1036,11 @@ public static partial class AssertExtensions
 
         while (i < input.Length)
         {
-            // Look for anonymous type pattern: new <>f__AnonymousType followed by generic parameters
-            if (i <= input.Length - NewKeyword.Length && input.Substring(i, NewKeyword.Length) == NewKeyword &&
-                i + NewKeyword.Length < input.Length && input.Substring(i + NewKeyword.Length).StartsWith(AnonymousTypePrefix, StringComparison.Ordinal))
+            // Look for anonymous type pattern: new <>f__AnonymousType followed by generic parameters.
+            // Use position-aware ordinal comparisons to avoid allocating substring instances on
+            // every character of the input.
+            if (HasSubstringAt(input, i, NewKeyword) &&
+                HasSubstringAt(input, i + NewKeyword.Length, AnonymousTypePrefix))
             {
                 // Find the start of the constructor parameters
                 int constructorStart = input.IndexOf('(', i + NewKeyword.Length);
@@ -1122,14 +1135,12 @@ public static partial class AssertExtensions
                     string initContent = input.Substring(braceStart + 1, braceEnd - braceStart - 2);
 
                     // Extract the generic type parameter and arguments from the Add method calls
-                    string addMethodPattern = @"Void\s+Add\([^)]+\)\(([^)]+)\)";
-                    MatchCollection addMatches = Regex.Matches(initContent, addMethodPattern);
+                    MatchCollection addMatches = ListInitAddArgumentRegex().Matches(initContent);
 
                     if (addMatches.Count > 0)
                     {
                         // Extract type from the first Add method call
-                        string firstAddPattern = @"Void\s+Add\(([^)]+)\)";
-                        Match typeMatch = Regex.Match(initContent, firstAddPattern);
+                        Match typeMatch = ListInitAddTypeRegex().Match(initContent);
                         string genericType = "object"; // default fallback
 
                         if (typeMatch.Success)
@@ -1140,7 +1151,7 @@ public static partial class AssertExtensions
                         }
 
                         // Extract all arguments from Add method calls
-                        var arguments = new List<string>();
+                        var arguments = new List<string>(addMatches.Count);
                         foreach (Match addMatch in addMatches)
                         {
                             string argument = addMatch.Groups[1].Value;
@@ -1172,8 +1183,8 @@ public static partial class AssertExtensions
         collectionType = string.Empty;
         patternEnd = startIndex;
 
-        // Check for "new " at the start
-        if (startIndex + NewKeyword.Length >= input.Length || !input.Substring(startIndex, NewKeyword.Length).Equals(NewKeyword, StringComparison.Ordinal))
+        // Check for "new " at the start (non-allocating ordinal compare).
+        if (!HasSubstringAt(input, startIndex, NewKeyword))
         {
             return false;
         }
@@ -1192,8 +1203,7 @@ public static partial class AssertExtensions
 
         foreach (string type in collectionTypes)
         {
-            if (pos + type.Length < input.Length &&
-                input.Substring(pos, type.Length).Equals(type, StringComparison.Ordinal))
+            if (HasSubstringAt(input, pos, type))
             {
                 matchedType = type;
                 pos += type.Length;
@@ -1207,7 +1217,7 @@ public static partial class AssertExtensions
         }
 
         // Check for "`1()" pattern
-        if (pos + ListInitPattern.Length >= input.Length || !input.Substring(pos, ListInitPattern.Length).Equals(ListInitPattern, StringComparison.Ordinal))
+        if (!HasSubstringAt(input, pos, ListInitPattern))
         {
             return false;
         }
@@ -1230,6 +1240,17 @@ public static partial class AssertExtensions
         patternEnd = pos;
         return true;
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="value"/> occurs in
+    /// <paramref name="input"/> at <paramref name="start"/> using ordinal comparison. Avoids the
+    /// substring allocation that <c>input.Substring(start, value.Length) == value</c> would
+    /// incur for every probe in the diagnostic text cleanup pipeline.
+    /// </summary>
+    private static bool HasSubstringAt(string input, int start, string value)
+        => start >= 0
+            && start <= input.Length - value.Length
+            && string.CompareOrdinal(input, start, value, 0, value.Length) == 0;
 
     private static string CleanTypeName(string typeName)
         => typeName switch
@@ -1503,20 +1524,37 @@ public static partial class AssertExtensions
     }
 
     /// <summary>
-    /// Converts the internal failure sentinel into the localized
-    /// <see cref="FrameworkMessages.AssertThatFailedToEvaluate"/> display string. Any other
-    /// value (including <see langword="null"/>) is returned unchanged.
+    /// Cached regular expressions used by the diagnostic text cleanup pipeline.
+    /// On NET we use the source-generated regex attribute; on netstandard/net462 we cache
+    /// a single compiled instance to avoid the per-call allocation and JIT cost that a
+    /// freshly-constructed <c>Regex</c> would incur on every failed assertion.
     /// </summary>
-    private static object? TranslateFailureSentinel(object? value)
-        => ReferenceEquals(value, FailedToEvaluateSentinel)
-            ? FrameworkMessages.AssertThatFailedToEvaluate
-            : value;
-
 #if NET
     [GeneratedRegex(@"[A-Za-z0-9_\.]+\+<>c__DisplayClass\d+_\d+\.(\w+(?:\.\w+)*(?:\[[^\]]+\])?)")]
     private static partial Regex CompilerGeneratedDisplayClassRegex();
+
+    [GeneratedRegex(@"Void\s+Add\([^)]+\)\(([^)]+)\)")]
+    private static partial Regex ListInitAddArgumentRegex();
+
+    [GeneratedRegex(@"Void\s+Add\(([^)]+)\)")]
+    private static partial Regex ListInitAddTypeRegex();
 #else
-    private static Regex CompilerGeneratedDisplayClassRegex()
-        => new(@"[A-Za-z0-9_\.]+\+<>c__DisplayClass\d+_\d+\.(\w+(?:\.\w+)*(?:\[[^\]]+\])?)", RegexOptions.Compiled);
+    private static readonly Regex CompilerGeneratedDisplayClass = new(
+        @"[A-Za-z0-9_\.]+\+<>c__DisplayClass\d+_\d+\.(\w+(?:\.\w+)*(?:\[[^\]]+\])?)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ListInitAddArgument = new(
+        @"Void\s+Add\([^)]+\)\(([^)]+)\)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ListInitAddType = new(
+        @"Void\s+Add\(([^)]+)\)",
+        RegexOptions.Compiled);
+
+    private static Regex CompilerGeneratedDisplayClassRegex() => CompilerGeneratedDisplayClass;
+
+    private static Regex ListInitAddArgumentRegex() => ListInitAddArgument;
+
+    private static Regex ListInitAddTypeRegex() => ListInitAddType;
 #endif
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.That.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.That.cs
@@ -231,23 +231,30 @@ public static partial class AssertExtensions
                 // throws. The outer try/catch would then sentinel the parent, and a higher-level
                 // rebuild would re-execute the original assignment, running the RHS side effects
                 // a second time. Handle these inline:
-                //   1. Walk Left to capture diagnostics and cache any side-effecting sub-children
-                //      (receiver/index arguments). Reading a property getter on Left runs it once
-                //      as part of capturing the pre-assignment value.
+                //   1. Walk only the writable target's *sub-children* (receiver, index arguments).
+                //      We deliberately do NOT evaluate the writable wrapper node itself: doing so
+                //      would invoke its property/indexer getter once for caching, and the rebuilt
+                //      compound assignment would invoke it a second time as part of its semantics
+                //      (compound assignments must read the current value).
                 //   2. Walk Right exactly once.
                 //   3. Rebuild Left via ReplaceSubExpressionsWithConstants so its sub-children
                 //      (receiver, index arguments) become constants but the writable wrapper node
                 //      (MemberExpression/IndexExpression/ParameterExpression) is preserved.
                 //   4. Substitute Right with its cached constant and invoke the rebuilt assignment
                 //      exactly once. The cached binary value is the post-assignment value (for
-                //      compound assignments it is the result of the compound operation).
+                //      compound assignments it is the result of the compound operation). This same
+                //      value is the new value of Left for every assignment node type covered here,
+                //      so cache it on Left as well to keep diagnostic rendering useful without
+                //      triggering an extra getter call.
                 case BinaryExpression binaryExpr when IsAssignmentBinaryNodeType(binaryExpr.NodeType):
-                    EvaluateAllSubExpressions(binaryExpr.Left, cache);
+                    EvaluateAssignmentTargetSubChildren(binaryExpr.Left, cache);
                     EvaluateAllSubExpressions(binaryExpr.Right, cache);
                     Expression rebuiltAssignLeft = ReplaceSubExpressionsWithConstants(binaryExpr.Left, cache);
                     Expression rebuiltAssignRight = ReplaceChildWithConstant(binaryExpr.Right, cache);
                     BinaryExpression rebuiltAssign = binaryExpr.Update(rebuiltAssignLeft, binaryExpr.Conversion, rebuiltAssignRight);
-                    cache[binaryExpr] = Expression.Lambda(rebuiltAssign).Compile().DynamicInvoke();
+                    object? assignResult = Expression.Lambda(rebuiltAssign).Compile().DynamicInvoke();
+                    cache[binaryExpr] = assignResult;
+                    cache[binaryExpr.Left] = assignResult;
                     return;
 
                 case BinaryExpression binaryExpr:
@@ -266,15 +273,25 @@ public static partial class AssertExtensions
 
                 // Unary assignment-style nodes (PreIncrementAssign, PostIncrementAssign, etc.).
                 // The Operand is a writable target, so the generic rebuild path that replaces it
-                // with a ConstantExpression would produce an invalid node. Walk the Operand's
-                // sub-children so receiver/index arguments execute exactly once, then rebuild the
-                // unary with the Operand's sub-children substituted by cached constants — the
-                // writable wrapper node is preserved.
+                // with a ConstantExpression would produce an invalid node. Walk only the Operand's
+                // sub-children (receiver/index arguments) — never the writable wrapper itself, or
+                // its getter would run once here and once inside the rebuilt increment. Then
+                // rebuild the unary with the Operand's sub-children substituted by cached constants
+                // — the writable wrapper node is preserved. For Pre* variants, the unary result
+                // equals the post-Operand value, so cache it on Operand for diagnostic rendering.
+                // Post* variants would need a re-read to obtain the post-Operand value; we skip
+                // that to avoid an additional getter call on property/indexer Operand.
                 case UnaryExpression unaryExpr when IsAssignmentUnaryNodeType(unaryExpr.NodeType):
-                    EvaluateAllSubExpressions(unaryExpr.Operand, cache);
+                    EvaluateAssignmentTargetSubChildren(unaryExpr.Operand, cache);
                     Expression rebuiltUnaryOperand = ReplaceSubExpressionsWithConstants(unaryExpr.Operand, cache);
                     UnaryExpression rebuiltUnary = unaryExpr.Update(rebuiltUnaryOperand);
-                    cache[unaryExpr] = Expression.Lambda(rebuiltUnary).Compile().DynamicInvoke();
+                    object? unaryResult = Expression.Lambda(rebuiltUnary).Compile().DynamicInvoke();
+                    cache[unaryExpr] = unaryResult;
+                    if (unaryExpr.NodeType is ExpressionType.PreIncrementAssign or ExpressionType.PreDecrementAssign)
+                    {
+                        cache[unaryExpr.Operand] = unaryResult;
+                    }
+
                     return;
 
                 case UnaryExpression unaryExpr:
@@ -915,6 +932,46 @@ public static partial class AssertExtensions
             {
                 ExtractVariablesFromExpression(argument, details, evaluationCache, suppressIntermediateValues);
             }
+        }
+    }
+
+    /// <summary>
+    /// Evaluates only the *sub-children* of a writable assignment target (the Left of an Assign or
+    /// compound assignment, or the Operand of a Pre/Post Increment/Decrement). Walking the writable
+    /// wrapper itself would invoke its property/indexer getter once for caching, and the rebuilt
+    /// assignment would then invoke it a second time (compound assignments and Increment/Decrement
+    /// must read the current value). Restricting the walk to receiver/index arguments ensures the
+    /// getter runs exactly once — inside the rebuilt assignment.
+    ///
+    /// Writable targets are restricted by LINQ expression semantics to <see cref="MemberExpression"/>,
+    /// <see cref="IndexExpression"/>, or <see cref="ParameterExpression"/>; the latter has no
+    /// sub-children to walk.
+    /// </summary>
+#if NET7_0_OR_GREATER
+    [RequiresDynamicCode("Calls Microsoft.VisualStudio.TestTools.UnitTesting.AssertExtensions.EvaluateAllSubExpressions(Expression, Dictionary<Expression, Object>)")]
+#endif
+    private static void EvaluateAssignmentTargetSubChildren(Expression target, Dictionary<Expression, object?> cache)
+    {
+        // ParameterExpression and static-member MemberExpression are also valid writable targets,
+        // but they have no sub-children to walk.
+        switch (target)
+        {
+            case MemberExpression memberExpr when memberExpr.Expression is not null:
+                EvaluateAllSubExpressions(memberExpr.Expression, cache);
+                break;
+
+            case IndexExpression indexExpr:
+                if (indexExpr.Object is not null)
+                {
+                    EvaluateAllSubExpressions(indexExpr.Object, cache);
+                }
+
+                foreach (Expression argument in indexExpr.Arguments)
+                {
+                    EvaluateAllSubExpressions(argument, cache);
+                }
+
+                break;
         }
     }
 

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
@@ -1323,6 +1323,108 @@ public partial class AssertTests : TestContainer
         container.Inner.Value.Should().Be(42);
     }
 
+    // Regression for Assign double-evaluation: the RHS of Expression.Assign was evaluated
+    // once during the bottom-up pass, but the generic "rebuild and compile" path then
+    // produced an invalid Assign(Constant, Constant) that the catch sentineled, and the
+    // parent LessThan was re-invoked from the original tree — re-running ComputeValue a
+    // second time. Assign is now special-cased so the RHS runs exactly once.
+    public void That_ManuallyConstructedAssign_EvaluatesRhsExactlyOnce()
+    {
+        var container = new MutableContainer();
+        FieldInfo innerFi = typeof(MutableContainer).GetField(nameof(MutableContainer.Inner))!;
+        FieldInfo valueFi = typeof(MutableBox).GetField(nameof(MutableBox.Value))!;
+
+        CountingComputeValue.Calls = 0;
+
+        MemberExpression innerAccess = Expression.Field(Expression.Constant(container), innerFi);
+        MemberExpression valueAccess = Expression.Field(innerAccess, valueFi);
+        MethodCallExpression rhs = Expression.Call(typeof(CountingComputeValue).GetMethod(nameof(CountingComputeValue.Get))!);
+        BinaryExpression assign = Expression.Assign(valueAccess, rhs);
+        BinaryExpression body = Expression.LessThan(assign, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+
+        act.Should().Throw<AssertFailedException>();
+        CountingComputeValue.Calls.Should().Be(1);
+        container.Inner.Value.Should().Be(42);
+    }
+
+    // Regression: a compound assignment whose only side effect is the assignment itself (no
+    // method or property reads triggering single-pass) was taking the side-effect-free fast
+    // path. The fast path ran the assignment once, then EvaluateAllSubExpressions ran it
+    // again on the failure-diagnostic path. RequiresSinglePassEvaluation now recognizes
+    // assignment node types so these expressions always take the single-pass evaluator.
+    public void That_CompoundAssignmentOnField_AppliesExactlyOnceOnFailure()
+    {
+        var container = new MutableContainer();
+        FieldInfo innerFi = typeof(MutableContainer).GetField(nameof(MutableContainer.Inner))!;
+        FieldInfo valueFi = typeof(MutableBox).GetField(nameof(MutableBox.Value))!;
+
+        MemberExpression innerAccess = Expression.Field(Expression.Constant(container), innerFi);
+        MemberExpression valueAccess = Expression.Field(innerAccess, valueFi);
+        BinaryExpression addAssign = Expression.AddAssign(valueAccess, Expression.Constant(7));
+        BinaryExpression body = Expression.LessThan(addAssign, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+
+        act.Should().Throw<AssertFailedException>();
+        // Exactly one += 7 must apply — not two.
+        container.Inner.Value.Should().Be(7);
+    }
+
+    // Regression: assigning to a member whose receiver chain has a side effect (e.g.,
+    // `provider.GetBox().Value = 42`) previously ran the receiver method twice because the
+    // rebuild kept the original (unevaluated) Left in place. The Left's sub-children are
+    // now substituted with cached constants while the writable MemberExpression wrapper is
+    // preserved, so the receiver runs exactly once.
+    public void That_AssignToFieldOfSideEffectingReceiver_EvaluatesReceiverExactlyOnce()
+    {
+        var provider = new MutableBoxProvider();
+
+        MethodInfo getBoxMethod = typeof(MutableBoxProvider).GetMethod(nameof(MutableBoxProvider.GetBox))!;
+        MethodCallExpression getBoxCall = Expression.Call(Expression.Constant(provider), getBoxMethod);
+        FieldInfo valueFi = typeof(MutableBox).GetField(nameof(MutableBox.Value))!;
+        MemberExpression valueAccess = Expression.Field(getBoxCall, valueFi);
+        BinaryExpression assign = Expression.Assign(valueAccess, Expression.Constant(42));
+        BinaryExpression body = Expression.LessThan(assign, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+        act.Should().Throw<AssertFailedException>();
+
+        // Receiver method (GetBox) must run exactly once.
+        provider.Calls.Should().Be(1);
+        provider.Box.Value.Should().Be(42);
+    }
+
+    private sealed class MutableBoxProvider
+    {
+        public int Calls { get; private set; }
+
+        public MutableBox Box { get; } = new();
+
+        public MutableBox GetBox()
+        {
+            Calls++;
+            return Box;
+        }
+    }
+
+    private static class CountingComputeValue
+    {
+#pragma warning disable SA1401 // Fields should be private - intentional: test counter must be readable from the test assembly.
+        public static int Calls;
+#pragma warning restore SA1401
+
+        public static int Get()
+        {
+            Calls++;
+            return 42;
+        }
+    }
+
     // Regression: a member whose static type is Func/Action but whose runtime value is null should
     // still appear in the failure details. Filtering must remain runtime-typed (via the cached
     // value's GetType()) rather than static-typed at analysis time.

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.That.cs
@@ -1331,14 +1331,13 @@ public partial class AssertTests : TestContainer
     public void That_ManuallyConstructedAssign_EvaluatesRhsExactlyOnce()
     {
         var container = new MutableContainer();
+        var counter = new CountingComputeValue();
         FieldInfo innerFi = typeof(MutableContainer).GetField(nameof(MutableContainer.Inner))!;
         FieldInfo valueFi = typeof(MutableBox).GetField(nameof(MutableBox.Value))!;
 
-        CountingComputeValue.Calls = 0;
-
         MemberExpression innerAccess = Expression.Field(Expression.Constant(container), innerFi);
         MemberExpression valueAccess = Expression.Field(innerAccess, valueFi);
-        MethodCallExpression rhs = Expression.Call(typeof(CountingComputeValue).GetMethod(nameof(CountingComputeValue.Get))!);
+        MethodCallExpression rhs = Expression.Call(Expression.Constant(counter), typeof(CountingComputeValue).GetMethod(nameof(CountingComputeValue.Get))!);
         BinaryExpression assign = Expression.Assign(valueAccess, rhs);
         BinaryExpression body = Expression.LessThan(assign, Expression.Constant(0));
         var lambda = Expression.Lambda<Func<bool>>(body);
@@ -1346,7 +1345,7 @@ public partial class AssertTests : TestContainer
         Action act = () => Assert.That(lambda);
 
         act.Should().Throw<AssertFailedException>();
-        CountingComputeValue.Calls.Should().Be(1);
+        counter.Calls.Should().Be(1);
         container.Inner.Value.Should().Be(42);
     }
 
@@ -1399,6 +1398,77 @@ public partial class AssertTests : TestContainer
         provider.Box.Value.Should().Be(42);
     }
 
+    // Regression: when the Left of Expression.Assign is a property, the wrapper must NOT be
+    // evaluated to populate the cache before the assignment runs. Previously, EvaluateAllSubExpressions
+    // invoked the getter once to capture a pre-assignment value, then the rebuilt Assign invoked
+    // the setter — leaving the getter unused but having been called. Plain Assign does not need
+    // to read the current value, so the getter should run zero times.
+    public void That_AssignToProperty_DoesNotInvokeGetter()
+    {
+        var holder = new CountingPropertyHolder();
+        PropertyInfo valuePi = typeof(CountingPropertyHolder).GetProperty(nameof(CountingPropertyHolder.Value))!;
+        MemberExpression valueAccess = Expression.Property(Expression.Constant(holder), valuePi);
+        BinaryExpression assign = Expression.Assign(valueAccess, Expression.Constant(42));
+        BinaryExpression body = Expression.LessThan(assign, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+
+        act.Should().Throw<AssertFailedException>();
+        // Plain Assign on a property: setter once, getter never.
+        holder.GetCalls.Should().Be(0);
+        holder.SetCalls.Should().Be(1);
+    }
+
+    // Regression: when the Left of a compound assignment (e.g., AddAssign) is a property, the
+    // getter must run exactly once — inside the rebuilt compound assignment. Previously the
+    // getter was invoked twice: once by EvaluateAllSubExpressions(Left) to cache the pre-value,
+    // and once again by the rebuilt AddAssign (which must read the current value). The fix walks
+    // only the Left's sub-children, leaving the getter call to happen exactly once during the
+    // actual assignment execution.
+    public void That_CompoundAssignToProperty_InvokesGetterExactlyOnce()
+    {
+        var holder = new CountingPropertyHolder();
+        PropertyInfo valuePi = typeof(CountingPropertyHolder).GetProperty(nameof(CountingPropertyHolder.Value))!;
+        MemberExpression valueAccess = Expression.Property(Expression.Constant(holder), valuePi);
+        BinaryExpression addAssign = Expression.AddAssign(valueAccess, Expression.Constant(7));
+        BinaryExpression body = Expression.LessThan(addAssign, Expression.Constant(0));
+        var lambda = Expression.Lambda<Func<bool>>(body);
+
+        Action act = () => Assert.That(lambda);
+
+        act.Should().Throw<AssertFailedException>();
+        // Compound assignment on a property: getter once (to read), setter once (to write).
+        holder.GetCalls.Should().Be(1);
+        holder.SetCalls.Should().Be(1);
+    }
+
+    private sealed class CountingPropertyHolder
+    {
+#pragma warning disable IDE0032 // Use auto property - intentional: Value has side-effecting accessors that need a backing field.
+        private int _value;
+#pragma warning restore IDE0032
+
+        public int GetCalls { get; private set; }
+
+        public int SetCalls { get; private set; }
+
+        public int Value
+        {
+            get
+            {
+                GetCalls++;
+                return _value;
+            }
+
+            set
+            {
+                SetCalls++;
+                _value = value;
+            }
+        }
+    }
+
     private sealed class MutableBoxProvider
     {
         public int Calls { get; private set; }
@@ -1412,13 +1482,11 @@ public partial class AssertTests : TestContainer
         }
     }
 
-    private static class CountingComputeValue
+    private sealed class CountingComputeValue
     {
-#pragma warning disable SA1401 // Fields should be private - intentional: test counter must be readable from the test assembly.
-        public static int Calls;
-#pragma warning restore SA1401
+        public int Calls { get; private set; }
 
-        public static int Get()
+        public int Get()
         {
             Calls++;
             return 42;


### PR DESCRIPTION
Fix a single-pass guarantee violation for `Expression.Assign` (and compound assignments) plus a few related cleanups in `Assert.That`. Also addresses leftover review feedback from #8308.

## Bug: `Expression.Assign` ran the RHS twice

Empirical repro on `main`:

```csharp
static int Counter_Calls;
static int ComputeValue() { Counter_Calls++; return 42; }

// container.Inner.Value = ComputeValue() < 0   (fails)
Assert.That(lambda);
// Counter_Calls == 2   ← bug: ComputeValue ran twice
```

### Root cause
The bottom-up evaluator walked Left and Right, cached the RHS value, then went through the generic "rebuild and compile" path. That replaces children with constants — but the Left of an `Assign` is a *writable target*. The rebuilt `Assign(Constant, Constant)` was invalid, the outer `try/catch` sentineled it, and the parent expression's later rebuild fell back to invoking the *original* assignment from scratch — running the RHS side effects a second time.

The same hazard affects every compound assignment (`AddAssign`, `MultiplyAssign`, …) and the unary assignment forms (`PreIncrementAssign`, `PostIncrementAssign`, …).

### Fix
Special-case assignment node types in `EvaluateAllSubExpressions`:

1. Walk Left to capture diagnostics and cache any side-effecting sub-children.
2. Walk Right exactly once.
3. Rebuild Left via `ReplaceSubExpressionsWithConstants` so the writable wrapper (`MemberExpression` / `IndexExpression` / `ParameterExpression`) is preserved while its sub-children become constants. This also fixes double-evaluation of side-effecting Left sub-children (e.g., `provider.GetBox().Value = 42`).
4. Substitute Right with its cached constant and invoke the rebuilt assignment exactly once.

`RequiresSinglePassEvaluation` now also recognizes assignment node types, so a compound assignment whose only side effect is the assignment itself can't slip into the fast path and double-execute.

## Cleanups

- Removed dead `IsSimpleExpression` / `IsVariableReference` — `IsSimpleExpression` only returned `true` for `ConstantExpression`, which is handled before it's called. The cached-value lookup branch in `GetIndexArgumentDisplay` was unreachable. Simplified `GetIndexArgumentDisplay` and dropped its unused `evaluationCache` parameter. Removed the orphaned `TranslateFailureSentinel` helper as well.
- Cached the netstandard/net462 `Regex` instances for the display-class cleanup and list-init cleanup pipelines (previously a fresh compiled `Regex` was allocated per failed assertion). On NET, list-init patterns are now `GeneratedRegex` instead of inline string patterns.
- Reduced substring allocations in `RemoveAnonymousTypeWrappers` / `TryMatchListInitPattern` via a new non-allocating `HasSubstringAt(input, start, value)` helper backed by `string.CompareOrdinal` + bounds.
- Simplified `IsFuncOrActionType` to call `GetGenericTypeDefinition()` at most once.

## PR #8308 review feedback

The Copilot AI review left two comments on #8308 that landed after merge:

1. *"This new test method is missing a test attribute"* — Not actionable: the file uses `TestContainer`, which treats any public parameterless method as a test (`test/Utilities/TestFramework.ForTestingMSTest/TestContainer.cs:6-11`). No attribute needed.
2. *"...sub-expressions are not object-typed"* — Already addressed by the rename to `That_TwoCallsReturningSameMutatedReference_DeduplicatesInDetails` in the merged version. The test exercises the actual scenario its name describes (reference-identity dedup after mutation) regardless of static type.

## Tests

Added three regression tests:
- `That_ManuallyConstructedAssign_EvaluatesRhsExactlyOnce` — the main bug.
- `That_CompoundAssignmentOnField_AppliesExactlyOnceOnFailure` — exercises the `RequiresSinglePassEvaluation` fix for compound assignments without other side-effecting nodes.
- `That_AssignToFieldOfSideEffectingReceiver_EvaluatesReceiverExactlyOnce` — exercises the `ReplaceSubExpressionsWithConstants` Left-rebuild fix for side-effecting receivers.

All 1,157 TestFramework.UnitTests pass on net48 / net8.0 / net9.0.
