### PR TITLE
fix(aw): Issue Arborist - revert curl /meta workaround now that mcpg v0.3.12+ ships

### DIFF
--- a/.github/workflows/issue-arborist.lock.yml
+++ b/.github/workflows/issue-arborist.lock.yml
@@ -193,20 +193,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
+          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
           <system>
-          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
+          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
+          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
           <safe-output-tools>
           Tools: create_issue(max:5), link_sub_issue(max:50), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
+          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
+          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -235,12 +235,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
+          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_10f1748ca2fa7aee_EOF'
+          cat << 'GH_AW_PROMPT_ad7efa4f9a7d1295_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-arborist.md}}
-          GH_AW_PROMPT_10f1748ca2fa7aee_EOF
+          GH_AW_PROMPT_ad7efa4f9a7d1295_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -379,12 +379,40 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Start DIFC Proxy
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          DIFC_PROXY_POLICY: '{"allow-only":{"min-integrity":"none","repos":"all"}}'
+          DIFC_PROXY_IMAGE: 'ghcr.io/github/gh-aw-mcpg:v0.3.17'
+        run: |
+          bash "${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh"
       - env:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
-          GH_AW_ORIGINAL_GITHUB_API_URL: ${{ github.api_url }}
+          GH_HOST: localhost:18443
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_URL: https://localhost:18443/api/v3
+          GITHUB_GRAPHQL_URL: https://localhost:18443/api/graphql
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_EXTRA_CA_CERTS: /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt
         name: Fetch issues data
-        run: "# Create output directory\nmkdir -p /tmp/gh-aw/issues-data\n\necho \"⬇ Downloading the last 100 open issues (excluding sub-issues)...\"\n\n# Use REST API directly to avoid gh CLI /meta check blocked by DIFC proxy.\n# Fetches the most recently created 100 issues (intentional limit matching previous behavior).\n# State is normalized to uppercase (OPEN/CLOSED) to match gh CLI GraphQL output format.\ncurl -s \\\n  -H \"Authorization: Bearer ${GITHUB_TOKEN}\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  --get \\\n  --data-urlencode \"q=repo:${GH_AW_GITHUB_REPOSITORY} is:issue is:open -is:sub-issue\" \\\n  --data-urlencode \"sort=created\" \\\n  --data-urlencode \"order=desc\" \\\n  --data-urlencode \"per_page=100\" \\\n  \"${GH_AW_ORIGINAL_GITHUB_API_URL}/search/issues\" \\\n  | jq '.items // [] | map({\n      number: .number,\n      title: .title,\n      author: {login: .user.login},\n      createdAt: .created_at,\n      state: (.state | ascii_upcase),\n      url: .html_url,\n      body: .body,\n      labels: [.labels[] | {name: .name}],\n      updatedAt: .updated_at,\n      closedAt: .closed_at,\n      milestone: (if .milestone != null then {title: .milestone.title} else null end),\n      assignees: [.assignees[] | {login: .login}]\n    })' \\\n  > /tmp/gh-aw/issues-data/issues.json \\\n  || echo '[]' > /tmp/gh-aw/issues-data/issues.json\n\necho \"✓ Issues data saved to /tmp/gh-aw/issues-data/issues.json\"\necho \"Total issues fetched: $(jq 'length' /tmp/gh-aw/issues-data/issues.json)\"\n"
+        run: |
+          # Create output directory
+          mkdir -p /tmp/gh-aw/issues-data
+
+          echo "⬇ Downloading the last 100 open issues (excluding sub-issues)..."
+
+          # Fetch the last 100 open issues that don't have a parent issue
+          gh issue list --repo $GH_AW_GITHUB_REPOSITORY \
+            --search "-parent-issue:*" \
+            --state open \
+            --json number,title,author,createdAt,state,url,body,labels,updatedAt,closedAt,milestone,assignees \
+            --limit 100 \
+            > /tmp/gh-aw/issues-data/issues.json
+
+          echo "✓ Issues data saved to /tmp/gh-aw/issues-data/issues.json"
+          echo "Total issues fetched: $(jq 'length' /tmp/gh-aw/issues-data/issues.json)"
 
       - name: Configure Git credentials
         env:
