### PR TITLE
Fix folded data-driven tests sharing TestContextImplementation across iterations

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -123,7 +123,7 @@ internal sealed class TestMethodRunner
             }
 
             object?[]? data = _test.ActualData ?? DataSerializationHelper.Deserialize(_test.SerializedData);
-            TestResult[] testResults = await ExecuteTestWithDataSourceAsync(null, data, actualDataAlreadyHandledDuringDiscovery: true).ConfigureAwait(false);
+            TestResult[] testResults = await ExecuteTestWithDataSourceAsync(_testContext, null, data, actualDataAlreadyHandledDuringDiscovery: true).ConfigureAwait(false);
             results.AddRange(testResults);
         }
         else if (await TryExecuteDataSourceBasedTestsAsync(results).ConfigureAwait(false))
@@ -137,7 +137,7 @@ internal sealed class TestMethodRunner
         else
         {
             _testContext.SetDisplayName(_test.DisplayName);
-            TestResult[] testResults = await ExecuteTestAsync(_testMethodInfo).ConfigureAwait(false);
+            TestResult[] testResults = await ExecuteTestAsync(_testContext, _testMethodInfo).ConfigureAwait(false);
 
             foreach (TestResult testResult in testResults)
             {
@@ -207,6 +207,8 @@ internal sealed class TestMethodRunner
     private async Task<bool> TryExecuteFoldedDataDrivenTestsAsync(List<TestResult> results)
     {
         bool hasTestDataSource = false;
+        var outerContext = (TestContextImplementation)_testContext.Context;
+
         foreach (Attribute attribute in PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(_testMethodInfo.MethodInfo))
         {
             if (attribute is not UTF.ITestDataSource testDataSource)
@@ -227,15 +229,24 @@ internal sealed class TestMethodRunner
             foreach (object?[] data in testDataSource.GetData(_testMethodInfo.MethodInfo))
             {
                 dataSourceHasData = true;
+
+                // Create a fresh TestContextImplementation per iteration so the folded path is
+                // structurally equivalent to the unfolded path (where each row gets its own
+                // context). This isolates per-row state (captured output, diagnostic messages,
+                // result files, outcome, exception, property bag mutations, ...) so a leak in
+                // any current or future TestContextImplementation field cannot accumulate across
+                // rows. See https://github.com/microsoft/testfx/issues/7933.
+                TestContextImplementation iterationContext = outerContext.CloneForDataDrivenIteration();
                 try
                 {
-                    TestResult[] testResults = await ExecuteTestWithDataSourceAsync(testDataSource, data, actualDataAlreadyHandledDuringDiscovery: false).ConfigureAwait(false);
+                    TestResult[] testResults = await ExecuteTestWithDataSourceAsync(iterationContext, testDataSource, data, actualDataAlreadyHandledDuringDiscovery: false).ConfigureAwait(false);
 
                     results.AddRange(testResults);
                 }
                 finally
                 {
                     _testMethodInfo.SetArguments(null);
+                    iterationContext.Dispose();
                 }
             }
 
@@ -278,11 +289,23 @@ internal sealed class TestMethodRunner
             try
             {
                 int rowIndex = 0;
+                var outerContext = (TestContextImplementation)_testContext.Context;
 
                 foreach (object dataRow in dataRows)
                 {
-                    TestResult[] testResults = await ExecuteTestWithDataRowAsync(dataRow, rowIndex++).ConfigureAwait(false);
-                    results.AddRange(testResults);
+                    // Create a fresh TestContextImplementation per row for the same structural
+                    // reason as in TryExecuteFoldedDataDrivenTestsAsync — each row should
+                    // start with no accumulated per-test state.
+                    TestContextImplementation iterationContext = outerContext.CloneForDataDrivenIteration();
+                    try
+                    {
+                        TestResult[] testResults = await ExecuteTestWithDataRowAsync(iterationContext, dataRow, rowIndex++).ConfigureAwait(false);
+                        results.AddRange(testResults);
+                    }
+                    finally
+                    {
+                        iterationContext.Dispose();
+                    }
                 }
             }
             finally
@@ -303,7 +326,7 @@ internal sealed class TestMethodRunner
         }
     }
 
-    private async Task<TestResult[]> ExecuteTestWithDataSourceAsync(UTF.ITestDataSource? testDataSource, object?[]? data, bool actualDataAlreadyHandledDuringDiscovery)
+    private async Task<TestResult[]> ExecuteTestWithDataSourceAsync(ITestContext executionContext, UTF.ITestDataSource? testDataSource, object?[]? data, bool actualDataAlreadyHandledDuringDiscovery)
     {
         string? displayName = StringEx.IsNullOrWhiteSpace(_test.DisplayName)
             ? _test.Name
@@ -353,12 +376,12 @@ internal sealed class TestMethodRunner
 
         var stopwatch = Stopwatch.StartNew();
         _testMethodInfo.SetArguments(data);
-        _testContext.SetTestData(data);
-        _testContext.SetDisplayName(displayName);
+        executionContext.SetTestData(data);
+        executionContext.SetDisplayName(displayName);
 
         TestResult[] testResults = ignoreFromTestDataRow is not null
             ? [TestResult.CreateIgnoredResult(ignoreFromTestDataRow)]
-            : await ExecuteTestAsync(_testMethodInfo).ConfigureAwait(false);
+            : await ExecuteTestAsync(executionContext, _testMethodInfo).ConfigureAwait(false);
 
         stopwatch.Stop();
 
@@ -375,7 +398,7 @@ internal sealed class TestMethodRunner
         return testResults;
     }
 
-    private async Task<TestResult[]> ExecuteTestWithDataRowAsync(object dataRow, int rowIndex)
+    private async Task<TestResult[]> ExecuteTestWithDataRowAsync(ITestContext executionContext, object dataRow, int rowIndex)
     {
         string displayName = string.Format(CultureInfo.CurrentCulture, Resource.DataDrivenResultDisplayName, _test.DisplayName, rowIndex);
         Stopwatch? stopwatch = null;
@@ -384,13 +407,13 @@ internal sealed class TestMethodRunner
         try
         {
             stopwatch = Stopwatch.StartNew();
-            _testContext.SetDataRow(dataRow);
-            testResults = await ExecuteTestAsync(_testMethodInfo).ConfigureAwait(false);
+            executionContext.SetDataRow(dataRow);
+            testResults = await ExecuteTestAsync(executionContext, _testMethodInfo).ConfigureAwait(false);
         }
         finally
         {
             stopwatch?.Stop();
-            _testContext.SetDataRow(null);
+            executionContext.SetDataRow(null);
         }
 
         foreach (TestResult testResult in testResults)
@@ -402,7 +425,7 @@ internal sealed class TestMethodRunner
         return testResults;
     }
 
-    private async Task<TestResult[]> ExecuteTestAsync(TestMethodInfo testMethodInfo)
+    private async Task<TestResult[]> ExecuteTestAsync(ITestContext executionContext, TestMethodInfo testMethodInfo)
     {
         try
         {
@@ -415,9 +438,9 @@ internal sealed class TestMethodRunner
                 {
                     try
                     {
-                        using (TestContextImplementation.SetCurrentTestContext(_testContext as TestContext))
+                        using (TestContextImplementation.SetCurrentTestContext(executionContext as TestContext))
                         {
-                            testMethodInfo.TestContext = _testContext;
+                            testMethodInfo.TestContext = executionContext;
                             tcs.SetResult(await _testMethodInfo.Executor.ExecuteAsync(testMethodInfo).ConfigureAwait(false));
                         }
                     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -468,8 +468,9 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// of the folded data-driven test execution path.
     /// <para>
     /// The clone inherits the same configuration as this context (a shallow snapshot of the
-    /// property bag, the message logger, and the test-run cancellation token registration),
-    /// but starts with no accumulated per-test state (no captured stdout/stderr/trace,
+    /// property bag, the message logger, the same test-run cancellation token, and on .NET
+    /// Framework the current data connection), but registers its own cancellation callback and
+    /// starts with no accumulated per-test state (no captured stdout/stderr/trace,
     /// no diagnostic messages, no result files, no outcome, no exception, no data row).
     /// This keeps the folded path structurally equivalent to the unfolded path, where each
     /// row gets its own <see cref="TestContextImplementation"/>.
@@ -494,6 +495,10 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
         // execution-attempt count of this test, not per-row state, so it must flow into
         // each iteration's context.
         clone.Context.TestRunCount = Context.TestRunCount;
+
+#if NETFRAMEWORK
+        clone.SetDataConnection(_dbConnection);
+#endif
 
         return clone;
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -471,7 +471,8 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// property bag, the message logger, the same test-run cancellation token, and on .NET
     /// Framework the current data connection), but registers its own cancellation callback and
     /// starts with no accumulated per-test state (no captured stdout/stderr/trace,
-    /// no diagnostic messages, no result files, no outcome, no exception, no data row).
+    /// no diagnostic messages, no result files, no exception, no data row, and the
+    /// default <see cref="UnitTestOutcome"/> value rather than the original's current outcome).
     /// This keeps the folded path structurally equivalent to the unfolded path, where each
     /// row gets its own <see cref="TestContextImplementation"/>.
     /// </para>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -67,6 +67,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// </summary>
     private readonly Dictionary<string, object?> _properties;
     private readonly IMessageLogger? _messageLogger;
+    private readonly TestRunCancellationToken? _testRunCancellationToken;
 
     private CancellationTokenRegistration? _cancellationTokenRegistration;
 
@@ -140,6 +141,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
         }
 
         _messageLogger = messageLogger;
+        _testRunCancellationToken = testRunCancellationToken;
         _cancellationTokenRegistration = testRunCancellationToken?.Register(CancelDelegate, this);
     }
 
@@ -460,4 +462,39 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
 
     internal string? GetAndClearTrace()
         => _traceStringBuilder?.GetAndClear();
+
+    /// <summary>
+    /// Creates a sibling <see cref="TestContextImplementation"/> for use by a single iteration
+    /// of the folded data-driven test execution path.
+    /// <para>
+    /// The clone inherits the same configuration as this context (a shallow snapshot of the
+    /// property bag, the message logger, and the test-run cancellation token registration),
+    /// but starts with no accumulated per-test state (no captured stdout/stderr/trace,
+    /// no diagnostic messages, no result files, no outcome, no exception, no data row).
+    /// This keeps the folded path structurally equivalent to the unfolded path, where each
+    /// row gets its own <see cref="TestContextImplementation"/>.
+    /// </para>
+    /// </summary>
+    /// <returns>A fresh context suitable for one folded data-driven iteration.</returns>
+    internal TestContextImplementation CloneForDataDrivenIteration()
+    {
+        // Take a shallow snapshot of the current property bag so that the clone starts with
+        // the same properties (including TestNameLabel / FullyQualifiedTestClassNameLabel and
+        // anything merged from AssemblyInitialize / ClassInitialize) but is otherwise isolated.
+        // Per-iteration mutations to the clone's property bag won't leak back to this instance
+        // nor to subsequent iterations.
+        var snapshot = new Dictionary<string, object?>(_properties);
+
+        // Pass testMethod: null and testClassFullName: null because the relevant labels are
+        // already in the snapshot. The constructor will copy the snapshot as-is.
+        var clone = new TestContextImplementation(testMethod: null, testClassFullName: null, snapshot, _messageLogger, _testRunCancellationToken);
+
+        // Preserve TestRunCount so user code that observes it (e.g. retry-aware tests) sees
+        // the same value it would see in the unfolded path. TestRunCount represents the
+        // execution-attempt count of this test, not per-row state, so it must flow into
+        // each iteration's context.
+        clone.Context.TestRunCount = Context.TestRunCount;
+
+        return clone;
+    }
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
@@ -437,6 +437,110 @@ public class TestMethodRunnerTests : TestContainer
         results[0].Outcome.Should().Be(UnitTestOutcome.Passed);
     }
 
+    public async Task RunTestMethodShouldUseFreshTestContextPerIterationForFoldedDataDrivenTests()
+    {
+        // Capture TestContext.Current per iteration so we can verify each row gets a distinct
+        // TestContextImplementation instance — see https://github.com/microsoft/testfx/issues/7933.
+#pragma warning disable MSTESTEXP // TestContext.Current is experimental.
+        var observedContexts = new List<TestContext?>();
+        DataRowAttribute dataRowAttribute1 = new(1);
+        DataRowAttribute dataRowAttribute2 = new(2);
+        DataRowAttribute dataRowAttribute3 = new(3);
+        var attributes = new Attribute[] { dataRowAttribute1, dataRowAttribute2, dataRowAttribute3 };
+
+        _testablePlatformServiceProvider.MockReflectionOperations.Setup(ro => ro.GetCustomAttributes(_methodInfo)).Returns(attributes);
+
+        var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () =>
+        {
+            observedContexts.Add(TestContext.Current);
+            return new TestResult { Outcome = UnitTestOutcome.Passed };
+        });
+        var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
+
+        _ = await testMethodRunner.RunTestMethodAsync();
+
+        observedContexts.Should().HaveCount(3);
+        observedContexts.Should().AllSatisfy(c => c.Should().NotBeNull());
+
+        // Each iteration must observe its own fresh context instance — none should be the
+        // outer shared context, and no two iterations should share an instance.
+        observedContexts.Should().OnlyHaveUniqueItems();
+        observedContexts.Should().NotContain(_testContextImplementation);
+#pragma warning restore MSTESTEXP
+    }
+
+    public async Task RunTestMethodShouldNotLeakCapturedOutputAcrossFoldedDataDrivenIterations()
+    {
+        // Each iteration writes to its own context's console-out buffer. With a fresh
+        // per-iteration context, the iteration that fires write N must observe an empty buffer
+        // before writing — without the fix, row 2 would observe row 1's content.
+        var observedLengthsBeforeWrite = new List<int>();
+        DataRowAttribute dataRowAttribute1 = new(1);
+        DataRowAttribute dataRowAttribute2 = new(2);
+        DataRowAttribute dataRowAttribute3 = new(3);
+        var attributes = new Attribute[] { dataRowAttribute1, dataRowAttribute2, dataRowAttribute3 };
+
+        _testablePlatformServiceProvider.MockReflectionOperations.Setup(ro => ro.GetCustomAttributes(_methodInfo)).Returns(attributes);
+
+        var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () =>
+        {
+#pragma warning disable MSTESTEXP // TestContext.Current is experimental.
+            var current = (TestContextImplementation?)TestContext.Current;
+#pragma warning restore MSTESTEXP
+            current.Should().NotBeNull();
+            string? existing = current!.GetAndClearOutput();
+            observedLengthsBeforeWrite.Add(existing?.Length ?? 0);
+
+            // Write a fairly large chunk of console output. If contexts were shared, the next
+            // iteration would observe a non-zero existing length.
+            current.WriteConsoleOut(new string('x', 1024));
+            return new TestResult { Outcome = UnitTestOutcome.Passed };
+        });
+        var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
+
+        _ = await testMethodRunner.RunTestMethodAsync();
+
+        observedLengthsBeforeWrite.Should().HaveCount(3);
+        observedLengthsBeforeWrite.Should().AllSatisfy(len => len.Should().Be(0));
+    }
+
+    public async Task RunTestMethodShouldNotLeakPropertyBagMutationsAcrossFoldedDataDrivenIterations()
+    {
+        // Each iteration adds a unique property key. If contexts were shared, row N would see
+        // the keys added by rows 1..N-1. With a fresh per-iteration context, every row starts
+        // with the same baseline property set.
+        var observedKeyCounts = new List<int>();
+        DataRowAttribute dataRowAttribute1 = new(1);
+        DataRowAttribute dataRowAttribute2 = new(2);
+        DataRowAttribute dataRowAttribute3 = new(3);
+        var attributes = new Attribute[] { dataRowAttribute1, dataRowAttribute2, dataRowAttribute3 };
+
+        _testablePlatformServiceProvider.MockReflectionOperations.Setup(ro => ro.GetCustomAttributes(_methodInfo)).Returns(attributes);
+
+        int iteration = 0;
+        var testMethodInfo = new TestableTestMethodInfo(_methodInfo, _testClassInfo, _testMethodOptions, () =>
+        {
+#pragma warning disable MSTESTEXP // TestContext.Current is experimental.
+            TestContext? current = TestContext.Current;
+#pragma warning restore MSTESTEXP
+            current.Should().NotBeNull();
+            observedKeyCounts.Add(current!.Properties.Count);
+            current.Properties[$"AddedByIteration_{iteration++}"] = "value";
+            return new TestResult { Outcome = UnitTestOutcome.Passed };
+        });
+        var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);
+
+        _ = await testMethodRunner.RunTestMethodAsync();
+
+        // All three iterations observe the same key count (no leak from prior iterations) and
+        // the outer context is unchanged.
+        observedKeyCounts.Should().HaveCount(3);
+        observedKeyCounts.Should().AllSatisfy(c => c.Should().Be(observedKeyCounts[0]));
+        _testContextImplementation.Properties.Should().NotContainKey("AddedByIteration_0");
+        _testContextImplementation.Properties.Should().NotContainKey("AddedByIteration_1");
+        _testContextImplementation.Properties.Should().NotContainKey("AddedByIteration_2");
+    }
+
     #region Test data
 
     private sealed class ExecutionContextUnsafeThreadTestMethodAttribute : TestMethodAttribute

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -303,6 +303,20 @@ public class TestContextImplementationTests : TestContainer
         _testContextImplementation.DataConnection!.ConnectionString
             .Should().Be("Dsn=Excel Files;dbq=.\\data.xls;defaultdir=.; driverid=790;maxbuffersize=2048;pagetimeout=5");
     }
