### PR TITLE
Add [UnsupportedOSPlatform("wasi")] to HangDump / Console / Process surface

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpActivityIndicator.cs
@@ -17,6 +17,7 @@ using Microsoft.Testing.Platform.Services;
 namespace Microsoft.Testing.Extensions.Diagnostics;
 
 [UnsupportedOSPlatform("browser")]
+[UnsupportedOSPlatform("wasi")]
 internal sealed class HangDumpActivityIndicator : IDataConsumer, ITestSessionLifetimeHandler,
 #if NETCOREAPP
     IAsyncDisposable,

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpExtensions.cs
@@ -25,6 +25,7 @@ public static class HangDumpExtensions
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public static void AddHangDumpProvider(this ITestApplicationBuilder builder)
     {
         if (OperatingSystem.IsBrowser())
@@ -35,6 +36,11 @@ public static class HangDumpExtensions
         if (OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
         {
             throw new PlatformNotSupportedException("Hang dump extension is not available on ios nor tvos");
+        }
+
+        if (OperatingSystem.IsWasi())
+        {
+            throw new PlatformNotSupportedException("Hang dump extension is not available on wasi");
         }
 
         PipeNameDescription pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Testing.Extensions.Diagnostics;
 [UnsupportedOSPlatform("browser")]
 [UnsupportedOSPlatform("ios")]
 [UnsupportedOSPlatform("tvos")]
+[UnsupportedOSPlatform("wasi")]
 internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeHandler, IOutputDeviceDataProducer, IDataProducer,
 #if NETCOREAPP
     IAsyncDisposable,
@@ -222,6 +223,7 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     private async Task TakeDumpOfTreeAsync(CancellationToken cancellationToken)
     {
         ApplicationStateGuard.Ensure(_testHostProcessInformation is not null);

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Helpers/IProcessExtensions.cs
@@ -23,6 +23,7 @@ internal static class IProcessExtensions
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public static async Task<List<ProcessTreeNode>> GetProcessTreeAsync(this IProcess process, ILogger logger, OutputDeviceWriter outputDisplay, CancellationToken cancellationToken)
     {
         var childProcesses = Process.GetProcesses()
@@ -72,6 +73,7 @@ internal static class IProcessExtensions
                     : throw new PlatformNotSupportedException();
 
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     internal static int GetParentPidWindows(Process process)
     {
         IntPtr handle = process.Handle;
@@ -86,6 +88,7 @@ internal static class IProcessExtensions
     /// <param name="process">The process to get the parent process from.</param>
     /// <returns>The process id.</returns>
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     internal static int GetParentPidLinux(Process process)
         => ParseParentPidFromProcStat(File.ReadAllText($"/proc/{process.Id}/stat"));
 
@@ -120,6 +123,7 @@ internal static class IProcessExtensions
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     internal static async Task<int> GetParentPidMacOsAsync(Process process, ILogger logger, OutputDeviceWriter outputDisplay, CancellationToken cancellationToken)
     {
         var output = new StringBuilder();
@@ -176,6 +180,7 @@ internal static class IProcessExtensions
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     private static bool IsChildCandidate(Process child, IProcess parent)
     {
         // this is extremely slow under debugger, but fast without it

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/TestingPlatformBuilderHook.cs
@@ -18,6 +18,7 @@ public static class TestingPlatformBuilderHook
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public static void AddExtensions(ITestApplicationBuilder testApplicationBuilder, string[] _)
         => testApplicationBuilder.AddHangDumpProvider();
 }

--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -86,6 +86,11 @@ public sealed class TestApplication : ITestApplication
                 throw new PlatformNotSupportedException(PlatformResources.WaitDebuggerAttachNotSupportedInBrowserErrorMessage);
             }
 
+            if (OperatingSystem.IsWasi())
+            {
+                throw new PlatformNotSupportedException(PlatformResources.WaitDebuggerAttachNotSupportedInWasiErrorMessage);
+            }
+
             WaitForDebuggerToAttach(systemEnvironment, systemConsole, systemProcess);
         }
 
@@ -238,11 +243,17 @@ public sealed class TestApplication : ITestApplication
                 throw new PlatformNotSupportedException(PlatformResources.WaitDebuggerAttachNotSupportedInBrowserErrorMessage);
             }
 
+            if (OperatingSystem.IsWasi())
+            {
+                throw new PlatformNotSupportedException(PlatformResources.WaitDebuggerAttachNotSupportedInWasiErrorMessage);
+            }
+
             WaitForDebuggerToAttach(environment, console, systemProcess);
         }
     }
 
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     private static void WaitForDebuggerToAttach(SystemEnvironment environment, SystemConsole console, SystemProcessHandler systemProcess)
     {
         using IProcess currentProcess = systemProcess.GetCurrentProcess();

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IConsole.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IConsole.cs
@@ -12,30 +12,35 @@ internal interface IConsole
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     event ConsoleCancelEventHandler? CancelKeyPress;
 
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     int BufferHeight { get; }
 
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     int BufferWidth { get; }
 
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     int WindowHeight { get; }
 
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     int WindowWidth { get; }
 
     bool IsOutputRedirected { get; }
@@ -44,12 +49,14 @@ internal interface IConsole
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     void SetForegroundColor(ConsoleColor color);
 
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     ConsoleColor GetForegroundColor();
 
     void WriteLine();

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemConsole.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemConsole.cs
@@ -15,6 +15,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public int BufferHeight => Console.BufferHeight;
 
     /// <summary>
@@ -24,6 +25,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public int BufferWidth => Console.BufferWidth;
 
     /// <summary>
@@ -33,6 +35,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public int WindowHeight => Console.WindowHeight;
 
     /// <summary>
@@ -42,6 +45,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public int WindowWidth => Console.WindowWidth;
 
     /// <summary>
@@ -66,6 +70,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     public event ConsoleCancelEventHandler? CancelKeyPress
     {
         add => Console.CancelKeyPress += value;
@@ -110,6 +115,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     public void SetForegroundColor(ConsoleColor color)
         => Console.ForegroundColor = color;
 
@@ -117,6 +123,7 @@ internal sealed class SystemConsole : IConsole
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     public ConsoleColor GetForegroundColor()
         => Console.ForegroundColor;
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcessHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemProcessHandler.cs
@@ -9,14 +9,17 @@ namespace Microsoft.Testing.Platform.Helpers;
 internal sealed class SystemProcessHandler : IProcessHandler
 {
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     public IProcess GetCurrentProcess() => new SystemProcess(Process.GetCurrentProcess());
 
     [UnsupportedOSPlatform("browser")]
+    [UnsupportedOSPlatform("wasi")]
     public IProcess GetProcessById(int pid) => new SystemProcess(Process.GetProcessById(pid));
 
     [UnsupportedOSPlatform("browser")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]
+    [UnsupportedOSPlatform("wasi")]
     public IProcess Start(ProcessStartInfo startInfo)
     {
         Process process = Process.Start(startInfo)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -54,12 +54,12 @@ internal sealed class AnsiTerminal : ITerminal
     }
 
     public int Width
-        => _console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()
+        => _console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWasi()
             ? int.MaxValue
             : _console.WindowWidth;
 
     public int Height
-        => _console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()
+        => _console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWasi()
             ? int.MaxValue
             : _console.WindowHeight;
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NativeMethods.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NativeMethods.cs
@@ -34,7 +34,7 @@ internal static class NativeMethods
             return (AcceptAnsiColorCodes: false, OutputIsScreen: false, OriginalConsoleMode: null);
         }
 
-        if (!OperatingSystem.IsAndroid() && !OperatingSystem.IsBrowser() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS())
+        if (!OperatingSystem.IsAndroid() && !OperatingSystem.IsBrowser() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsWasi())
         {
             if (Console.BufferHeight == 0 || Console.BufferWidth == 0)
             {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleTerminalBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleTerminalBase.cs
@@ -15,12 +15,12 @@ internal abstract class SimpleTerminal : ITerminal
         => Console = console;
 
     public int Width
-        => Console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()
+        => Console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWasi()
             ? int.MaxValue
             : Console.WindowWidth;
 
     public int Height
-        => Console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS()
+        => Console.IsOutputRedirected || OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWasi()
             ? int.MaxValue
             : Console.WindowHeight;
 

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -791,4 +791,7 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
   <data name="WaitDebuggerAttachNotSupportedInBrowserErrorMessage" xml:space="preserve">
     <value>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported in browser environments.</value>
   </data>
+  <data name="WaitDebuggerAttachNotSupportedInWasiErrorMessage" xml:space="preserve">
+    <value>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -1079,6 +1079,11 @@ Platné hodnoty jsou All, Failed, None. Výchozí hodnota je All.</target>
         <target state="translated">Čekání na připojení ladicího programu (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) se v prostředích prohlížeče nepodporuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Spustila se nula testů</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -1079,6 +1079,11 @@ Gültige Werte sind „Alle“, „Fehlgeschlagen“ und „Keine“. Der Standa
         <target state="translated">Das Warten auf das Anfügen des Debuggers (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) wird in Browserumgebungen nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Es wurden keine Tests ausgeführt.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -1079,6 +1079,11 @@ Los valores válidos son "All", "Failed", "None". El valor predeterminado es "Al
         <target state="translated">La espera para que se adjunte el depurador (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) no es compatible con los entornos de explorador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">No se ejecutaron pruebas</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -1079,6 +1079,11 @@ Les valeurs valides sont « All », « Failed » et « None ». La valeur 
         <target state="translated">L’attente de la connexion du débogueur (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) n’est pas prise en charge dans les environnements navigateur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Zéro tests exécutés</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -1079,6 +1079,11 @@ I valori validi sono 'All', 'Failed', 'None'. L'impostazione predefinita è 'All
         <target state="translated">L'attesa per il collegamento di (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) non è supportata negli ambienti browser.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Nessun test eseguito</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -1080,6 +1080,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All'.</source>
         <target state="translated">デバッガーのアタッチの待機 (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) は、ブラウザー環境ではサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">0 件のテストが実行されました</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -1079,6 +1079,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All'.</source>
         <target state="translated">디버거 연결 대기(TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1)는 브라우저 환경에서 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">테스트가 0개 실행됨</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -1079,6 +1079,11 @@ Prawidłowe wartości to „All”, „Failed”, „None”. Wartość domyśln
         <target state="translated">Oczekiwanie na dołączenie debugera (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) nie jest obsługiwane w środowiskach przeglądarki.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Uruchomiono zero testów</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -1079,6 +1079,11 @@ Os valores válidos são 'All', 'Failed', 'None'. O padrão é 'All'.</target>
         <target state="translated">Não há suporte para aguardar a anexação do depurador (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) em ambientes de navegador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Zero testes executados</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -1079,6 +1079,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All'.</source>
         <target state="translated">Ожидание подключения отладчика (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) не поддерживается в браузерных средах.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Запущено ноль тестов</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -1079,6 +1079,11 @@ Geçerli değerler: 'Tümü', 'Başarısız', 'Yok'. Varsayılan değer: 'Tümü
         <target state="translated">Hata ayıklayıcısının eklenmesini bekleme (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) tarayıcı ortamlarında desteklenmez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">Sıfır test çalıştırıldı</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -1079,6 +1079,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All'.</source>
         <target state="translated">浏览器环境不支持等待调试器附加(TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">运行了零个测试</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -1079,6 +1079,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All'.</source>
         <target state="translated">瀏覽器環境不支援等待除錯器附加 (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WaitDebuggerAttachNotSupportedInWasiErrorMessage">
+        <source>Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</source>
+        <target state="new">Waiting for debugger to attach (TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER=1) is not supported on wasi.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>
         <target state="translated">已執行零項測試</target>


### PR DESCRIPTION
Closes #8557. Related: #2196, #5366.

MTP projects already advertise wasi support via `<SupportedPlatform Include="wasi" />`, so CA1416 now requires call sites and exposed members to be annotated for wasi the same way they are for browser/ios/tvos. This PR closes the annotation gap on the parts of MTP that structurally cannot work on wasi-wasm today (single-instance wasm, no PID/process model, no `PosixSignalRegistration`, no tty buffer/window APIs).

## Why these surfaces?

- **`Console.CancelKeyPress`** is implemented via `PosixSignalRegistration` which is unavailable on wasi (this is the original [#5366](https://github.com/microsoft/testfx/issues/5366) crash).
- **Buffer/window/foreground-color console APIs** require a tty which wasi-wasm doesn't expose.
- **`System.Diagnostics.Process`** has no analog on wasi: one wasm instance per program, no PID, no `/proc`, no `Process.Start`.
- **HangDump** is structurally inapplicable on wasi: no watchdog process, no `MiniDumpWriteDump`, no threading.

## Changes

- **Console abstraction** (`IConsole` / `SystemConsole`): mirror existing `browser` annotations on `CancelKeyPress`, `BufferHeight/Width`, `WindowHeight/Width`, and `SetForegroundColor`/`GetForegroundColor`.
- **Process abstraction** (`SystemProcessHandler`): `GetCurrentProcess`, `GetProcessById`, `Start`.
- **HangDump extension**: `AddHangDumpProvider` entry point (plus matching PNSE runtime guard), `TestingPlatformBuilderHook.AddExtensions`, `HangDumpProcessLifetimeHandler` (class + `TakeDumpOfTreeAsync`), `HangDumpActivityIndicator`, and the `IProcessExtensions` helpers (`GetProcessTreeAsync`, `GetParentPidWindows/Linux/MacOsAsync`, `IsChildCandidate`).
- **`TestApplication.WaitForDebuggerToAttach`**: add `wasi` to the attribute and add a sibling runtime guard at both call sites (env-var driven and command-line option driven). New localized resource `WaitDebuggerAttachNotSupportedInWasiErrorMessage`.
- **Terminal helpers** (`AnsiTerminal`/`SimpleTerminalBase` `Width`/`Height` and `NativeMethods.QueryIsScreenAndTryEnableAnsiColorCodes`): include wasi in the existing `browser/android/ios/tvos` guards so the call sites stop CA1416-warning once the underlying APIs are flagged.

`CTRLPlusCCancellationTokenSource`, `NonAnsiTerminal`, `HotReloadHandler` and `OutputDeviceManager` already had `OperatingSystem.IsWasi()` guards (plus matching `[SupportedOSPlatformGuard("wasi")]`) and continue to compile cleanly.

## Out of scope

- `IConsole.Clear()` (no `browser` annotation today; `Console.Clear()` may work on wasi via ANSI escapes — separate concern).
- Normalizing `HangDumpActivityIndicator`'s `browser`-only annotation up to the full `browser/ios/tvos/wasi` quartet (kept minimal here).
- `IProcessHandler` interface remains attribute-free (only the concrete `SystemProcessHandler` impl carries the annotations).

## Validation

- `.\build.cmd -c Debug` succeeds with no CA1416 warnings.
- No public API change: `[UnsupportedOSPlatform]` is not part of the `PublicAPI.txt` format.
- All 13 localized XLF files regenerated via `UpdateXlf`.