### PR TITLE
Support class-level [Retry] attribute (#7556)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Execution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Execution.cs
@@ -52,6 +52,19 @@ internal partial class TestMethodInfo
         throw new TypeInspectionException(errorMessage);
     }
 
+    [DoesNotReturn]
+    private void ThrowMultipleClassAttributesException(string attributeName)
+    {
+        // Note: even if the given attribute has AllowMultiple = false, we can
+        // still reach here if a derived attribute authored by the user re-defines AttributeUsage
+        string errorMessage = string.Format(
+            CultureInfo.CurrentCulture,
+            Resource.UTA_MultipleAttributesOnTestClass,
+            Parent.ClassType.FullName,
+            attributeName);
+        throw new TypeInspectionException(errorMessage);
+    }
+
     /// <summary>
     /// Execute test without timeout.
     /// </summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -190,16 +190,28 @@ internal partial class TestMethodInfo : ITestMethod
     {
         RetryBaseAttribute? methodRetry = GetSingleRetryAttribute(
             PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(MethodInfo),
-            isClassLevel: false);
+            RetryAttributeScope.Method);
 
+        // Always scan the class as well so a misuse there (multiple class-level retry
+        // attributes) is reported even when the method has its own retry override.
         RetryBaseAttribute? classRetry = GetSingleRetryAttribute(
             PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(Parent.ClassType),
-            isClassLevel: true);
+            RetryAttributeScope.Class);
 
+        // Method-level retry fully overrides class-level retry when present.
         return methodRetry ?? classRetry;
     }
 
