### PR TITLE
RFC 012: align AreNotEqual/MatchesRegex summaries with catalog and close discussion phase

### DIFF
--- a/docs/RFCs/012-Structured-Assertion-Messages.md
+++ b/docs/RFCs/012-Structured-Assertion-Messages.md
@@ -1,7 +1,7 @@
 # RFC 012 - Structured Assertion Messages
 
 - [x] Approved in principle
-- [ ] Under discussion
+- [x] Under discussion
 - [x] Implementation
 - [ ] Shipped
 

--- a/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
+++ b/src/TestFramework/TestFramework/Resources/FrameworkMessages.resx
@@ -522,7 +522,7 @@ Actual: {2}</value>
     <value>Expected strings to be equal.</value>
   </data>
   <data name="AreNotEqualFailedSummary" xml:space="preserve">
-    <value>Expected values to not be equal.</value>
+    <value>Expected values to differ.</value>
   </data>
   <data name="AreNotEqualStringsCaseInsensitiveFailedSummary" xml:space="preserve">
     <value>Expected strings to differ (case-insensitive).</value>
@@ -540,10 +540,10 @@ Actual: {2}</value>
     <value>Expected all items in collection to be of the specified type.</value>
   </data>
   <data name="MatchesRegexFailedSummary" xml:space="preserve">
-    <value>Expected string to match the specified regular expression.</value>
+    <value>Expected string to match the specified pattern.</value>
   </data>
   <data name="DoesNotMatchRegexFailedSummary" xml:space="preserve">
