### PR TITLE
Automate drift detection for vendored source files (#8548)

### DIFF
--- a/.github/scripts/check_vendored_files.py
+++ b/.github/scripts/check_vendored_files.py
@@ -260,7 +260,7 @@ def check_source(entry: Entry, source_index: int, source: Source) -> DriftResult
             current_content.splitlines(keepends=True),
             fromfile=f"{source.path}@{source.baseline_blob_sha[:7]}",
             tofile=f"{source.path}@{(current_blob_sha or 'HEAD')[:7]}",
-            lineterm="",
+            lineterm="\n",
         )
         diff_text = _truncate_diff(list(diff_iter), MAX_DIFF_LINES)
 
@@ -415,10 +415,18 @@ def ensure_label() -> None:
     ])
 
 
+_STATUS_TITLES = {
+    "drift": "drift detected",
+    "missing": "upstream path missing",
+    "error": "drift check error",
+}
+
+
 def upsert_issue(result: DriftResult, dry_run: bool) -> None:
     marker = _marker(result.entry.id, result.source_index)
     body = _render_issue_body(result)
-    title = f"[vendored-sync] {result.entry.id}: drift detected (#{result.source_index})"
+    status_text = _STATUS_TITLES.get(result.status, result.status)
+    title = f"[vendored-sync] {result.entry.id}: {status_text} (#{result.source_index})"
 
     if dry_run:
         print(f"\n--- would create/update issue ({result.entry.id}#{result.source_index}) ---")

