### PR TITLE
Fix HangDump GetParentPidLinux mis-parsing /proc/<pid>/stat when comm contains spaces

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -87,19 +87,34 @@ internal static class IProcessExtensions
     /// <returns>The process id.</returns>
     [UnsupportedOSPlatform("browser")]
     internal static int GetParentPidLinux(Process process)
+        => ParseParentPidFromProcStat(File.ReadAllText($"/proc/{process.Id}/stat"));
+
+    /// <summary>
+    /// Parses the parent PID out of a line read from <c>/proc/&lt;pid&gt;/stat</c>.
+    /// </summary>
+    /// <remarks>
+    /// Per <c>proc(5)</c>, the line has the format <c>pid (comm) state ppid pgrp ...</c>.
+    /// The <c>comm</c> field is allowed to contain spaces and parentheses (the kernel only
+    /// truncates it to 16 chars and does not escape its content), so the line cannot be split
+    /// on <c>' '</c>. The kernel does guarantee that <c>)</c> terminates <c>comm</c>, so the
+    /// last <c>)</c> in the line marks its end. After that, fields are space-separated:
+    /// <c>[0] = state</c>, <c>[1] = ppid</c>, <c>[2] = pgrp</c>, ...
+    /// </remarks>
+    /// <param name="stat">The full contents of <c>/proc/&lt;pid&gt;/stat</c>.</param>
+    /// <returns>The parent process id, or <see cref="InvalidProcessId"/> if the input is malformed.</returns>
+    internal static int ParseParentPidFromProcStat(string stat)
     {
-        int pid = process.Id;
+        int commEnd = stat.LastIndexOf(')');
+        if (commEnd < 0 || commEnd + 2 >= stat.Length)
+        {
+            return InvalidProcessId;
+        }
 
-        // read /proc/<pid>/stat
-        // 4th column will contain the ppid, 92 in the example below
-        // ex: 93 (bash) S 92 93 2 4294967295 ...
-        string path = $"/proc/{pid}/stat";
-        string stat = File.ReadAllText(path);
-        string[] parts = stat.Split(' ');
-
-        int ppid = parts.Length < 5 ? InvalidProcessId : int.Parse(parts[3], CultureInfo.CurrentCulture);
-
-        return ppid;
+        string[] afterComm = stat.Substring(commEnd + 2).Split(' ');
+        return afterComm.Length >= 2
+            && int.TryParse(afterComm[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out int ppid)
+            ? ppid
+            : InvalidProcessId;
     }
 
     [UnsupportedOSPlatform("browser")]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpProcStatParserTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpProcStatParserTests.cs
@@ -42,22 +42,4 @@ public sealed class HangDumpProcStatParserTests
     [TestMethod]
     public void ParseParentPidFromProcStat_NotEnoughFieldsAfterComm_ReturnsInvalidProcessId()
         => Assert.AreEqual(InvalidProcessId, IProcessExtensions.ParseParentPidFromProcStat("1 (a) S"));
-
-    [TestMethod]
-    public void ParseParentPidFromProcStat_NonInvariantCulture_StillParses()
-    {
-        // PIDs are ASCII decimals; parsing must use InvariantCulture so cultures with
-        // non-ASCII digit shapes or different separators don't break the parse.
-        CultureInfo previous = CultureInfo.CurrentCulture;
-        try
-        {
-            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
-            int actual = IProcessExtensions.ParseParentPidFromProcStat("1234 (Web Content) S 4567 1234 1234 0 -1 0 0 0");
-            Assert.AreEqual(4567, actual);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = previous;
-        }
-    }
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpProcStatParserTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpProcStatParserTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.Diagnostics.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class HangDumpProcStatParserTests
+{
+    // The implementation's InvalidProcessId constant is private, so we reference the literal -1 here.
+    private const int InvalidProcessId = -1;
+
+    [TestMethod]
+    [DataRow("93 (bash) S 92 93 2 4294967295 0 0 0 0", 92)]
+    [DataRow("1234 (Web Content) S 4567 1234 1234 0 -1 4194304 0 0", 4567)]
+    [DataRow("42 (My (App)) R 100 42 42 0 -1 4194304 0 0", 100)]
+    [DataRow("5000 (chrome_helper_re) S 4999 5000 5000 0 -1 4194304 0 0", 4999)]
+    [DataRow("1 (systemd) S 0 1 1 0 -1 4194560 0 0", 0)]
+    public void ParseParentPidFromProcStat_ValidInput_ReturnsParentPid(string stat, int expected)
+    {
+        int actual = IProcessExtensions.ParseParentPidFromProcStat(stat);
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ParseParentPidFromProcStat_EmptyString_ReturnsInvalidProcessId()
+        => Assert.AreEqual(InvalidProcessId, IProcessExtensions.ParseParentPidFromProcStat(string.Empty));
+
+    [TestMethod]
+    public void ParseParentPidFromProcStat_NoClosingParen_ReturnsInvalidProcessId()
+        => Assert.AreEqual(InvalidProcessId, IProcessExtensions.ParseParentPidFromProcStat("93 (bash S 92 93 2"));
+
+    [TestMethod]
+    public void ParseParentPidFromProcStat_ClosingParenAtEnd_ReturnsInvalidProcessId()
+        => Assert.AreEqual(InvalidProcessId, IProcessExtensions.ParseParentPidFromProcStat("93 (bash)"));
+
+    [TestMethod]
+    public void ParseParentPidFromProcStat_NonNumericPpid_ReturnsInvalidProcessId()
+        => Assert.AreEqual(InvalidProcessId, IProcessExtensions.ParseParentPidFromProcStat("1 (a) S notanumber 1 1 0 -1 0 0 0"));
+
+    [TestMethod]
+    public void ParseParentPidFromProcStat_NotEnoughFieldsAfterComm_ReturnsInvalidProcessId()
+        => Assert.AreEqual(InvalidProcessId, IProcessExtensions.ParseParentPidFromProcStat("1 (a) S"));
+
+    [TestMethod]
+    public void ParseParentPidFromProcStat_NonInvariantCulture_StillParses()
+    {
+        // PIDs are ASCII decimals; parsing must use InvariantCulture so cultures with
+        // non-ASCII digit shapes or different separators don't break the parse.
+        CultureInfo previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            int actual = IProcessExtensions.ParseParentPidFromProcStat("1234 (Web Content) S 4567 1234 1234 0 -1 0 0 0");
+            Assert.AreEqual(4567, actual);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #8379

See the linked issue for full context, repro, and rationale.

## Changes
- `IProcessExtensions.GetParentPidLinux` now finds the last `)` (which terminates `comm` per proc(5)) and reads the ppid from the fields after `comm`. This correctly handles process names containing spaces or `)`.
- PID parsing uses `InvariantCulture` (PIDs are ASCII decimal).
- Extracted a pure-string `ParseParentPidFromProcStat` helper so the parser is unit-testable without `/proc`.
- Added regression unit tests covering single-word comm, comm with spaces, comm with parens, and malformed input.