+
+    public void CloneForDataDrivenIterationShouldPreserveDataConnection()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+
+        DbProviderFactory factory = DbProviderFactories.GetFactory("System.Data.Odbc");
+        DbConnection connection = factory.CreateConnection();
+        connection.ConnectionString = @"Dsn=Excel Files;dbq=.\data.xls;defaultdir=.; driverid=790;maxbuffersize=2048;pagetimeout=5";
+        _testContextImplementation.SetDataConnection(connection);
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        clone.DataConnection.Should().BeSameAs(connection);
+    }
 #endif
 
 #if NETCOREAPP

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -591,17 +591,22 @@ public class TestContextImplementationTests : TestContainer
     public void CloneForDataDrivenIterationShouldStartWithFreshOutcomeAndException()
     {
         _testContextImplementation = CreateTestContextImplementation();
-        _testContextImplementation.SetOutcome(UnitTestOutcome.Failed);
+
+        // Set outcome to a non-default value (Passed) on the original so the assertion below
+        // actually verifies that the clone is reset to the default rather than inheriting
+        // from the original. If we left the original at the default UnitTestOutcome.Failed,
+        // a buggy clone that copied the outcome would still appear correct.
+        _testContextImplementation.SetOutcome(UnitTestOutcome.Passed);
         _testContextImplementation.SetException(new InvalidOperationException("boom"));
 
         TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
 
-        clone.CurrentTestOutcome.Should().Be(UnitTestOutcome.Failed); // default initial value
+        clone.CurrentTestOutcome.Should().Be(UnitTestOutcome.Failed); // default value of UnitTestOutcome
         clone.TestException.Should().BeNull();
 
         // Setting outcome on the clone does not leak back to the original.
-        clone.SetOutcome(UnitTestOutcome.Passed);
-        _testContextImplementation.CurrentTestOutcome.Should().Be(UnitTestOutcome.Failed);
+        clone.SetOutcome(UnitTestOutcome.Inconclusive);
+        _testContextImplementation.CurrentTestOutcome.Should().Be(UnitTestOutcome.Passed);
     }
 
     public void CloneForDataDrivenIterationShouldStartWithFreshResultFiles()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -517,4 +517,117 @@ public class TestContextImplementationTests : TestContainer
         // The per-context value wins.
         ctx.Properties["FullyQualifiedTestClassName"].Should().Be("A.C.M");
     }
