### PR TITLE
Harden TerminalTestReporter teardown and remove dead _buildErrorsCount

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -57,12 +57,13 @@ internal sealed partial class TerminalTestReporter
         _terminalWithProgress.WriteToTerminal(_isDiscovery ? AppendTestDiscoverySummary : AppendTestRunSummary);
 
         NativeMethods.RestoreConsoleMode(_originalConsoleMode);
+        // Consume the saved console mode so a later Dispose does not try to restore again.
+        _originalConsoleMode = null;
 
         // This is relevant for HotReload scenarios. We want the next test sessions to start
         // on a new TestProgressState
         _testProgressState = null;
 
-        _buildErrorsCount = 0;
         _testExecutionStartTime = null;
         _testExecutionEndTime = null;
     }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -56,10 +56,6 @@ internal sealed partial class TerminalTestReporter
 
         _terminalWithProgress.WriteToTerminal(_isDiscovery ? AppendTestDiscoverySummary : AppendTestRunSummary);
 
-        NativeMethods.RestoreConsoleMode(_originalConsoleMode);
-        // Consume the saved console mode so a later Dispose does not try to restore again.
-        _originalConsoleMode = null;
-
         // This is relevant for HotReload scenarios. We want the next test sessions to start
         // on a new TestProgressState
         _testProgressState = null;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -89,8 +89,8 @@ internal sealed partial class TerminalTestReporter
         TimeSpan runDuration = _testExecutionStartTime != null && _testExecutionEndTime != null ? (_testExecutionEndTime - _testExecutionStartTime).Value : TimeSpan.Zero;
 
         bool colorizeFailed = failed > 0;
-        bool colorizePassed = passed > 0 && _buildErrorsCount == 0 && failed == 0;
-        bool colorizeSkipped = skipped > 0 && skipped == total && _buildErrorsCount == 0 && failed == 0;
+        bool colorizePassed = passed > 0 && failed == 0;
+        bool colorizeSkipped = skipped > 0 && skipped == total && failed == 0;
 
         string totalText = $"{SingleIndentation}{PlatformResources.TotalLowercase}: {total}";
         string failedText = $"{SingleIndentation}{PlatformResources.FailedLowercase}: {failed}";

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -53,7 +53,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private readonly object _lock = new();
 #endif
 
-    private uint? _originalConsoleMode;
+    private readonly uint? _originalConsoleMode;
 
     private TestProgressState? _testProgressState;
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -53,7 +53,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private readonly object _lock = new();
 #endif
 
-    private readonly uint? _originalConsoleMode;
+    private uint? _originalConsoleMode;
 
     private TestProgressState? _testProgressState;
 
@@ -61,8 +61,6 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private DateTimeOffset? _testExecutionStartTime;
 
     private DateTimeOffset? _testExecutionEndTime;
-
-    private int _buildErrorsCount;
 
     private bool WasCancelled
     {
@@ -145,7 +143,16 @@ internal sealed partial class TerminalTestReporter : IDisposable
         });
     }
 
-    public void Dispose() => _terminalWithProgress.Dispose();
+    public void Dispose()
+    {
+        _terminalWithProgress.Dispose();
+
+        // Restore the console mode that we may have changed when enabling ANSI output. If
+        // TestExecutionCompleted already ran, the saved mode was consumed there; if it did not
+        // (e.g. on an abnormal teardown path where Dispose is the only thing called), this is the
+        // last chance to leave the user's terminal in the state we found it in.
+        NativeMethods.RestoreConsoleMode(_originalConsoleMode);
+    }
 
     public void ArtifactAdded(bool outOfProcess, string? testName, string path)
         => _artifacts.Add(new TestRunArtifact(outOfProcess, testName, path));

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
@@ -33,6 +33,8 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
     /// </summary>
     private Thread? _refresher;
     private long _counter;
+    private bool _stopped;
+    private bool _disposed;
 
     public event EventHandler? OnProgressStartUpdate;
 
@@ -74,8 +76,22 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         {
             // When we dispose _cts too early this will throw.
         }
+        catch (Exception)
+        {
+            // Any other failure (broken pipe, IO error writing to the console, etc.) must not silently
+            // tear down the refresher without making a best-effort attempt to clean up the screen. We
+            // intentionally swallow because there is no other thread to surface this to and the test
+            // run itself should still be allowed to complete.
+        }
 
