### PR TITLE
Flow TestContext.Properties through Assembly/Class lifecycle

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
@@ -57,7 +57,13 @@ internal sealed class ClassCleanupManager
         IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;
         foreach (TestClassInfo classInfo in classInfoCache)
         {
-            TestContext testContext = new TestContextImplementation(null, classInfo.ClassType.FullName, sourceLevelParameters, logger, testRunCancellationToken: null);
+            var testContext = new TestContextImplementation(null, classInfo.ClassType.FullName, sourceLevelParameters, logger, testRunCancellationToken: null);
+
+            // Flow properties set during AssemblyInitialize and ClassInitialize so the
+            // ClassCleanup method observes them when invoked via the fallback path.
+            testContext.MergeProperties(classInfo.Parent.PostAssemblyInitProperties);
+            testContext.MergeProperties(classInfo.PostClassInitProperties);
+
             TestFailedException? ex = classInfo.ExecuteClassCleanupAsync(testContext).GetAwaiter().GetResult();
             if (ex is not null)
             {
@@ -68,7 +74,12 @@ internal sealed class ClassCleanupManager
         IEnumerable<TestAssemblyInfo> assemblyInfoCache = typeCache.AssemblyInfoListWithExecutableCleanupMethods;
         foreach (TestAssemblyInfo assemblyInfo in assemblyInfoCache)
         {
-            TestContext testContext = new TestContextImplementation(null, null, sourceLevelParameters, logger, testRunCancellationToken: null);
+            var testContext = new TestContextImplementation(null, null, sourceLevelParameters, logger, testRunCancellationToken: null);
+
+            // Flow properties set during AssemblyInitialize so the AssemblyCleanup method observes
+            // them when invoked via the fallback path.
+            testContext.MergeProperties(assemblyInfo.PostAssemblyInitProperties);
+
             TestFailedException? ex = assemblyInfo.ExecuteAssemblyCleanupAsync(testContext).GetAwaiter().GetResult();
             if (ex is not null)
             {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestAssemblyInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestAssemblyInfo.cs
@@ -94,6 +94,26 @@ internal sealed class TestAssemblyInfo
     public TestFailedException? AssemblyInitializationException { get; internal set; }
 
     /// <summary>
+    /// Gets a snapshot of <see cref="TestContext.Properties"/> captured after the
+    /// <c>AssemblyInitialize</c> method completes. Used to flow properties set during
+    /// <c>AssemblyInitialize</c> into subsequent contexts (class init, test execution,
+    /// class cleanup, assembly cleanup). <see langword="null"/> if no
+    /// <c>AssemblyInitialize</c> method was registered or it has not yet executed
+    /// successfully.
+    /// <para>
+    /// The snapshot is shallow: reference-type values stored in the bag are shared (aliased)
+    /// across every context the snapshot is merged into. Mutations of those reference-type
+    /// instances are visible everywhere.
+    /// </para>
+    /// <para>
+    /// Class-init properties are intentionally NOT included by callers when seeding the
+    /// assembly-cleanup context, because <c>AssemblyCleanup</c> is assembly-scoped and runs
+    /// once across many classes; including a single class's snapshot would be arbitrary.
+    /// </para>
+    /// </summary>
+    internal IReadOnlyDictionary<string, object?>? PostAssemblyInitProperties { get; private set; }
+
+    /// <summary>
     /// Gets the assembly cleanup exception.
     /// </summary>
     internal Exception? AssemblyCleanupException { get; private set; }
@@ -160,6 +180,25 @@ internal sealed class TestAssemblyInfo
                                 // **After** we have executed the assembly initialize, we save the current context.
                                 // This context will contain async locals set by the assembly initialize method.
                                 ExecutionContext = ExecutionContext.Capture();
+
+                                // The `is` check is defensive: this method is part of an internal
+                                // but mockable surface, so unit tests can legitimately pass a
+                                // mocked TestContext. Production callers always pass a
+                                // TestContextImplementation.
+                                if (testContext is TestContextImplementation testContextImpl)
+                                {
+                                    // Capture a snapshot of TestContext.Properties so that values
+                                    // set during AssemblyInitialize flow to subsequent contexts
+                                    // (class init, test execution, class cleanup, assembly cleanup).
+                                    // TODO: PostAssemblyInitProperties is published outside the
+                                    // _assemblyInfoExecuteSyncSemaphore via the
+                                    // IsAssemblyInitializeExecuted fast path in this method. This
+                                    // is consistent with the existing pattern used by
+                                    // AssemblyInitializationException and ExecutionContext;
+                                    // revisit memory-barrier semantics for all three together
+                                    // if it becomes a problem.
+                                    PostAssemblyInitProperties = testContextImpl.CaptureLifecycleProperties();
+                                }
                             },
                             testContext.CancellationTokenSource,
                             AssemblyInitializeMethodTimeoutMilliseconds,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
@@ -144,6 +144,25 @@ internal sealed class TestClassInfo
     public Exception? ClassCleanupException { get; internal set; }
 
     /// <summary>
+    /// Gets a snapshot of <see cref="TestContext.Properties"/> captured after the
+    /// <c>ClassInitialize</c> method completes. Used to flow properties set during
+    /// <c>ClassInitialize</c> into subsequent contexts (test execution, class cleanup).
+    /// <see langword="null"/> if no <c>ClassInitialize</c> method was registered or it has
+    /// not yet executed successfully.
+    /// <para>
+    /// When the test class inherits from a base class that has a <c>ClassInitialize</c>
+    /// method declared with <see cref="InheritanceBehavior.BeforeEachDerivedClass"/>, all
+    /// class-init bodies in the chain run against the same context, so the captured snapshot
+    /// includes properties set by both base and derived class-init methods.
+    /// </para>
+    /// <para>
+    /// The snapshot is shallow: reference-type values stored in the bag are shared (aliased)
+    /// across every context the snapshot is merged into.
+    /// </para>
+    /// </summary>
+    internal IReadOnlyDictionary<string, object?>? PostClassInitProperties { get; private set; }
+
+    /// <summary>
     /// Gets or sets the class cleanup method.
     /// </summary>
     public MethodInfo? ClassCleanupMethod
@@ -441,6 +460,18 @@ internal sealed class TestClassInfo
             {
                 // This runs the ClassInitialize methods only once but saves the
                 await RunClassInitializeAsync(testContext.Context).ConfigureAwait(false);
+
+                // Capture a snapshot of TestContext.Properties so that values set during
+                // ClassInitialize (and any base-class ClassInitialize methods that ran in the
+                // same RunClassInitializeAsync call) flow to subsequent contexts
+                // (test execution, class cleanup).
+                // The `is` check is defensive: this method is part of an internal but mockable
+                // surface, so unit tests can legitimately pass an ITestContext wrapping a mock.
+                // Production callers always wrap a TestContextImplementation.
+                if (testContext.Context is TestContextImplementation classInitContextImpl)
+                {
+                    PostClassInitProperties = classInitContextImpl.CaptureLifecycleProperties();
+                }
             }
             catch (TestFailedException ex)
             {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -157,6 +157,10 @@ internal sealed class UnitTestRunner
 
                     testContextForClassInit = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, testMethod.FullClassName, testContextProperties, messageLogger, testContextForAssemblyInit.Context.CurrentTestOutcome);
 
+                    // Flow properties set during AssemblyInitialize into the class-init context so the
+                    // ClassInitialize method observes them.
+                    ((TestContextImplementation)testContextForClassInit.Context).MergeProperties(testMethodInfo.Parent.Parent.PostAssemblyInitProperties);
+
                     TestResult classInitializeResult = await testMethodInfo.Parent.GetResultOrRunClassInitializeAsync(testContextForClassInit, assemblyInitializeResult.LogOutput, assemblyInitializeResult.LogError, assemblyInitializeResult.DebugTrace, assemblyInitializeResult.TestContextMessages).ConfigureAwait(false);
                     DebugEx.Assert(testMethodInfo.Parent.IsClassInitializeExecuted, "IsClassInitializeExecuted should be true after attempting to run it.");
                     if (classInitializeResult.Outcome != UnitTestOutcome.Passed)
@@ -167,6 +171,16 @@ internal sealed class UnitTestRunner
                     {
                         // Run the test method
                         testContextForTestExecution.SetOutcome(testContextForClassInit.Context.CurrentTestOutcome);
+
+                        // Flow properties set during AssemblyInitialize and ClassInitialize into the
+                        // per-test execution context so the test class constructor, [TestInitialize],
+                        // the test method itself and [TestCleanup] observe them.
+                        // Note: when a test method has multiple data rows, the merge is applied once
+                        // before all rows; data rows share the same execution context (and bag).
+                        var testExecImpl = (TestContextImplementation)testContextForTestExecution.Context;
+                        testExecImpl.MergeProperties(testMethodInfo.Parent.Parent.PostAssemblyInitProperties);
+                        testExecImpl.MergeProperties(testMethodInfo.Parent.PostClassInitProperties);
+
                         RetryBaseAttribute? retryAttribute = testMethodInfo.RetryAttribute;
                         var testMethodRunner = new TestMethodRunner(testMethodInfo, testMethod, testContextForTestExecution);
                         result = await testMethodRunner.ExecuteAsync(classInitializeResult.LogOutput, classInitializeResult.LogError, classInitializeResult.DebugTrace, classInitializeResult.TestContextMessages).ConfigureAwait(false);
@@ -190,6 +204,13 @@ internal sealed class UnitTestRunner
             {
                 if (testMethodInfo is not null)
                 {
+                    // Flow properties set during AssemblyInitialize and ClassInitialize so the
+                    // ClassCleanup method observes them. Done here rather than on every test to
+                    // avoid wasted dictionary copies for non-last tests.
+                    var classCleanupImpl = (TestContextImplementation)testContextForClassCleanup.Context;
+                    classCleanupImpl.MergeProperties(testMethodInfo.Parent.Parent.PostAssemblyInitProperties);
+                    classCleanupImpl.MergeProperties(testMethodInfo.Parent.PostClassInitProperties);
+
                     TestResult? cleanupResult = await testMethodInfo.Parent.RunClassCleanupAsync(testContextForClassCleanup, result).ConfigureAwait(false);
                     if (cleanupResult is not null)
                     {
@@ -216,6 +237,14 @@ internal sealed class UnitTestRunner
                 _classCleanupManager.ShouldRunEndOfAssemblyCleanup)
             {
                 testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, testContextProperties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
+
+                // Flow properties set during AssemblyInitialize so the AssemblyCleanup method
+                // observes them. Class-init properties are intentionally NOT flowed here because
+                // AssemblyCleanup is assembly-scoped and runs once across many classes; picking
+                // a single class's snapshot would be arbitrary.
+                // testMethodInfo is non-null inside this block thanks to the guard above.
+                ((TestContextImplementation)testContextForAssemblyCleanup.Context).MergeProperties(testMethodInfo.Parent.Parent.PostAssemblyInitProperties);
+
                 TestResult? assemblyCleanupResult = await RunAssemblyCleanupAsync(testContextForAssemblyCleanup, _typeCache, result).ConfigureAwait(false);
                 if (assemblyCleanupResult is not null)
                 {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -6,6 +6,8 @@ using System.Data;
 using System.Data.Common;
 #endif
 
+using System.Collections.ObjectModel;
+
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -125,12 +127,15 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
 
             if (testClassFullName is not null)
             {
-                _properties.Add(FullyQualifiedTestClassNameLabel, testClassFullName);
+                // Use indexer assignment instead of Add so that re-seeding from a parent property
+                // snapshot that may already contain this key does not throw.
+                _properties[FullyQualifiedTestClassNameLabel] = testClassFullName;
             }
 
             if (testMethod is not null)
             {
-                _properties.Add(TestNameLabel, testMethod.Name);
+                // Use indexer assignment instead of Add for the same reason.
+                _properties[TestNameLabel] = testMethod.Name;
             }
         }
 
@@ -280,6 +285,64 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// <param name="propertyValue">The property value.</param>
     public void AddProperty(string propertyName, string propertyValue)
         => _properties.Add(propertyName, propertyValue);
+
+    /// <summary>
+    /// Merges the given properties into this context's property bag using indexer semantics
+    /// (existing keys are overwritten, except the per-context labels
+    /// <see cref="TestContext.FullyQualifiedTestClassNameLabel"/> and
+    /// <see cref="TestContext.TestNameLabel"/>, which are preserved).
+    /// Used to flow properties set during <c>AssemblyInitialize</c> / <c>ClassInitialize</c>
+    /// into subsequent contexts.
+    /// </summary>
+    /// <param name="propertiesToMerge">The properties to merge in. May be <see langword="null"/>.</param>
+    internal void MergeProperties(IReadOnlyDictionary<string, object?>? propertiesToMerge)
+    {
+        if (propertiesToMerge is null)
+        {
+            return;
+        }
+
+        foreach (KeyValuePair<string, object?> kvp in propertiesToMerge)
+        {
+            // Never overwrite the per-context labels.
+            if (kvp.Key == FullyQualifiedTestClassNameLabel || kvp.Key == TestNameLabel)
+            {
+                continue;
+            }
+
+            _properties[kvp.Key] = kvp.Value;
+        }
+    }
+
+    /// <summary>
+    /// Captures a snapshot of the current property bag, excluding the per-context labels
+    /// (<see cref="TestContext.FullyQualifiedTestClassNameLabel"/> and
+    /// <see cref="TestContext.TestNameLabel"/>). The returned dictionary is intended to be
+    /// stored on a <c>TestAssemblyInfo</c> / <c>TestClassInfo</c> and later merged into other
+    /// contexts via <see cref="MergeProperties(IReadOnlyDictionary{string, object?}?)"/>.
+    /// <para>
+    /// The snapshot is shallow: keys and value references are copied as-is. Reference-type
+    /// values stored in the bag (e.g. a mocked file system, a connection pool, a list) are
+    /// shared across every context the snapshot is later merged into. Mutations of those
+    /// reference-type instances are visible everywhere.
+    /// </para>
+    /// </summary>
+    /// <returns>A read-only snapshot of the current properties.</returns>
+    internal IReadOnlyDictionary<string, object?> CaptureLifecycleProperties()
+    {
+        var snapshot = new Dictionary<string, object?>(_properties.Count);
+        foreach (KeyValuePair<string, object?> kvp in _properties)
+        {
+            if (kvp.Key == FullyQualifiedTestClassNameLabel || kvp.Key == TestNameLabel)
+            {
+                continue;
+            }
+
+            snapshot[kvp.Key] = kvp.Value;
+        }
+
+        return new ReadOnlyDictionary<string, object?>(snapshot);
+    }
 
     /// <summary>
     /// Result files attached.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestContextPropertyFlowTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestContextPropertyFlowTests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Acceptance tests for the flow of <see cref="TestContext.Properties"/> values across the
+/// AssemblyInitialize / ClassInitialize / TestMethod / ClassCleanup / AssemblyCleanup lifecycle.
+/// See https://github.com/microsoft/testfx/issues/5986.
+/// </summary>
+[TestClass]
+public sealed class TestContextPropertyFlowTests : AcceptanceTestBase<TestContextPropertyFlowTests.TestAssetFixture>
+{
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task PropertiesSetInAssemblyInitAndClassInitAreVisibleEverywhere(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(0);
+        // PropertyFlowTests: TestMethodOne + TestMethodTwo = 2
+        // SecondClassTests: TestMethod = 1
+        // DataRowFlowTests: two data rows = 2
+        // Total = 5
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 5, skipped: 0);
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        public const string ProjectName = "TestContextPropertyFlow";
+
+        public string ProjectPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file TestContextPropertyFlow.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+    <EnableMicrosoftTestingPlatform>true</EnableMicrosoftTestingPlatform>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+</Project>
+
+#file UnitTest1.cs
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class PropertyFlowTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [AssemblyInitialize]
+    public static void AssemblyInit(TestContext context)
+    {
+        context.Properties["AssemblyInitKey"] = "AssemblyInitValue";
+        context.Properties["SharedKey"] = "FromAssemblyInit";
+    }
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext context)
+    {
+        // AssemblyInit-set properties must be visible inside ClassInitialize.
+        Assert.AreEqual("AssemblyInitValue", context.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("FromAssemblyInit", context.Properties["SharedKey"]);
+
+        context.Properties["ClassInitKey"] = "ClassInitValue";
+        // ClassInit overrides a value previously set by AssemblyInit; the override should win
+        // in subsequent contexts (tests, cleanups) of this class.
+        context.Properties["SharedKey"] = "FromClassInit";
+    }
+
+    [TestMethod]
+    public void TestMethodOne()
+    {
+        Assert.AreEqual("AssemblyInitValue", TestContext.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("ClassInitValue", TestContext.Properties["ClassInitKey"]);
+        // ClassInit's override of SharedKey must win.
+        Assert.AreEqual("FromClassInit", TestContext.Properties["SharedKey"]);
+
+        // Properties added by a sibling test method must NOT leak across tests.
+        Assert.IsFalse(
+            TestContext.Properties.ContainsKey("FromTestTwo"),
+            "Properties set by TestMethodTwo should not leak into TestMethodOne.");
+
+        TestContext.Properties["FromTestOne"] = "ShouldNotLeak";
+    }
+
+    [TestMethod]
+    public void TestMethodTwo()
+    {
+        Assert.AreEqual("AssemblyInitValue", TestContext.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("ClassInitValue", TestContext.Properties["ClassInitKey"]);
+        Assert.AreEqual("FromClassInit", TestContext.Properties["SharedKey"]);
+
+        // Properties added by a sibling test method must NOT leak across tests.
+        Assert.IsFalse(
+            TestContext.Properties.ContainsKey("FromTestOne"),
+            "Properties set by TestMethodOne should not leak into TestMethodTwo.");
+
+        TestContext.Properties["FromTestTwo"] = "ShouldNotLeak";
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup(TestContext context)
+    {
+        Assert.AreEqual("AssemblyInitValue", context.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("ClassInitValue", context.Properties["ClassInitKey"]);
+        Assert.AreEqual("FromClassInit", context.Properties["SharedKey"]);
+    }
+
+    [AssemblyCleanup]
+    public static void AssemblyCleanup(TestContext context)
+    {
+        // AssemblyCleanup must see AssemblyInit-set properties, including any override the
+        // AssemblyInit itself made. It must NOT see ClassInit-set properties (those are class-scoped).
+        Assert.AreEqual("AssemblyInitValue", context.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("FromAssemblyInit", context.Properties["SharedKey"]);
+        Assert.IsFalse(
+            context.Properties.ContainsKey("ClassInitKey"),
+            "Properties set by ClassInitialize should not flow to AssemblyCleanup.");
+        // SecondClassTests.ClassInit must not leak into the AssemblyCleanup either.
+        Assert.IsFalse(
+            context.Properties.ContainsKey("SecondClassKey"),
+            "Properties set by SecondClassTests.ClassInitialize should not flow to AssemblyCleanup.");
+    }
+}
+
+// Second class to verify that the assembly-init snapshot flows here too, AND that the
+// FIRST class's class-init snapshot does NOT leak into THIS class's contexts.
+[TestClass]
+public sealed class SecondClassTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext context)
+    {
+        // AssemblyInit-set properties must be visible here too.
+        Assert.AreEqual("AssemblyInitValue", context.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("FromAssemblyInit", context.Properties["SharedKey"]);
+        // PropertyFlowTests's class-init properties must NOT leak across classes.
+        Assert.IsFalse(
+            context.Properties.ContainsKey("ClassInitKey"),
+            "Properties set by another class's ClassInitialize should not flow to this class's ClassInitialize.");
+
+        context.Properties["SecondClassKey"] = "SecondClassValue";
+    }
+
+    [TestMethod]
+    public void TestMethod()
+    {
+        Assert.AreEqual("AssemblyInitValue", TestContext.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("SecondClassValue", TestContext.Properties["SecondClassKey"]);
+        // First class's class-init properties must not leak.
+        Assert.IsFalse(
+            TestContext.Properties.ContainsKey("ClassInitKey"),
+            "Properties set by another class's ClassInitialize should not flow to this class's tests.");
+    }
+}
+
+// Data-driven flow: a single TestContext is used for all data rows so the merged properties
+// from AssemblyInit/ClassInit are visible to every row.
+[TestClass]
+public sealed class DataRowFlowTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext context)
+        => context.Properties["DataRowClassInitKey"] = "DataRowClassInitValue";
+
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    public void DataRowSeesFlowedProperties(int rowNumber)
+    {
+        Assert.AreEqual("AssemblyInitValue", TestContext.Properties["AssemblyInitKey"]);
+        Assert.AreEqual("DataRowClassInitValue", TestContext.Properties["DataRowClassInitKey"]);
+        Assert.IsTrue(rowNumber > 0);
+    }
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+}

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
@@ -229,6 +229,68 @@ public class TestAssemblyInfoTests : TestContainer
         result.Outcome.Should().Be(UnitTestOutcome.Passed);
     }
 
+    public async Task RunAssemblyInitializeShouldCapturePostAssemblyInitPropertiesOnSuccess()
+    {
+        DummyTestClass.AssemblyInitializeMethodBody = tc =>
+        {
+            var context = (TestContext)tc;
+            context.Properties["AssemblyInitKey"] = "AssemblyInitValue";
+            context.Properties["AnotherKey"] = 42;
+        };
+        _testAssemblyInfo.AssemblyInitializeMethod = typeof(DummyTestClass).GetMethod("AssemblyInitializeMethod")!;
+
+        TestContextImplementation testContext = GetTestContext();
+        TestResult result = await _testAssemblyInfo.RunAssemblyInitializeAsync(testContext);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().NotBeNull();
+        _testAssemblyInfo.PostAssemblyInitProperties!.Should().ContainKey("AssemblyInitKey");
+        _testAssemblyInfo.PostAssemblyInitProperties["AssemblyInitKey"].Should().Be("AssemblyInitValue");
+        _testAssemblyInfo.PostAssemblyInitProperties["AnotherKey"].Should().Be(42);
+    }
+
+    public async Task RunAssemblyInitializeShouldExcludePerContextLabelsFromPostAssemblyInitProperties()
+    {
+        DummyTestClass.AssemblyInitializeMethodBody = tc => ((TestContext)tc).Properties["UserKey"] = "UserValue";
+        _testAssemblyInfo.AssemblyInitializeMethod = typeof(DummyTestClass).GetMethod("AssemblyInitializeMethod")!;
+
+        // Use a context with a class name so the FullyQualifiedTestClassName label is present.
+        TestContextImplementation testContext = new(null, "Dummy.ClassName", new Dictionary<string, object?>(), null, null);
+        TestResult result = await _testAssemblyInfo.RunAssemblyInitializeAsync(testContext);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().NotBeNull();
+        _testAssemblyInfo.PostAssemblyInitProperties!.Should().NotContainKey(TestContext.FullyQualifiedTestClassNameLabel);
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().NotContainKey(TestContext.TestNameLabel);
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().ContainKey("UserKey");
+    }
+
+    public async Task RunAssemblyInitializeShouldLeavePostAssemblyInitPropertiesNullWhenAssemblyInitMethodIsNull()
+    {
+        _testAssemblyInfo.AssemblyInitializeMethod = null;
+
+        TestResult result = await _testAssemblyInfo.RunAssemblyInitializeAsync(null!);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().BeNull();
+    }
+
+    public async Task RunAssemblyInitializeShouldLeavePostAssemblyInitPropertiesNullOnFailure()
+    {
+        DummyTestClass.AssemblyInitializeMethodBody = tc =>
+        {
+            ((TestContext)tc).Properties["AssemblyInitKey"] = "AssemblyInitValue";
+            throw new InvalidOperationException("boom");
+        };
+        _testAssemblyInfo.AssemblyInitializeMethod = typeof(DummyTestClass).GetMethod("AssemblyInitializeMethod")!;
+
+        TestContextImplementation testContext = GetTestContext();
+        TestResult result = await _testAssemblyInfo.RunAssemblyInitializeAsync(testContext);
+
+        result.Outcome.Should().NotBe(UnitTestOutcome.Passed);
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().BeNull();
+    }
+
     #endregion
 
     #region Run Assembly Cleanup tests

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
@@ -426,6 +426,79 @@ public class TestClassInfoTests : TestContainer
         exception.InnerException.Should().BeOfType<InvalidOperationException>();
     }
 
+    public async Task GetResultOrRunClassInitializeAsyncShouldCapturePostClassInitPropertiesOnSuccess()
+    {
+        DummyTestClass.ClassInitializeMethodBody = tc =>
+        {
+            var context = (TestContext)tc;
+            context.Properties["ClassInitKey"] = "ClassInitValue";
+            context.Properties["AnotherKey"] = 123;
+        };
+        _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.ClassInitializeMethod));
+
+        TestContextImplementation realTestContext = new(null, _testClassType.FullName, new Dictionary<string, object?>(), null, null);
+        TestResult result = await _testClassInfo.GetResultOrRunClassInitializeAsync(realTestContext, string.Empty, string.Empty, string.Empty, string.Empty);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+        _testClassInfo.PostClassInitProperties.Should().NotBeNull();
+        _testClassInfo.PostClassInitProperties!.Should().ContainKey("ClassInitKey");
+        _testClassInfo.PostClassInitProperties["ClassInitKey"].Should().Be("ClassInitValue");
+        _testClassInfo.PostClassInitProperties["AnotherKey"].Should().Be(123);
+        // The per-context label must never leak into the snapshot.
+        _testClassInfo.PostClassInitProperties.Should().NotContainKey(TestContext.FullyQualifiedTestClassNameLabel);
+    }
+
+    public async Task GetResultOrRunClassInitializeAsyncShouldLeavePostClassInitPropertiesNullWhenClassInitMethodIsNull()
+    {
+        _testClassInfo.ClassInitializeMethod = null;
+
+        TestContextImplementation realTestContext = new(null, _testClassType.FullName, new Dictionary<string, object?>(), null, null);
+        TestResult result = await _testClassInfo.GetResultOrRunClassInitializeAsync(realTestContext, string.Empty, string.Empty, string.Empty, string.Empty);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+        _testClassInfo.PostClassInitProperties.Should().BeNull();
+    }
+
+    public async Task GetResultOrRunClassInitializeAsyncShouldLeavePostClassInitPropertiesNullOnFailure()
+    {
+        DummyTestClass.ClassInitializeMethodBody = tc =>
+        {
+            ((TestContext)tc).Properties["ClassInitKey"] = "ClassInitValue";
+            throw new InvalidOperationException("boom");
+        };
+        _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.ClassInitializeMethod));
+
+        TestContextImplementation realTestContext = new(null, _testClassType.FullName, new Dictionary<string, object?>(), null, null);
+        TestResult result = await _testClassInfo.GetResultOrRunClassInitializeAsync(realTestContext, string.Empty, string.Empty, string.Empty, string.Empty);
+
+        result.Outcome.Should().NotBe(UnitTestOutcome.Passed);
+        _testClassInfo.PostClassInitProperties.Should().BeNull();
+    }
+
+    public async Task GetResultOrRunClassInitializeAsyncShouldCapturePropertiesFromBaseAndDerivedClassInitMethods()
+    {
+        // Base class init runs first (added via BaseClassInitMethods), then derived class init.
+        DummyBaseTestClass.ClassInitializeMethodBody = tc => ((TestContext)tc).Properties["BaseKey"] = "BaseValue";
+        DummyTestClass.ClassInitializeMethodBody = tc =>
+        {
+            var context = (TestContext)tc;
+            // Derived class init can see what base set.
+            context.Properties["BaseKey"].Should().Be("BaseValue");
+            context.Properties["DerivedKey"] = "DerivedValue";
+        };
+
+        _testClassInfo.BaseClassInitMethods.Add(typeof(DummyBaseTestClass).GetMethod(nameof(DummyBaseTestClass.InitBaseClassMethod))!);
+        _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.ClassInitializeMethod));
+
+        TestContextImplementation realTestContext = new(null, _testClassType.FullName, new Dictionary<string, object?>(), null, null);
+        TestResult result = await _testClassInfo.GetResultOrRunClassInitializeAsync(realTestContext, string.Empty, string.Empty, string.Empty, string.Empty);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+        _testClassInfo.PostClassInitProperties.Should().NotBeNull();
+        _testClassInfo.PostClassInitProperties!["BaseKey"].Should().Be("BaseValue");
+        _testClassInfo.PostClassInitProperties["DerivedKey"].Should().Be("DerivedValue");
+    }
+
     private TestResult GetResultOrRunClassInitialize()
         => GetResultOrRunClassInitialize(_testContext);
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -401,4 +401,120 @@ public class TestContextImplementationTests : TestContainer
         _ = testContextImplementation.GetAndClearTrace();
         t.Join();
     }
+
+    public void MergePropertiesShouldAddNewKeysIntoThePropertyBag()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        IReadOnlyDictionary<string, object?> snapshot = new Dictionary<string, object?>
+        {
+            ["NewKey"] = "NewValue",
+            ["AnotherKey"] = 42,
+        };
+
+        _testContextImplementation.MergeProperties(snapshot);
+
+        _testContextImplementation.Properties["NewKey"].Should().Be("NewValue");
+        _testContextImplementation.Properties["AnotherKey"].Should().Be(42);
+    }
+
+    public void MergePropertiesShouldOverwriteExistingKeys()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["Key"] = "Original";
+
+        _testContextImplementation.MergeProperties(new Dictionary<string, object?> { ["Key"] = "Overwritten" });
+
+        _testContextImplementation.Properties["Key"].Should().Be("Overwritten");
+    }
+
+    public void MergePropertiesShouldIgnoreNull()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["Key"] = "Original";
+
+        _testContextImplementation.MergeProperties(null);
+
+        _testContextImplementation.Properties["Key"].Should().Be("Original");
+    }
+
+    public void MergePropertiesShouldNotOverwritePerContextLabels()
+    {
+        _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
+        _testMethod.Setup(tm => tm.Name).Returns("M");
+        _testContextImplementation = CreateTestContextImplementation();
+
+        _testContextImplementation.MergeProperties(new Dictionary<string, object?>
+        {
+            ["FullyQualifiedTestClassName"] = "Hacked.Class",
+            ["TestName"] = "HackedTestName",
+            ["LegitKey"] = "LegitValue",
+        });
+
+        _testContextImplementation.Properties["FullyQualifiedTestClassName"].Should().Be("A.C.M");
+        _testContextImplementation.Properties["TestName"].Should().Be("M");
+        _testContextImplementation.Properties["LegitKey"].Should().Be("LegitValue");
+    }
+
+    public void CaptureLifecyclePropertiesShouldReturnAllPropertiesExceptPerContextLabels()
+    {
+        _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
+        _testMethod.Setup(tm => tm.Name).Returns("M");
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["UserKey"] = "UserValue";
+        _testContextImplementation.Properties["AnotherKey"] = 7;
+
+        IReadOnlyDictionary<string, object?> snapshot = _testContextImplementation.CaptureLifecycleProperties();
+
+        snapshot.Should().ContainKey("UserKey");
+        snapshot["UserKey"].Should().Be("UserValue");
+        snapshot.Should().ContainKey("AnotherKey");
+        snapshot["AnotherKey"].Should().Be(7);
+        snapshot.Should().NotContainKey("FullyQualifiedTestClassName");
+        snapshot.Should().NotContainKey("TestName");
+    }
+
+    public void CaptureLifecyclePropertiesShouldReturnSnapshotIndependentOfTheLiveBag()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["Key"] = "OriginalValue";
+
+        IReadOnlyDictionary<string, object?> snapshot = _testContextImplementation.CaptureLifecycleProperties();
+
+        // Mutating the live bag must not affect the snapshot.
+        _testContextImplementation.Properties["Key"] = "ChangedValue";
+        _testContextImplementation.Properties["NewKey"] = "NewValue";
+
+        snapshot["Key"].Should().Be("OriginalValue");
+        snapshot.Should().NotContainKey("NewKey");
+    }
+
+    public void CaptureLifecyclePropertiesShouldAliasReferenceTypeValues()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        var bag = new List<int> { 1 };
+        _testContextImplementation.Properties["RefKey"] = bag;
+
+        IReadOnlyDictionary<string, object?> snapshot = _testContextImplementation.CaptureLifecycleProperties();
+
+        // The snapshot is shallow: the snapshot's value and the live bag share the same instance.
+        // Mutating the instance must therefore be visible through both. This guards the documented
+        // contract on CaptureLifecycleProperties from accidentally regressing to a deep copy.
+        bag.Add(2);
+        ((List<int>)snapshot["RefKey"]!).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    public void ConstructorShouldNotThrowWhenSeededPropertiesAlreadyContainFullyQualifiedTestClassName()
+    {
+        _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
+        var seeded = new Dictionary<string, object?>
+        {
+            ["FullyQualifiedTestClassName"] = "Old.Class.Name",
+        };
+
+        // Should not throw — the ctor now uses indexer assignment for labels.
+        var ctx = new TestContextImplementation(_testMethod.Object, null, seeded, null, null);
+
+        // The per-context value wins.
+        ctx.Properties["FullyQualifiedTestClassName"].Should().Be("A.C.M");
+    }
 }


