### PR TITLE
Add telemetry tracking to new collection Assert overloads

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
@@ -36,6 +36,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllDistinct<T>([NotNull] IEnumerable<T>? collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllDistinct");
         CheckParameterNotNull(collection, "Assert.AreAllDistinct", "collection");
         AreAllDistinctImpl(collection, EqualityComparer<T>.Default, comparerTypeName: null, message, collectionExpression);
     }
@@ -65,6 +66,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllDistinct<T>([NotNull] IEnumerable<T>? collection, [NotNull] IEqualityComparer<T>? comparer, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllDistinct");
         CheckParameterNotNull(collection, "Assert.AreAllDistinct", "collection");
         CheckParameterNotNull(comparer, "Assert.AreAllDistinct", "comparer");
         AreAllDistinctImpl(collection, comparer, comparerTypeName: comparer.GetType().Name, message, collectionExpression);
@@ -91,6 +93,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllDistinct([NotNull] IEnumerable? collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllDistinct");
         CheckParameterNotNull(collection, "Assert.AreAllDistinct", "collection");
         AreAllDistinctImpl(collection.Cast<object?>(), EqualityComparer<object?>.Default, comparerTypeName: null, message, collectionExpression);
     }
@@ -119,6 +122,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllDistinct([NotNull] IEnumerable? collection, [NotNull] IEqualityComparer? comparer, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllDistinct");
         CheckParameterNotNull(collection, "Assert.AreAllDistinct", "collection");
         CheckParameterNotNull(comparer, "Assert.AreAllDistinct", "comparer");
         AreAllDistinctImpl(collection.Cast<object?>(), new NonGenericEqualityComparerAdapter(comparer), comparerTypeName: comparer.GetType().Name, message, collectionExpression);

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllNotNull.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllNotNull.cs
@@ -34,6 +34,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllNotNull([NotNull] IEnumerable? collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllNotNull");
         CheckParameterNotNull(collection, "Assert.AreAllNotNull", "collection");
         AreAllNotNullImpl(collection.Cast<object?>(), message, collectionExpression);
     }
@@ -59,6 +60,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllNotNull<T>([NotNull] IEnumerable<T>? collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllNotNull");
         CheckParameterNotNull(collection, "Assert.AreAllNotNull", "collection");
         AreAllNotNullImpl(collection, message, collectionExpression);
     }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllOfType.cs
@@ -46,6 +46,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllOfType([NotNull] Type? expectedType, [NotNull] IEnumerable? collection, string? message = "", [CallerArgumentExpression(nameof(expectedType))] string expectedTypeExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllOfType");
         CheckParameterNotNull(expectedType, "Assert.AreAllOfType", "expectedType");
         CheckParameterNotNull(collection, "Assert.AreAllOfType", "collection");
         AreAllOfTypeImpl(collection, expectedType, genericTypeArgumentName: null, message, collectionExpression, expectedTypeExpression);
@@ -77,6 +78,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreAllOfType<TExpected>([NotNull] IEnumerable? collection, string? message = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreAllOfType");
         CheckParameterNotNull(collection, "Assert.AreAllOfType", "collection");
         AreAllOfTypeImpl(collection, typeof(TExpected), genericTypeArgumentName: "TExpected", message, collectionExpression, expectedTypeExpression: null);
     }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.cs
@@ -158,6 +158,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreEquivalent<T>(T? expected, T? actual, bool strict, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreEquivalent");
         EquivalenceComparer comparer = new(strict);
         EquivalenceMismatch? mismatch = comparer.Compare(expected, actual);
         if (mismatch is null)
@@ -242,6 +243,7 @@ public sealed partial class Assert
     /// </exception>
     public static void AreNotEquivalent<T>(T? notExpected, T? actual, bool strict, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(actual))] string actualExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.AreNotEquivalent");
         EquivalenceComparer comparer = new(strict);
         EquivalenceMismatch? mismatch = comparer.Compare(notExpected, actual);
         if (mismatch is null)

--- a/src/TestFramework/TestFramework/Assertions/Assert.ContainsAll.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ContainsAll.cs
@@ -47,6 +47,7 @@ public sealed partial class Assert
     /// </exception>
     public static void ContainsAll<T>([NotNull] IEnumerable<T>? expected, [NotNull] IEnumerable<T>? collection, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.ContainsAll");
         CheckParameterNotNull(expected, "Assert.ContainsAll", "expected");
         CheckParameterNotNull(collection, "Assert.ContainsAll", "collection");
         ContainsAllImpl(expected, collection, EqualityComparer<T>.Default, comparerName: null, message, expectedExpression, collectionExpression);
@@ -88,6 +89,7 @@ public sealed partial class Assert
     /// </exception>
     public static void ContainsAll<T>([NotNull] IEnumerable<T>? expected, [NotNull] IEnumerable<T>? collection, [NotNull] IEqualityComparer<T>? comparer, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.ContainsAll");
         CheckParameterNotNull(expected, "Assert.ContainsAll", "expected");
         CheckParameterNotNull(collection, "Assert.ContainsAll", "collection");
         CheckParameterNotNull(comparer, "Assert.ContainsAll", "comparer");
@@ -126,6 +128,7 @@ public sealed partial class Assert
     /// </exception>
     public static void ContainsAll([NotNull] IEnumerable? expected, [NotNull] IEnumerable? collection, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.ContainsAll");
         CheckParameterNotNull(expected, "Assert.ContainsAll", "expected");
         CheckParameterNotNull(collection, "Assert.ContainsAll", "collection");
 
@@ -167,6 +170,7 @@ public sealed partial class Assert
     /// </exception>
     public static void ContainsAll([NotNull] IEnumerable? expected, [NotNull] IEnumerable? collection, [NotNull] IEqualityComparer? comparer, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.ContainsAll");
         CheckParameterNotNull(expected, "Assert.ContainsAll", "expected");
         CheckParameterNotNull(collection, "Assert.ContainsAll", "collection");
         CheckParameterNotNull(comparer, "Assert.ContainsAll", "comparer");
@@ -211,6 +215,7 @@ public sealed partial class Assert
     /// </exception>
     public static void DoesNotContainAll<T>([NotNull] IEnumerable<T>? notExpected, [NotNull] IEnumerable<T>? collection, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContainAll");
         CheckParameterNotNull(notExpected, "Assert.DoesNotContainAll", "notExpected");
         CheckParameterNotNull(collection, "Assert.DoesNotContainAll", "collection");
         DoesNotContainAllImpl(notExpected, collection, EqualityComparer<T>.Default, comparerName: null, message, notExpectedExpression, collectionExpression);
@@ -252,6 +257,7 @@ public sealed partial class Assert
     /// </exception>
     public static void DoesNotContainAll<T>([NotNull] IEnumerable<T>? notExpected, [NotNull] IEnumerable<T>? collection, [NotNull] IEqualityComparer<T>? comparer, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContainAll");
         CheckParameterNotNull(notExpected, "Assert.DoesNotContainAll", "notExpected");
         CheckParameterNotNull(collection, "Assert.DoesNotContainAll", "collection");
         CheckParameterNotNull(comparer, "Assert.DoesNotContainAll", "comparer");
@@ -290,6 +296,7 @@ public sealed partial class Assert
     /// </exception>
     public static void DoesNotContainAll([NotNull] IEnumerable? notExpected, [NotNull] IEnumerable? collection, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContainAll");
         CheckParameterNotNull(notExpected, "Assert.DoesNotContainAll", "notExpected");
         CheckParameterNotNull(collection, "Assert.DoesNotContainAll", "collection");
 
@@ -331,6 +338,7 @@ public sealed partial class Assert
     /// </exception>
     public static void DoesNotContainAll([NotNull] IEnumerable? notExpected, [NotNull] IEnumerable? collection, [NotNull] IEqualityComparer? comparer, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
     {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContainAll");
         CheckParameterNotNull(notExpected, "Assert.DoesNotContainAll", "notExpected");
         CheckParameterNotNull(collection, "Assert.DoesNotContainAll", "collection");
         CheckParameterNotNull(comparer, "Assert.DoesNotContainAll", "comparer");


### PR DESCRIPTION
Adds `TelemetryCollector.TrackAssertionCall()` to 18 collection `Assert` overloads that were missing telemetry, fixing task 1 of #8440.

## Changes

| File | Overloads tracked |
|---|---|
| `Assert.AreAllDistinct.cs` | 4 |
| `Assert.AreAllNotNull.cs` | 2 |
| `Assert.AreAllOfType.cs` | 2 |
| `Assert.ContainsAll.cs` | 4 `ContainsAll` + 4 `DoesNotContainAll` |
| `Assert.AreEquivalent.cs` | 1 `AreEquivalent` (strict) + 1 `AreNotEquivalent` (strict) |

The pattern follows `Assert.AreSequenceEqual.cs`: `TelemetryCollector.TrackAssertionCall("Assert.<MethodName>")` is the first statement in each overload body, before any `CheckParameterNotNull`.

## Design note on `AreEquivalent` / `AreNotEquivalent`

The issue counted 20 missing overloads but two of them are simple delegating overloads:

```csharp
public static void AreEquivalent<T>(T? expected, T? actual, string? message = "", ...)
    => AreEquivalent(expected, actual, strict: false, message, ...);
```

Adding telemetry to those would double-count. I tracked only the strict (work-doing) variant — matching the convention in `Assert.Contains.cs` (e.g. line 486-487 delegates to line 520 which is the single tracking site). Each user call records exactly one telemetry event.

## Verification

- `TestFramework.csproj` builds clean (0 warnings, 0 errors)
- All 187 related unit tests pass (`AreAll*` 60, `AreEquivalent*` 68, `AreNotEquivalent*` 14, `ContainsAll*` 26, `DoesNotContainAll*` 19)
- No public API surface added → no `PublicAPI.Unshipped.txt` change
- No `.resx` / `.xlf` impact — telemetry strings are technical identifiers

Fixes task 1 of #8440.