-        _terminal.EraseProgress();
+        try
+        {
+            _terminal.EraseProgress();
+        }
+        catch
+        {
+            // Best-effort cleanup; we are already in teardown.
+        }
     }
 
     public TestProgressStateAwareTerminal(ITerminal terminal, Func<bool?> showProgress)
@@ -117,18 +133,43 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 
     internal void StopShowingProgress()
     {
-        if (GetShowProgress())
+        if (_stopped || !GetShowProgress())
         {
-            _cts.Cancel();
-            _refresher?.Join();
+            return;
+        }
 
+        _stopped = true;
+        _cts.Cancel();
+        _refresher?.Join();
+
+        try
+        {
             _terminal.EraseProgress();
             _terminal.StopBusyIndicator();
         }
+        catch
+        {
+            // Best-effort cleanup; we are already in teardown.
+        }
     }
 
-    public void Dispose() =>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // Ensure that even when callers forget to call StopShowingProgress (e.g. because the process
+        // is being torn down by an unhandled exception), we still bring the refresher thread down,
+        // erase any in-flight progress, restore the busy-indicator and show the cursor again so the
+        // user's terminal is left in a sane state.
+        StopShowingProgress();
+
         ((IDisposable)_cts).Dispose();
+    }
 
     internal void WriteToTerminal(Action<ITerminal> write)
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
@@ -10,11 +10,6 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 {
     /// <summary>
-    /// A cancellation token to signal the rendering thread that it should exit.
-    /// </summary>
-    private readonly CancellationTokenSource _cts = new();
-
-    /// <summary>
     /// Protects access to state shared between the logger callbacks and the rendering thread.
     /// </summary>
 #if NET9_0_OR_GREATER
@@ -25,6 +20,11 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 
     private readonly ITerminal _terminal;
     private readonly Func<bool?> _showProgress;
+
+    /// <summary>
+    /// A cancellation token to signal the rendering thread that it should exit.
+    /// </summary>
+    private CancellationTokenSource? _cts;
     private TestProgressState?[] _progressItems = [];
     private bool? _showProgressCached;
 
@@ -43,7 +43,7 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
     /// <summary>
     /// The <see cref="_refresher"/> thread proc.
     /// </summary>
-    private void ThreadProc()
+    private void ThreadProc(CancellationTokenSource cancellationTokenSource)
     {
         try
         {
@@ -51,7 +51,7 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
             // update every half second, because we only show seconds on the screen, so it is good enough.
             // When writing to non-ANSI, we never show progress as the output can get long and messy.
             const int AnsiUpdateCadenceInMs = 500;
-            while (!_cts.Token.WaitHandle.WaitOne(AnsiUpdateCadenceInMs))
+            while (!cancellationTokenSource.Token.WaitHandle.WaitOne(AnsiUpdateCadenceInMs))
             {
                 // Note: OnProgressStartUpdate is invoked outside the lock to avoid a deadlock where
                 // a test subscriber blocks the event handler (e.g. with WaitOne) while the lock is held,
@@ -74,7 +74,7 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         }
         catch (ObjectDisposedException)
         {
-            // When we dispose _cts too early this will throw.
+            // When we dispose the cancellation token source too early this will throw.
         }
         catch (Exception)
         {
@@ -88,7 +88,7 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         {
             _terminal.EraseProgress();
         }
-        catch
+        catch (Exception)
         {
             // Best-effort cleanup; we are already in teardown.
         }
@@ -121,14 +121,21 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 
     public void StartShowingProgress(int workerCount)
     {
-        if (GetShowProgress())
+        if (!GetShowProgress())
         {
-            _progressItems = new TestProgressState[workerCount];
-            _terminal.StartBusyIndicator();
-            // If we crash unexpectedly without completing this thread we don't want it to keep the process running.
-            _refresher = new Thread(ThreadProc) { IsBackground = true };
-            _refresher.Start();
+            return;
         }
+
+        _progressItems = new TestProgressState[workerCount];
+        _stopped = false;
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        _cts = cancellationTokenSource;
+
+        _terminal.StartBusyIndicator();
+        // If we crash unexpectedly without completing this thread we don't want it to keep the process running.
+        _refresher = new Thread(() => ThreadProc(cancellationTokenSource)) { IsBackground = true };
+        _refresher.Start();
     }
 
     internal void StopShowingProgress()
@@ -139,15 +146,22 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         }
 
         _stopped = true;
-        _cts.Cancel();
-        _refresher?.Join();
+
+        CancellationTokenSource? cancellationTokenSource = _cts;
+        Thread? refresher = _refresher;
+        _cts = null;
+        _refresher = null;
+
+        cancellationTokenSource?.Cancel();
+        refresher?.Join();
+        cancellationTokenSource?.Dispose();
 
         try
         {
             _terminal.EraseProgress();
             _terminal.StopBusyIndicator();
         }
-        catch
+        catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or System.IO.IOException)
         {
             // Best-effort cleanup; we are already in teardown.
         }
@@ -167,8 +181,6 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         // erase any in-flight progress, restore the busy-indicator and show the cursor again so the
         // user's terminal is left in a sane state.
         StopShowingProgress();
-
-        ((IDisposable)_cts).Dispose();
     }
 
     internal void WriteToTerminal(Action<ITerminal> write)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressStateAwareTerminal.cs
@@ -27,14 +27,15 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
     private CancellationTokenSource? _cts;
     private TestProgressState?[] _progressItems = [];
     private bool? _showProgressCached;
+    private int _progressErased;
 
     /// <summary>
     /// The thread that performs periodic refresh of the console output.
     /// </summary>
     private Thread? _refresher;
     private long _counter;
-    private bool _stopped;
-    private bool _disposed;
+    private int _stopped;
+    private int _disposed;
 
     public event EventHandler? OnProgressStartUpdate;
 
@@ -78,15 +79,15 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         }
         catch (Exception)
         {
-            // Any other failure (broken pipe, IO error writing to the console, etc.) must not silently
-            // tear down the refresher without making a best-effort attempt to clean up the screen. We
-            // intentionally swallow because there is no other thread to surface this to and the test
-            // run itself should still be allowed to complete.
+            // Swallow so that the unconditional EraseProgress() below still runs.
+            // There is no other thread to surface this to; the test run itself should
+            // still be allowed to complete.
         }
 
         try
         {
             _terminal.EraseProgress();
+            Interlocked.Exchange(ref _progressErased, 1);
         }
         catch (Exception)
         {
@@ -127,7 +128,8 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
         }
 
         _progressItems = new TestProgressState[workerCount];
