### PR TITLE
[code-simplifier] Simplify validation and flush logic for improved clarity

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
@@ -440,14 +440,15 @@ internal sealed class AzureDevOpsTestResultsPublisher : IDataConsumer, ITestSess
     private bool ShouldFlushUnsafe(bool force)
     {
         int pendingResultsCount = _retryResults.Count + _pendingResults.Count;
-        if (force)
-        {
-            return pendingResultsCount > 0;
-        }
 
         if (pendingResultsCount == 0)
         {
             return false;
+        }
+
+        if (force)
+        {
+            return true;
         }
 
         if (_clock.UtcNow - _lastFlushTime >= _options.FlushInterval)

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
@@ -182,19 +182,18 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
     {
         timeout = TimeSpan.Zero;
 
-        // We need at least one digit plus a unit suffix (e.g. "1s").
         if (arg is null || arg.Length < 2)
         {
             return false;
         }
 
-        char unit = char.ToLowerInvariant(arg[arg.Length - 1]);
-        if (unit is not 'h' and not 'm' and not 's')
+        char unit = char.ToLowerInvariant(arg[^1]);
+        if (unit is not ('h' or 'm' or 's'))
         {
             return false;
         }
 
-        if (!float.TryParse(arg[..(arg.Length - 1)], NumberStyles.Float, CultureInfo.InvariantCulture, out float value)
+        if (!float.TryParse(arg[..^1], NumberStyles.Float, CultureInfo.InvariantCulture, out float value)
             || float.IsNaN(value)
             || float.IsInfinity(value)
             || value < 0)


### PR DESCRIPTION
## Code Simplification - 2026-05-24

This PR simplifies recently modified code to improve clarity, consistency, and maintainability while preserving all functionality.

### Files Simplified

- `src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs` - Simplified timeout parsing with modern C# syntax
- `src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs` - Improved flush condition ordering for clarity

### Improvements Made

1. **Modern C# Syntax**
   - Replaced `arg[arg.Length - 1]` with `arg[^1]` (index-from-end operator)
   - Replaced `arg[..(arg.Length - 1)]` with `arg[..^1]` (range-from-end operator)
   - Changed `is not 'h' and not 'm' and not 's'` to `is not ('h' or 'm' or 's')` (nested pattern matching)

2. **Enhanced Clarity**
   - Reordered `ShouldFlushUnsafe` conditions to check empty state first, making the logic flow more intuitive
   - Simplified force-flag check by eliminating redundant condition after empty-state check
   - Removed unnecessary comment that merely restated obvious logic

3. **Applied Project Standards**
   - Used modern C# features consistently with codebase conventions
   - Maintained all existing comments that explain non-obvious design decisions
   - Preserved exact functional behavior

### Changes Based On

Recent changes from:
- #8512 - Preserve Azure DevOps live publish batches on failure
- #8496 - Reject negative timeout values during command-line validation

### Testing

- ✅ All tests pass (55 tests in PlatformCommandLineProviderTests, 22 tests in AzureDevOpsLivePublishingTests)
- ✅ Build succeeds with no warnings or errors
- ✅ No functional changes - behavior is identical

### Review Focus

Please verify:
- Functionality is preserved
- Simplifications improve code quality
- Changes align with project conventions
- No unintended side effects

---

*Automated by Code Simplifier Agent*


<!-- gh-aw-tracker-id: code-simplifier -->




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item was blocked because it doesn't meet the GitHub integrity level.
>
> - [#8529](https://github.com/microsoft/testfx/pull/8529) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/26362775004) · ● 1.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-05-25T13:48:13.786Z --> on May 25, 2026, 1:48 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.48, model: claude-sonnet-4.5, id: 26362775004, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/26362775004 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->