### PR TITLE
Fix RetryOrchestrator leaking CancellationTokenSource and Process.Exited handler per attempt

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -293,7 +293,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
             };
 
             await logger.LogDebugAsync($"Starting test host process, attempt {attemptCount}/{userMaxRetryCount}").ConfigureAwait(false);
-            IProcess testHostProcess = _serviceProvider.GetProcessHandler().Start(processStartInfo)
+            using IProcess testHostProcess = _serviceProvider.GetProcessHandler().Start(processStartInfo)
                 ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryFailedTestsCannotStartProcessErrorMessage, processStartInfo.FileName));
 
             using var processExitedCancellationToken = new CancellationTokenSource();
@@ -303,8 +303,14 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 {
                     processExitedCancellationToken.Cancel();
                 }
-                catch (ObjectDisposedException)
+                catch (ObjectDisposedException ex)
                 {
+                    // The handler can race with the end-of-iteration cleanup: if the OS process
+                    // exit signal is queued to the thread pool before we detach the handler but
+                    // executes after the CTS has been disposed, Cancel() throws. Log at debug
+                    // level so an unexpected pattern stays observable without becoming a fatal
+                    // failure in the retry loop.
+                    logger.LogDebug($"CancellationTokenSource already disposed when process exited: {ex.Message}");
                 }
 
                 logger.LogDebug($"Test host process exited, PID: '{(sender as Process)?.Id}'");

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -296,18 +296,27 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
             IProcess testHostProcess = _serviceProvider.GetProcessHandler().Start(processStartInfo)
                 ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryFailedTestsCannotStartProcessErrorMessage, processStartInfo.FileName));
 
-            CancellationTokenSource processExitedCancellationToken = new();
-            testHostProcess.Exited += (sender, e) =>
+            using var processExitedCancellationToken = new CancellationTokenSource();
+            EventHandler exitedHandler = (sender, e) =>
             {
-                processExitedCancellationToken.Cancel();
-                var processExited = sender as Process;
-                logger.LogDebug($"Test host process exited, PID: '{processExited?.Id}'");
+                try
+                {
+                    processExitedCancellationToken.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+
+                logger.LogDebug($"Test host process exited, PID: '{(sender as Process)?.Id}'");
             };
 
-            using (var timeout = new CancellationTokenSource(TimeoutHelper.DefaultHangTimeSpanTimeout))
-            using (var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken))
-            using (var linkedToken2 = CancellationTokenSource.CreateLinkedTokenSource(linkedToken.Token, processExitedCancellationToken.Token))
+            testHostProcess.Exited += exitedHandler;
+            try
             {
+                using var timeout = new CancellationTokenSource(TimeoutHelper.DefaultHangTimeSpanTimeout);
+                using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
+                using var linkedToken2 = CancellationTokenSource.CreateLinkedTokenSource(linkedToken.Token, processExitedCancellationToken.Token);
+
                 await logger.LogDebugAsync("Wait connection from the test host process").ConfigureAwait(false);
                 try
                 {
@@ -326,6 +335,10 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                     await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestHostProcessExitedBeforeRetryCouldConnect, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
                     return (int)ExitCode.GenericFailure;
                 }
+            }
+            finally
+            {
+                testHostProcess.Exited -= exitedHandler;
             }
 
             await testHostProcess.WaitForExitAsync().ConfigureAwait(false);


### PR DESCRIPTION
Fixes #8380

See the linked issue for full context and rationale.

## Changes
- `processExitedCancellationToken` is now a `using var` so it is disposed when the iteration's scope ends.
- The `Process.Exited` handler is stored in a local and detached in a `finally` block so it does not anchor the closure for the life of the process.
- The handler's `Cancel()` call is wrapped in a `try { ... } catch (ObjectDisposedException) { }` to make cleanup race-safe against a late `Exited` firing.