### PR TITLE
Replace internal GetServiceInternal with public IServiceProvider.GetService in Platform.AI

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.AI/ChatClientProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform.AI/ChatClientProviderExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Testing.Platform.AI.Resources;
 using Microsoft.Testing.Platform.Builder;
-using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Platform.AI;
 
@@ -37,7 +36,7 @@ public static class ChatClientProviderExtensions
     /// <returns>A task representing the asynchronous operation that returns an instance of <see cref="IChatClient"/>.</returns>
     public static async Task<IChatClient?> GetChatClientAsync(this IServiceProvider serviceProvider, CancellationToken cancellationToken)
     {
-        IChatClientProvider? provider = serviceProvider.GetServiceInternal<IChatClientProvider>();
+        var provider = (IChatClientProvider?)serviceProvider.GetService(typeof(IChatClientProvider));
         return provider is null
             ? null
             : await provider.CreateChatClientAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Preparatory step toward dropping the IVT from `Microsoft.Testing.Platform` to `Microsoft.Testing.Platform.AI`.

`IChatClientProvider` is a public TPEXP interface and is not in `ServiceProvider.InternalOnlyExtensions`, so the public `IServiceProvider.GetService(typeof(IChatClientProvider))` returns the same instance as the internal `GetServiceInternal<IChatClientProvider>()` extension method did.

Note: the IVT is **not** removed in this PR because `ChatClientProviderExtensions.AddChatClientProvider` still casts `ITestApplicationBuilder` to the internal `TestApplicationBuilder` to reach `ChatClientManager`. That will be addressed in a follow-up PR exposing a TPEXP hook for the chat client manager, after which the IVT line can be dropped.

Continues the IVT-reduction series started in #7443, #7813, #7842 and #8180.
