### PR TITLE
Remove IVT from Microsoft.Testing.Platform to Microsoft.Testing.Extensions.AzureFoundry

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.AI;
 using Microsoft.Testing.Extensions.AzureFoundry.Resources;
 using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.AI;
-using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.AzureFoundry;
 
@@ -18,33 +17,24 @@ namespace Microsoft.Testing.Extensions.AzureFoundry;
 /// </summary>
 internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
 {
-    private readonly IEnvironment _environment;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AzureOpenAIChatClientProvider"/> class.
-    /// </summary>
-    /// <param name="environment">The environment service.</param>
-    internal AzureOpenAIChatClientProvider(IEnvironment environment)
-        => _environment = environment;
-
     /// <inheritdoc />
     public bool IsAvailable =>
-        !RoslynString.IsNullOrEmpty(_environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")) &&
-        !RoslynString.IsNullOrEmpty(_environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")) &&
-        !RoslynString.IsNullOrEmpty(_environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY"));
+        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")) &&
+        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")) &&
+        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY"));
 
     /// <inheritdoc />
     public bool HasToolsCapability => true;
 
     /// <inheritdoc />
-    public string ModelName => _environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "unknown";
+    public string ModelName => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "unknown";
 
     /// <inheritdoc />
     public Task<IChatClient> CreateChatClientAsync(CancellationToken cancellationToken)
     {
-        string? endpoint = _environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
-        string? deploymentName = _environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME");
-        string? apiKey = _environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+        string? endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+        string? deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME");
+        string? apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
 
         if (RoslynString.IsNullOrEmpty(endpoint))
         {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/TestApplicationBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/TestApplicationBuilderExtensions.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.Testing.Platform.AI;
 using Microsoft.Testing.Platform.Builder;
-using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.AzureFoundry;
 
@@ -19,5 +17,5 @@ public static class TestApplicationBuilderExtensions
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
     public static void AddAzureOpenAIChatClientProvider(this ITestApplicationBuilder testApplicationBuilder)
-        => testApplicationBuilder.AddChatClientProvider(sp => new AzureOpenAIChatClientProvider(sp.GetRequiredService<IEnvironment>()));
+        => testApplicationBuilder.AddChatClientProvider(_ => new AzureOpenAIChatClientProvider());
 }

--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -41,7 +41,6 @@ This package provides the core platform and the .NET implementation of the proto
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.OpenTelemetry" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Key="$(VsPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.AzureFoundry" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.CrashDump" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.HangDump" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.HotReload" Key="$(VsPublicKey)" />


### PR DESCRIPTION
`AzureFoundry` only used the internal `IEnvironment` helper from `Microsoft.Testing.Platform` to read three Azure OpenAI environment variables (`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_KEY`).

This PR:

- Switches `AzureOpenAIChatClientProvider` to use `System.Environment.GetEnvironmentVariable` directly.
- Drops the `IEnvironment` constructor dependency (no unit tests rely on it).
- Removes the `Microsoft.Testing.Extensions.AzureFoundry` `InternalsVisibleTo` entry from `Microsoft.Testing.Platform.csproj`.

Continues the IVT-reduction series started in #7443, #7813, #7842 and #8180.
