### PR TITLE
Fix flaky TimingProperty.ToString test by using an explicit format string

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/TimingProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TimingProperties.cs
@@ -42,9 +42,9 @@ public readonly struct TimingInfo : IEquatable<TimingInfo>
         var builder = new StringBuilder();
         builder.Append($"{nameof(TimingInfo)} {{ ");
         builder.Append($"{nameof(StartTime)} = ");
-        builder.Append(StartTime.ToString(CultureInfo.InvariantCulture));
+        builder.Append(StartTime.ToString("MM/dd/yyyy HH:mm:ss zzz", CultureInfo.InvariantCulture));
         builder.Append($", {nameof(EndTime)} = ");
-        builder.Append(EndTime.ToString(CultureInfo.InvariantCulture));
+        builder.Append(EndTime.ToString("MM/dd/yyyy HH:mm:ss zzz", CultureInfo.InvariantCulture));
         builder.Append($", {nameof(Duration)} = ");
         builder.Append(Duration.ToString("c", CultureInfo.InvariantCulture));
         builder.Append(" }");

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
@@ -155,41 +155,23 @@ public sealed class TestNodePropertiesTests
     [TestMethod]
     public void TimingProperty_ToStringIsCorrect()
     {
-        CultureInfo originalCulture = CultureInfo.CurrentCulture;
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-            DateTimeOffset startTime = new(2021, 9, 1, 0, 0, 0, default);
-            DateTimeOffset endTime = new(2021, 9, 1, 1, 2, 3, default);
-            TimeSpan duration = endTime - startTime;
-            Assert.AreEqual(
-                    "TimingProperty { GlobalTiming = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 }, StepTimings = [] }",
-                    new TimingProperty(new(startTime, endTime, duration)).ToString());
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-        }
+        DateTimeOffset startTime = new(2021, 9, 1, 0, 0, 0, default);
+        DateTimeOffset endTime = new(2021, 9, 1, 1, 2, 3, default);
+        TimeSpan duration = endTime - startTime;
+        Assert.AreEqual(
+                "TimingProperty { GlobalTiming = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 }, StepTimings = [] }",
+                new TimingProperty(new(startTime, endTime, duration)).ToString());
     }
 
     [TestMethod]
     public void TimingProperty_WithStepTimings_ToStringIsCorrect()
     {
-        CultureInfo originalCulture = CultureInfo.CurrentCulture;
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-            DateTimeOffset startTime = new(2021, 9, 1, 0, 0, 0, default);
-            DateTimeOffset endTime = new(2021, 9, 1, 1, 2, 3, default);
-            TimeSpan duration = endTime - startTime;
-            Assert.AreEqual(
-                    "TimingProperty { GlobalTiming = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 }, StepTimings = [StepTimingInfo { Id = run, Description = some description, Timing = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 } }] }",
-                    new TimingProperty(new(startTime, endTime, duration), [new("run", "some description", new(startTime, endTime, duration))]).ToString());
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-        }
+        DateTimeOffset startTime = new(2021, 9, 1, 0, 0, 0, default);
+        DateTimeOffset endTime = new(2021, 9, 1, 1, 2, 3, default);
+        TimeSpan duration = endTime - startTime;
+        Assert.AreEqual(
+                "TimingProperty { GlobalTiming = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 }, StepTimings = [StepTimingInfo { Id = run, Description = some description, Timing = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 } }] }",
+                new TimingProperty(new(startTime, endTime, duration), [new("run", "some description", new(startTime, endTime, duration))]).ToString());
     }
 
     [TestMethod]


### PR DESCRIPTION
## Problem

`TimingProperty_ToStringIsCorrect` (and its sibling `_WithStepTimings_` variant) occasionally fails with:

```
expected: "TimingProperty { GlobalTiming = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00, Duration = 01:02:03 }, StepTimings = [] }"
actual:   "TimingProperty { GlobalTiming = TimingInfo { StartTime = 09/01/2021 00:00:00 +00:00 +00:00, EndTime = 09/01/2021 01:02:03 +00:00 +00:00, Duration = 01:02:03 }, StepTimings = [] }"
```

Note the duplicated `+00:00 +00:00` in the actual output.

## Root cause

`TimingInfo.ToString` formats the start/end via:

```csharp
StartTime.ToString(CultureInfo.InvariantCulture)
```

`DateTimeOffset.ToString(IFormatProvider)` is implemented as roughly `format = dtfi.GeneralLongTimePattern + " zzz"`. If anything causes `GeneralLongTimePattern` (which derives from `ShortDatePattern + " " + LongTimePattern`) to already contain `zzz`, you get the doubled offset.

The existing tests tried to defend against this by setting `CultureInfo.CurrentCulture = CultureInfo.InvariantCulture`, but `ToString(InvariantCulture)` does not consult `CurrentCulture` (`DateTimeFormat.GetInstance(provider)` uses the explicit provider when non-null), so the workaround did not actually protect the formatter path that fails.

## Fix

- `TimingInfo.ToString` now uses an explicit format string `"MM/dd/yyyy HH:mm:ss zzz"` with `InvariantCulture`. Output is fully deterministic regardless of culture/runtime state.
- Removed the no-longer-needed `CultureInfo.CurrentCulture` mutation from the two timing tests.

## Verification

- Full `build.cmd -c Debug` succeeds (0 warnings, 0 errors).
- Ran the 3 timing tests 5× on `net9.0` and 1× on `net8.0` — all 3/3 pass on every iteration.
