### PR TITLE
fix(aw): Issue Arborist - re-apply curl REST API workaround for DIFC proxy /meta block

### DIFF
--- a/.github/workflows/issue-arborist.lock.yml
+++ b/.github/workflows/issue-arborist.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c82efeb35e2216aab9e894a1502b03706d2ea6009e15e5e9a23a988f007a17c0","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fbba8406bcb3cf31f105153b216a3944ad23f46e40241289d036be94bad56cb4","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49","digest":"sha256:9e4b936d4215af09fa412e12a5fc82f97f2cde4993eefc85980a900122fa9062","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49@sha256:9e4b936d4215af09fa412e12a5fc82f97f2cde4993eefc85980a900122fa9062"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49","digest":"sha256:b795506f6b4fd12694a29f964b4d38d2d29ac3aaafe3394131619ce36020b646","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49@sha256:b795506f6b4fd12694a29f964b4d38d2d29ac3aaafe3394131619ce36020b646"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49","digest":"sha256:f6c6998edfb9f58b6e12d3f148e6f2104747a7702d563a9e8b13d4b2ae6997dd","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49@sha256:f6c6998edfb9f58b6e12d3f148e6f2104747a7702d563a9e8b13d4b2ae6997dd"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -193,20 +193,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
+          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
           <system>
-          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
+          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
+          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
           <safe-output-tools>
           Tools: create_issue(max:5), link_sub_issue(max:50), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
+          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
+          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -235,12 +235,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
+          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
+          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-arborist.md}}
-          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
+          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -379,40 +379,12 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Start DIFC Proxy
-        env:
-          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"none","repos":"all"}}'
-          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.9'
-        run: |
-          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
       - env:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
-          GH_HOST: localhost:18443
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_API_URL: https://localhost:18443/api/v3
-          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
+          GH_AW_ORIGINAL_GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         name: Fetch issues data
-        run: |
-          # Create output directory
-          mkdir -p /tmp/gh-aw/issues-data
-
-          echo "⬇ Downloading the last 100 open issues (excluding sub-issues)..."
-
-          # Fetch the last 100 open issues that don't have a parent issue
-          gh issue list --repo $GH_AW_GITHUB_REPOSITORY \
-            --search "-parent-issue:*" \
-            --state open \
-            --json number,title,author,createdAt,state,url,body,labels,updatedAt,closedAt,milestone,assignees \
-            --limit 100 \
-            > /tmp/gh-aw/issues-data/issues.json
-
-          echo "✓ Issues data saved to /tmp/gh-aw/issues-data/issues.json"
-          echo "Total issues fetched: $(jq 'length' /tmp/gh-aw/issues-data/issues.json)"
+        run: "# Create output directory\nmkdir -p /tmp/gh-aw/issues-data\n\necho \"⬇ Downloading the last 100 open issues (excluding sub-issues)...\"\n\n# Use REST API directly to avoid gh CLI /meta check blocked by DIFC proxy.\n# Fetches the most recently created 100 issues (intentional limit matching previous behavior).\n# State is normalized to uppercase (OPEN/CLOSED) to match gh CLI GraphQL output format.\ncurl -s \\\n  -H \"Authorization: Bearer ${GITHUB_TOKEN}\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  --get \\\n  --data-urlencode \"q=repo:${GH_AW_GITHUB_REPOSITORY} is:issue is:open -is:sub-issue\" \\\n  --data-urlencode \"sort=created\" \\\n  --data-urlencode \"order=desc\" \\\n  --data-urlencode \"per_page=100\" \\\n  \"${GH_AW_ORIGINAL_GITHUB_API_URL}/search/issues\" \\\n  | jq '.items // [] | map({\n      number: .number,\n      title: .title,\n      author: {login: .user.login},\n      createdAt: .created_at,\n      state: (.state | ascii_upcase),\n      url: .html_url,\n      body: .body,\n      labels: [.labels[] | {name: .name}],\n      updatedAt: .updated_at,\n      closedAt: .closed_at,\n      milestone: (if .milestone != null then {title: .milestone.title} else null end),\n      assignees: [.assignees[] | {login: .login}]\n    })' \\\n  > /tmp/gh-aw/issues-data/issues.json \\\n  || echo '[]' > /tmp/gh-aw/issues-data/issues.json\n\necho \"✓ Issues data saved to /tmp/gh-aw/issues-data/issues.json\"\necho \"Total issues fetched: $(jq 'length' /tmp/gh-aw/issues-data/issues.json)\"\n"
 
       - name: Configure Git credentials
         env:
@@ -454,10 +426,6 @@ jobs:
           GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
-      - name: Stop DIFC Proxy
-        if: always()
-        continue-on-error: true
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -481,9 +449,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8c6671b8f4012a32_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2b5ec42f26931b4d_EOF'
           {"create_issue":{"expires":48,"group":true,"max":5,"title_prefix":"[parent] "},"create_report_incomplete_issue":{},"link_sub_issue":{"max":50},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8c6671b8f4012a32_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2b5ec42f26931b4d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -708,7 +676,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_2f3e317a7a79f1bc_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8934d07aaa70c5c7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -753,7 +721,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2f3e317a7a79f1bc_EOF
+          GH_AW_MCP_CONFIG_8934d07aaa70c5c7_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/issue-arborist.md
+++ b/.github/workflows/issue-arborist.md
@@ -29,20 +29,42 @@ steps:
   - name: Fetch issues data
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_AW_ORIGINAL_GITHUB_API_URL: ${{ github.api_url }}
+      GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
     run: |
       # Create output directory
       mkdir -p /tmp/gh-aw/issues-data
 
       echo "⬇ Downloading the last 100 open issues (excluding sub-issues)..."
 
-      # Fetch the last 100 open issues that don't have a parent issue
-      gh issue list --repo ${{ github.repository }} \
-        --search "-parent-issue:*" \
-        --state open \
-        --json number,title,author,createdAt,state,url,body,labels,updatedAt,closedAt,milestone,assignees \
-        --limit 100 \
-        > /tmp/gh-aw/issues-data/issues.json
+      # Use REST API directly to avoid gh CLI /meta check blocked by DIFC proxy.
+      # Fetches the most recently created 100 issues (intentional limit matching previous behavior).
+      # State is normalized to uppercase (OPEN/CLOSED) to match gh CLI GraphQL output format.
+      curl -s \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        --get \
+        --data-urlencode "q=repo:${GH_AW_GITHUB_REPOSITORY} is:issue is:open -is:sub-issue" \
+        --data-urlencode "sort=created" \
+        --data-urlencode "order=desc" \
+        --data-urlencode "per_page=100" \
+        "${GH_AW_ORIGINAL_GITHUB_API_URL}/search/issues" \
+        | jq '.items // [] | map({
+            number: .number,
+            title: .title,
+            author: {login: .user.login},
+            createdAt: .created_at,
+            state: (.state | ascii_upcase),
+            url: .html_url,
+            body: .body,
+            labels: [.labels[] | {name: .name}],
+            updatedAt: .updated_at,
+            closedAt: .closed_at,
+            milestone: (if .milestone != null then {title: .milestone.title} else null end),
+            assignees: [.assignees[] | {login: .login}]
+          })' \
+        > /tmp/gh-aw/issues-data/issues.json \
+        || echo '[]' > /tmp/gh-aw/issues-data/issues.json
 
       echo "✓ Issues data saved to /tmp/gh-aw/issues-data/issues.json"
       echo "Total issues fetched: $(jq 'length' /tmp/gh-aw/issues-data/issues.json)"


### PR DESCRIPTION
The agentic-workflows reset in #8491 reverted the Issue Arborist `Fetch issues data` step back to `gh issue list`, which immediately fails in CI because the gh CLI hits `/meta` against the corporate DIFC proxy and gets HTTP 403. That breaks the run before the MCP server can start, which is what produces the `ERR_SYSTEM: rpc-messages.jsonl is present but zero bytes — MCP telemetry capture failed` annotation seen in [run 26294701799](https://github.com/microsoft/testfx/actions/runs/26294701799).

Re-applies the same fix as #8185: call the GitHub Search REST API directly with `curl`, using `GH_AW_ORIGINAL_GITHUB_API_URL` to bypass the DIFC proxy. The lock file is regenerated via `gh aw compile issue-arborist --strict`.