### PR DESCRIPTION
## Summary

Flows `TestContext.Properties` written during `[AssemblyInitialize]` and `[ClassInitialize]` down through the rest of the test lifecycle. Fixes #5986.

Today, every call to `PlatformServiceProvider.GetTestContext` builds a brand-new `TestContextImplementation` with its own private dictionary copied from the per-test seed. So a `context.Properties[`X`] = ...` written inside `AssemblyInitialize` is stored in a context that's thrown away when the method returns - subsequent tests, class-init, and cleanups never see it. (And on tests #2+ the assembly-init context is never even passed in because of the cached-result short-circuit.) The MSTest [docs](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-writing-tests-testcontext#store-and-retrieve-runtime-data) say this scenario should work; this PR makes it work.

## Behavior after this change

- Properties set in `[AssemblyInitialize]` are visible in `[ClassInitialize]`, the test class ctor, `[TestInitialize]`, the test method, `[TestCleanup]`, `[ClassCleanup]` and `[AssemblyCleanup]` of every test in the assembly.
- Properties set in `[ClassInitialize]` are visible in tests, `[TestInitialize]`, `[TestCleanup]` and `[ClassCleanup]` of that class. They override any conflicting assembly-init value within that class's scope.
- `[AssemblyCleanup]` deliberately does **not** see `[ClassInitialize]` properties (assembly-scoped, picking any one class would be arbitrary).
- Per-test writes to `Properties` still don't propagate to sibling tests (no behavioral regression).