+
+    public void CloneForDataDrivenIterationShouldCopyPropertyBagShallowly()
+    {
+        _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
+        _testMethod.Setup(tm => tm.Name).Returns("M");
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["UserKey"] = "UserValue";
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        clone.Properties["FullyQualifiedTestClassName"].Should().Be("A.C.M");
+        clone.Properties["TestName"].Should().Be("M");
+        clone.Properties["UserKey"].Should().Be("UserValue");
+    }
+
+    public void CloneForDataDrivenIterationShouldIsolatePropertyBagFromOriginal()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["Key"] = "Original";
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        // Mutations on the clone must not leak back to the original.
+        clone.Properties["Key"] = "MutatedOnClone";
+        clone.Properties["NewKey"] = "AddedOnClone";
+
+        _testContextImplementation.Properties["Key"].Should().Be("Original");
+        _testContextImplementation.Properties.Should().NotContainKey("NewKey");
+
+        // And mutations on the original after the clone is created must not leak to the clone.
+        _testContextImplementation.Properties["Key"] = "MutatedOnOriginal";
+        clone.Properties["Key"].Should().Be("MutatedOnClone");
+    }
+
+    public void CloneForDataDrivenIterationShouldStartWithNoAccumulatedOutput()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.WriteConsoleOut("orig-out");
+        _testContextImplementation.WriteConsoleErr("orig-err");
+        _testContextImplementation.WriteTrace("orig-trace");
+        _testContextImplementation.WriteLine("orig-diag");
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        // The clone has no captured output of its own yet.
+        clone.GetAndClearOutput().Should().BeNullOrEmpty();
+        clone.GetAndClearError().Should().BeNullOrEmpty();
+        clone.GetAndClearTrace().Should().BeNullOrEmpty();
+        clone.GetDiagnosticMessages().Should().BeNullOrEmpty();
+
+        // The clone's output buffers are independent: writing to the clone does not flow back
+        // to the original.
+        clone.WriteConsoleOut("clone-only");
+        _testContextImplementation.GetAndClearOutput().Should().Be("orig-out");
+        clone.GetAndClearOutput().Should().Be("clone-only");
+    }
+
+    public void CloneForDataDrivenIterationShouldStartWithFreshOutcomeAndException()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.SetOutcome(UnitTestOutcome.Failed);
+        _testContextImplementation.SetException(new InvalidOperationException("boom"));
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        clone.CurrentTestOutcome.Should().Be(UnitTestOutcome.Failed); // default initial value
+        clone.TestException.Should().BeNull();
+
+        // Setting outcome on the clone does not leak back to the original.
+        clone.SetOutcome(UnitTestOutcome.Passed);
+        _testContextImplementation.CurrentTestOutcome.Should().Be(UnitTestOutcome.Failed);
+    }
+
+    public void CloneForDataDrivenIterationShouldStartWithFreshResultFiles()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.AddResultFile("C:\\original.txt");
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        clone.GetResultFiles().Should().BeNull();
+
+        clone.AddResultFile("C:\\clone.txt");
+        IList<string>? originalResults = _testContextImplementation.GetResultFiles();
+        originalResults.Should().NotBeNull();
+        originalResults!.Should().Contain(s => s.EndsWith("original.txt", StringComparison.OrdinalIgnoreCase));
+        originalResults.Should().NotContain(s => s.EndsWith("clone.txt", StringComparison.OrdinalIgnoreCase));
+    }
+
+    public void CloneForDataDrivenIterationShouldCopyTestRunCount()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Context.TestRunCount = 7;
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+
+        clone.Context.TestRunCount.Should().Be(7);
+
+        // After clone creation, TestRunCount on the original and clone are independent.
+        _testContextImplementation.Context.TestRunCount = 8;
+        clone.Context.TestRunCount.Should().Be(7);
+    }
+
+    public void CloneForDataDrivenIterationShouldShareMessageLogger()
+    {
+        var messageLoggerMock = new Mock<IMessageLogger>();
+        _testContextImplementation = CreateTestContextImplementation(messageLoggerMock.Object);
+
+        TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
+        clone.DisplayMessage(MessageLevel.Informational, "from-clone");
+
+        messageLoggerMock.Verify(x => x.SendMessage(TestMessageLevel.Informational, "from-clone"), Times.Once);
+    }
 }


