### PR TITLE
Exclude gh agentic workflow .md files from markdownlint

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -154,6 +154,8 @@
     ".github/ISSUE_TEMPLATE/**/*.md",
     ".github/skills/**/*.md",
     ".github/agents/**/*.md",
+    // GitHub agentic workflow sources (compiled by `gh aw compile`)
+    ".github/workflows/**/*.md",
     "**/AnalyzerReleases.*.md"
   ]
 }

--- a/docs/RFCs/014-TestRun-Current-PlannedTests.md
+++ b/docs/RFCs/014-TestRun-Current-PlannedTests.md
@@ -1,0 +1,174 @@
+# RFC 014 - TestRun.Current ambient run-state API
+
+- [ ] Approved in principle
+- [x] Under discussion
+- [x] Implementation (initial slice: `PlannedTests`)
+- [ ] Shipped
+
+## Summary
+
+Introduce a static, ambient `TestRun.Current` surface on top of an `ITestRunInfo` abstraction that exposes information about the *test run as a whole* (as opposed to `TestContext`, which describes a single executing test). The v1 slice exposes the set of tests that have been discovered and have passed the active filter for the current assembly (`PlannedTests`). Later additions can extend the surface with running/completed snapshots and events without breaking consumers.
+
+The motivating scenario is [microsoft/testfx#7311](https://github.com/microsoft/testfx/issues/7311): inside `[AssemblyInitialize]`, decide whether to perform expensive partial setup based on whether any test matching a given criterion will actually run.
+
+## Motivation
+
+Users today have no supported way to ask "given the filter the user typed in VS / on the command line, which tests are actually going to run in this assembly?". The information exists inside the adapter (it has to, in order to dispatch the tests), but it is not exposed.
+
+Concrete scenarios from the field (issue #7311 and adjacent feedback):
+
+- Building a compatibility solution before integration tests, but only when at least one compatibility test will run.
+- Spinning up a Docker container or a real database before tests that need it, and skipping it entirely when the user runs a single non-DB test in VS.
+- In `[AssemblyCleanup]`, deciding whether to publish telemetry based on whether any test of category X actually executed.
+- Letting fixtures (NUnit-style shared setup) decide whether to spin up their dependency, without forcing users to wire ad-hoc booleans through `[AssemblyInitialize]`.
+
+Two design directions were discussed on the issue:
+
+1. **Put it on `TestContext`** (or a new per-phase `AssemblyInitializeTestContext`). This was rejected because `TestContext` is by design per-test, `TestContext.Current` is an `AsyncLocal` that is `null` outside test execution (so a static helper, fixture, or extension can't read it), and growing the surface to "the whole run" muddies what `TestContext` represents.
+2. **Add a separate ambient run-state object.** This is what this RFC proposes.
+
+The same shape is used by other frameworks: xUnit v3 separates per-test `TestContext.Current` from run-wide pipeline objects, and NUnit separates `TestContext.CurrentContext` from `TestExecutionContext.CurrentContext`.
+
+## Detailed design
+
+### Public API
+
+All types live in `Microsoft.VisualStudio.TestTools.UnitTesting` (same as `TestContext`) and ship inside `MSTest.TestFramework.Extensions` (where `TestContext` lives). All are gated behind `[Experimental("MSTESTEXP")]` for v1.
+
+```csharp
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+public static class TestRun
+{
+    public static ITestRunInfo Current { get; }
+}
+
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+public interface ITestRunInfo
+{
+    IReadOnlyCollection<PlannedTest> PlannedTests { get; }
+}
+
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+public sealed class PlannedTest
+{
+    public PlannedTest(
+        string fullyQualifiedTestClassName,
+        string testName,
+        string? testDisplayName,
+        string assemblyPath,
+        string? managedTypeName,
+        string? managedMethodName,
+        string? declaringFilePath,
+        int? declaringLineNumber,
+        IReadOnlyCollection<string> testCategories,
+        IReadOnlyCollection<KeyValuePair<string, string>> testProperties);
+
+    public string FullyQualifiedTestClassName { get; }      // mirrors TestContext
+    public string TestName { get; }                         // mirrors TestContext
+    public string? TestDisplayName { get; }                 // mirrors TestContext
+    public string AssemblyPath { get; }
+    public string? ManagedTypeName { get; }                 // ECMA-335 stable id
+    public string? ManagedMethodName { get; }               // ECMA-335 stable id (incl. parameter types)
+    public string? DeclaringFilePath { get; }               // matches TestMethodAttribute.DeclaringFilePath
+    public int? DeclaringLineNumber { get; }                // matches TestMethodAttribute.DeclaringLineNumber
+    public IReadOnlyCollection<string> TestCategories { get; }                                  // [TestCategory]
+    public IReadOnlyCollection<KeyValuePair<string, string>> TestProperties { get; }            // [TestProperty]
+}
+```
+
+### Naming rationale
+
+Every property name on `PlannedTest` either mirrors an existing public MSTest API or matches the user-facing attribute the user wrote:
+
+- `FullyQualifiedTestClassName` / `TestName` / `TestDisplayName` → mirror `TestContext`.
+- `DeclaringFilePath` / `DeclaringLineNumber` → mirror the public `TestMethodAttribute` properties auto-captured via `[CallerFilePath]` / `[CallerLineNumber]`.
+- `TestCategories` → mirrors `TestCategoryAttribute.TestCategories`.
+- `TestProperties` → mirrors `[TestProperty(Name, Value)]`. Internally MSTest converts these to VSTest "Trait" objects (`GetTestPropertiesAsTraits` in `ReflectionHelper.cs`), but the user-facing concept the user wrote is `[TestProperty]`, so the public surface uses that name.
+
+### Type choices
+
+- **`TestRun` is a `static class`.** Matches `TestContext.Current` ambient-access habit. There is only one current run; no instance to manage.
+- **`ITestRunInfo` is an `interface`.** Lets the platform swap the concrete impl (empty default, populated, future test doubles for advanced scenarios).
+- **`PlannedTest` is a `sealed class`** with public constructor and get-only properties.
+  - Not a `struct`: 10 reference-typed fields, far past the size at which value semantics make sense.
+  - Not a `record`: structural equality across collection fields is surprising and expensive; positional records emit `init` accessors which the [repo guidelines explicitly forbid for new public APIs](../../.github/copilot-instructions.md#public-api-guidelines).
+  - `sealed` to lock in the shape and allow non-breaking additions later (extra get-only properties + extra ctor overload).
+- **Collections**:
+  - `IReadOnlyCollection<string>` for `TestCategories` rather than `IReadOnlySet<string>` because `IReadOnlySet<T>` is not available on netstandard2.0 / net462 (the TFMs `TestFramework.Extensions` targets) and the repo does not currently polyfill it.
+  - `IReadOnlyCollection<KeyValuePair<string, string>>` for `TestProperties` (flat list) because `[TestProperty]` is multi-valued — the same name may appear several times — and a flat list represents that naturally without forcing an inner collection on every entry.
+
+### Lifetime / scoping
+
+- `TestRun.Current` is **never `null`**. Before any source begins execution, it returns an empty `ITestRunInfo` whose `PlannedTests` is empty. After execution, it retains the most recently populated snapshot until the next source replaces it.
+- `PlannedTests` is scoped to **the current assembly's filtered tests**, populated once by the platform before the first test in the assembly runs.
+- Scope: process-wide and (on .NET Framework with AppDomain isolation) AppDomain-wide. The implementation populates the static *inside* the `UnitTestRunner` constructor, which is the type instantiated in the child AppDomain when isolation is in use — so the snapshot is visible in the same domain that runs `[AssemblyInitialize]` and the tests themselves. Cross-process test hosts each have their own snapshot.
+
+### Implementation outline
+
+1. New types in `src/TestFramework/TestFramework.Extensions/`:
+   - `TestRun.cs` — static class with `Current` (get) and `internal SetCurrent(ITestRunInfo?)`. Default value is an internal `EmptyTestRunInfo` that returns empty collections.
+   - `ITestRunInfo.cs` — the interface.
+   - `PlannedTest.cs` — the DTO.
+2. Internal adapter type `TestRunInfo` in `src/Adapter/MSTestAdapter.PlatformServices/Execution/TestRunInfo.cs`:
+   - Implements `ITestRunInfo`.
+   - Provides `static TestRunInfo CreateFrom(IReadOnlyList<UnitTestElement>)` that materializes one `PlannedTest` per filtered `UnitTestElement`, reading `TestMethod.{FullClassName,Name,DisplayName,AssemblyName,ManagedTypeName,ManagedMethodName}`, `UnitTestElement.{DeclaringFilePath,DeclaringLineNumber,TestCategory,Traits}`.
+3. Wire-up in `UnitTestRunner` constructor (post `_classCleanupManager = …`):
+
+   ```csharp
+   TestRun.SetCurrent(TestRunInfo.CreateFrom(testsToRun));
+   ```
+
+   This runs in the right domain/process for both the VSTest adapter path and the Microsoft.Testing.Platform path.
+
+### Example consumer code
+
+```csharp
+[TestClass]
+public static class GlobalSetup
+{
+    [AssemblyInitialize]
+    public static void Init(TestContext _)
+    {
+        bool anyCompatibilityTest = TestRun.Current.PlannedTests
+            .Any(t => t.TestCategories.Contains("Compatibility"));
+
+        if (anyCompatibilityTest)
+        {
+            BuildCompatibilitySolution();
+        }
+    }
+}
+```
+
+The same call works from a helper class, a fixture, or any other code reachable during the run — not only from `[AssemblyInitialize]`.
+
+## Drawbacks
+
+- **New public API surface.** Adds three new public types (`TestRun`, `ITestRunInfo`, `PlannedTest`) to an already broad framework. Mitigation: `[Experimental]`, narrow v1 surface, minimal DTO shape designed for additive growth.
+- **Ambient state is easy to misuse.** Reading run-wide state from inside `[TestMethod]` bodies can encourage hidden coupling between tests (test order dependencies based on what other tests have / haven't passed). Mitigation: v1 only exposes the plan (no outcomes), and a future analyzer can flag access from `[TestMethod]` bodies once `RunningTests` / `CompletedTests` are added.
+- **AppDomain / process isolation.** Each test host process and each child AppDomain has its own snapshot. This is documented but may surprise users running multi-targeted tests in VSTest's parallel out-of-proc host.
+- **Data-driven rows.** Tests whose data rows are only unfolded at execution time (non-serializable data, `UnfoldingStrategy.Fold`, `[DataSource]`) appear as a single `PlannedTest` rather than one per row. This is documented on `PlannedTests`.
+
+## Alternatives
+
+1. **Add `PlannedTests` (and friends) to `TestContext`** — rejected. `TestContext.Current` is `null` outside test execution (defeats the "queryable from anywhere" goal), per-run data on a per-test type is the bloat the team already pushed back on, and once we add `RunningTests` / `CompletedTests` they cannot live on `TestContext`.
+2. **Split `TestContext` into per-lifecycle-phase subtypes** (`AssemblyInitializeTestContext`, `ClassInitializeTestContext`, …) and put `PlannedTests` on the assembly/class ones. Larger refactor; doesn't help consumers outside the lifecycle hooks (fixtures, helpers, extensions); doesn't compose with the future ambient state additions. Useful as an orthogonal cleanup, not as the place to put run-wide data.
+3. **A first-class fixture model** (NUnit/xUnit-style) where setup runs the first time a class requesting the fixture is about to execute. Strongly preferred in the long run and complementary to this RFC: a fixture implementation can use `TestRun.Current.PlannedTests` internally. Tracked separately.
+4. **Multiple gated `[AssemblyInitialize(WhenAnyTestMatches=…)]` attributes** — declarative, but only handles a single predicate per init method and adds a new gating-expression language.
+5. **Do nothing.** Forces users to either over-eager setup in `[AssemblyInitialize]` (slow) or lazy `Lazy<T>` patterns that start mid-run (breaks the "report time spent on setup" desire from the issue thread).
+
+## Compatibility
+
+- **Not a breaking change.** All additions; no existing types are modified.
+- **Experimental.** The whole surface is annotated with `[Experimental("MSTESTEXP")]`. Consumers must explicitly opt in with `#pragma warning disable MSTESTEXP` (or equivalent). This lets us evolve the shape based on early feedback before locking it.
+- **TFM coverage.** `TestFramework.Extensions` targets are unchanged; the new types compile across `netstandard2.0`, `net462`, `net8.0`, `net9.0`, UWP and WinUI.
+- **Source compatibility for derived `TestContext`s.** None affected; we did not touch `TestContext`.
+
+### Unresolved questions
+
+- Should `Current` reset to empty between sources, or accumulate across all sources in the run? v1 ships per-source semantics (matches the AssemblyInitialize use case). A future `IRunWideTestInfo` could expose the union.
+- Should we additionally expose `Hierarchy` (Namespace / Class / Method) on `PlannedTest`? Skipped in v1 since `FullyQualifiedTestClassName` is sufficient; add later if requested.
+- Will users want a `TryGetTestProperty(name, out values)` convenience on `PlannedTest`, or always do their own LINQ? Defer until we see feedback.
+- Future extensions to `ITestRunInfo` (e.g. `RunningTests`, `CompletedTests`, `TestStateChanged` event) — separate RFC once this slice ships.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestRunInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestRunInfo.cs
@@ -40,30 +40,36 @@ internal sealed class TestRunInfo : ITestRunInfo
     private static PlannedTest ToPlannedTest(UnitTestElement element)
     {
         Trait[]? traits = element.Traits;
-        IReadOnlyCollection<KeyValuePair<string, string>> testProperties;
+        KeyValuePair<string, string>[] testProperties;
         if (traits is { Length: > 0 })
         {
-            var converted = new KeyValuePair<string, string>[traits.Length];
+            testProperties = new KeyValuePair<string, string>[traits.Length];
             for (int i = 0; i < traits.Length; i++)
             {
-                converted[i] = new KeyValuePair<string, string>(traits[i].Name, traits[i].Value);
+                testProperties[i] = new KeyValuePair<string, string>(traits[i].Name, traits[i].Value);
             }
-
-            testProperties = converted;
         }
         else
         {
             testProperties = EmptyProperties;
         }
 
-        IReadOnlyCollection<string> categories = element.TestCategory is { Length: > 0 }
+        string[] categories = element.TestCategory is { Length: > 0 }
             ? element.TestCategory
             : EmptyCategories;
 
-        return new PlannedTest(
+        // TestMethod.DisplayName defaults to TestMethod.Name when no display name was explicitly set;
+        // surface that distinction by passing null to PlannedTest so consumers can tell them apart.
+        string testName = element.TestMethod.Name;
+        string adapterDisplayName = element.TestMethod.DisplayName;
+        string? testDisplayName = string.Equals(adapterDisplayName, testName, StringComparison.Ordinal)
+            ? null
+            : adapterDisplayName;
+
+        return PlannedTest.CreateFromOwnedArrays(
             fullyQualifiedTestClassName: element.TestMethod.FullClassName,
-            testName: element.TestMethod.Name,
-            testDisplayName: element.TestMethod.DisplayName,
+            testName: testName,
+            testDisplayName: testDisplayName,
             assemblyPath: element.TestMethod.AssemblyName,
             managedTypeName: element.TestMethod.ManagedTypeName,
             managedMethodName: element.TestMethod.ManagedMethodName,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestRunInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestRunInfo.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+
+/// <summary>
+/// Builds <see cref="ITestRunInfo"/> snapshots from internal MSTest discovery data so that user
+/// code (typically <c>[AssemblyInitialize]</c> or fixtures) can query <see cref="TestRun.Current"/>.
+/// </summary>
+internal sealed class TestRunInfo : ITestRunInfo
+{
+    private static readonly KeyValuePair<string, string>[] EmptyProperties = [];
+    private static readonly string[] EmptyCategories = [];
+
+    public TestRunInfo(IReadOnlyCollection<PlannedTest> plannedTests)
+        => PlannedTests = plannedTests;
+
+    public IReadOnlyCollection<PlannedTest> PlannedTests { get; }
+
+    public static TestRunInfo CreateFrom(IReadOnlyList<UnitTestElement> testsToRun)
+    {
+        if (testsToRun.Count == 0)
+        {
+            return new TestRunInfo([]);
+        }
+
+        var planned = new PlannedTest[testsToRun.Count];
+        for (int i = 0; i < testsToRun.Count; i++)
+        {
+            planned[i] = ToPlannedTest(testsToRun[i]);
+        }
+
+        return new TestRunInfo(planned);
+    }
+
+    private static PlannedTest ToPlannedTest(UnitTestElement element)
+    {
+        Trait[]? traits = element.Traits;
+        IReadOnlyCollection<KeyValuePair<string, string>> testProperties;
+        if (traits is { Length: > 0 })
+        {
+            var converted = new KeyValuePair<string, string>[traits.Length];
+            for (int i = 0; i < traits.Length; i++)
+            {
+                converted[i] = new KeyValuePair<string, string>(traits[i].Name, traits[i].Value);
+            }
+
+            testProperties = converted;
+        }
+        else
+        {
+            testProperties = EmptyProperties;
+        }
+
+        IReadOnlyCollection<string> categories = element.TestCategory is { Length: > 0 }
+            ? element.TestCategory
+            : EmptyCategories;
+
+        return new PlannedTest(
+            fullyQualifiedTestClassName: element.TestMethod.FullClassName,
+            testName: element.TestMethod.Name,
+            testDisplayName: element.TestMethod.DisplayName,
+            assemblyPath: element.TestMethod.AssemblyName,
+            managedTypeName: element.TestMethod.ManagedTypeName,
+            managedMethodName: element.TestMethod.ManagedMethodName,
+            declaringFilePath: element.DeclaringFilePath,
+            declaringLineNumber: element.DeclaringLineNumber,
+            testCategories: categories,
+            testProperties: testProperties);
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -73,6 +73,12 @@ internal sealed class UnitTestRunner
         _typeCache = new TypeCache(reflectHelper);
 
         _classCleanupManager = new ClassCleanupManager(testsToRun);
+
+        // Expose the planned (post-filter) test list so that user code (typically [AssemblyInitialize]
+        // or fixtures) can query TestRun.Current.PlannedTests to decide whether expensive setup is
+        // needed. Set here so the snapshot lives in the same AppDomain/process that will execute the
+        // assembly initialize and the tests themselves.
+        TestRun.SetCurrent(TestRunInfo.CreateFrom(testsToRun));
     }
 
 #pragma warning disable CA1822 // Mark members as static

--- a/src/TestFramework/TestFramework.Extensions/ITestRunInfo.cs
+++ b/src/TestFramework/TestFramework.Extensions/ITestRunInfo.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Read-only ambient information about the current test run. Accessed via <see cref="TestRun.Current"/>.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="TestContext"/>, which describes the test currently executing, an
+/// <see cref="ITestRunInfo"/> describes the run as a whole and is queryable from any code reachable
+/// during a test run (for example helpers, fixtures, or <c>[AssemblyInitialize]</c> methods).
+/// </remarks>
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+public interface ITestRunInfo
+{
+    /// <summary>
+    /// Gets the tests that have been discovered and have passed the active filter for the
+    /// currently-executing assembly. The collection is empty until the platform begins executing
+    /// tests for an assembly.
+    /// </summary>
+    /// <remarks>
+    /// Data-driven tests whose rows are unfolded only at execution time may appear here as a
+    /// single entry rather than one entry per row.
+    /// </remarks>
+    IReadOnlyCollection<PlannedTest> PlannedTests { get; }
+}

--- a/src/TestFramework/TestFramework.Extensions/PlannedTest.cs
+++ b/src/TestFramework/TestFramework.Extensions/PlannedTest.cs
@@ -59,6 +59,60 @@ public sealed class PlannedTest
         TestProperties = copiedTestProperties;
     }
 
+    private PlannedTest(
+        string fullyQualifiedTestClassName,
+        string testName,
+        string? testDisplayName,
+        string assemblyPath,
+        string? managedTypeName,
+        string? managedMethodName,
+        string? declaringFilePath,
+        int? declaringLineNumber,
+        string[] testCategories,
+        KeyValuePair<string, string>[] testProperties,
+        bool _ /* trusted-arrays marker */)
+    {
+        FullyQualifiedTestClassName = fullyQualifiedTestClassName;
+        TestName = testName;
+        TestDisplayName = testDisplayName;
+        AssemblyPath = assemblyPath;
+        ManagedTypeName = managedTypeName;
+        ManagedMethodName = managedMethodName;
+        DeclaringFilePath = declaringFilePath;
+        DeclaringLineNumber = declaringLineNumber;
+        TestCategories = testCategories;
+        TestProperties = testProperties;
+    }
+
+    /// <summary>
+    /// Internal factory used by the adapter to construct a <see cref="PlannedTest"/> without the
+    /// defensive copy performed by the public constructor. The supplied arrays MUST NOT be retained
+    /// or mutated by the caller after this call.
+    /// </summary>
+    internal static PlannedTest CreateFromOwnedArrays(
+        string fullyQualifiedTestClassName,
+        string testName,
+        string? testDisplayName,
+        string assemblyPath,
+        string? managedTypeName,
+        string? managedMethodName,
+        string? declaringFilePath,
+        int? declaringLineNumber,
+        string[] testCategories,
+        KeyValuePair<string, string>[] testProperties)
+        => new(
+            fullyQualifiedTestClassName,
+            testName,
+            testDisplayName,
+            assemblyPath,
+            managedTypeName,
+            managedMethodName,
+            declaringFilePath,
+            declaringLineNumber,
+            testCategories,
+            testProperties,
+            _: true);
+
     /// <summary>
     /// Gets the fully-qualified name of the class declaring the test method.
     /// Mirrors <see cref="TestContext.FullyQualifiedTestClassName"/>.

--- a/src/TestFramework/TestFramework.Extensions/PlannedTest.cs
+++ b/src/TestFramework/TestFramework.Extensions/PlannedTest.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Represents a single test that is planned to run (i.e. has been discovered and passed the active
+/// filter) in the current test run. Returned by <see cref="ITestRunInfo.PlannedTests"/>.
+/// </summary>
+/// <remarks>
+/// Instances are immutable snapshots produced at the start of test execution for the assembly.
+/// They are intended for read-only inspection (for example to decide whether expensive setup is
+/// needed in <c>[AssemblyInitialize]</c>); they do not carry execution-time state such as outcome,
+/// exceptions, or data-driven rows.
+/// </remarks>
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+public sealed class PlannedTest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlannedTest"/> class.
+    /// </summary>
+    /// <param name="fullyQualifiedTestClassName">The fully-qualified name of the class declaring the test method.</param>
+    /// <param name="testName">The simple name of the test method.</param>
+    /// <param name="testDisplayName">The display name of the test, when set; otherwise <see langword="null"/>.</param>
+    /// <param name="assemblyPath">The full path of the assembly that declares the test, on disk.</param>
+    /// <param name="managedTypeName">The ECMA-335 managed type name for the declaring type, when available.</param>
+    /// <param name="managedMethodName">The ECMA-335 managed method name (encoding parameter types) for the test method, when available.</param>
+    /// <param name="declaringFilePath">The source file that declares the test, captured at compile-time by <see cref="TestMethodAttribute"/>, when available.</param>
+    /// <param name="declaringLineNumber">The line number within <paramref name="declaringFilePath"/> at which the test is declared, when available.</param>
+    /// <param name="testCategories">The categories applied via <see cref="TestCategoryAttribute"/>.</param>
+    /// <param name="testProperties">The name/value pairs applied via <see cref="TestPropertyAttribute"/>. Multiple entries with the same name are preserved.</param>
+    public PlannedTest(
+        string fullyQualifiedTestClassName,
+        string testName,
+        string? testDisplayName,
+        string assemblyPath,
+        string? managedTypeName,
+        string? managedMethodName,
+        string? declaringFilePath,
+        int? declaringLineNumber,
+        IReadOnlyCollection<string> testCategories,
+        IReadOnlyCollection<KeyValuePair<string, string>> testProperties)
+    {
+        FullyQualifiedTestClassName = fullyQualifiedTestClassName ?? throw new ArgumentNullException(nameof(fullyQualifiedTestClassName));
+        TestName = testName ?? throw new ArgumentNullException(nameof(testName));
+        TestDisplayName = testDisplayName;
+        AssemblyPath = assemblyPath ?? throw new ArgumentNullException(nameof(assemblyPath));
+        ManagedTypeName = managedTypeName;
+        ManagedMethodName = managedMethodName;
+        DeclaringFilePath = declaringFilePath;
+        DeclaringLineNumber = declaringLineNumber;
+
+        IReadOnlyCollection<string> nonNullTestCategories = testCategories ?? throw new ArgumentNullException(nameof(testCategories));
+        IReadOnlyCollection<KeyValuePair<string, string>> nonNullTestProperties = testProperties ?? throw new ArgumentNullException(nameof(testProperties));
+
+        string[] copiedTestCategories = [.. nonNullTestCategories];
+        KeyValuePair<string, string>[] copiedTestProperties = [.. nonNullTestProperties];
+        TestCategories = copiedTestCategories;
+        TestProperties = copiedTestProperties;
+    }
+
+    /// <summary>
+    /// Gets the fully-qualified name of the class declaring the test method.
+    /// Mirrors <see cref="TestContext.FullyQualifiedTestClassName"/>.
+    /// </summary>
+    public string FullyQualifiedTestClassName { get; }
+
+    /// <summary>
+    /// Gets the simple name of the test method. Mirrors <see cref="TestContext.TestName"/>.
+    /// </summary>
+    public string TestName { get; }
+
+    /// <summary>
+    /// Gets the display name of the test, when one was set; otherwise <see langword="null"/>.
+    /// Mirrors <see cref="TestContext.TestDisplayName"/>.
+    /// </summary>
+    public string? TestDisplayName { get; }
+
+    /// <summary>
+    /// Gets the full path of the assembly that declares the test, on disk.
+    /// </summary>
+    public string AssemblyPath { get; }
+
+    /// <summary>
+    /// Gets the ECMA-335 managed type name for the declaring type, when available.
+    /// </summary>
+    public string? ManagedTypeName { get; }
+
+    /// <summary>
+    /// Gets the ECMA-335 managed method name (encoding parameter types) for the test method,
+    /// when available. Use this for unambiguous identification of overloaded methods.
+    /// </summary>
+    public string? ManagedMethodName { get; }
+
+    /// <summary>
+    /// Gets the source file path that declares the test. This value is captured at compile time
+    /// by <see cref="TestMethodAttribute"/>; it can be <see langword="null"/> when the test is
+    /// declared via a custom test-method attribute that does not propagate the caller information.
+    /// </summary>
+    public string? DeclaringFilePath { get; }
+
+    /// <summary>
+    /// Gets the line number within <see cref="DeclaringFilePath"/> at which the test is declared,
+    /// when available; otherwise <see langword="null"/>.
+    /// </summary>
+    public int? DeclaringLineNumber { get; }
+
+    /// <summary>
+    /// Gets the categories applied to this test via <see cref="TestCategoryAttribute"/> at the
+    /// method, class, or assembly level.
+    /// </summary>
+    public IReadOnlyCollection<string> TestCategories { get; }
+
+    /// <summary>
+    /// Gets the name/value pairs applied to this test via <see cref="TestPropertyAttribute"/>.
+    /// Multiple attributes with the same name are preserved as separate entries.
+    /// </summary>
+    public IReadOnlyCollection<KeyValuePair<string, string>> TestProperties { get; }
+}

--- a/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,17 @@
 #nullable enable
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.ITestRunInfo
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.ITestRunInfo.PlannedTests.get -> System.Collections.Generic.IReadOnlyCollection<Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest!>!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.AssemblyPath.get -> string!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.DeclaringFilePath.get -> string?
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.DeclaringLineNumber.get -> int?
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.FullyQualifiedTestClassName.get -> string!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.ManagedMethodName.get -> string?
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.ManagedTypeName.get -> string?
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.PlannedTest(string! fullyQualifiedTestClassName, string! testName, string? testDisplayName, string! assemblyPath, string? managedTypeName, string? managedMethodName, string? declaringFilePath, int? declaringLineNumber, System.Collections.Generic.IReadOnlyCollection<string!>! testCategories, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string!, string!>>! testProperties) -> void
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.TestCategories.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.TestDisplayName.get -> string?
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.TestName.get -> string!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest.TestProperties.get -> System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string!, string!>>!
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.TestRun
+[MSTESTEXP]static Microsoft.VisualStudio.TestTools.UnitTesting.TestRun.Current.get -> Microsoft.VisualStudio.TestTools.UnitTesting.ITestRunInfo!

--- a/src/TestFramework/TestFramework.Extensions/TestRun.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestRun.cs
@@ -22,7 +22,7 @@ public static class TestRun
     /// <summary>
     /// Gets information about the currently-executing test run. Never returns <see langword="null"/>.
     /// </summary>
-    public static ITestRunInfo Current { get; internal set; } = EmptyTestRunInfo.Instance;
+    public static ITestRunInfo Current { get; private set; } = EmptyTestRunInfo.Instance;
 
     /// <summary>
     /// Set by the platform before executing tests for an assembly. Pass <see langword="null"/> to

--- a/src/TestFramework/TestFramework.Extensions/TestRun.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestRun.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Provides ambient access to information about the currently-executing test run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Current"/> always returns a non-<see langword="null"/> <see cref="ITestRunInfo"/>;
+/// before tests start executing it exposes empty collections.
+/// </para>
+/// <para>
+/// The information is scoped to the current process and (on .NET Framework) the current
+/// AppDomain. Cross-process or cross-AppDomain test runs each have their own snapshot.
+/// </para>
+/// </remarks>
+[Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+public static class TestRun
+{
+    /// <summary>
+    /// Gets information about the currently-executing test run. Never returns <see langword="null"/>.
+    /// </summary>
+    public static ITestRunInfo Current { get; internal set; } = EmptyTestRunInfo.Instance;
+
+    /// <summary>
+    /// Set by the platform before executing tests for an assembly. Pass <see langword="null"/> to
+    /// reset to the empty implementation.
+    /// </summary>
+    internal static void SetCurrent(ITestRunInfo? info)
+        => Current = info ?? EmptyTestRunInfo.Instance;
+
+    private sealed class EmptyTestRunInfo : ITestRunInfo
+    {
+        public static EmptyTestRunInfo Instance { get; } = new();
+
+        public IReadOnlyCollection<PlannedTest> PlannedTests { get; } = [];
+    }
+}

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestRunInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestRunInfoTests.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestFramework.ForTestingMSTest;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Execution;
+
+public sealed class TestRunInfoTests : TestContainer
+{
+    public void CreateFromEmptyListReturnsInfoWithEmptyPlannedTests()
+    {
+        var info = TestRunInfo.CreateFrom([]);
+
+        info.PlannedTests.Should().BeEmpty();
+    }
+
+    public void CreateFromSingleElementPopulatesAllRequiredFields()
+    {
+        var testMethod = new TestMethod(
+            managedMethodName: "MyMethod",
+            hierarchyValues: null,
+            name: "MyMethod",
+            fullClassName: "Some.Namespace.MyClass",
+            assemblyName: @"c:\repo\bin\MyTests.dll",
+            displayName: "My Display Name",
+            parameterTypes: null);
+
+        var element = new UnitTestElement(testMethod);
+
+        var info = TestRunInfo.CreateFrom([element]);
+
+        info.PlannedTests.Should().HaveCount(1);
+        PlannedTest planned = info.PlannedTests.Single();
+        planned.FullyQualifiedTestClassName.Should().Be("Some.Namespace.MyClass");
+        planned.TestName.Should().Be("MyMethod");
+        planned.TestDisplayName.Should().Be("My Display Name");
+        planned.AssemblyPath.Should().Be(@"c:\repo\bin\MyTests.dll");
+        planned.ManagedMethodName.Should().Be("MyMethod");
+        planned.ManagedTypeName.Should().Be("Some.Namespace.MyClass");
+        planned.TestCategories.Should().BeEmpty();
+        planned.TestProperties.Should().BeEmpty();
+    }
+
+    public void CreateFromPopulatesCategoriesAndProperties()
+    {
+        var testMethod = new TestMethod("Run", "Tests.MyClass", "MyTests.dll", null);
+        var element = new UnitTestElement(testMethod)
+        {
+            TestCategory = ["Smoke", "Compatibility"],
+            Traits = [new Trait("Owner", "alice"), new Trait("Owner", "bob"), new Trait("Priority", "1")],
+        };
+
+        var info = TestRunInfo.CreateFrom([element]);
+
+        PlannedTest planned = info.PlannedTests.Single();
+        planned.TestCategories.Should().BeEquivalentTo(["Smoke", "Compatibility"]);
+        planned.TestProperties.Should().BeEquivalentTo(new[]
+        {
+            new KeyValuePair<string, string>("Owner", "alice"),
+            new KeyValuePair<string, string>("Owner", "bob"),
+            new KeyValuePair<string, string>("Priority", "1"),
+        });
+    }
+
+    public void TestRunCurrentIsNeverNull()
+        => TestRun.Current.Should().NotBeNull();
+
+    public void SetCurrentNullResetsToEmpty()
+    {
+        var testMethod = new TestMethod("M", "T", "A.dll", null);
+        TestRun.SetCurrent(TestRunInfo.CreateFrom([new UnitTestElement(testMethod)]));
+        TestRun.Current.PlannedTests.Should().HaveCount(1);
+
+        TestRun.SetCurrent(null);
+
+        TestRun.Current.Should().NotBeNull();
+        TestRun.Current.PlannedTests.Should().BeEmpty();
+    }
+
+    public void PlannedTestCopiesInputCollections()
+    {
+        string[] categories = ["Smoke"];
+        KeyValuePair<string, string>[] properties = [new("Owner", "alice")];
+
+        var plannedTest = new PlannedTest(
+            fullyQualifiedTestClassName: "Tests.MyClass",
+            testName: "Run",
+            testDisplayName: null,
+            assemblyPath: "MyTests.dll",
+            managedTypeName: "Tests.MyClass",
+            managedMethodName: "Run",
+            declaringFilePath: "Tests.cs",
+            declaringLineNumber: 42,
+            testCategories: categories,
+            testProperties: properties);
+
+        categories[0] = "Changed";
+        properties[0] = new KeyValuePair<string, string>("Owner", "bob");
+
+        plannedTest.TestCategories.Should().Equal("Smoke");
+        plannedTest.TestProperties.Should().Equal([new KeyValuePair<string, string>("Owner", "alice")]);
+    }
+}

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestRunInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestRunInfoTests.cs
@@ -84,6 +84,21 @@ public sealed class TestRunInfoTests : TestContainer
         TestRun.Current.PlannedTests.Should().BeEmpty();
     }
 
+    public void CreateFromMapsDefaultDisplayNameToNull()
+    {
+        // TestMethod.DisplayName defaults to TestMethod.Name when no display name is explicitly provided.
+        // PlannedTest.TestDisplayName should be null in that case so consumers can distinguish
+        // "no explicit display name" from "display name set".
+        var testMethod = new TestMethod("MyMethod", "Tests.MyClass", "MyTests.dll", displayName: null);
+        var element = new UnitTestElement(testMethod);
+
+        var info = TestRunInfo.CreateFrom([element]);
+
+        PlannedTest planned = info.PlannedTests.Single();
+        planned.TestName.Should().Be("MyMethod");
+        planned.TestDisplayName.Should().BeNull();
+    }
+
     public void PlannedTestCopiesInputCollections()
     {
         string[] categories = ["Smoke"];


### PR DESCRIPTION
The `.md` files under `.github/workflows/` are source for the `gh aw compile` extension. They follow agentic workflow conventions (custom frontmatter, free-form structure) that don't match the repo's markdownlint config and shouldn't be linted.

Adds `.github/workflows/**/*.md` to the `ignores` list in `.markdownlint-cli2.jsonc`.