### PR TITLE
[link-checker] Update Microsoft documentation URLs from docs.microsoft.com to learn.microsoft.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The following official [learn.microsoft.com website](https://learn.microsoft.com
 
 This [blog post](https://devblogs.microsoft.com/devops/mstest-v2-now-and-ahead/) announces the vision for MSTest V2.
 
-For API documentation refer [to Microsoft Documentation](https://docs.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting).
+For API documentation refer [to Microsoft Documentation](https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting).
 
 ## Contributing
 

--- a/docs/RFCs/007-DataSource-Attribute-VS-ITestDataSource.md
+++ b/docs/RFCs/007-DataSource-Attribute-VS-ITestDataSource.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-This details the MSTest V2 framework attribute "DataSource" for data driven tests where test data can be present in an excel file, xml file, sql database or OleDb. You can refer to documentation [of datasourceattribute here](https://docs.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.datasourceattribute) for more details.
+This details the MSTest V2 framework attribute "DataSource" for data driven tests where test data can be present in an excel file, xml file, sql database or OleDb. You can refer to documentation [of datasourceattribute here](https://learn.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting.datasourceattribute) for more details.
 
 ## Motivation
 


### PR DESCRIPTION
The docs.microsoft.com domain has been migrated to learn.microsoft.com.
Updated API documentation links in:
- docs/README.md
- docs/RFCs/007-DataSource-Attribute-VS-ITestDataSource.md

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Fixes #8561