--- a/.github/scripts/check_vendored_files.py
+++ b/.github/scripts/check_vendored_files.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""
+Detect drift between locally-vendored source files and their upstream sources.
+
+Reads eng/vendored-files.json and, for each tracked file, compares the recorded
+baseline blob SHA against the current blob SHA on the tracked branch via the
+GitHub Contents API. When drift is detected, opens (or updates) a tracking
+issue containing a unified diff of the upstream changes.
+
+Modes:
+    validate    - Structural validation only. No network calls. Safe for PRs.
+    check       - Full drift detection. Requires GH_TOKEN. Creates/edits issues.
+
+The check mode is idempotent: existing issues are matched by label
+`area-vendored-sync` plus a hidden HTML marker in the body of the form
+`<!-- vendored-sync:id=<entry-id>:<source-index> -->`.
+
+See eng/vendored-files.md for the manifest schema and reconciliation workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "eng" / "vendored-files.json"
+ISSUE_LABEL = "area-vendored-sync"
+ISSUE_REPO = os.environ.get("VENDORED_SYNC_REPO", "microsoft/testfx")
+MAX_DIFF_LINES = 300
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+API_BASE = "https://api.github.com"
+RAW_BASE = "https://raw.githubusercontent.com"
+
+
+@dataclass
+class Source:
+    repo: str
+    ref: str
+    path: str
+    baseline_ref_sha: str
+    baseline_blob_sha: str
+    scope: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Source":
+        return cls(
+            repo=d["repo"],
+            ref=d["ref"],
+            path=d["path"],
+            baseline_ref_sha=d["baseline_ref_sha"],
+            baseline_blob_sha=d["baseline_blob_sha"],
+            scope=d.get("scope", ""),
+        )
+
+
+@dataclass
+class Entry:
+    id: str
+    local_path: str
+    notes: str
+    sources: list[Source]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "Entry":
+        return cls(
+            id=d["id"],
+            local_path=d["local_path"],
+            notes=d.get("notes", ""),
+            sources=[Source.from_dict(s) for s in d["sources"]],
+        )
+
+
+def load_manifest() -> list[Entry]:
+    with MANIFEST_PATH.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return [Entry.from_dict(e) for e in data["entries"]]
+
+
+# ---------- validation ----------
+
+def validate(entries: list[Entry]) -> int:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    for entry in entries:
+        if not entry.id:
+            errors.append("Entry missing id.")
+            continue
+        if entry.id in seen_ids:
+            errors.append(f"Duplicate entry id: {entry.id}")
+        seen_ids.add(entry.id)
+
+        local = REPO_ROOT / entry.local_path
+        if not local.is_file():
+            errors.append(f"{entry.id}: local_path does not exist: {entry.local_path}")
+
+        if not entry.sources:
+            errors.append(f"{entry.id}: must declare at least one source.")
+
+        for index, source in enumerate(entry.sources):
+            tag = f"{entry.id}#sources[{index}]"
+            if not re.match(r"^[\w.-]+/[\w.-]+$", source.repo):
+                errors.append(f"{tag}: invalid repo '{source.repo}' (expected owner/name).")
+            if not source.ref:
+                errors.append(f"{tag}: missing ref.")
+            if not source.path or source.path.startswith("/"):
+                errors.append(f"{tag}: invalid path '{source.path}'.")
+            if not SHA_RE.match(source.baseline_ref_sha):
+                errors.append(f"{tag}: baseline_ref_sha must be a 40-char hex SHA.")
+            if not SHA_RE.match(source.baseline_blob_sha):
+                errors.append(f"{tag}: baseline_blob_sha must be a 40-char hex SHA.")
+
+    if errors:
+        print("Manifest validation FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    total_sources = sum(len(entry.sources) for entry in entries)
+    print(f"Manifest OK: {len(entries)} entries, {total_sources} sources.")
+    return 0
+
+
+# ---------- HTTP helpers ----------
+
+def _request(url: str, accept: str = "application/vnd.github+json") -> tuple[int, bytes, dict[str, str]]:
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    req = urllib.request.Request(url)
+    req.add_header("Accept", accept)
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "testfx-vendored-sync")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read(), dict(resp.headers)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), dict(e.headers or {})
+
+
+def api_json(path: str) -> tuple[int, Any]:
+    url = f"{API_BASE}{path}"
+    status, body, _ = _request(url)
+    if not body:
+        return status, None
+    try:
+        return status, json.loads(body)
+    except json.JSONDecodeError:
+        return status, None
+
+
+def fetch_blob_content(repo: str, blob_sha: str) -> str | None:
+    status, data = api_json(f"/repos/{repo}/git/blobs/{blob_sha}")
+    if status != 200 or not isinstance(data, dict):
+        return None
+    if data.get("encoding") != "base64":
+        return None
+    try:
+        return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
+    except (KeyError, ValueError):
+        return None
+
+
+def fetch_raw(repo: str, ref: str, path: str) -> str | None:
+    url = f"{RAW_BASE}/{repo}/{ref}/{urllib.parse.quote(path)}"
+    status, body, _ = _request(url, accept="text/plain")
+    if status != 200:
+        return None
+    return body.decode("utf-8", errors="replace")
+
+
+# ---------- drift detection ----------
+
+@dataclass
+class DriftResult:
+    entry: Entry
+    source_index: int
+    source: Source
+    status: str            # "drift", "missing", "ref_missing", "ok", "error"
+    current_blob_sha: str | None
+    current_ref_sha: str | None
+    detail: str
+    diff_text: str
+
+
+def _resolve_ref_sha(repo: str, ref: str) -> str | None:
+    status, data = api_json(f"/repos/{repo}/commits/{urllib.parse.quote(ref, safe='/')}")
+    if status == 200 and isinstance(data, dict):
+        return data.get("sha")
+    return None
+
+
+def _get_blob_sha(repo: str, ref: str, path: str) -> tuple[int, str | None]:
+    status, data = api_json(
+        f"/repos/{repo}/contents/{urllib.parse.quote(path)}?ref={urllib.parse.quote(ref, safe='/')}"
+    )
+    if status == 200 and isinstance(data, dict) and data.get("type") == "file":
+        return status, data.get("sha")
+    return status, None
+
+
+def _truncate_diff(diff_lines: list[str], max_lines: int) -> str:
+    if len(diff_lines) <= max_lines:
+        return "".join(diff_lines)
+    head = "".join(diff_lines[:max_lines])
+    return f"{head}\n... (diff truncated; {len(diff_lines) - max_lines} more lines)"
+
+
+def check_source(entry: Entry, source_index: int, source: Source) -> DriftResult:
+    status, current_blob_sha = _get_blob_sha(source.repo, source.ref, source.path)
+
+    if status == 404:
+        return DriftResult(
+            entry=entry, source_index=source_index, source=source,
+            status="missing", current_blob_sha=None, current_ref_sha=None,
+            detail=(
+                f"Upstream path `{source.path}` no longer exists on "
+                f"`{source.repo}@{source.ref}`. The file may have been renamed, "
+                f"deleted, or the tracked ref was renamed."
+            ),
+            diff_text="",
+        )
+
+    if current_blob_sha is None:
+        return DriftResult(
+            entry=entry, source_index=source_index, source=source,
+            status="error", current_blob_sha=None, current_ref_sha=None,
+            detail=f"Unexpected response from contents API (HTTP {status}).",
+            diff_text="",
+        )
+
+    if current_blob_sha == source.baseline_blob_sha:
+        return DriftResult(
+            entry=entry, source_index=source_index, source=source,
+            status="ok", current_blob_sha=current_blob_sha, current_ref_sha=None,
+            detail="", diff_text="",
+        )
+
+    current_ref_sha = _resolve_ref_sha(source.repo, source.ref)
+    baseline_content = fetch_blob_content(source.repo, source.baseline_blob_sha)
+    current_content = fetch_raw(source.repo, source.ref, source.path)
+
+    if baseline_content is None or current_content is None:
+        diff_text = "(unable to fetch one or both file revisions for diff)"
+    else:
+        diff_iter = difflib.unified_diff(
+            baseline_content.splitlines(keepends=True),
+            current_content.splitlines(keepends=True),
+            fromfile=f"{source.path}@{source.baseline_blob_sha[:7]}",
+            tofile=f"{source.path}@{(current_blob_sha or 'HEAD')[:7]}",
+            lineterm="",
+        )
+        diff_text = _truncate_diff(list(diff_iter), MAX_DIFF_LINES)
+
+    return DriftResult(
+        entry=entry, source_index=source_index, source=source,
+        status="drift", current_blob_sha=current_blob_sha, current_ref_sha=current_ref_sha,
+        detail="Upstream blob SHA changed since the recorded baseline.",
+        diff_text=diff_text,
+    )
+
+
+# ---------- issue rendering / updating ----------
+
+def _marker(entry_id: str, source_index: int) -> str:
+    return f"<!-- vendored-sync:id={entry_id}:{source_index} -->"
+
+
+def _render_issue_body(result: DriftResult) -> str:
+    entry = result.entry
+    source = result.source
+    marker = _marker(entry.id, result.source_index)
+    cur_ref = result.current_ref_sha or source.ref
+    base_ref = source.baseline_ref_sha
+    repo = source.repo
+
+    lines = [
+        marker,
+        "",
+        f"Automated drift report for vendored file **`{entry.local_path}`**.",
+        "",
+        "## Source",
+        f"- Upstream repo: [`{repo}`](https://github.com/{repo})",
+        f"- Upstream path: [`{source.path}`](https://github.com/{repo}/blob/{cur_ref}/{source.path})",
+        f"- Tracked ref: `{source.ref}`",
+        f"- Scope: {source.scope or '_unspecified_'}",
+        "",
+        "## Drift",
+    ]
+
+    if result.status == "drift":
+        lines += [
+            f"- Baseline blob SHA: `{source.baseline_blob_sha}`",
+            f"- Current  blob SHA: `{result.current_blob_sha}`",
+            f"- Baseline ref SHA : `{base_ref}`",
+            f"- Current  ref SHA : `{result.current_ref_sha or '(unknown)'}`",
+            "",
+            "### Links",
+            f"- [File history]({_history_url(repo, source.ref, source.path)})",
+            f"- [Baseline blob]({_blob_url(repo, base_ref, source.path)})",
+            f"- [Current blob]({_blob_url(repo, cur_ref, source.path)})",
+        ]
+        if result.current_ref_sha:
+            lines.append(f"- [Upstream ref compare]({_compare_url(repo, base_ref, result.current_ref_sha)}) (whole-repo diff, may be noisy)")
+        lines += [
+            "",
+            "### Upstream-only diff",
+            "```diff",
+            result.diff_text.rstrip(),
+            "```",
+        ]
+    else:
+        lines += [
+            f"- Status: **{result.status}**",
+            f"- Detail: {result.detail}",
+        ]
+
+    if entry.notes:
+        lines += ["", "## Local adaptation notes", entry.notes]
+
+    lines += [
+        "",
+        "## How to reconcile",
+        "1. Review the upstream changes and decide whether they should be ported.",
+        f"2. Port the relevant changes to `{entry.local_path}`.",
+        f"3. Update `eng/vendored-files.json` entry `{entry.id}` (source index {result.source_index}):",
+        "   - bump `baseline_ref_sha` to the new upstream ref SHA,",
+        "   - bump `baseline_blob_sha` to the new upstream blob SHA.",
+        "4. Close this issue once the reconciliation PR is merged.",
+        "",
+        "If no port is needed (e.g. whitespace-only upstream change), still bump the baseline SHAs to silence future runs.",
+    ]
+
+    return "\n".join(lines)
+
+
+def _history_url(repo: str, ref: str, path: str) -> str:
+    return f"https://github.com/{repo}/commits/{ref}/{path}"
+
+
+def _blob_url(repo: str, ref: str, path: str) -> str:
+    return f"https://github.com/{repo}/blob/{ref}/{path}"
+
+
+def _compare_url(repo: str, old_sha: str, new_sha: str) -> str:
+    return f"https://github.com/{repo}/compare/{old_sha}...{new_sha}"
+
+
+def _gh(args: list[str], input_data: str | None = None) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["gh", *args], input=input_data, capture_output=True, text=True, check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+_issue_cache: list[dict[str, Any]] | None = None
+
+
+def _list_open_sync_issues() -> list[dict[str, Any]]:
+    """List all open issues with the sync label once and cache the result.
+
+    Issue search with HTML-comment markers is unreliable, so we fetch the full
+    label-filtered set (capped at 200, which is far more than we expect) and
+    filter in Python by exact marker match.
+    """
+    global _issue_cache
+    if _issue_cache is not None:
+        return _issue_cache
+    rc, out, err = _gh([
+        "issue", "list",
+        "--repo", ISSUE_REPO,
+        "--label", ISSUE_LABEL,
+        "--state", "open",
+        "--limit", "200",
+        "--json", "number,title,body",
+    ])
+    if rc != 0:
+        print(f"gh issue list failed: {err}", file=sys.stderr)
+        _issue_cache = []
+        return _issue_cache
+    try:
+        _issue_cache = json.loads(out)
+    except json.JSONDecodeError:
+        _issue_cache = []
+    return _issue_cache
+
+
+def find_existing_issue(marker: str) -> dict[str, Any] | None:
+    for item in _list_open_sync_issues():
+        if marker in (item.get("body") or ""):
+            return item
+    return None
+
+
+def ensure_label() -> None:
+    """Ensure the sync label exists. `gh label create --force` is idempotent."""
+    _gh([
+        "label", "create", ISSUE_LABEL,
+        "--repo", ISSUE_REPO,
+        "--description", "Drift detected between a vendored source file and its upstream copy",
+        "--color", "fbca04",
+        "--force",
+    ])
+
+
+def upsert_issue(result: DriftResult, dry_run: bool) -> None:
+    marker = _marker(result.entry.id, result.source_index)
+    body = _render_issue_body(result)
+    title = f"[vendored-sync] {result.entry.id}: drift detected (#{result.source_index})"
+
+    if dry_run:
+        print(f"\n--- would create/update issue ({result.entry.id}#{result.source_index}) ---")
+        print(f"title: {title}")
+        print(body[:2000])
+        print("---")
+        return
+
+    existing = find_existing_issue(marker)
+    if existing is None:
+        rc, out, err = _gh([
+            "issue", "create",
+            "--repo", ISSUE_REPO,
+            "--title", title,
+            "--label", ISSUE_LABEL,
+            "--body-file", "-",
+        ], input_data=body)
+        if rc != 0:
+            print(f"Failed to create issue for {result.entry.id}: {err}", file=sys.stderr)
+        else:
+            print(f"Created issue for {result.entry.id}#{result.source_index}: {out.strip()}")
+        return
+
+    if (existing.get("body") or "").strip() == body.strip():
+        print(f"Issue #{existing['number']} already up to date for {result.entry.id}#{result.source_index}.")
+        return
+
+    rc, _, err = _gh([
+        "issue", "edit", str(existing["number"]),
+        "--repo", ISSUE_REPO,
+        "--body-file", "-",
+    ], input_data=body)
+    if rc != 0:
+        print(f"Failed to update issue #{existing['number']}: {err}", file=sys.stderr)
+    else:
+        print(f"Updated issue #{existing['number']} for {result.entry.id}#{result.source_index}.")
+
+
+# ---------- entry points ----------
+
+def cmd_validate(_args: argparse.Namespace) -> int:
+    return validate(load_manifest())
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    if not (os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")):
+        print("GH_TOKEN or GITHUB_TOKEN must be set for `check` mode.", file=sys.stderr)
+        return 2
+
+    entries = load_manifest()
+    if validate(entries) != 0:
+        return 1
+
+    if not args.dry_run:
+        ensure_label()
+
+    drift_count = 0
+    error_count = 0
+    for entry in entries:
+        for index, source in enumerate(entry.sources):
+            result = check_source(entry, index, source)
+            short_id = f"{entry.id}#{index}"
+            if result.status == "ok":
+                print(f"[ok]      {short_id} ({source.repo}:{source.path})")
+                continue
+            if result.status == "error":
+                error_count += 1
+                print(f"[ERROR]   {short_id}: {result.detail}", file=sys.stderr)
+                continue
+            drift_count += 1
+            print(f"[{result.status:<7}] {short_id}: {result.detail}")
+            upsert_issue(result, args.dry_run)
+
+    print(f"\nSummary: {drift_count} drifted, {error_count} errors.")
+    return 1 if error_count else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_validate = sub.add_parser("validate", help="Validate manifest structure (no network).")
+    p_validate.set_defaults(func=cmd_validate)
+
+    p_check = sub.add_parser("check", help="Run drift detection against upstream repos.")
+    p_check.add_argument("--dry-run", action="store_true", help="Skip creating/updating issues; print what would happen.")
+    p_check.set_defaults(func=cmd_check)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-vendored-files.yml
+++ b/.github/workflows/check-vendored-files.yml
@@ -1,0 +1,67 @@
+name: Check vendored source files
+
+# Detects drift between source files copied into this repo and their upstream
+# sources, as listed in eng/vendored-files.json. See eng/vendored-files.md.
+#
+# - Scheduled runs and manual dispatch perform full drift detection and open
+#   (or update) tracking issues labelled `area-vendored-sync`.
+# - Pull-request runs that touch the manifest, script, or workflow validate the
+#   manifest structure only (no network, no issue mutation).
+
+on:
+  schedule:
+    # Weekly, Monday 08:00 UTC (aligned with dedup-analysis).
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print drift results without creating or updating issues.'
+        required: false
+        default: 'false'
+  pull_request:
+    paths:
+      - 'eng/vendored-files.json'
+      - 'eng/vendored-files.md'
+      - '.github/scripts/check_vendored_files.py'
+      - '.github/workflows/check-vendored-files.yml'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: vendored-files-check
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Validate vendored-files.json
+        run: python .github/scripts/check_vendored_files.py validate
+
+  check:
+    name: Check upstream drift
+    needs: validate
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check vendored files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VENDORED_SYNC_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python .github/scripts/check_vendored_files.py check --dry-run
+          else
+            python .github/scripts/check_vendored_files.py check
+          fi

--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -1,0 +1,148 @@
+{
+  "$comment": "Manifest of source files copied (verbatim or adapted) from other repositories. See eng/vendored-files.md.",
+  "entries": [
+    {
+      "id": "polyfill-nullable-attributes",
+      "local_path": "src/Polyfills/NullableAttribtues.cs",
+      "notes": "Polyfill for downlevel TFMs; scope changed to internal.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs",
+          "baseline_ref_sha": "39b9607807f29e48cae4652cd74735182b31182e",
+          "baseline_blob_sha": "ff64dbf87889bd5fe2f19e13dff9b762c9be2dc7",
+          "scope": "entire file; attribute scope changed to internal"
+        }
+      ]
+    },
+    {
+      "id": "source-gen-system-polyfills",
+      "local_path": "src/Analyzers/MSTest.SourceGeneration/Helpers/SystemPolyfills.cs",
+      "notes": "Nullable attribute polyfills for source generator. Originally referenced retired dotnet/coreclr@60f1e626 -- successor file lives in dotnet/runtime with the same content.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs",
+          "baseline_ref_sha": "39b9607807f29e48cae4652cd74735182b31182e",
+          "baseline_blob_sha": "ff64dbf87889bd5fe2f19e13dff9b762c9be2dc7",
+          "scope": "Nullable attribute types only; combined with locally-defined IsExternalInit"
+        }
+      ]
+    },
+    {
+      "id": "source-gen-symbol-visibility",
+      "local_path": "src/Analyzers/MSTest.SourceGeneration/Helpers/SymbolVisibility.cs",
+      "notes": "Verbatim copy with namespace adjustment.",
+      "sources": [
+        {
+          "repo": "dotnet/roslyn-analyzers",
+          "ref": "main",
+          "path": "src/Utilities/Compiler/Extensions/SymbolVisibility.cs",
+          "baseline_ref_sha": "b47230ca1e40c844d733a2f32d2bf6010f9eeb73",
+          "baseline_blob_sha": "aa8a66f56e8b92672d5cd1f940fb9b0841b5dab1",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "platform-roslyn-debug",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs",
+      "notes": "Adapted to internal class with [ExcludeFromCodeCoverage].",
+      "sources": [
+        {
+          "repo": "dotnet/roslyn-analyzers",
+          "ref": "main",
+          "path": "src/Utilities/Compiler/Debug.cs",
+          "baseline_ref_sha": "b47230ca1e40c844d733a2f32d2bf6010f9eeb73",
+          "baseline_blob_sha": "8488921e8a603d8e4eb1f5f90da0dc6c415eb9ae",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "platform-file-utilities-case-sensitivity",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs",
+      "notes": "Only GetIsFileSystemCaseSensitive is copied. Drift signal fires on the whole upstream file; reviewer should check whether changes touch the copied region (lines 41-59 at baseline).",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs",
+          "baseline_ref_sha": "73ba11f3015216b39cb866d9fb7d3d25e93489f2",
+          "baseline_blob_sha": "e5e97847ddd8e678112b31fa123932463170ccb5",
+          "scope": "lines 41-59 only (GetIsFileSystemCaseSensitive)"
+        }
+      ]
+    },
+    {
+      "id": "msbuild-dotnet-muxer-locator",
+      "local_path": "src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/DotnetMuxerLocator.cs",
+      "notes": "Adapted from vstest's DotnetHostHelper.",
+      "sources": [
+        {
+          "repo": "microsoft/vstest",
+          "ref": "main",
+          "path": "src/Microsoft.TestPlatform.CoreUtilities/Helpers/DotnetHostHelper.cs",
+          "baseline_ref_sha": "d5a7e3b67a2ccb6dc5b3b81255f3e6571c318b78",
+          "baseline_blob_sha": "d9bc7043f4612d95b7415f3512cbb2b188e825ec",
+          "scope": "muxer location logic"
+        }
+      ]
+    },
+    {
+      "id": "platform-env-config-provider",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationProvider.cs",
+      "notes": "Adapted from runtime's Microsoft.Extensions.Configuration.EnvironmentVariables.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs",
+          "baseline_ref_sha": "c1793efdf8af240a8006b0fc6f05f580c81fccdb",
+          "baseline_blob_sha": "0d321e49332c8f04a039b394c69d2b7389f07fad",
+          "scope": "entire file with internal adaptations"
+        }
+      ]
+    },
+    {
+      "id": "platform-json-config-parser",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationFileParser.cs",
+      "notes": "Adapted from runtime's Microsoft.Extensions.Configuration.Json; additional _propertyToAllChildren dictionary for round-trip serialization.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/Microsoft.Extensions.Configuration.Json/src/JsonConfigurationFileParser.cs",
+          "baseline_ref_sha": "c1793efdf8af240a8006b0fc6f05f580c81fccdb",
+          "baseline_blob_sha": "28e68f1607b148d1169670bf0f7107460dc03b6c",
+          "scope": "entire file with local additions"
+        }
+      ]
+    },
+    {
+      "id": "platform-response-file-helper",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs",
+      "notes": "Core logic taken from command-line-api's CliParser and StringExtensions response-file parsing.",
+      "sources": [
+        {
+          "repo": "dotnet/command-line-api",
+          "ref": "main",
+          "path": "src/System.CommandLine/Parsing/CliParser.cs",
+          "baseline_ref_sha": "feb61c7f328a2401d74f4317b39d02126cfdfe24",
+          "baseline_blob_sha": "d05b9f05521af2ed05f7f33cf319255820b338de",
+          "scope": "response-file expansion logic (around line 40)"
+        },
+        {
+          "repo": "dotnet/command-line-api",
+          "ref": "main",
+          "path": "src/System.CommandLine/Parsing/StringExtensions.cs",
+          "baseline_ref_sha": "feb61c7f328a2401d74f4317b39d02126cfdfe24",
+          "baseline_blob_sha": "169070c5f707aee86c376bad6456e00183718763",
+          "scope": "ExpandResponseFile and string-splitting helpers (around line 349)"
+        }
+      ]
+    }
+  ]
+}

