### PR TITLE
Document strict "skipped == not run" default at the 3 enforcement sites

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -508,6 +508,17 @@ public class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisposable
 
         if (request is RunSummaryInfoRequest runSummaryInfoRequest)
         {
+            // DESIGN: `TotalPassed == 0` is intentionally treated as a failed run. Skipped tests don't count as
+            // "ran", so an all-skipped (or zero-test) run is reported as `Failed!`. This is the strict default
+            // chosen in #3216 / #3243 ("Skipped tests count as not run") to flag the common "invalid filter ran
+            // nothing" mistake. Users who legitimately expect all-skipped runs should opt out via
+            // `--ignore-exit-code 8` (in that scenario the MSBuild target will succeed but this summary line will
+            // still say `Failed!` until we plumb the effective outcome through `RunSummaryInfoRequest`).
+            //
+            // Two sibling sites mirror this decision and must stay in lockstep:
+            //   - TestApplicationResult.ConsumeAsync (excludes skipped from `_totalRanTests` -> exit code 8)
+            //   - TerminalTestReporter.Summary.cs (`allTestsWereSkipped` -> red "Zero tests ran")
+            // Do NOT relax this to `TotalFailed > 0` without revisiting those sites and the design discussion above.
             string summary = string.Format(
                 CultureInfo.CurrentCulture,
                 Resources.MSBuildResources.Summary,

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -45,6 +45,15 @@ internal sealed partial class TerminalTestReporter
         int totalFailedTests = _testProgressState?.FailedTests ?? 0;
         int totalSkippedTests = _testProgressState?.SkippedTests ?? 0;
 
+        // DESIGN: `allTestsWereSkipped` is intentionally treated as a failed run. Skipped tests don't count as
+        // "ran", so an all-skipped (or zero-test) run is reported in red as "Zero tests ran". This is the strict
+        // default chosen in #3216 / #3243 ("Skipped tests count as not run") to flag the common "invalid filter
+        // ran nothing" mistake. Users who legitimately expect all-skipped runs should opt out via
+        // `--ignore-exit-code 8`.
+        //
+        // Two sibling sites mirror this decision and must stay in lockstep:
+        //   - TestApplicationResult.ConsumeAsync (excludes skipped from `_totalRanTests` -> exit code 8)
+        //   - Microsoft.Testing.Platform.MSBuild InvokeTestingPlatformTask (run-summary verdict)
         bool notEnoughTests = totalTests < _options.MinimumExpectedTests;
         bool allTestsWereSkipped = totalTests == 0 || totalTests == totalSkippedTests;
         bool anyTestFailed = totalFailedTests > 0;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -48,8 +48,8 @@ internal sealed partial class TerminalTestReporter
         // DESIGN: `allTestsWereSkipped` is intentionally treated as a failed run. Skipped tests don't count as
         // "ran", so an all-skipped (or zero-test) run is reported in red as "Zero tests ran". This is the strict
         // default chosen in #3216 / #3243 ("Skipped tests count as not run") to flag the common "invalid filter
-        // ran nothing" mistake. Users who legitimately expect all-skipped runs should opt out via
-        // `--ignore-exit-code 8`.
+        // ran nothing" mistake. `--ignore-exit-code 8` only affects the process exit code; it does not change
+        // this terminal summary/verdict/coloring, which still reports the run as failed by design.
         //
         // Two sibling sites mirror this decision and must stay in lockstep:
         //   - TestApplicationResult.ConsumeAsync (excludes skipped from `_totalRanTests` -> exit code 8)

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -119,6 +119,7 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
         {
             _totalRanTests++;
         }
+
         // DESIGN: Skipped tests are intentionally excluded from `_totalRanTests`.
         // `WellKnownTestNodeTestRunOutcomeProperties` does not contain `SkippedTestNodeStateProperty`, so an
         // all-skipped (or zero-test) run leaves `_totalRanTests == 0` and yields exit code `ExitCode.ZeroTests` (8)

--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -119,6 +119,17 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
         {
             _totalRanTests++;
         }
+        // DESIGN: Skipped tests are intentionally excluded from `_totalRanTests`.
+        // `WellKnownTestNodeTestRunOutcomeProperties` does not contain `SkippedTestNodeStateProperty`, so an
+        // all-skipped (or zero-test) run leaves `_totalRanTests == 0` and yields exit code `ExitCode.ZeroTests` (8)
+        // in `GetProcessExitCode`. This is the strict default chosen in #3216 / #3243 ("Skipped tests count as not
+        // run") to surface the common "invalid filter ran nothing" mistake. The documented opt-out for users who
+        // legitimately expect all-skipped runs is `--ignore-exit-code 8`.
+        //
+        // Two other layers mirror this decision and must stay in lockstep:
+        //   - TerminalTestReporter.Summary.cs (`allTestsWereSkipped`)
+        //   - Microsoft.Testing.Platform.MSBuild InvokeTestingPlatformTask (run-summary verdict)
+        // Do not relax this without revisiting those sites and the design discussion above.
         else if (Array.IndexOf(TestNodePropertiesCategories.WellKnownTestNodeTestRunOutcomeProperties, outcomeType) != -1)
         {
             _totalRanTests++;


### PR DESCRIPTION
## Why

The strict default introduced in #3216 / #3243 ("Skipped tests count as not run") is enforced in three different files that intentionally agree with each other. There is no central place that explains the rationale, so it is easy to misread any single site as a bug.

Concrete evidence: the automated MTP Integration Analysis just filed #8433 reading the MSBuild summary verdict as a contradiction, and the auto-generated #8509 proposed relaxing it to `TotalFailed > 0`. That would have desynchronized the three layers (MSBuild would say `Passed!` while the test host still exits with `ZeroTests` (8) and the standalone terminal still says "Zero tests ran" in red), without changing the actual build outcome. Both issues have been closed as by design.

## What

Inline comment at each of the three sites that cross-reference each other and the original design discussion:

1. `Microsoft.Testing.Platform/Services/TestApplicationResult.cs` -- `_totalRanTests` excludes skipped, so an all-skipped run gets `ExitCode.ZeroTests` (8). Opt-out: `--ignore-exit-code 8`.
2. `Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs` -- `allTestsWereSkipped` is treated as `runFailed`, prints "Zero tests ran" in red.
3. `Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs` -- `TotalPassed == 0` ⇒ `Failed!` in the per-TFM summary, with a `Do NOT relax this to TotalFailed > 0 without ...` note pointing at the other two sites.

## What this does NOT do

- No behavior change.
- No new public API.
- No resource / xlf updates needed.
- Does not address the narrow real edge case (user with `--ignore-exit-code 8` sees a misleading `Failed!` summary); the comment in `InvokeTestingPlatformTask.cs` notes that the principled fix is to thread the effective outcome through `RunSummaryInfoRequest`, which is a separate change.

Refs: #3216, #3243, #8433, #8509