## Design

After each init body completes successfully, capture a shallow snapshot of the live property bag onto the corresponding `TestAssemblyInfo` / `TestClassInfo`, then merge those snapshots into all subsequent contexts:

| Capture | Where | When |
|---|---|---|
| `TestAssemblyInfo.PostAssemblyInitProperties` | inside `_assemblyInfoExecuteSyncSemaphore` | after `AssemblyInitialize` body returns |
| `TestClassInfo.PostClassInitProperties` | inside `_testClassExecuteSyncSemaphore` | after `RunClassInitializeAsync` returns (includes base-chain writes) |

| Merge | Snapshot used |
|---|---|
| class-init context | `PostAssemblyInitProperties` |
| test-execution context | `PostAssemblyInitProperties` + `PostClassInitProperties` (merged in place before `TestMethodRunner.ExecuteAsync`) |
| class-cleanup context (gated on `isLastTestInClass`) | `PostAssemblyInitProperties` + `PostClassInitProperties` |
| assembly-cleanup context | `PostAssemblyInitProperties` |
| `ClassCleanupManager.ForceCleanup` fallback contexts | same as above |

Snapshots exclude the per-context labels (`FullyQualifiedTestClassName`, `TestName`) and `MergeProperties` refuses to overwrite them, so per-test identity stays intact. Snapshots are shallow (reference-type values are aliased across all flowed contexts) - documented on the new XML doc-comments.