### PR DESCRIPTION
Fixes #7933.

## Problem

The folded data-driven test execution path in TestMethodRunner (TryExecuteFoldedDataDrivenTestsAsync and the legacy ExecuteTestFromDataSourceAttributeAsync) reused the same TestContextImplementation across all `DataRow` iterations, while the unfolded path (`DataType == ITestDataSource`) creates a fresh `TestMethodRunner` -> own `TestContextImplementation` per row.

Any per-test state on `TestContextImplementation` that accumulates (captured stdout/stderr/trace, diagnostic messages, result files, outcome, exception, property bag mutations, ...) was therefore visible to subsequent iterations in the folded path. PR #7926 fixed the immediate O(n^2) TRX output symptom by clearing the three string builders, but any new accumulated field would be a repeat of the same bug.

## Fix

Each iteration now runs against a fresh TestContextImplementation produced by CloneForDataDrivenIteration:
- Shares the message logger, the `TestRunCancellationToken` registration, `TestRunCount`, and a **shallow snapshot** of the property bag.
- Starts with **no** accumulated per-iteration state (output buffers, diagnostic messages, result files, outcome, exception, `TestData`, `DataRow`).

The clone is disposed at the end of each iteration. `ExecuteTestWithDataSourceAsync` / `ExecuteTestWithDataRowAsync` / `ExecuteTestAsync` now take the iteration context explicitly rather than reading the field `_testContext` directly, so the same code path serves both single-test and per-iteration execution.

This makes the folded path structurally equivalent to the unfolded path - mutations made by row N can no longer be observed by row N+1, and any new accumulated state field added to `TestContextImplementation` in the future is automatically isolated.

## Tests added

- `TestContextImplementationTests`: 7 unit tests for `CloneForDataDrivenIteration` covering property-bag isolation, fresh output buffers, fresh outcome/exception, fresh result files, `TestRunCount` preservation, and message logger sharing.
- `TestMethodRunnerTests`: 3 regression tests for `TryExecuteFoldedDataDrivenTestsAsync`:
  - Each folded iteration receives a unique `TestContext` instance distinct from the outer one.
  - Console-out buffer is empty at the start of each iteration (no leak between rows).
  - Property bag is the same size at the start of each iteration even when each row adds a key (no leak between rows).

All 814 unit tests in `MSTestAdapter.PlatformServices.UnitTests` pass on net9.0, net8.0, and net462. Full `build.cmd` succeeds with 0 errors / 0 warnings.