@@ -426,6 +454,10 @@ jobs:
           GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
+      - name: Stop DIFC Proxy
+        if: always()
+        continue-on-error: true
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh"
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -449,9 +481,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2b5ec42f26931b4d_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8c6671b8f4012a32_EOF'
           {"create_issue":{"expires":48,"group":true,"max":5,"title_prefix":"[parent] "},"create_report_incomplete_issue":{},"link_sub_issue":{"max":50},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2b5ec42f26931b4d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8c6671b8f4012a32_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -676,7 +708,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8934d07aaa70c5c7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_2f3e317a7a79f1bc_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -721,7 +753,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8934d07aaa70c5c7_EOF
+          GH_AW_MCP_CONFIG_2f3e317a7a79f1bc_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/issue-arborist.md
+++ b/.github/workflows/issue-arborist.md
@@ -29,42 +29,20 @@ steps:
   - name: Fetch issues data
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_AW_ORIGINAL_GITHUB_API_URL: ${{ github.api_url }}
-      GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     run: |
       # Create output directory
       mkdir -p /tmp/gh-aw/issues-data
 
       echo "⬇ Downloading the last 100 open issues (excluding sub-issues)..."
 
-      # Use REST API directly to avoid gh CLI /meta check blocked by DIFC proxy.
-      # Fetches the most recently created 100 issues (intentional limit matching previous behavior).
-      # State is normalized to uppercase (OPEN/CLOSED) to match gh CLI GraphQL output format.
-      curl -s \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        -H "Accept: application/vnd.github+json" \
-        --get \
-        --data-urlencode "q=repo:${GH_AW_GITHUB_REPOSITORY} is:issue is:open -is:sub-issue" \
-        --data-urlencode "sort=created" \
-        --data-urlencode "order=desc" \
-        --data-urlencode "per_page=100" \
-        "${GH_AW_ORIGINAL_GITHUB_API_URL}/search/issues" \
-        | jq '.items // [] | map({
-            number: .number,
-            title: .title,
-            author: {login: .user.login},
-            createdAt: .created_at,
-            state: (.state | ascii_upcase),
-            url: .html_url,
-            body: .body,
-            labels: [.labels[] | {name: .name}],
-            updatedAt: .updated_at,
-            closedAt: .closed_at,
-            milestone: (if .milestone != null then {title: .milestone.title} else null end),
-            assignees: [.assignees[] | {login: .login}]
-          })' \
-        > /tmp/gh-aw/issues-data/issues.json \
-        || echo '[]' > /tmp/gh-aw/issues-data/issues.json
+      # Fetch the last 100 open issues that don't have a parent issue
+      gh issue list --repo ${{ github.repository }} \
+        --search "-parent-issue:*" \
+        --state open \
+        --json number,title,author,createdAt,state,url,body,labels,updatedAt,closedAt,milestone,assignees \
+        --limit 100 \
+        > /tmp/gh-aw/issues-data/issues.json
 
       echo "✓ Issues data saved to /tmp/gh-aw/issues-data/issues.json"
       echo "Total issues fetched: $(jq 'length' /tmp/gh-aw/issues-data/issues.json)"


### PR DESCRIPTION
Per https://github.com/githubnext/agentics/issues/339 the DIFC proxy `/meta` block was fixed in `gh-aw-mcpg v0.3.12`.

This PR:

- Upgrades the bundled `gh-aw-actions/setup` to `v0.75.4` (recompiled with `gh aw v0.75.4 compile --strict`), which now pins `ghcr.io/github/gh-aw-mcpg:v0.3.18` as the DIFC proxy image.
- Reverts `.github/workflows/issue-arborist.md` to the upstream `githubnext/agentics` source (`gh issue list` instead of the curl + REST API workaround from #8507 / #8185).
- Regenerates `.github/workflows/issue-arborist.lock.yml` and `.github/aw/actions-lock.json` accordingly.

The point of this PR is to validate the GH team's fix once the next scheduled run executes. If the `Fetch issues data` step succeeds, we can keep the upstream version; otherwise we'll restore the curl workaround.