### PR TITLE
Use union merge driver for .resx and .xlf files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -68,3 +68,26 @@
 #*.RTF   diff=astextplain
 
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
+
+###############################################################################
+# Localization resource files
+#
+# Edits to .resx and .xlf files are nearly always additive (new entries with
+# distinct keys), so the union merge driver concatenates both sides instead of
+# producing conflict markers. This significantly reduces friction when several
+# PRs add new strings in parallel.
+#
+# Caveats:
+#   * If two PRs add an entry with the SAME name/id, both will end up in the
+#     file and the build will fail with a duplicate-resource error. Resolve by
+#     editing the .resx and re-running the project's `/t:UpdateXlf` target.
+#   * If two PRs modify the SAME existing line (e.g. retouch the same English
+#     string or translation), union merges both sides silently with no
+#     conflict marker. Review resx/xlf hunks during PR review when both sides
+#     touched pre-existing entries.
+#   * XLF files are generated from the neutral .resx via the `UpdateXlf`
+#     MSBuild target, so any union artefact in an xlf can be recovered by
+#     running that target.
+###############################################################################
+*.resx merge=union
+*.xlf  merge=union


### PR DESCRIPTION
Edits to `.resx` and `.xlf` files in this repo are nearly always additive (new entries with distinct keys), yet they still produce textual conflicts whenever two PRs add strings around the same line. With 13 language XLFs per project, `FrameworkMessages.*.xlf` alone changed 40+ times in the last 6 months — every parallel PR contends on 14 files.

This change enables Git's built-in `union` merge driver for `*.resx` and `*.xlf` so additive edits from parallel PRs concatenate instead of producing conflict markers.

### Caveats (documented inline in `.gitattributes`)

- If two PRs add an entry with the **same name/id**, both end up in the file and the build fails with a duplicate-resource error. Resolve by editing the `.resx` and re-running `/t:UpdateXlf`.
- If two PRs **modify the same existing line** (e.g. retouch the same English string or translation), union merges both sides silently with no conflict marker. Reviewers should glance at resx/xlf hunks when both sides touched pre-existing entries.
- XLF files are generated from the neutral `.resx` via the `UpdateXlf` MSBuild target, so any union artefact in an xlf can be recovered by running that target.

### Companion tips for parallel-PR workflows

- Enable `git rerere` (`git config --global rerere.enabled true`) so a conflict resolved once auto-resolves on sibling PRs.
- After a rebase that touched resources, run `dotnet msbuild <project> /t:UpdateXlf` to deterministically re-sync the XLFs from the `.resx`.

### Verification

`git check-attr merge -- *.xlf *.resx *.csproj` confirms `merge: union` is applied only to `.xlf` / `.resx` and unspecified for everything else.