## Files

**Source (5)**
- `TestContextImplementation.cs` - new internal `CaptureLifecycleProperties()` + `MergeProperties()`; defensive switch from `_properties.Add` to indexer assignment for the label keys so a seeded bag never throws.
- `TestAssemblyInfo.cs` - new `PostAssemblyInitProperties` capture point.
- `TestClassInfo.cs` - new `PostClassInitProperties` capture point.
- `UnitTestRunner.cs` - 4 merge sites + perf tweak (class-cleanup merge moved inside the `isLastTestInClass` guard).
- `ClassCleanupManager.cs` - merges in the fallback path.

**Tests (4)**
- `TestContextImplementationTests` - 7 new tests covering `MergeProperties` (skip labels, null-tolerant, overwrite semantics), `CaptureLifecycleProperties` (snapshot independence, shallow/aliasing), and the defensive ctor change.
- `TestAssemblyInfoTests` - 4 new tests (capture on success, label exclusion, null when no init method, null on failure).
- `TestClassInfoTests` - 4 new tests (capture on success, null when no init method, null on failure, base+derived chain).
- New `TestContextPropertyFlowTests` acceptance suite (its own asset, runs on net462/net8.0/net10.0) covering: AssemblyInit→tests, ClassInit→tests, ClassInit override of AssemblyInit value, ClassCleanup observes both, AssemblyCleanup observes AssemblyInit only, cross-class isolation, no per-test leakage, `[DataRow]` shared bag.

## API surface

None. Public API unchanged; all new types/properties are internal.

## Verification

- `build.cmd -pack -c Release` -> **0 warnings, 0 errors**.
- **804 / 804** `MSTestAdapter.PlatformServices.UnitTests` pass on net9.0.
- **3 / 3** new acceptance test runs pass (one per TFM).
- **10 / 10** existing `TestContextTests` acceptance tests still pass.
- Reviewed twice with the expert-reviewer agent; all actionable findings addressed.

Fixes #5986