### PR TITLE
Test only: verify IncrementalClean removes stale generated testconfig (validates #8495 premise)

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.ConfigurationFile.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.ConfigurationFile.cs
@@ -17,15 +17,17 @@ public class MSBuildTests : AcceptanceTestBase<NopAssetFixture>
                 .PatchCodeWithReplace("$JsonContent$", ConfigurationContent)
                 .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
 
-        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{(verb == Verb.publish ? $"publish -f {tfm}" : "build")} -v:normal {testAsset.TargetAssetPath} -c {compilationMode}", cancellationToken: TestContext.CancellationToken);
+        string buildOrPublishCommand = verb == Verb.publish ? $"publish -f {tfm}" : "build";
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{buildOrPublishCommand} -v:normal {testAsset.TargetAssetPath} -c {compilationMode}", cancellationToken: TestContext.CancellationToken);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(testAsset.TargetAssetPath, "MSBuildTests", tfm, verb: verb, buildConfiguration: compilationMode);
         string generatedConfigurationFile = Path.Combine(testHost.DirectoryName, "MSBuildTests.testconfig.json");
+        string generatedConfigurationFileInBuildOutput = Path.Combine(testAsset.TargetAssetPath, "bin", compilationMode.ToString(), tfm, "MSBuildTests.testconfig.json");
         Assert.IsTrue(File.Exists(generatedConfigurationFile));
         Assert.AreEqual(ConfigurationContent.Trim(), File.ReadAllText(generatedConfigurationFile).Trim());
         Assert.Contains("Microsoft Testing Platform configuration file written", compilationResult.StandardOutput);
 
-        compilationResult = await DotnetCli.RunAsync($"{(verb == Verb.publish ? $"publish -f {tfm}" : "build")} -v:normal {testAsset.TargetAssetPath} -c {compilationMode}", cancellationToken: TestContext.CancellationToken);
+        compilationResult = await DotnetCli.RunAsync($"{buildOrPublishCommand} -v:normal {testAsset.TargetAssetPath} -c {compilationMode}", cancellationToken: TestContext.CancellationToken);
         Assert.IsTrue(File.Exists(generatedConfigurationFile));
         Assert.AreEqual(ConfigurationContent.Trim(), File.ReadAllText(generatedConfigurationFile).Trim());
         // Assert is failing, probably the MSBuild regression which is being fixed in https://github.com/dotnet/msbuild/pull/12431 ?
@@ -36,6 +38,22 @@ public class MSBuildTests : AcceptanceTestBase<NopAssetFixture>
 \s*_GenerateTestingPlatformConfigurationFileCore:
 \s*Skipping target "_GenerateTestingPlatformConfigurationFileCore" because all output files are up\-to\-date with respect to the input files\.
 """));
+
+        await DotnetCli.RunAsync($"{buildOrPublishCommand} -v:normal {testAsset.TargetAssetPath} -c {compilationMode} /p:GenerateTestingPlatformConfigurationFile=false", cancellationToken: TestContext.CancellationToken);
+        Assert.IsFalse(File.Exists(generatedConfigurationFile));
+        Assert.IsFalse(File.Exists(generatedConfigurationFileInBuildOutput));
+
+        File.WriteAllText(generatedConfigurationFile, ConfigurationContent);
+        if (verb == Verb.publish)
+        {
+            File.WriteAllText(generatedConfigurationFileInBuildOutput, ConfigurationContent);
+        }
+
+        File.Delete(Path.Combine(testAsset.TargetAssetPath, "testconfig.json"));
+        await DotnetCli.RunAsync($"{buildOrPublishCommand} -v:normal {testAsset.TargetAssetPath} -c {compilationMode}", cancellationToken: TestContext.CancellationToken);
+        Assert.IsFalse(File.Exists(generatedConfigurationFile));
+        Assert.IsFalse(File.Exists(generatedConfigurationFileInBuildOutput));
+
         await DotnetCli.RunAsync($"clean -c {compilationMode} -v:normal {testAsset.TargetAssetPath}", cancellationToken: TestContext.CancellationToken);
 
         // dotnet clean doesn't clean the publish output folder


### PR DESCRIPTION
**Test-only experiment — do not merge.**

Extracts the regression test from #8495 _without_ the cleanup targets it adds. The goal is to verify whether MSBuild's built-in `IncrementalClean` (and `_IncrementalCleanPublishDirectory` for publish) already handle the stale `$(AssemblyName).testconfig.json` removal scenarios on its own.

The test asserts that after:
- toggling `GenerateTestingPlatformConfigurationFile=false`, and
- deleting the source `testconfig.json` between builds,

the previously-generated `bin/$(AssemblyName).testconfig.json` (and the corresponding publish-output copy) no longer exists.

Local repro (synthetic project that registers `<FileWrites>` + `<ResolvedFileToPublish>` the same way `_GenerateTestingPlatformConfigurationFileCore` does) shows that `IncrementalClean` removes the orphan from `bin/` and `_IncrementalCleanPublishDirectory` removes it from `bin/.../publish/` on the next incremental build. If CI here is green, the added cleanup targets in #8495 are redundant and that PR can be closed (keeping only this test as the regression guard).

Related: #8434, #8495