-    <value>Expected string to not match the specified regular expression.</value>
+    <value>Expected string to not match the specified pattern.</value>
   </data>
   <data name="ContainsAllFailedSummary" xml:space="preserve">
     <value>Expected collection to contain all specified items.</value>

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Skutečnost: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Skutečnost: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Tatsächlich: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Tatsächlich: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Real: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Real: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Réel : {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Réel : {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Effettivo: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Effettivo: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Rzeczywiste: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Rzeczywiste: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Real: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Real: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Gerçekte olan: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Gerçekte olan: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -454,8 +454,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoesNotMatchRegexFailedSummary">
-        <source>Expected string to not match the specified regular expression.</source>
-        <target state="new">Expected string to not match the specified regular expression.</target>
+        <source>Expected string to not match the specified pattern.</source>
+        <target state="new">Expected string to not match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoesNotStartWithFail">
@@ -633,8 +633,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="AreNotEqualFailedSummary">
-        <source>Expected values to not be equal.</source>
-        <target state="new">Expected values to not be equal.</target>
+        <source>Expected values to differ.</source>
+        <target state="new">Expected values to differ.</target>
         <note />
       </trans-unit>
       <trans-unit id="AreEqualStringsFailedSummary">
@@ -668,8 +668,8 @@ Actual: {2}</source>
         <note />
       </trans-unit>
       <trans-unit id="MatchesRegexFailedSummary">
-        <source>Expected string to match the specified regular expression.</source>
-        <target state="new">Expected string to match the specified regular expression.</target>
+        <source>Expected string to match the specified pattern.</source>
+        <target state="new">Expected string to match the specified pattern.</target>
         <note />
       </trans-unit>
       <trans-unit id="PrivateAccessorMemberNotFound">

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -362,7 +362,7 @@ public partial class AssertTests : TestContainer
         action.Should().Throw<AssertFailedException>()
             .Which.Message.Should().Be(
                 """
-                Assertion failed. Expected values to not be equal.
+                Assertion failed. Expected values to differ.
 
                 notExpected: 0
                 actual:      0
@@ -503,7 +503,7 @@ public partial class AssertTests : TestContainer
         (await action.Should().ThrowAsync<Exception>())
             .Which.Message.Should().Be(
                 $"""
-                Assertion failed. Expected values to not be equal.
+                Assertion failed. Expected values to differ.
                 User-provided message. DummyClassTrackingToStringCalls,     DummyClassTrackingToStringCalls, Hello, DummyIFormattable.ToString(), {string.Format(null, "{0:tt}", dateTime)}, {string.Format(null, "{0,5:tt}", dateTime)}
 
                 notExpected: 0

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
@@ -24,7 +24,7 @@ public partial class AssertTests
         AssertFailedException ex = action.Should().Throw<AssertFailedException>()
             .WithMessage(
                 """
-                Assertion failed. Expected string to match the specified regular expression.
+                Assertion failed. Expected string to match the specified pattern.
                 User-provided message
 
                 expected pattern: "^foo"
@@ -49,7 +49,7 @@ public partial class AssertTests
         action.Should().Throw<AssertFailedException>()
             .WithMessage(
                 """
-                Assertion failed. Expected string to match the specified regular expression.
+                Assertion failed. Expected string to match the specified pattern.
 
                 expected pattern: "^foo"
                 actual:           "hello"
@@ -73,7 +73,7 @@ public partial class AssertTests
         AssertFailedException ex = action.Should().Throw<AssertFailedException>()
             .WithMessage(
                 """
-                Assertion failed. Expected string to not match the specified regular expression.
+                Assertion failed. Expected string to not match the specified pattern.
                 User-provided message
 
                 unexpected pattern: "world"
@@ -98,7 +98,7 @@ public partial class AssertTests
         action.Should().Throw<AssertFailedException>()
             .WithMessage(
                 """
-                Assertion failed. Expected string to not match the specified regular expression.
+                Assertion failed. Expected string to not match the specified pattern.
 
                 unexpected pattern: "world"
                 actual:             "hello world"


### PR DESCRIPTION
## Summary

Following up on the RFC 012 implementation push, this PR:

1. **Aligns three `Assert.*` failure summaries with the RFC 012 catalog** that previously diverged:
   - `Assert.AreNotEqual` (generic): `Expected values to not be equal.` → `Expected values to differ.`
     - Matches the RFC catalog and is consistent with the `to differ` wording already used by `AreNotEqual` (string/delta) and `AreSequenceEqual`.
   - `Assert.MatchesRegex`: `Expected string to match the specified regular expression.` → `Expected string to match the specified pattern.`
   - `Assert.DoesNotMatchRegex`: `Expected string to not match the specified regular expression.` → `Expected string to not match the specified pattern.`
     - Match the RFC catalog and the `pattern` parameter name (and `pattern:` evidence label) used by these APIs.

2. **Regenerates the XLF resources** for all 13 locales via `dotnet msbuild /t:UpdateXlf`.

3. **Updates unit tests** to match the new strings.

4. **Updates RFC 012 status** to check `Under discussion` (the discussion phase is closed and the entire catalog is implemented), matching the convention used by RFC 011. `Shipped` will be checked once a release containing all RFC 012 work is published.

## Catalog audit

I walked the entire RFC 012 [Assertion Message Catalog](https://github.com/microsoft/testfx/blob/main/docs/RFCs/012-Structured-Assertion-Messages.md#assertion-message-catalog) and verified every entry is implemented:

| Section | API(s) | Status |
| --- | --- | --- |
| Equality | `AreEqual` / `AreNotEqual` (generic, delta, string, string+ignoreCase/culture) | ✅ #8231, #8331, #8336, this PR |
| Reference equality | `AreSame` / `AreNotSame` (incl. null sides + value-type guard) | ✅ #8214 |
| Boolean | `IsTrue` / `IsFalse` (incl. null condition) | ✅ #8187 |
| Null | `IsNull` / `IsNotNull` | ✅ #8187 |
| Type checking | `IsInstanceOfType`, `IsNotInstanceOfType`, `IsExactInstanceOfType`, `IsNotExactInstanceOfType` (incl. null) | ✅ #8214 |
| Exceptions | `Throws`, `ThrowsExactly`, `ThrowsAsync`, `ThrowsExactlyAsync` (incl. `messageBuilder` overloads) | ✅ #9210 |
| String ops | `Contains`, `DoesNotContain`, `StartsWith`, `DoesNotStartWith`, `EndsWith`, `DoesNotEndWith` | ✅ #8265, #8258 |
| Regex | `MatchesRegex`, `DoesNotMatchRegex` | ✅ #8259 + this PR (wording) |
| Collection ops | `Contains` (item / predicate) | ✅ #8265 |

Beyond the catalog, the following structured-message APIs have also been added/migrated since the RFC was approved: `AreEquivalent` / `AreNotEquivalent`, `AreSequenceEqual` / `AreNotSequenceEqual`, `HasCount` / `IsEmpty` / `IsNotEmpty`, `ContainsAll` / `DoesNotContainAll`, `IsGreaterThan` / `IsLessThan` / `IsGreaterThanOrEqualTo` / `IsLessThanOrEqualTo` / `IsPositive` / `IsNegative` / `IsInRange`, `AreAllNotNull` / `AreAllDistinct` / `AreAllOfType`, and `Fail` / `Inconclusive`.

## Validation

- `dotnet build test/UnitTests/TestFramework.UnitTests/TestFramework.UnitTests.csproj -f net9.0` ✅
- `Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.exe` ✅ (1154 / 1154 tests passing on `net9.0`)