-        _stopped = false;
+        Interlocked.Exchange(ref _progressErased, 0);
+        Interlocked.Exchange(ref _stopped, 0);
 
         var cancellationTokenSource = new CancellationTokenSource();
         _cts = cancellationTokenSource;
@@ -140,12 +142,10 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 
     internal void StopShowingProgress()
     {
-        if (_stopped || !GetShowProgress())
+        if (Interlocked.CompareExchange(ref _stopped, 1, 0) != 0 || !GetShowProgress())
         {
             return;
         }
-
-        _stopped = true;
 
         CancellationTokenSource? cancellationTokenSource = _cts;
         Thread? refresher = _refresher;
@@ -158,7 +158,11 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 
         try
         {
-            _terminal.EraseProgress();
+            if (Interlocked.CompareExchange(ref _progressErased, 1, 0) == 0)
+            {
+                _terminal.EraseProgress();
+            }
+
             _terminal.StopBusyIndicator();
         }
         catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException or System.IO.IOException)
@@ -169,12 +173,10 @@ internal sealed partial class TestProgressStateAwareTerminal : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
         {
             return;
         }
-
-        _disposed = true;
 
         // Ensure that even when callers forget to call StopShowingProgress (e.g. because the process
         // is being torn down by an unhandled exception), we still bring the refresher thread down,

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -525,6 +525,7 @@ public sealed class TerminalTestReporterTests
         progressAwareTerminal.StopShowingProgress();
 
         Assert.HasCount(2, terminal.Events.Where(e => e == "StartBusyIndicator"));