--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -34,14 +34,14 @@
     {
       "id": "source-gen-symbol-visibility",
       "local_path": "src/Analyzers/MSTest.SourceGeneration/Helpers/SymbolVisibility.cs",
-      "notes": "Verbatim copy with namespace adjustment.",
+      "notes": "Verbatim copy with namespace adjustment. Previously sourced from dotnet/roslyn-analyzers, which was archived and moved into dotnet/sdk.",
       "sources": [
         {
-          "repo": "dotnet/roslyn-analyzers",
+          "repo": "dotnet/sdk",
           "ref": "main",
-          "path": "src/Utilities/Compiler/Extensions/SymbolVisibility.cs",
-          "baseline_ref_sha": "b47230ca1e40c844d733a2f32d2bf6010f9eeb73",
-          "baseline_blob_sha": "aa8a66f56e8b92672d5cd1f940fb9b0841b5dab1",
+          "path": "src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Extensions/SymbolVisibility.cs",
+          "baseline_ref_sha": "d5c887dad9f06cbc451869ed8ad63f8916528b73",
+          "baseline_blob_sha": "f7dce8f0f785208e3b1f55555b997fdafac18ec4",
           "scope": "entire file"
         }
       ]
@@ -49,14 +49,14 @@
     {
       "id": "platform-roslyn-debug",
       "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs",
-      "notes": "Adapted to internal class with [ExcludeFromCodeCoverage].",
+      "notes": "Adapted to internal class with [ExcludeFromCodeCoverage]. Previously sourced from dotnet/roslyn-analyzers, which was archived and moved into dotnet/sdk.",
       "sources": [
         {
-          "repo": "dotnet/roslyn-analyzers",
+          "repo": "dotnet/sdk",
           "ref": "main",
-          "path": "src/Utilities/Compiler/Debug.cs",
-          "baseline_ref_sha": "b47230ca1e40c844d733a2f32d2bf6010f9eeb73",
-          "baseline_blob_sha": "8488921e8a603d8e4eb1f5f90da0dc6c415eb9ae",
+          "path": "src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Debug.cs",
+          "baseline_ref_sha": "d5c887dad9f06cbc451869ed8ad63f8916528b73",
+          "baseline_blob_sha": "01b829261af9497a7557538a271b9e1c5b5e09ec",
           "scope": "entire file"
         }
       ]

--- a/eng/vendored-files.md
+++ b/eng/vendored-files.md
@@ -1,0 +1,114 @@
+# Vendored source files
+
+A small set of source files in this repo are copied (verbatim or adapted) from
+other repositories — for example, polyfills from
+[`dotnet/runtime`](https://github.com/dotnet/runtime) or utility classes from
+[`dotnet/roslyn-analyzers`](https://github.com/dotnet/roslyn-analyzers).
+
+We don't want to lose track of these when upstream fixes/updates land. To make
+this manageable, the repo tracks each copied file in a manifest and a
+[scheduled GitHub Actions workflow](../.github/workflows/check-vendored-files.yml)
+opens (or updates) a tracking issue whenever upstream changes are detected.
+
+The implementation is intentionally simple: no auto-merging, no patch
+application. The bot's job is to **notify**; a human decides what to port.
+
+## Files involved
+
+| File | Purpose |
+| --- | --- |
+| [`vendored-files.json`](./vendored-files.json) | Manifest. Source of truth for every tracked file and its baseline. |
+| [`../.github/scripts/check_vendored_files.py`](../.github/scripts/check_vendored_files.py) | Drift detection logic (`validate` + `check` modes). |
+| [`../.github/workflows/check-vendored-files.yml`](../.github/workflows/check-vendored-files.yml) | Weekly schedule + manual dispatch + PR validation. |
+
+## Manifest schema
+
+```jsonc
+{
+  "entries": [
+    {
+      "id": "stable-kebab-case-id",
+      "local_path": "src/path/to/Local.cs",
+      "notes": "free-form description of local adaptations",
+      "sources": [
+        {
+          "repo": "owner/repo",
+          "ref": "main",
+          "path": "path/in/upstream/repo.cs",
+          "baseline_ref_sha": "<40-char SHA>",   // upstream branch HEAD at last sync
+          "baseline_blob_sha": "<40-char SHA>",  // upstream file blob SHA at last sync (primary drift signal)
+          "scope": "optional human description (e.g. 'lines 41-59 only')"
+        }
+      ]
+    }
+  ]
+}
+```
+
+A single local file may declare multiple upstream sources (e.g.
+[`ResponseFileHelper.cs`](../src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs)
+combines logic from two `dotnet/command-line-api` files). Each source is
+tracked independently.
+
+## How drift is detected
+
+For every `(entry, source)` pair the workflow:
+
+1. Calls `GET /repos/{repo}/contents/{path}?ref={ref}` to get the current blob SHA.
+2. Compares it with `baseline_blob_sha`. Equal → no drift, no issue activity.
+3. Otherwise fetches the baseline content (via the blobs API, robust to
+   force-pushes) and the current content (via `raw.githubusercontent.com`),
+   computes a unified diff, and opens/updates a tracking issue labelled
+   `area-vendored-sync` containing:
+   - links to the upstream file history, baseline blob, current blob, and the
+     whole-repo compare URL,
+   - the upstream-only diff (truncated at 300 lines),
+   - the local adaptation notes,
+   - a reconciliation checklist.
+
+Idempotency uses a hidden marker `<!-- vendored-sync:id={id}:{source-index} -->`
+in the issue body, not the title. Existing matching issues are updated in place
+when the rendered body changes; otherwise they are left alone.
+
+The workflow never auto-closes issues. A reviewer closes the issue after the
+reconciliation PR is merged.
+
+## Adding a new vendored file
+
+1. Add a comment in the local file pointing at the upstream URL (existing files
+   use `// Copied from <url>` or `// Adapted from <url>`).
+2. Add an entry to `eng/vendored-files.json` with a stable kebab-case `id`,
+   the local path, and at least one source. Fill in:
+   - `baseline_ref_sha`: the upstream branch SHA you copied from
+     (`gh api repos/{repo}/commits/{ref} --jq .sha`),
+   - `baseline_blob_sha`: the upstream file's blob SHA at that ref
+     (`gh api "repos/{repo}/contents/{path}?ref={ref}" --jq .sha`).
+3. Run `python .github/scripts/check_vendored_files.py validate` locally to
+   confirm the structure is correct.
+
+## Reconciling drift
+
+When a `[vendored-sync]` issue is opened:
+
+1. Read the upstream diff in the issue body and check the file history link.
+2. Port the relevant changes to the local file. If the upstream change is
+   irrelevant to the copied region (e.g. an unrelated method was modified),
+   no code change is required.
+3. Update the corresponding `baseline_ref_sha` and `baseline_blob_sha` in
+   `eng/vendored-files.json`.
+4. Open a PR with the local change (if any) and the manifest bump in a single
+   commit. After it merges, close the tracking issue.
+
+If the issue is closed without bumping the manifest, the next scheduled run
+will detect the same drift and open a new issue. That is intentional: closing
+without a manifest update is a "remind me later" action.
+
+## Excluded files
+
+Some files contain "copied from" comments but are out of scope for this
+automation:
+
+- `src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs` —
+  intra-repo copy, no external upstream.
+- `src/TestFramework/TestFramework.Extensions/AppModel.cs` — only mentions
+  "WinUI source base" without a concrete upstream URL.

--- a/src/Analyzers/MSTest.SourceGeneration/Helpers/SymbolVisibility.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Helpers/SymbolVisibility.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
 
-// Copied from https://github.com/dotnet/roslyn-analyzers/blob/main/src/Utilities/Compiler/Extensions/SymbolVisibility.cs
+// Copied from https://github.com/dotnet/sdk/blob/main/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Extensions/SymbolVisibility.cs
+// (previously sourced from dotnet/roslyn-analyzers before that repo was archived).
 namespace Analyzers.Utilities;
 
 #pragma warning disable CA1027 // Mark enums with FlagsAttribute

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// Copied from https://github.com/dotnet/roslyn-analyzers/blob/main/src/Utilities/Compiler/Debug.cs
+// Copied from https://github.com/dotnet/sdk/blob/main/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Debug.cs
+// (previously sourced from dotnet/roslyn-analyzers before that repo was archived).
 namespace Microsoft.Testing.Platform;
 
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "This is the replacement type for Debug")]


### PR DESCRIPTION
Fixes #8548.

## Summary

Adds a small, manifest-driven workflow that detects when source files copied into this repo from upstream repositories have changed upstream, so a reviewer can decide whether to port the changes. No auto-merging; the bot's job is to notify, a human decides what to port.

## How it works

For each `(local file, upstream source)` pair in `eng/vendored-files.json`:

1. Call `GET /repos/{repo}/contents/{path}?ref={ref}` → current blob SHA.
2. Compare against the recorded `baseline_blob_sha`. Equal → no drift.
3. Otherwise fetch baseline content via the blobs API (robust to force-pushes since blobs survive as long as any ref references them) and current content via raw URL, generate a unified diff, and open or update a tracking issue labelled `area-vendored-sync` containing the diff plus reconciliation steps.

Idempotency uses a hidden HTML marker (`<!-- vendored-sync:id=<entry-id>:<source-index> -->`) in the issue body — not the title — so editing titles or renaming local files doesn't create duplicate issues. Issues are never auto-closed; a reviewer closes them after the reconciliation PR merges.

## Why blob SHA (not commit SHA)

I started with the commits-by-path API but it returns empty for files inside roslyn-analyzers' Shared Projects (verified). Blob SHA from the contents API works everywhere and directly reflects file content, so it's both more robust and a more accurate drift signal.

## Files tracked initially

9 entries, 10 upstream sources (one local file has 2 upstream sources):

| Entry | Local | Upstream |
| --- | --- | --- |
| `polyfill-nullable-attributes` | `src/Polyfills/NullableAttribtues.cs` | `dotnet/runtime` |
| `source-gen-system-polyfills` | `src/Analyzers/MSTest.SourceGeneration/Helpers/SystemPolyfills.cs` | `dotnet/runtime` |
| `source-gen-symbol-visibility` | `src/Analyzers/MSTest.SourceGeneration/Helpers/SymbolVisibility.cs` | `dotnet/roslyn-analyzers` |
| `platform-roslyn-debug` | `src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs` | `dotnet/roslyn-analyzers` |
| `platform-file-utilities-case-sensitivity` | `src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs` | `dotnet/runtime` |
| `msbuild-dotnet-muxer-locator` | `src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/DotnetMuxerLocator.cs` | `microsoft/vstest` |
| `platform-env-config-provider` | `src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationProvider.cs` | `dotnet/runtime` |
| `platform-json-config-parser` | `src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationFileParser.cs` | `dotnet/runtime` |
| `platform-response-file-helper` | `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs` | `dotnet/command-line-api` (2 files) |

Excluded: `RetryOrchestrator.cs` (intra-repo copy) and `AppModel.cs` (vague "WinUI source base" reference, no concrete upstream URL).

## Validation

Locally:

```
$ python .github/scripts/check_vendored_files.py validate
Manifest OK: 9 entries, 10 sources.

$ python .github/scripts/check_vendored_files.py check --dry-run
[drift  ] polyfill-nullable-attributes#0: Upstream blob SHA changed since the recorded baseline.
[drift  ] source-gen-system-polyfills#0: Upstream blob SHA changed since the recorded baseline.
[ok]      source-gen-symbol-visibility#0
[ok]      platform-roslyn-debug#0
[drift  ] platform-file-utilities-case-sensitivity#0: ...
[ok]      msbuild-dotnet-muxer-locator#0
[ok]      platform-env-config-provider#0
[ok]      platform-json-config-parser#0
[missing] platform-response-file-helper#0: Upstream path `src/System.CommandLine/Parsing/CliParser.cs` no longer exists on `dotnet/command-line-api@main`. ...
[drift  ] platform-response-file-helper#1: Upstream blob SHA changed since the recorded baseline.
Summary: 5 drifted, 0 errors.
```

So once this merges and the first scheduled run executes, we should expect ~5 tracking issues to appear immediately, all expected (the original copies were made against old upstream SHAs). Those issues are the **starting backlog**: someone reviews each, ports anything relevant, and bumps the baseline SHAs.

The `[missing]` case on `CliParser.cs` is also expected: it was renamed upstream to `CommandLineParser.cs`. The tracking issue will tell the reviewer that and they can update the manifest's `path`.

## Workflow

- `schedule`: Mon 08:00 UTC (aligned with `dedup-analysis`).
- `workflow_dispatch`: manual run with optional `dry_run` input.
- `pull_request` (paths: manifest/script/workflow): runs `validate` only — no network, no issue mutation.
- `permissions: contents: read, issues: write`.
- `concurrency: vendored-files-check`.

## Design notes (full thread in #8548)

- Manifest splits `baseline_ref_sha` (branch HEAD at sync) from `baseline_blob_sha` (file blob SHA at sync). The blob SHA is the drift signal; the ref SHA anchors reproducibility and the compare URL.
- Multiple upstream sources per local file supported.
- Renames/deletes detected via `404` on the contents API and reported as `missing`.
- No auto-close on issues — closing without bumping the manifest will recur at the next run, which is intentional ("remind me later").
- Validate-only mode used on PRs so the manifest can be schema-checked without granting write access on PR contexts.

I'd appreciate a review from a maintainer; happy to iterate on the issue body template or label naming. Once this merges, I'll watch the first run and triage the initial backlog of tracking issues.