-    private RetryBaseAttribute? GetSingleRetryAttribute(Attribute[] attributes, bool isClassLevel)
+    /// <summary>
+    /// Returns the single <see cref="RetryBaseAttribute"/> found in <paramref name="attributes"/>,
+    /// or <see langword="null"/> if none is present.
+    /// </summary>
+    /// <param name="attributes">The attribute set to scan (method-level or class-level).</param>
+    /// <param name="scope">Indicates whether <paramref name="attributes"/> comes from a method or a class; only used to pick the right error message when more than one retry attribute is found.</param>
+    /// <exception cref="ObjectModel.TypeInspectionException">
+    /// Thrown when <paramref name="attributes"/> contains more than one <see cref="RetryBaseAttribute"/>.
+    /// </exception>
+    private RetryBaseAttribute? GetSingleRetryAttribute(Attribute[] attributes, RetryAttributeScope scope)
     {
         RetryBaseAttribute? result = null;
         foreach (Attribute attribute in attributes)
@@ -208,7 +220,7 @@ internal partial class TestMethodInfo : ITestMethod
             {
                 if (result is not null)
                 {
-                    if (isClassLevel)
+                    if (scope == RetryAttributeScope.Class)
                     {
                         ThrowMultipleClassAttributesException(nameof(RetryBaseAttribute));
                     }
@@ -223,5 +235,11 @@ internal partial class TestMethodInfo : ITestMethod
         }
 
         return result;
+    }
+
+    private enum RetryAttributeScope
+    {
+        Method,
+        Class,
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -174,15 +174,33 @@ internal partial class TestMethodInfo : ITestMethod
     }
 
     /// <summary>
-    /// Gets the number of retries this test method should make in case of failure.
+    /// Resolves the retry attribute that applies to this test method, considering both
+    /// method-level and class-level <see cref="RetryBaseAttribute"/> attributes.
     /// </summary>
+    /// <remarks>
+    /// A method-level retry attribute fully overrides any class-level retry attribute.
+    /// Class-level retry attributes are always validated (even when the method has its own
+    /// retry) so that misuse on the test class is reported regardless of method overrides.
+    /// </remarks>
     /// <returns>
-    /// The number of retries, which is always greater than or equal to 1.
-    /// If RetryAttribute is not present, returns 1.
+    /// The resolved <see cref="RetryBaseAttribute"/>, or <see langword="null"/> if neither
+    /// the method nor the declaring class is decorated.
     /// </returns>
     private RetryBaseAttribute? GetRetryAttribute()
     {
-        Attribute[] attributes = PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(MethodInfo);
+        RetryBaseAttribute? methodRetry = GetSingleRetryAttribute(
+            PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(MethodInfo),
+            isClassLevel: false);
+
+        RetryBaseAttribute? classRetry = GetSingleRetryAttribute(
+            PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(Parent.ClassType),
+            isClassLevel: true);
+
+        return methodRetry ?? classRetry;
+    }
+
+    private RetryBaseAttribute? GetSingleRetryAttribute(Attribute[] attributes, bool isClassLevel)
+    {
         RetryBaseAttribute? result = null;
         foreach (Attribute attribute in attributes)
         {
@@ -190,7 +208,14 @@ internal partial class TestMethodInfo : ITestMethod
             {
                 if (result is not null)
                 {
-                    ThrowMultipleAttributesException(nameof(RetryBaseAttribute));
+                    if (isClassLevel)
+                    {
+                        ThrowMultipleClassAttributesException(nameof(RetryBaseAttribute));
+                    }
+                    else
+                    {
+                        ThrowMultipleAttributesException(nameof(RetryBaseAttribute));
+                    }
                 }
 
                 result = retryAttribute;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
@@ -399,6 +399,9 @@ but received {4} argument(s), with types '{5}'.</value>
   <data name="UTA_MultipleAttributesOnTestMethod" xml:space="preserve">
     <value>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</value>
   </data>
+  <data name="UTA_MultipleAttributesOnTestClass" xml:space="preserve">
+    <value>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</value>
+  </data>
   <data name="UTA_NoTestResult" xml:space="preserve">
     <value>Error in executing test. No result returned by extension. If using extension of TestMethodAttribute then please contact vendor.</value>
   </data>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
@@ -462,6 +462,11 @@ byl však přijat tento počet argumentů: {4} s typy {5}.</target>
         <target state="translated">Metoda {0}.{1} neexistuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">Testovací metoda {0}.{1} má definovaných více atributů odvozených od atributu {2}. Povolený je jenom jeden takový atribut.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
@@ -462,6 +462,11 @@ aber empfing {4} Argument(e) mit den Typen „{5}“.</target>
         <target state="translated">Die Methode "{0}.{1}" ist nicht vorhanden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">Für die Testmethode „{0}.{1}“ sind mehrere Attribute definiert, die von „{2}“ abgeleitet sind. Nur ein einziges solches Attribut ist zulässig.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
@@ -462,6 +462,11 @@ pero recibió {4} argumentos, con los tipos '{5}'.</target>
         <target state="translated">El método {0}.{1} no existe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">El método de prueba '{0}.{1}' tiene varios atributos derivados de '{2}' definidos en él. Solo se permite un atributo de este tipo.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
@@ -462,6 +462,11 @@ mais a reçu {4} argument(s), avec les types « {5} ».</target>
         <target state="translated">La méthode {0}.{1} n'existe pas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">La méthode de test « {0}.{1} » possède plusieurs attributs dérivés de « {2} » qui lui sont définis. Un seul attribut de ce type est autorisé.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
@@ -462,6 +462,11 @@ ma ha ricevuto {4} argomenti, con tipi '{5}'.</target>
         <target state="translated">Il metodo {0}.{1} non esiste.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">Il metodo di test '{0}.{1}' contiene più attributi derivati da '{2}' definito in esso. È consentito solo uno di tali attributi.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
@@ -463,6 +463,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">メソッド {0}.{1} は存在しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">テスト メソッド '{0}.{1}' には、 '{2}' から派生した属性が複数定義されています。このような属性は 1 つしか許可されません。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
@@ -462,6 +462,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">{0}.{1} 메서드가 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">테스트 메서드 '{0}.{1}'에 {2}에서 파생된 여러 특성이 정의되어 있습니다. 이러한 특성은 하나만 허용됩니다.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
@@ -462,6 +462,11 @@ ale odebrał argumenty {4} z typami „{5}”.</target>
         <target state="translated">Metoda {0}.{1} nie istnieje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">Metoda testowa "{0}.{1}” ma zdefiniowanych wiele atrybutów pochodzących z „{2}”. Dozwolony jest tylko jeden taki atrybut.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
@@ -462,6 +462,11 @@ mas {4} argumentos recebidos, com tipos '{5}'.</target>
         <target state="translated">O método {0}.{1} não existe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">O método de teste '{0}.{1}' tem várias características derivadas de '{2}' definidas nele. Apenas uma dessas características tem permissão.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
@@ -462,6 +462,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">Метод {0}.{1} не существует.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">У метода тестирования "{0}.{1}" есть несколько атрибутов, производных от заданного в нем "{2}". Допускается только один такой атрибут.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
@@ -462,6 +462,11 @@ ancak, '{5}' türünde {4} bağımsız değişken aldı.</target>
         <target state="translated">{0}.{1} metodu yok.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">“{0}.{1}” test yöntemi, üzerinde tanımlanan “{2}” öğesinden türetilmiş birden fazla öznitelik içeriyor. Bu türde yalnızca bir tane özniteliğe izin verilir.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
@@ -462,6 +462,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">方法 {0}.{1} 不存在。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">测试方法“{0}.{1}”具有多个在其上定义的“{2}”的派生属性。仅允许一个此类属性。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
@@ -462,6 +462,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">方法 {0}.{1} 不存在。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UTA_MultipleAttributesOnTestClass">
+        <source>The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</source>
+        <target state="new">The test class '{0}' has multiple attributes derived from '{1}' defined on it. Only one such attribute is allowed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UTA_MultipleAttributesOnTestMethod">
         <source>The test method '{0}.{1}' has multiple attributes derived from '{2}' defined on it. Only one such attribute is allowed.</source>
         <target state="translated">測試方法 '{0}.{1}' 具有多個衍生自 '{2}' 的屬性根據其定義。只允許一個此類屬性。</target>

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -583,10 +583,10 @@ The type declaring these methods should also respect the following rules:
     <value>Do not duplicate 'DataRow' attributes. This is usually a copy/paste error. The attribute indices are '{0}' and '{1}'.</value>
   </data>
   <data name="UseRetryWithTestMethodTitle" xml:space="preserve">
-    <value>Use retry attribute on test method</value>
+    <value>Use retry attribute on test method or test class</value>
   </data>
   <data name="UseRetryWithTestMethodMessageFormat" xml:space="preserve">
-    <value>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</value>
+    <value>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</value>
   </data>
   <data name="PreferTestMethodOverDataTestMethodAnalyzerTitle" xml:space="preserve">
     <value>Prefer 'TestMethod' over 'DataTestMethod'</value>

--- a/src/Analyzers/MSTest.Analyzers/UseRetryWithTestMethodAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseRetryWithTestMethodAnalyzer.cs
@@ -42,25 +42,33 @@ public sealed class UseRetryWithTestMethodAnalyzer : DiagnosticAnalyzer
 
         context.RegisterCompilationStartAction(context =>
         {
-            if (context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute, out INamedTypeSymbol? testMethodAttributeSymbol) &&
-                context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingRetryBaseAttribute, out INamedTypeSymbol? retryBaseAttributeSymbol))
+            if (context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute, out INamedTypeSymbol? testMethodAttributeSymbol)
+                && context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestClassAttribute, out INamedTypeSymbol? testClassAttributeSymbol)
+                && context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingRetryBaseAttribute, out INamedTypeSymbol? retryBaseAttributeSymbol))
             {
                 context.RegisterSymbolAction(
-                    context => AnalyzeSymbol(context, testMethodAttributeSymbol, retryBaseAttributeSymbol),
-                    SymbolKind.Method);
+                    context => AnalyzeSymbol(context, testMethodAttributeSymbol, testClassAttributeSymbol, retryBaseAttributeSymbol),
+                    SymbolKind.Method,
+                    SymbolKind.NamedType);
             }
         });
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol testMethodAttributeSymbol, INamedTypeSymbol retryBaseAttributeSymbol)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol testMethodAttributeSymbol, INamedTypeSymbol testClassAttributeSymbol, INamedTypeSymbol retryBaseAttributeSymbol)
     {
         bool hasRetryBaseAttribute = false;
         foreach (AttributeData attribute in context.Symbol.GetAttributes())
         {
-            if (attribute.AttributeClass.Inherits(testMethodAttributeSymbol))
+            if (context.Symbol.Kind == SymbolKind.Method && attribute.AttributeClass.Inherits(testMethodAttributeSymbol))
             {
                 // We are looking for retry attributes that are not applied to test methods.
                 // If this is already a test method, we just return.
+                return;
+            }
+
+            if (context.Symbol.Kind == SymbolKind.NamedType && attribute.AttributeClass.Inherits(testClassAttributeSymbol))
+            {
+                // Similarly, if this is already a test class, we just return.
                 return;
             }
 
@@ -70,7 +78,7 @@ public sealed class UseRetryWithTestMethodAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        // We looked all attributes, and we found a retry attribute, but didn't find TestMethodAttribute.
+        // We looked all attributes, and we found a retry attribute, but didn't find TestMethodAttribute or TestClassAttribute.
         if (hasRetryBaseAttribute)
         {
             context.ReportDiagnostic(context.Symbol.CreateDiagnostic(UseRetryWithTestMethodRule));

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -990,13 +990,13 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Atribut, který je odvozen od retryBaseAttribute, lze zadat pouze v testovací metodě.</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Atribut, který je odvozen od retryBaseAttribute, lze zadat pouze v testovací metodě.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Použití atributu opakování u testovací metody</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Použití atributu opakování u testovací metody</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -991,13 +991,13 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Ein von „RetryBaseAttribute“ abgeleitetes Attribut kann nur für eine Testmethode angegeben werden.</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Ein von „RetryBaseAttribute“ abgeleitetes Attribut kann nur für eine Testmethode angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Verwenden des Wiederholungsattributs für die Testmethode</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Verwenden des Wiederholungsattributs für die Testmethode</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -990,13 +990,13 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Un atributo que deriva de 'RetryBaseAttribute' solo se puede especificar en un método de prueba</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Un atributo que deriva de 'RetryBaseAttribute' solo se puede especificar en un método de prueba</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Usar el atributo de reintento en el método de prueba</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Usar el atributo de reintento en el método de prueba</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -990,13 +990,13 @@ Le type doit être une classe
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Vous ne pouvez spécifier un attribut dérivant de « RetryBaseAttribute » que sur une méthode de test</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Vous ne pouvez spécifier un attribut dérivant de « RetryBaseAttribute » que sur une méthode de test</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Utilisez l’attribut de nouvelle tentative sur la méthode de test</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Utilisez l’attribut de nouvelle tentative sur la méthode de test</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -990,13 +990,13 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">È possibile specificare un attributo che deriva da ‘RetryBaseAttribute’ solo in un metodo di test</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">È possibile specificare un attributo che deriva da ‘RetryBaseAttribute’ solo in un metodo di test</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Utilizzare l'attributo di ripetizione nel metodo di test</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Utilizzare l'attributo di ripetizione nel metodo di test</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -990,13 +990,13 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">'RetryBaseAttribute' から派生する属性は、テスト メソッドでのみ指定できます</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">'RetryBaseAttribute' から派生する属性は、テスト メソッドでのみ指定できます</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">テスト メソッドで retry 属性を使用する</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">テスト メソッドで retry 属性を使用する</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -990,13 +990,13 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">'RetryBaseAttribute'에서 파생된 속성은 테스트 메서드에서만 지정할 수 있습니다.</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">'RetryBaseAttribute'에서 파생된 속성은 테스트 메서드에서만 지정할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">테스트 메서드에 재시도 속성 사용</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">테스트 메서드에 재시도 속성 사용</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -990,13 +990,13 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Atrybut pochodzący od atrybutu „RetryBaseAttribute” można określić tylko w metodzie testowej</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Atrybut pochodzący od atrybutu „RetryBaseAttribute” można określić tylko w metodzie testowej</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Użyj atrybutu ponawiania dla metody testowej</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Użyj atrybutu ponawiania dla metody testowej</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -990,13 +990,13 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Um atributo derivado de “RetryBaseAttribute” só pode ser especificado em um método de teste</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Um atributo derivado de “RetryBaseAttribute” só pode ser especificado em um método de teste</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Usar o atributo de repetição no método de teste</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Usar o atributo de repetição no método de teste</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -1002,13 +1002,13 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">Атрибут, производный от "RetryBaseAttribute", может быть указан только в тестовом методе</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">Атрибут, производный от "RetryBaseAttribute", может быть указан только в тестовом методе</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Использовать атрибут retry в тестовом методе</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Использовать атрибут retry в тестовом методе</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -992,13 +992,13 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">'RetryBaseAttribute' özniteliğinden türetilen bir öznitelik yalnızca bir test yönteminde belirtilebilir</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">'RetryBaseAttribute' özniteliğinden türetilen bir öznitelik yalnızca bir test yönteminde belirtilebilir</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">Test yönteminde yeniden deneme özniteliğini kullan</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">Test yönteminde yeniden deneme özniteliğini kullan</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -990,13 +990,13 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">只能在测试方法上指定派生自 ‘RetryBaseAttribute’ 的属性</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">只能在测试方法上指定派生自 ‘RetryBaseAttribute’ 的属性</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">对测试方法使用重试属性</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">对测试方法使用重试属性</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -990,13 +990,13 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodMessageFormat">
-        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method</source>
-        <target state="translated">衍生自 'RetryBaseAttribute' 的屬性只能在測試方法上指定</target>
+        <source>An attribute that derives from 'RetryBaseAttribute' can be specified only on a test method or a test class</source>
+        <target state="needs-review-translation">衍生自 'RetryBaseAttribute' 的屬性只能在測試方法上指定</target>
         <note />
       </trans-unit>
       <trans-unit id="UseRetryWithTestMethodTitle">
-        <source>Use retry attribute on test method</source>
-        <target state="translated">在測試方法上使用重試屬性</target>
+        <source>Use retry attribute on test method or test class</source>
+        <target state="needs-review-translation">在測試方法上使用重試屬性</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextPropertyUsageTitle">

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryAttribute.cs
@@ -6,7 +6,13 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// <summary>
 /// This attribute is used to set a retry count on a test method in case of failure.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+/// <remarks>
+/// When applied to a test class, the attribute is used as a default for every test method declared on the class.
+/// A <see cref="RetryAttribute"/> placed directly on a test method takes precedence over a class-level one
+/// (the method-level value fully replaces the class-level value, regardless of whether it is larger or smaller).
+/// The attribute is not inherited: applying it to a base test class does not apply it to derived test classes.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public sealed class RetryAttribute : RetryBaseAttribute
 {
     /// <summary>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
@@ -7,7 +7,12 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// An abstract attribute that controls retrying a test method if it failed. It's up to the derived classes to
 /// define how the retry is done.
 /// </summary>
-[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+/// <remarks>
+/// When applied to a test class, the attribute is used as a default for every test method declared on the class.
+/// A retry attribute placed directly on a test method takes precedence over a class-level one.
+/// The attribute is not inherited: applying it to a base test class does not apply it to derived test classes.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public abstract class RetryBaseAttribute : Attribute
 {
     /// <summary>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RetryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -132,6 +132,115 @@ public class UnitTest1
         Console.WriteLine($"TestMethod3 executed {_count3} times.");
         Console.WriteLine($"TestMethod4 executed {_count4} times.");
         Console.WriteLine($"TestMethod5 executed {_count5} times.");
+    }
+}
+
+#file my.runsettings
+<RunSettings>
+  <MSTest>
+    <CaptureTraceOutput>false</CaptureTraceOutput>
+  </MSTest>
+</RunSettings>
+""";
+    }
+
+    public TestContext TestContext { get; set; }
+}
+
+[TestClass]
+public sealed class ClassLevelRetryTests : AcceptanceTestBase<ClassLevelRetryTests.TestAssetFixture>
+{
+    [TestMethod]
+    public async Task ClassLevelRetry_AppliesToAllTestMethods_AndMethodLevelOverrides()
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
+
+        // ClassLevelOnly is decorated only by class-level [Retry(3)] => 4 total runs.
+        // MethodLevelOverride overrides the class-level [Retry(3)] with method-level [Retry(1)] => 2 total runs.
+        // PassingMethod also has class-level retry but passes on first attempt => 1 total run.
+        testHostResult.AssertOutputContains("""
+            ClassLevelOnly executed 4 times.
+            MethodLevelOverride executed 2 times.
+            PassingMethod executed 1 time.
+            """);
+        testHostResult.AssertOutputContainsSummary(failed: 2, passed: 1, skipped: 0);
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        public const string ProjectName = "ClassLevelRetryTests";
+
+        public string ProjectPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file ClassLevelRetryTests.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="*.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>
+
+#file UnitTest1.cs
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+[Retry(3)]
+public class UnitTest1
+{
+    private static int _classLevelOnly;
+    private static int _methodOverride;
+    private static int _passing;
+
+    [TestMethod]
+    public void ClassLevelOnly()
+    {
+        _classLevelOnly++;
+        Assert.Fail("Always failing ClassLevelOnly");
+    }
+
+    [TestMethod]
+    [Retry(1)]
+    public void MethodLevelOverride()
+    {
+        _methodOverride++;
+        Assert.Fail("Always failing MethodLevelOverride");
+    }
+
+    [TestMethod]
+    public void PassingMethod()
+    {
+        _passing++;
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        Console.WriteLine($"ClassLevelOnly executed {_classLevelOnly} times.");
+        Console.WriteLine($"MethodLevelOverride executed {_methodOverride} times.");
+        Console.WriteLine($"PassingMethod executed {_passing} time{(_passing == 1 ? string.Empty : "s")}.");
     }
 }
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseRetryWithTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseRetryWithTestMethodAnalyzerTests.cs
@@ -112,4 +112,88 @@ public sealed class UseRetryWithTestMethodAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenTestClassHasRetryAttribute_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            internal sealed class MyTestClassAttribute : TestClassAttribute { }
+
+            [TestClass]
+            [Retry(maxRetryAttempts: 3)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void M()
+                {
+                }
+            }
+
+            [Retry(maxRetryAttempts: 3)]
+            [TestClass]
+            public class MyTestClass2
+            {
+                [TestMethod]
+                public void M()
+                {
+                }
+            }
+
+            [MyTestClass]
+            [Retry(maxRetryAttempts: 3)]
+            public class MyTestClass3
+            {
+                [TestMethod]
+                public void M()
+                {
+                }
+            }
+
+            [Retry(maxRetryAttempts: 3)]
+            [MyTestClass]
+            public class MyTestClass4
+            {
+                [TestMethod]
+                public void M()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestClassHasRetryAttribute_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [Retry(maxRetryAttempts: 3)]
+            public class [|MyClass|]
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestClassDoesNotHaveRetryAttribute_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                public void M()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -208,6 +208,67 @@ public class TestMethodInfoTests : TestContainer
             nameof(RetryBaseAttribute)));
     }
 
+    public void TestMethodInfoCtorShouldUseClassLevelRetryAttributeWhenMethodHasNone()
+    {
+        TestMethodInfo testMethodInfo = CreateTestMethodInfoForRetryAttributeTests<DummyTestClassWithClassLevelRetry>(
+            nameof(DummyTestClassWithClassLevelRetry.MethodWithoutRetryAttribute));
+
+        testMethodInfo.RetryAttribute.Should().BeOfType<RetryAttribute>();
+        ((RetryAttribute)testMethodInfo.RetryAttribute!).MaxRetryAttempts.Should().Be(4);
+    }
+
+    public void TestMethodInfoCtorShouldPreferMethodLevelRetryAttributeOverClassLevel()
+    {
+        TestMethodInfo testMethodInfo = CreateTestMethodInfoForRetryAttributeTests<DummyTestClassWithClassLevelRetry>(
+            nameof(DummyTestClassWithClassLevelRetry.MethodWithRetryAttribute));
+
+        testMethodInfo.RetryAttribute.Should().BeOfType<RetryAttribute>();
+        ((RetryAttribute)testMethodInfo.RetryAttribute!).MaxRetryAttempts.Should().Be(7);
+    }
+
+    public void TestMethodInfoCtorShouldPreferMethodLevelRetryEvenWhenSmallerThanClassLevel()
+    {
+        TestMethodInfo testMethodInfo = CreateTestMethodInfoForRetryAttributeTests<DummyTestClassWithClassLevelRetry>(
+            nameof(DummyTestClassWithClassLevelRetry.MethodWithSmallerRetryAttribute));
+
+        testMethodInfo.RetryAttribute.Should().BeOfType<RetryAttribute>();
+        ((RetryAttribute)testMethodInfo.RetryAttribute!).MaxRetryAttempts.Should().Be(1);
+    }
+
+    public void TestMethodInfoCtorShouldNotInheritRetryAttributeFromBaseClass()
+    {
+        TestMethodInfo testMethodInfo = CreateTestMethodInfoForRetryAttributeTests<DerivedFromClassWithClassLevelRetry>(
+            nameof(DerivedFromClassWithClassLevelRetry.MethodInDerivedClass));
+
+        testMethodInfo.RetryAttribute.Should().BeNull();
+    }
+
+    public void TestMethodInfoCtorShouldThrowWhenMultipleClassLevelRetryBaseAttributesExist()
+    {
+        Action action = () => _ = CreateTestMethodInfoForRetryAttributeTests<DummyTestClassWithMultipleClassLevelRetryAttributes>(
+            nameof(DummyTestClassWithMultipleClassLevelRetryAttributes.TestMethod));
+
+        TypeInspectionException exception = action.Should().Throw<TypeInspectionException>().Which;
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.CurrentCulture,
+            Resource.UTA_MultipleAttributesOnTestClass,
+            typeof(DummyTestClassWithMultipleClassLevelRetryAttributes).FullName,
+            nameof(RetryBaseAttribute)));
+    }
+
+    public void TestMethodInfoCtorShouldThrowOnMultipleClassLevelRetryEvenWhenMethodHasItsOwnRetry()
+    {
+        Action action = () => _ = CreateTestMethodInfoForRetryAttributeTests<DummyTestClassWithMultipleClassLevelRetryAttributes>(
+            nameof(DummyTestClassWithMultipleClassLevelRetryAttributes.TestMethodWithOwnRetry));
+
+        TypeInspectionException exception = action.Should().Throw<TypeInspectionException>().Which;
+        exception.Message.Should().Be(string.Format(
+            CultureInfo.CurrentCulture,
+            Resource.UTA_MultipleAttributesOnTestClass,
+            typeof(DummyTestClassWithMultipleClassLevelRetryAttributes).FullName,
+            nameof(RetryBaseAttribute)));
+    }
+
     #region TestMethod invoke scenarios
 
     public async Task TestMethodInfoInvokeShouldWaitForAsyncTestMethodsToComplete()
@@ -1791,8 +1852,11 @@ public class TestMethodInfoTests : TestContainer
     }
 
     private TestMethodInfo CreateTestMethodInfoForRetryAttributeTests(string methodName)
+        => CreateTestMethodInfoForRetryAttributeTests<DummyTestClassWithRetryAttributeMethods>(methodName);
+
+    private TestMethodInfo CreateTestMethodInfoForRetryAttributeTests<TClass>(string methodName)
     {
-        Type classType = typeof(DummyTestClassWithRetryAttributeMethods);
+        Type classType = typeof(TClass);
         MethodInfo methodInfo = classType.GetMethod(methodName)!;
         ConstructorInfo constructorInfo = classType.GetConstructor([])!;
         var testClassInfo = new TestClassInfo(classType, constructorInfo, isParameterlessConstructor: true, _classAttribute, _testAssemblyInfo);
@@ -1994,6 +2058,63 @@ public class TestMethodInfoTests : TestContainer
     {
         protected internal override Task<RetryResult> ExecuteAsync(RetryContext retryContext)
             => throw new NotSupportedException();
+    }
+
+    [Retry(4)]
+    public class DummyTestClassWithClassLevelRetry
+    {
+        [TestMethod]
+        public void MethodWithoutRetryAttribute()
+        {
+        }
+
+        [TestMethod]
+        [Retry(7)]
+        public void MethodWithRetryAttribute()
+        {
+        }
+
+        [TestMethod]
+        [Retry(1)]
+        public void MethodWithSmallerRetryAttribute()
+        {
+        }
+    }
+
+    public class DerivedFromClassWithClassLevelRetry : DummyTestClassWithClassLevelRetry
+    {
+        [TestMethod]
+        public void MethodInDerivedClass()
+        {
+        }
+    }
+
+    [DummyClassLevelRetry1]
+    [DummyClassLevelRetry2]
+    public class DummyTestClassWithMultipleClassLevelRetryAttributes
+    {
+        [TestMethod]
+        public void TestMethod()
+        {
+        }
+
+        [TestMethod]
+        [Retry(2)]
+        public void TestMethodWithOwnRetry()
+        {
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    private sealed class DummyClassLevelRetry1Attribute : RetryBaseAttribute
+    {
+        protected internal override Task<RetryResult> ExecuteAsync(RetryContext retryContext) => throw new NotSupportedException();
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    private sealed class DummyClassLevelRetry2Attribute : RetryBaseAttribute
+    {
+        protected internal override Task<RetryResult> ExecuteAsync(RetryContext retryContext) => throw new NotSupportedException();
     }
 
     public class DummyTestClassWithParameterizedCtor


### PR DESCRIPTION
Resolves #7556.

## Summary

Adds support for decorating `[TestClass]` types with `[Retry(N)]` (or any `RetryBaseAttribute`-derived attribute). When a class-level retry is present, every test method in the class retries on failure with the specified count. A method-level retry attribute, when present, **fully overrides** the class-level one (smaller, equal or larger).

Assembly-level retry is intentionally **out of scope** here (the user only asked for classes, and assembly-level retry is already supported via `Microsoft.Testing.Extensions.Retry` for MTP users).

## Behavior

| Class-level | Method-level | Effective |
|---|---|---|
| -            | `[Retry(N)]` | `[Retry(N)]` (existing) |
| `[Retry(N)]` | -              | `[Retry(N)]` (new) |
| `[Retry(N)]` | `[Retry(M)]` | `[Retry(M)]` (method wins) |
| 2+ at class  | any            | throws `TypeInspectionException` (new message `UTA_MultipleAttributesOnTestClass`) |
| any          | 2+ at method   | throws `TypeInspectionException` (existing message) |

Class-level duplicates are always validated, even when a method-level override is present, so misuse on the test class is never silenced.

`RetryAttribute`/`RetryBaseAttribute` keep `Inherited = false` — base-class retry does not flow to a derived test class. There is a regression test for this.

## Changes

- `RetryBaseAttribute`/`RetryAttribute`: `AttributeUsage` extended to `Method | Class`; added remarks doc explaining override semantics.
- `TestMethodInfo.GetRetryAttribute`: rewritten to walk method then class attributes via a shared `GetSingleRetryAttribute` helper.
- `Resource.resx`: new `UTA_MultipleAttributesOnTestClass` entry (xlf regenerated).
- `UseRetryWithTestMethodAnalyzer` (MSTEST0035): now also registers `SymbolKind.NamedType` and flags `[Retry]` on non-test classes; diagnostic text updated to mention test classes (xlf regenerated).

## Tests

- `TestMethodInfoTests`: 6 new unit tests covering class-level pickup, method-overrides-class (both larger and smaller), non-inheritance from a base class, and class-level duplicate validation (with and without a method-level override).
- `UseRetryWithTestMethodAnalyzerTests`: 3 new tests covering `[TestClass][Retry]`, `[Retry]` on non-test class, and custom-derived `TestClassAttribute`.
- `RetryTests` (acceptance): new `ClassLevelRetryTests` end-to-end scenario exercising class-level retry plus per-method override.