+        Assert.HasCount(2, terminal.Events.Where(e => e == "EraseProgress"));
         Assert.HasCount(2, terminal.Events.Where(e => e == "StopBusyIndicator"));
     }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -513,6 +513,22 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    public void TestProgressStateAwareTerminal_CanStopProgressAcrossMultipleSessions()
+    {
+        var terminal = new RecordingTerminal();
+        using var progressAwareTerminal = new TestProgressStateAwareTerminal(terminal, () => true);
+
+        progressAwareTerminal.StartShowingProgress(workerCount: 1);
+        progressAwareTerminal.StopShowingProgress();
+
+        progressAwareTerminal.StartShowingProgress(workerCount: 1);
+        progressAwareTerminal.StopShowingProgress();
+
+        Assert.HasCount(2, terminal.Events.Where(e => e == "StartBusyIndicator"));
+        Assert.HasCount(2, terminal.Events.Where(e => e == "StopBusyIndicator"));
+    }
+
+    [TestMethod]
     public void NonAnsiTerminal_ShowOutputNone_DoesNotShowOutput()
     {
         string targetFramework = "net8.0";


### PR DESCRIPTION
## What

Three small, independently-justified hardening changes to the MTP terminal output device, drawn from a recent terminal review.

### 1. Restore the Windows console mode in `TerminalTestReporter.Dispose`

When the terminal is set up, `NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes` may enable `ENABLE_VIRTUAL_TERMINAL_PROCESSING` and save the original mode in `_originalConsoleMode`. Today only the normal `TestExecutionCompleted` path restores it — so on an abnormal teardown (unhandled exception, `Dispose` called without a completed run, hot-reload session that never reached `TestExecutionCompleted`), the user's shell is left with whatever mode we enabled.

`Dispose` now also calls `RestoreConsoleMode`, and `TestExecutionCompleted` nulls out `_originalConsoleMode` after restoring so the second call is a no-op when the normal lifecycle runs.

### 2. Make `TestProgressStateAwareTerminal` resilient on shutdown

* `ThreadProc` used to catch only `ObjectDisposedException`. A broken pipe / `IOException` from the underlying console would silently kill the refresher thread, leaving subsequent writes flowing through `WriteToTerminal` (still under the lock) but with no spinner and no diagnostic. We now catch `Exception` and still attempt one `EraseProgress` on the way out.
* `StopShowingProgress` is now idempotent and resilient to `EraseProgress` / `StopBusyIndicator` throwing (it's a best-effort cleanup at that point).
* `Dispose` is now idempotent and always tears the refresher down, even when `StopShowingProgress` was never reached, so the cursor (`HideCursor` is emitted at start) and busy indicator are always restored.

### 3. Remove dead `_buildErrorsCount` field

The field was declared, reset to `0` in `TestExecutionCompleted`, and read by the summary colorization (`colorizePassed` / `colorizeSkipped`) — but nothing ever assigned it a non-zero value. The `_buildErrorsCount == 0` conjuncts were always true; dropping them does not change the rendered summary in any reachable state.

## Why now

These came out of a structured review of the terminal code. We started from a larger list of suspected concurrency issues, validated each one against the actual threading model (the platform's per-consumer `SingleReader=true` channel serializes `ConsumeAsync`, and the renderer ticks at 500ms), and confirmed that the **only** items that translated to user-observable defects were the abnormal-teardown cursor/console-mode leak and the over-narrow render-thread `catch`. The dead `_buildErrorsCount` is pure cleanup that came up while validating the summary path.

## Validation

* `dotnet build src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj` — succeeded on all TFMs (netstandard2.0, net8.0, net9.0) with 0 warnings.
* `Microsoft.Testing.Platform.UnitTests` — all 820 tests pass on both net8.0 and net9.0 (2 unrelated cancellation tests are skipped, matching baseline).

## Not in scope

The review also surfaced UX/feature ideas (`--reporter=llm` mode, `--max-stdout-lines`, source-context windows around failure frames, hint extension points, etc.) and refactoring opportunities (duplication between `HumanReadableDurationFormatter.Render` and `Append`, the `object`-typed list in `AnsiTerminalTestProgressFrame`). Those are intentionally left out of this PR so it stays narrowly scoped to the validated correctness issues.
