### PR TITLE
Standardize GitHub label taxonomy to prefix/lowercase-kebab

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve Microsoft.Testing.Platform and MSTest
-labels: [bug, need-triage]
+labels: [type/bug, needs/triage]
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest a new feature/idea for Microsoft.Testing.Platform or MSTest
-labels: [feature-request, need-triage]
+labels: [type/feature, needs/triage]
 ---
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,7 +1,7 @@
 ---
 name: Other issue
 about: Open an issue which does not belong to any categories above
-labels: [need-triage]
+labels: [needs/triage]
 ---
 
 <!-- Please, provide a clear and concise description of what the problem is below. -->

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -2,7 +2,7 @@
 name: MSTest RFC
 about: Request for Comments
 title: ''
-labels: ["Type: RFC", need-triage]
+labels: [type/rfc, needs/triage]
 ---
 
 # RFC NNN - (Fill me in with a feature name)

--- a/.github/policies/LabelManagement.IssueClosed.yml
+++ b/.github/policies/LabelManagement.IssueClosed.yml
@@ -15,13 +15,13 @@ configuration:
               action: Closed
         then:
           - removeLabel:
-              label: 'Needs: Triage :mag:'
+              label: 'needs/triage'
           - removeLabel:
-              label: 'Needs: Attention :wave:'
+              label: 'needs/attention'
           - removeLabel:
-              label: 'Needs: Author Feedback'
+              label: 'needs/author-feedback'
           - removeLabel:
-              label: Help-Wanted
+              label: 'help wanted'
       - description: Remove labels when a pull request is closed
         if:
           - payloadType: Pull_Request
@@ -29,8 +29,8 @@ configuration:
               action: Closed
         then:
           - removeLabel:
-              label: 'Needs: Attention :wave:'
+              label: 'needs/attention'
           - removeLabel:
-              label: 'Needs: Author Feedback'
+              label: 'needs/author-feedback'
 onFailure:
 onSuccess:

--- a/.github/policies/LabelManagement.IssueOpened.yml
+++ b/.github/policies/LabelManagement.IssueOpened.yml
@@ -24,6 +24,6 @@ configuration:
                 user: github-actions[bot]
         then:
           - addLabel:
-              label: 'Needs: Triage :mag:'
+              label: 'needs/triage'
 onFailure:
 onSuccess:

--- a/.github/policies/LabelManagement.IssueUpdated.yml
+++ b/.github/policies/LabelManagement.IssueUpdated.yml
@@ -9,7 +9,7 @@ configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
       - description: >-
-          Remove "State: No Recent Activity" when a pull request or issue is updated
+          Remove "state/stale" when a pull request or issue is updated
         if:
           - or:
               - payloadType: Pull_Request
@@ -21,10 +21,10 @@ configuration:
               isAction:
                 action: Closed
           - hasLabel:
-              label: "State: No Recent Activity"
+              label: "state/stale"
         then:
           - removeLabel:
-              label: "State: No Recent Activity"
+              label: "state/stale"
         # The policy service should not trigger itself here, or else the label would be removed immediately after being added
         triggerOnOwnActions: False
       - description: Clean email replies on every comment
@@ -32,20 +32,20 @@ configuration:
           - payloadType: Issue_Comment
         then:
           - cleanEmailReply
-      - description: Remove "Help-Wanted" label when an issue goes into PR
+      - description: Remove "help wanted" label when an issue goes into PR
         if:
           - payloadType: Issues
           - labelAdded:
-              label: In-PR
+              label: state/in-pr
           - hasLabel:
-              label: Help-Wanted
+              label: "help wanted"
         then:
           - removeLabel:
-              label: Help-Wanted
+              label: "help wanted"
       - description: >-
           If an author responds to an issue which needs author feedback
-          * Remove the "Needs: Author Feedback" Label
-          * Add the "Needs: Attention :wave:" Label
+          * Remove the "needs/author-feedback" Label
+          * Add the "needs/attention" Label
         if:
           - or:
               - payloadType: Pull_Request_Review
@@ -54,18 +54,18 @@ configuration:
           - isActivitySender:
               issueAuthor: True
           - hasLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
           - not:
               isAction:
                 action: Synchronize
         then:
           - removeLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
           - addLabel:
-              label: "Needs: Attention :wave:"
+              label: "needs/attention"
       - description: >-
           If team members respond to an issue which needs attention
-          * Remove the "Needs: Attention :wave:" Label
+          * Remove the "needs/attention" Label
         if:
           - or:
               - payloadType: Pull_Request_Review
@@ -74,7 +74,7 @@ configuration:
           - isActivitySender:
               issueAuthor: True
           - hasLabel:
-              label: "Needs: Attention :wave:"
+              label: "needs/attention"
           - not:
               isAction:
                 action: Synchronize
@@ -87,10 +87,10 @@ configuration:
                 association: Collaborator
         then:
           - removeLabel:
-              label: "Needs: Attention :wave:"
+              label: "needs/attention"
       - description: >-
           If team members respond to an issue which needs triage
-          * Remove the "Needs: Triage :mag:" Label
+          * Remove the "needs/triage" Label
         if:
           - or:
               - payloadType: Pull_Request_Review
@@ -99,7 +99,7 @@ configuration:
           - isActivitySender:
               issueAuthor: True
           - hasLabel:
-              label: "Needs: Triage :mag:"
+              label: "needs/triage"
           - not:
               isAction:
                 action: Synchronize
@@ -112,12 +112,12 @@ configuration:
                 association: Collaborator
         then:
           - removeLabel:
-              label: "Needs: Triage :mag:"
+              label: "needs/triage"
       - description: >-
           When changes are requested on a pull request
           * Disable automerge
           * Assign to the author
-          * Label with "Needs: Author Feedback"
+          * Label with "needs/author-feedback"
         if:
           - payloadType: Pull_Request_Review
           - isAction:
@@ -129,16 +129,16 @@ configuration:
           - assignTo:
               author: True
           - addLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
       - description: Sync labels from issues on all pull request events
         if:
           - payloadType: Pull_Request
         then:
           - labelSync:
-              pattern: "Area:"
+              pattern: "area/"
           - labelSync:
-              pattern: "Type:"
+              pattern: "type/"
           - inPrLabel:
-              label: In-PR
+              label: state/in-pr
 onFailure:
 onSuccess:

--- a/.github/policies/ScheduledSearch.AutoClose.yml
+++ b/.github/policies/ScheduledSearch.AutoClose.yml
@@ -11,8 +11,8 @@ configuration:
       - description: >-
           Search for PR where -
           * Pull Request is Open
-          * Pull request has the label "State: No Recent Activity"
-          * Pull request has the label "Needs: Author Feedback"
+          * Pull request has the label "state/stale"
+          * Pull request has the label "needs/author-feedback"
           * Has not had activity in the last 7 days
 
           Then -
@@ -24,9 +24,9 @@ configuration:
           - isPullRequest
           - isOpen
           - hasLabel:
-              label: "State: No Recent Activity"
+              label: "state/stale"
           - hasLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
           - noActivitySince:
               days: 7
         actions:
@@ -34,8 +34,8 @@ configuration:
       - description: >-
           Search for Issues where -
           * Issue is Open
-          * Issue has the label "State: No Recent Activity"
-          * Issue has the label "Needs: Author Feedback"
+          * Issue has the label "state/stale"
+          * Issue has the label "needs/author-feedback"
           * Has not had activity in the last 7 days
 
           Then -
@@ -47,9 +47,9 @@ configuration:
           - isIssue
           - isOpen
           - hasLabel:
-              label: "State: No Recent Activity"
+              label: "state/stale"
           - hasLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
           - noActivitySince:
               days: 7
         actions:
@@ -57,7 +57,7 @@ configuration:
       - description: >-
           Search for Issues where -
           * Issue is Open
-          * Issue has the label "State: Won't Fix"
+          * Issue has the label "resolution/wont-fix"
           * Has not had activity in the last 1 day
 
           Then -
@@ -69,7 +69,7 @@ configuration:
           - isIssue
           - isOpen
           - hasLabel:
-              label: "State: Won't Fix"
+              label: "resolution/wont-fix"
           - noActivitySince:
               days: 1
         actions:
@@ -79,7 +79,7 @@ configuration:
       - description: >-
           Search for Issues where -
           * Issue is Open
-          * Issue has the label "Resolution: Duplicate"
+          * Issue has the label "resolution/duplicate"
           * Has not had activity in the last 1 day
 
           Then -
@@ -91,7 +91,7 @@ configuration:
           - isIssue
           - isOpen
           - hasLabel:
-              label: "Resolution: Duplicate"
+              label: "resolution/duplicate"
           - noActivitySince:
               days: 1
         actions:

--- a/.github/policies/ScheduledSearch.MarkNoRecentActivity.yml
+++ b/.github/policies/ScheduledSearch.MarkNoRecentActivity.yml
@@ -11,12 +11,12 @@ configuration:
       - description: >-
           Search for PR where -
           * Pull Request is Open
-          * Pull request does not have the label "State: No Recent Activity"
-          * Pull request has the label "Needs: Author Feedback"
+          * Pull request does not have the label "state/stale"
+          * Pull request has the label "needs/author-feedback"
           * Has not had activity in the last 7 days
 
           Then -
-          * Add "State: No Recent Activity" label
+          * Add "state/stale" label
           * Warn user about pending closure
         frequencies:
           - hourly:
@@ -25,14 +25,14 @@ configuration:
           - isPullRequest
           - isOpen
           - isNotLabeledWith:
-              label: "State: No Recent Activity"
+              label: "state/stale"
           - hasLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
           - noActivitySince:
               days: 7
         actions:
           - addLabel:
-              label: "State: No Recent Activity"
+              label: "state/stale"
           - addReply:
               reply: >-
                 Hello ${issueAuthor},
@@ -41,12 +41,12 @@ configuration:
       - description: >-
           Search for Issues where -
           * Issue is Open
-          * Issue has the label "Needs: Author Feedback"
-          * Issue does not have the label "State: No Recent Activity"
+          * Issue has the label "needs/author-feedback"
+          * Issue does not have the label "state/stale"
           * Has not had activity in the last 7 days
 
           Then -
-          * Add "State: No Recent Activity" label
+          * Add "state/stale" label
           * Warn user about pending closure
         frequencies:
           - hourly:
@@ -55,14 +55,14 @@ configuration:
           - isIssue
           - isOpen
           - hasLabel:
-              label: "Needs: Author Feedback"
+              label: "needs/author-feedback"
           - isNotLabeledWith:
-              label: "State: No Recent Activity"
+              label: "state/stale"
           - noActivitySince:
               days: 7
         actions:
           - addLabel:
-              label: "State: No Recent Activity"
+              label: "state/stale"
           - addReply:
               reply: >-
                 Hello ${issueAuthor},

--- a/.github/workflows/add-tests.lock.yml
+++ b/.github/workflows/add-tests.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a750a393faeee9ec044e8734b50a209a0d4f6a56f7690952a552e719f47c5b18","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c6ef8b46aa5f6c9d5292092699fecc307d6de3bbe6211160fc3b7a2d1395aa91","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -240,23 +240,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9c877516a2095270_EOF'
+          cat << 'GH_AW_PROMPT_daf735eaf0d70772_EOF'
           <system>
-          GH_AW_PROMPT_9c877516a2095270_EOF
+          GH_AW_PROMPT_daf735eaf0d70772_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9c877516a2095270_EOF'
+          cat << 'GH_AW_PROMPT_daf735eaf0d70772_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_9c877516a2095270_EOF
+          GH_AW_PROMPT_daf735eaf0d70772_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_9c877516a2095270_EOF'
+          cat << 'GH_AW_PROMPT_daf735eaf0d70772_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_9c877516a2095270_EOF
+          GH_AW_PROMPT_daf735eaf0d70772_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9c877516a2095270_EOF'
+          cat << 'GH_AW_PROMPT_daf735eaf0d70772_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -285,16 +285,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9c877516a2095270_EOF
+          GH_AW_PROMPT_daf735eaf0d70772_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_9c877516a2095270_EOF'
+          cat << 'GH_AW_PROMPT_daf735eaf0d70772_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/repo-build-setup.md}}
           {{#runtime-import .github/workflows/add-tests.md}}
-          GH_AW_PROMPT_9c877516a2095270_EOF
+          GH_AW_PROMPT_daf735eaf0d70772_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -509,16 +509,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6bfa4e8f5c6e8b47_EOF'
-          {"add_comment":{"max":3},"create_pull_request":{"draft":true,"labels":["test","automated"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[tests] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6bfa4e8f5c6e8b47_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6ade875fefa27201_EOF'
+          {"add_comment":{"max":3},"create_pull_request":{"draft":true,"labels":["type/test-gap","type/automation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[tests] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_6ade875fefa27201_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 3 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[tests] \". Labels [\"test\" \"automated\"] will be automatically added. PRs will be created as drafts."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[tests] \". Labels [\"type/test-gap\" \"type/automation\"] will be automatically added. PRs will be created as drafts."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -745,7 +745,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8d2d3ab0b76147b7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_32016c806a9c3500_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -790,7 +790,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8d2d3ab0b76147b7_EOF
+          GH_AW_MCP_CONFIG_32016c806a9c3500_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1605,7 +1605,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":3},\"create_pull_request\":{\"draft\":true,\"labels\":[\"test\",\"automated\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[tests] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":3},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/test-gap\",\"type/automation\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[tests] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-tests.md
+++ b/.github/workflows/add-tests.md
@@ -27,7 +27,7 @@ safe-outputs:
     report-as-issue: false
   create-pull-request:
     title-prefix: "[tests] "
-    labels: [test, automated]
+    labels: [type/test-gap, type/automation]
     draft: true
     max: 1
     protected-files: fallback-to-issue

--- a/.github/workflows/adhoc-qa.lock.yml
+++ b/.github/workflows/adhoc-qa.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c107436f1b7cae6a7589d69cd8100954f75aceb26ae1bfb90bcfd5e9a274fd03","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"554a0349b0ded02dd7bac296f70b8bd43bd7578752dd9cf3c0db57897f047c90","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -208,23 +208,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_755426ad48a0c8b0_EOF'
+          cat << 'GH_AW_PROMPT_4ba49166f992aca8_EOF'
           <system>
-          GH_AW_PROMPT_755426ad48a0c8b0_EOF
+          GH_AW_PROMPT_4ba49166f992aca8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_755426ad48a0c8b0_EOF'
+          cat << 'GH_AW_PROMPT_4ba49166f992aca8_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_discussion, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_755426ad48a0c8b0_EOF
+          GH_AW_PROMPT_4ba49166f992aca8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_755426ad48a0c8b0_EOF'
+          cat << 'GH_AW_PROMPT_4ba49166f992aca8_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_755426ad48a0c8b0_EOF
+          GH_AW_PROMPT_4ba49166f992aca8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_755426ad48a0c8b0_EOF'
+          cat << 'GH_AW_PROMPT_4ba49166f992aca8_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,12 +253,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_755426ad48a0c8b0_EOF
+          GH_AW_PROMPT_4ba49166f992aca8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_755426ad48a0c8b0_EOF'
+          cat << 'GH_AW_PROMPT_4ba49166f992aca8_EOF'
           </system>
           {{#runtime-import .github/workflows/adhoc-qa.md}}
-          GH_AW_PROMPT_755426ad48a0c8b0_EOF
+          GH_AW_PROMPT_4ba49166f992aca8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -463,9 +463,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_03f5a140645defb4_EOF'
-          {"add_comment":{"max":5,"target":"*"},"create_discussion":{"category":"q-a","expires":168,"fallback_to_issue":true,"max":1,"title_prefix":"[adhoc-qa] "},"create_pull_request":{"draft":true,"labels":["automation","qa"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue"},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_03f5a140645defb4_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_827ea686ddb505f9_EOF'
+          {"add_comment":{"max":5,"target":"*"},"create_discussion":{"category":"q-a","expires":168,"fallback_to_issue":true,"max":1,"title_prefix":"[adhoc-qa] "},"create_pull_request":{"draft":true,"labels":["type/automation","type/qa"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue"},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_827ea686ddb505f9_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -473,7 +473,7 @@ jobs:
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 5 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
                 "create_discussion": " CONSTRAINTS: Maximum 1 discussion(s) can be created. Title will be prefixed with \"[adhoc-qa] \". Discussions will be created in category \"q-a\".",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Labels [\"automation\" \"qa\"] will be automatically added. PRs will be created as drafts."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Labels [\"type/automation\" \"type/qa\"] will be automatically added. PRs will be created as drafts."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -729,7 +729,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_110186a6c5209263_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e0f11436ddb8919d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -770,7 +770,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_110186a6c5209263_EOF
+          GH_AW_MCP_CONFIG_e0f11436ddb8919d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1550,7 +1550,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":5,\"target\":\"*\"},\"create_discussion\":{\"category\":\"q-a\",\"expires\":168,\"fallback_to_issue\":true,\"max\":1,\"title_prefix\":\"[adhoc-qa] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"automation\",\"qa\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\"},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":5,\"target\":\"*\"},\"create_discussion\":{\"category\":\"q-a\",\"expires\":168,\"fallback_to_issue\":true,\"max\":1,\"title_prefix\":\"[adhoc-qa] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"type/qa\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\"},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adhoc-qa.md
+++ b/.github/workflows/adhoc-qa.md
@@ -39,7 +39,7 @@ safe-outputs:
     max: 5
   create-pull-request:
     draft: true
-    labels: [automation, qa]
+    labels: [type/automation, type/qa]
     protected-files: fallback-to-issue
 
 tools:

--- a/.github/workflows/code-simplifier.lock.yml
+++ b/.github/workflows/code-simplifier.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"33f1ab6ead7c1ba1b36797db39c70195d1f61c9710a584e537e956173a32d329","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5accf4d8899a5c89ddf0b9898634659f9e7835c28f1929bf097cedd3f1962f49","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -202,23 +202,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d2565633d9068312_EOF'
+          cat << 'GH_AW_PROMPT_a4a7924700f5c88b_EOF'
           <system>
-          GH_AW_PROMPT_d2565633d9068312_EOF
+          GH_AW_PROMPT_a4a7924700f5c88b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d2565633d9068312_EOF'
+          cat << 'GH_AW_PROMPT_a4a7924700f5c88b_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_d2565633d9068312_EOF
+          GH_AW_PROMPT_a4a7924700f5c88b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_d2565633d9068312_EOF'
+          cat << 'GH_AW_PROMPT_a4a7924700f5c88b_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_d2565633d9068312_EOF
+          GH_AW_PROMPT_a4a7924700f5c88b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_d2565633d9068312_EOF'
+          cat << 'GH_AW_PROMPT_a4a7924700f5c88b_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -247,14 +247,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d2565633d9068312_EOF
+          GH_AW_PROMPT_a4a7924700f5c88b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d2565633d9068312_EOF'
+          cat << 'GH_AW_PROMPT_a4a7924700f5c88b_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/formatting.md}}
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/code-simplifier.md}}
-          GH_AW_PROMPT_d2565633d9068312_EOF
+          GH_AW_PROMPT_a4a7924700f5c88b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -460,15 +460,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e3e093db3db5a060_EOF'
-          {"create_pull_request":{"expires":24,"labels":["refactoring","code-quality","automation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[code-simplifier] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e3e093db3db5a060_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_75547554445a98c1_EOF'
+          {"create_pull_request":{"expires":24,"labels":["type/tech-debt","type/automation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[code-simplifier] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_75547554445a98c1_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[code-simplifier] \". Labels [\"refactoring\" \"code-quality\" \"automation\"] will be automatically added."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[code-simplifier] \". Labels [\"type/tech-debt\" \"type/automation\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -675,7 +675,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ff895320f958f3b5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_6b1f60efff5afc75_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -716,7 +716,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ff895320f958f3b5_EOF
+          GH_AW_MCP_CONFIG_6b1f60efff5afc75_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1499,7 +1499,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.gradle-enterprise.cloud,*.pythonhosted.org,*.vsblob.vsassets.io,adoptium.net,anaconda.org,api.adoptium.net,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.foojay.io,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.apache.org,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,binstar.org,bootstrap.pypa.io,builds.dotnet.microsoft.com,bun.sh,cdn.azul.com,cdn.jsdelivr.net,central.sonatype.com,ci.dot.net,conda.anaconda.org,conda.binstar.org,crates.io,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,develocity.apache.org,dist.nuget.org,dl.google.com,dlcdn.apache.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,download.eclipse.org,download.java.net,download.oracle.com,downloads.gradle-dn.com,esm.sh,files.pythonhosted.org,ge.spockframework.org,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,gradle.org,host.docker.internal,index.crates.io,jcenter.bintray.com,jdk.java.net,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,maven-central.storage-download.googleapis.com,maven.apache.org,maven.google.com,maven.oracle.com,maven.pkg.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,pkgs.dev.azure.com,plugins-artifacts.gradle.org,plugins.gradle.org,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.gradle.org,repo.grails.org,repo.maven.apache.org,repo.spring.io,repo.yarnpkg.com,repo1.maven.org,repository.apache.org,s.symcb.com,s.symcd.com,scans-in.gradle.com,security.ubuntu.com,services.gradle.org,sh.rustup.rs,skimdb.npmjs.com,static.crates.io,static.rust-lang.org,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.java.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"expires\":24,\"labels\":[\"refactoring\",\"code-quality\",\"automation\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[code-simplifier] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"expires\":24,\"labels\":[\"type/tech-debt\",\"type/automation\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[code-simplifier] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-simplifier.md
+++ b/.github/workflows/code-simplifier.md
@@ -18,9 +18,8 @@ safe-outputs:
   create-pull-request:
     expires: 1d
     labels:
-    - refactoring
-    - code-quality
-    - automation
+    - type/tech-debt
+    - type/automation
     protected-files: fallback-to-issue
     title-prefix: "[code-simplifier] "
 description: Analyzes recently modified code and creates pull requests with simplifications that improve clarity, consistency, and maintainability while preserving functionality

--- a/.github/workflows/daily-file-diet.lock.yml
+++ b/.github/workflows/daily-file-diet.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8984d225ddee5d75dd45eefe6aeb2c51a1dc00a03513fca540778d9a7365bf10","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"02f0e2cb85cba38abf3a9a2027d5598a26ebfae5b9e82d4eda187811133cefb1","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_AGENT_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -192,20 +192,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8190431257cf04b9_EOF'
+          cat << 'GH_AW_PROMPT_d3d4d3053fc1f413_EOF'
           <system>
-          GH_AW_PROMPT_8190431257cf04b9_EOF
+          GH_AW_PROMPT_d3d4d3053fc1f413_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8190431257cf04b9_EOF'
+          cat << 'GH_AW_PROMPT_d3d4d3053fc1f413_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_8190431257cf04b9_EOF
+          GH_AW_PROMPT_d3d4d3053fc1f413_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_8190431257cf04b9_EOF'
+          cat << 'GH_AW_PROMPT_d3d4d3053fc1f413_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -234,12 +234,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8190431257cf04b9_EOF
+          GH_AW_PROMPT_d3d4d3053fc1f413_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8190431257cf04b9_EOF'
+          cat << 'GH_AW_PROMPT_d3d4d3053fc1f413_EOF'
           </system>
           {{#runtime-import .github/workflows/daily-file-diet.md}}
-          GH_AW_PROMPT_8190431257cf04b9_EOF
+          GH_AW_PROMPT_d3d4d3053fc1f413_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -447,15 +447,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_00a925a96674df54_EOF'
-          {"create_issue":{"assignees":["copilot"],"expires":48,"labels":["refactoring","code-health","automated-analysis"],"max":1,"title_prefix":"[file-diet] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_00a925a96674df54_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f2063803100318c1_EOF'
+          {"create_issue":{"assignees":["copilot"],"expires":48,"labels":["type/tech-debt","type/automation"],"max":1,"title_prefix":"[file-diet] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_f2063803100318c1_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[file-diet] \". Labels [\"refactoring\" \"code-health\" \"automated-analysis\"] will be automatically added. Assignees [\"copilot\"] will be automatically assigned."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[file-diet] \". Labels [\"type/tech-debt\" \"type/automation\"] will be automatically added. Assignees [\"copilot\"] will be automatically assigned."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -657,7 +657,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_2ac9f9416a622960_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8b3bc672ddb7f25d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -698,7 +698,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2ac9f9416a622960_EOF
+          GH_AW_MCP_CONFIG_8b3bc672ddb7f25d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1421,7 +1421,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"assignees\":[\"copilot\"],\"expires\":48,\"labels\":[\"refactoring\",\"code-health\",\"automated-analysis\"],\"max\":1,\"title_prefix\":\"[file-diet] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"assignees\":[\"copilot\"],\"expires\":48,\"labels\":[\"type/tech-debt\",\"type/automation\"],\"max\":1,\"title_prefix\":\"[file-diet] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
           GH_AW_ASSIGN_COPILOT: "true"
           GH_AW_ASSIGN_TO_AGENT_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/daily-file-diet.md
+++ b/.github/workflows/daily-file-diet.md
@@ -20,7 +20,7 @@ safe-outputs:
   create-issue:
     expires: 2d
     title-prefix: "[file-diet] "
-    labels: [refactoring, code-health, automated-analysis]
+    labels: [type/tech-debt, type/automation]
     assignees: copilot
     max: 1
 

--- a/.github/workflows/dependabot-pr-bundler.lock.yml
+++ b/.github/workflows/dependabot-pr-bundler.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"67d68cb2039e400d6140a5f105402ec900e65b5c665e3e0cc2a38094ff6ae2a0","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e444fd948670cf76b95a3da3f8455299ac56ec766b5c2dfe554e9dce50746991","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -204,23 +204,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_90dcd44cf4cbec4d_EOF'
+          cat << 'GH_AW_PROMPT_1f44dbea6546fec4_EOF'
           <system>
-          GH_AW_PROMPT_90dcd44cf4cbec4d_EOF
+          GH_AW_PROMPT_1f44dbea6546fec4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_90dcd44cf4cbec4d_EOF'
+          cat << 'GH_AW_PROMPT_1f44dbea6546fec4_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_90dcd44cf4cbec4d_EOF
+          GH_AW_PROMPT_1f44dbea6546fec4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_90dcd44cf4cbec4d_EOF'
+          cat << 'GH_AW_PROMPT_1f44dbea6546fec4_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_90dcd44cf4cbec4d_EOF
+          GH_AW_PROMPT_1f44dbea6546fec4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_90dcd44cf4cbec4d_EOF'
+          cat << 'GH_AW_PROMPT_1f44dbea6546fec4_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -249,12 +249,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_90dcd44cf4cbec4d_EOF
+          GH_AW_PROMPT_1f44dbea6546fec4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_90dcd44cf4cbec4d_EOF'
+          cat << 'GH_AW_PROMPT_1f44dbea6546fec4_EOF'
           </system>
           {{#runtime-import .github/workflows/dependabot-pr-bundler.md}}
-          GH_AW_PROMPT_90dcd44cf4cbec4d_EOF
+          GH_AW_PROMPT_1f44dbea6546fec4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -459,16 +459,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7f91e8eca3658c47_EOF'
-          {"create_issue":{"max":1,"title_prefix":"[dependabot-pr-bundler] "},"create_pull_request":{"draft":true,"labels":["automation","dependencies"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_7f91e8eca3658c47_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_11aa82dbc4c0c36e_EOF'
+          {"create_issue":{"max":1,"title_prefix":"[dependabot-pr-bundler] "},"create_pull_request":{"draft":true,"labels":["type/automation","dependencies"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_11aa82dbc4c0c36e_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[dependabot-pr-bundler] \".",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Labels [\"automation\" \"dependencies\"] will be automatically added. PRs will be created as drafts."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Labels [\"type/automation\" \"dependencies\"] will be automatically added. PRs will be created as drafts."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -711,7 +711,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_816a11ae05ec41ee_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_06daca26751358d8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -752,7 +752,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_816a11ae05ec41ee_EOF
+          GH_AW_MCP_CONFIG_06daca26751358d8_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1523,7 +1523,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"max\":1,\"title_prefix\":\"[dependabot-pr-bundler] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"automation\",\"dependencies\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"max\":1,\"title_prefix\":\"[dependabot-pr-bundler] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"dependencies\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-pr-bundler.md
+++ b/.github/workflows/dependabot-pr-bundler.md
@@ -25,7 +25,7 @@ network: defaults
 safe-outputs:
   create-pull-request:
     draft: true
-    labels: [automation, dependencies]
+    labels: [type/automation, dependencies]
     protected-files: fallback-to-issue
   create-issue:
     title-prefix: "[dependabot-pr-bundler] "

--- a/.github/workflows/duplicate-code-detector.lock.yml
+++ b/.github/workflows/duplicate-code-detector.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"33f7231892ff293bbace12e565883549fd90e75032662a652a9343304d82670b","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8906c81c0469b205cc6f6c4396d12332654cf48b008fcd6b3a36f99aac261199","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_AGENT_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -193,20 +193,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_81d392fd0599e722_EOF'
+          cat << 'GH_AW_PROMPT_8a3b4c3d71563d8f_EOF'
           <system>
-          GH_AW_PROMPT_81d392fd0599e722_EOF
+          GH_AW_PROMPT_8a3b4c3d71563d8f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_81d392fd0599e722_EOF'
+          cat << 'GH_AW_PROMPT_8a3b4c3d71563d8f_EOF'
           <safe-output-tools>
           Tools: create_issue(max:3), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_81d392fd0599e722_EOF
+          GH_AW_PROMPT_8a3b4c3d71563d8f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_81d392fd0599e722_EOF'
+          cat << 'GH_AW_PROMPT_8a3b4c3d71563d8f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -235,12 +235,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_81d392fd0599e722_EOF
+          GH_AW_PROMPT_8a3b4c3d71563d8f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_81d392fd0599e722_EOF'
+          cat << 'GH_AW_PROMPT_8a3b4c3d71563d8f_EOF'
           </system>
           {{#runtime-import .github/workflows/duplicate-code-detector.md}}
-          GH_AW_PROMPT_81d392fd0599e722_EOF
+          GH_AW_PROMPT_8a3b4c3d71563d8f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -450,15 +450,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6127e11c6515d602_EOF'
-          {"create_issue":{"assignees":["copilot"],"expires":48,"group":true,"labels":["code-quality","automated-analysis"],"max":3,"title_prefix":"[duplicate-code] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6127e11c6515d602_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_32a4360bf280bd21_EOF'
+          {"create_issue":{"assignees":["copilot"],"expires":48,"group":true,"labels":["type/tech-debt","type/automation"],"max":3,"title_prefix":"[duplicate-code] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_32a4360bf280bd21_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 3 issue(s) can be created. Title will be prefixed with \"[duplicate-code] \". Labels [\"code-quality\" \"automated-analysis\"] will be automatically added. Assignees [\"copilot\"] will be automatically assigned."
+                "create_issue": " CONSTRAINTS: Maximum 3 issue(s) can be created. Title will be prefixed with \"[duplicate-code] \". Labels [\"type/tech-debt\" \"type/automation\"] will be automatically added. Assignees [\"copilot\"] will be automatically assigned."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -660,7 +660,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ac537b422d682a20_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_6db463b78ec1f4a0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -701,7 +701,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ac537b422d682a20_EOF
+          GH_AW_MCP_CONFIG_6db463b78ec1f4a0_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1368,7 +1368,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"assignees\":[\"copilot\"],\"expires\":48,\"group\":true,\"labels\":[\"code-quality\",\"automated-analysis\"],\"max\":3,\"title_prefix\":\"[duplicate-code] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"assignees\":[\"copilot\"],\"expires\":48,\"group\":true,\"labels\":[\"type/tech-debt\",\"type/automation\"],\"max\":3,\"title_prefix\":\"[duplicate-code] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_ASSIGN_COPILOT: "true"
           GH_AW_ASSIGN_TO_AGENT_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/duplicate-code-detector.md
+++ b/.github/workflows/duplicate-code-detector.md
@@ -16,7 +16,7 @@ safe-outputs:
   create-issue:
     expires: 2d
     title-prefix: "[duplicate-code] "
-    labels: [code-quality, automated-analysis]
+    labels: [type/tech-debt, type/automation]
     assignees: copilot
     group: true
     max: 3

--- a/.github/workflows/efficiency-improver.lock.yml
+++ b/.github/workflows/efficiency-improver.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc6bcf938dd333f45f5e7237513ebb8ffd8238b08ec9fd5a530fdd70b42a099e","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2dada739bbdddfdd41035a52e402e17ff247ee1fefa691e11881b4c51c4f5f82","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -221,25 +221,25 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0cfdec8b170eba68_EOF'
+          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
           <system>
-          GH_AW_PROMPT_0cfdec8b170eba68_EOF
+          GH_AW_PROMPT_265c3382ad5f7842_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0cfdec8b170eba68_EOF'
+          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:4), update_issue, create_pull_request(max:3), push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_0cfdec8b170eba68_EOF
+          GH_AW_PROMPT_265c3382ad5f7842_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_0cfdec8b170eba68_EOF'
+          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_0cfdec8b170eba68_EOF
+          GH_AW_PROMPT_265c3382ad5f7842_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0cfdec8b170eba68_EOF'
+          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -268,12 +268,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0cfdec8b170eba68_EOF
+          GH_AW_PROMPT_265c3382ad5f7842_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0cfdec8b170eba68_EOF'
+          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
           </system>
           {{#runtime-import .github/workflows/efficiency-improver.md}}
-          GH_AW_PROMPT_0cfdec8b170eba68_EOF
+          GH_AW_PROMPT_265c3382ad5f7842_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -504,17 +504,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0dadf2c6ca420abb_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["automation","efficiency","green-software"],"max":4,"title_prefix":"[efficiency-improver] "},"create_pull_request":{"draft":true,"labels":["automation","efficiency","green-software"],"max":3,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"[efficiency-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[efficiency-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0dadf2c6ca420abb_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6cb4915bd6b03b2d_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["type/automation","type/tech-debt"],"max":4,"title_prefix":"[efficiency-improver] "},"create_pull_request":{"draft":true,"labels":["type/automation","type/tech-debt"],"max":3,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"[efficiency-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[efficiency-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_6cb4915bd6b03b2d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"automation\" \"efficiency\" \"green-software\"] will be automatically added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 3 pull request(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"automation\" \"efficiency\" \"green-software\"] will be automatically added. PRs will be created as drafts.",
+                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"type/automation\" \"type/tech-debt\"] will be automatically added.",
+                "create_pull_request": " CONSTRAINTS: Maximum 3 pull request(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"type/automation\" \"type/tech-debt\"] will be automatically added. PRs will be created as drafts.",
                 "push_to_pull_request_branch": " CONSTRAINTS: The target pull request title must start with \"[efficiency-improver] \".",
                 "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated. Target: *."
               },
@@ -855,7 +855,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6323c1a84bd92145_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c382652d77ba8341_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -896,7 +896,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6323c1a84bd92145_EOF
+          GH_AW_MCP_CONFIG_c382652d77ba8341_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1777,7 +1777,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.gradle-enterprise.cloud,*.pythonhosted.org,*.vsblob.vsassets.io,adoptium.net,anaconda.org,api.adoptium.net,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.foojay.io,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.apache.org,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,binstar.org,bootstrap.pypa.io,builds.dotnet.microsoft.com,bun.sh,cdn.azul.com,cdn.jsdelivr.net,central.sonatype.com,ci.dot.net,conda.anaconda.org,conda.binstar.org,crates.io,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,develocity.apache.org,dist.nuget.org,dl.google.com,dlcdn.apache.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,download.eclipse.org,download.java.net,download.oracle.com,downloads.gradle-dn.com,esm.sh,files.pythonhosted.org,ge.spockframework.org,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,gradle.org,host.docker.internal,index.crates.io,jcenter.bintray.com,jdk.java.net,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,maven-central.storage-download.googleapis.com,maven.apache.org,maven.google.com,maven.oracle.com,maven.pkg.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,pkgs.dev.azure.com,plugins-artifacts.gradle.org,plugins.gradle.org,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.gradle.org,repo.grails.org,repo.maven.apache.org,repo.spring.io,repo.yarnpkg.com,repo1.maven.org,repository.apache.org,s.symcb.com,s.symcd.com,scans-in.gradle.com,security.ubuntu.com,services.gradle.org,sh.rustup.rs,skimdb.npmjs.com,static.crates.io,static.rust-lang.org,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.java.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"automation\",\"efficiency\",\"green-software\"],\"max\":4,\"title_prefix\":\"[efficiency-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"automation\",\"efficiency\",\"green-software\"],\"max\":3,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"[efficiency-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[efficiency-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"type/automation\",\"type/tech-debt\"],\"max\":4,\"title_prefix\":\"[efficiency-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"type/tech-debt\"],\"max\":3,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"[efficiency-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[efficiency-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/efficiency-improver.lock.yml
+++ b/.github/workflows/efficiency-improver.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2dada739bbdddfdd41035a52e402e17ff247ee1fefa691e11881b4c51c4f5f82","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7d3b28bbceafb8f1773f9384649be0f2f0d23fb4308698040188947ed79608ed","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -221,25 +221,25 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
+          cat << 'GH_AW_PROMPT_b89c00cf314d1f92_EOF'
           <system>
-          GH_AW_PROMPT_265c3382ad5f7842_EOF
+          GH_AW_PROMPT_b89c00cf314d1f92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
+          cat << 'GH_AW_PROMPT_b89c00cf314d1f92_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:4), update_issue, create_pull_request(max:3), push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_265c3382ad5f7842_EOF
+          GH_AW_PROMPT_b89c00cf314d1f92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
+          cat << 'GH_AW_PROMPT_b89c00cf314d1f92_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_265c3382ad5f7842_EOF
+          GH_AW_PROMPT_b89c00cf314d1f92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
+          cat << 'GH_AW_PROMPT_b89c00cf314d1f92_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -268,12 +268,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_265c3382ad5f7842_EOF
+          GH_AW_PROMPT_b89c00cf314d1f92_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_265c3382ad5f7842_EOF'
+          cat << 'GH_AW_PROMPT_b89c00cf314d1f92_EOF'
           </system>
           {{#runtime-import .github/workflows/efficiency-improver.md}}
-          GH_AW_PROMPT_265c3382ad5f7842_EOF
+          GH_AW_PROMPT_b89c00cf314d1f92_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -504,17 +504,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6cb4915bd6b03b2d_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["type/automation","type/tech-debt"],"max":4,"title_prefix":"[efficiency-improver] "},"create_pull_request":{"draft":true,"labels":["type/automation","type/tech-debt"],"max":3,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"[efficiency-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[efficiency-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6cb4915bd6b03b2d_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6c09cb065c2e15db_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["area/performance","type/automation"],"max":4,"title_prefix":"[efficiency-improver] "},"create_pull_request":{"draft":true,"labels":["area/performance","type/automation"],"max":3,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"[efficiency-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[efficiency-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_6c09cb065c2e15db_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"type/automation\" \"type/tech-debt\"] will be automatically added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 3 pull request(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"type/automation\" \"type/tech-debt\"] will be automatically added. PRs will be created as drafts.",
+                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"area/performance\" \"type/automation\"] will be automatically added.",
+                "create_pull_request": " CONSTRAINTS: Maximum 3 pull request(s) can be created. Title will be prefixed with \"[efficiency-improver] \". Labels [\"area/performance\" \"type/automation\"] will be automatically added. PRs will be created as drafts.",
                 "push_to_pull_request_branch": " CONSTRAINTS: The target pull request title must start with \"[efficiency-improver] \".",
                 "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated. Target: *."
               },
@@ -855,7 +855,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c382652d77ba8341_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_623ef952dc5ba6e9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -896,7 +896,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c382652d77ba8341_EOF
+          GH_AW_MCP_CONFIG_623ef952dc5ba6e9_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1777,7 +1777,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.gradle-enterprise.cloud,*.pythonhosted.org,*.vsblob.vsassets.io,adoptium.net,anaconda.org,api.adoptium.net,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.foojay.io,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.apache.org,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,binstar.org,bootstrap.pypa.io,builds.dotnet.microsoft.com,bun.sh,cdn.azul.com,cdn.jsdelivr.net,central.sonatype.com,ci.dot.net,conda.anaconda.org,conda.binstar.org,crates.io,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,develocity.apache.org,dist.nuget.org,dl.google.com,dlcdn.apache.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,download.eclipse.org,download.java.net,download.oracle.com,downloads.gradle-dn.com,esm.sh,files.pythonhosted.org,ge.spockframework.org,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,gradle.org,host.docker.internal,index.crates.io,jcenter.bintray.com,jdk.java.net,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,maven-central.storage-download.googleapis.com,maven.apache.org,maven.google.com,maven.oracle.com,maven.pkg.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,pkgs.dev.azure.com,plugins-artifacts.gradle.org,plugins.gradle.org,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.gradle.org,repo.grails.org,repo.maven.apache.org,repo.spring.io,repo.yarnpkg.com,repo1.maven.org,repository.apache.org,s.symcb.com,s.symcd.com,scans-in.gradle.com,security.ubuntu.com,services.gradle.org,sh.rustup.rs,skimdb.npmjs.com,static.crates.io,static.rust-lang.org,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.java.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"type/automation\",\"type/tech-debt\"],\"max\":4,\"title_prefix\":\"[efficiency-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"type/tech-debt\"],\"max\":3,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"[efficiency-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[efficiency-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"area/performance\",\"type/automation\"],\"max\":4,\"title_prefix\":\"[efficiency-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"area/performance\",\"type/automation\"],\"max\":3,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"[efficiency-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[efficiency-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/efficiency-improver.md
+++ b/.github/workflows/efficiency-improver.md
@@ -47,13 +47,13 @@ safe-outputs:
     max: 3
     draft: true
     title-prefix: "[efficiency-improver] "
-    labels: [type/automation, type/tech-debt]
+    labels: [area/performance, type/automation]
   push-to-pull-request-branch:
     target: "*"
     required-title-prefix: "[efficiency-improver] "
   create-issue:
     title-prefix: "[efficiency-improver] "
-    labels: [type/automation, type/tech-debt]
+    labels: [area/performance, type/automation]
     max: 4
   update-issue:
     target: "*"

--- a/.github/workflows/efficiency-improver.md
+++ b/.github/workflows/efficiency-improver.md
@@ -47,13 +47,13 @@ safe-outputs:
     max: 3
     draft: true
     title-prefix: "[efficiency-improver] "
-    labels: [automation, efficiency, green-software]
+    labels: [type/automation, type/tech-debt]
   push-to-pull-request-branch:
     target: "*"
     required-title-prefix: "[efficiency-improver] "
   create-issue:
     title-prefix: "[efficiency-improver] "
-    labels: [automation, efficiency, green-software]
+    labels: [type/automation, type/tech-debt]
     max: 4
   update-issue:
     target: "*"

--- a/.github/workflows/glossary-maintainer.lock.yml
+++ b/.github/workflows/glossary-maintainer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"edf4072c52d862a86189b4d74656ff10146a9be16efb0d03f8d753ac0b5a4b75","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1c3435c2e7564dae6994049406495db561e1e812e74356a1c222fcdd4bee20c3","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -207,24 +207,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_dc2cf41c04d136e8_EOF'
+          cat << 'GH_AW_PROMPT_6fb07afdff2cf58a_EOF'
           <system>
-          GH_AW_PROMPT_dc2cf41c04d136e8_EOF
+          GH_AW_PROMPT_6fb07afdff2cf58a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dc2cf41c04d136e8_EOF'
+          cat << 'GH_AW_PROMPT_6fb07afdff2cf58a_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_dc2cf41c04d136e8_EOF
+          GH_AW_PROMPT_6fb07afdff2cf58a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_dc2cf41c04d136e8_EOF'
+          cat << 'GH_AW_PROMPT_6fb07afdff2cf58a_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_dc2cf41c04d136e8_EOF
+          GH_AW_PROMPT_6fb07afdff2cf58a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_dc2cf41c04d136e8_EOF'
+          cat << 'GH_AW_PROMPT_6fb07afdff2cf58a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,12 +253,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_dc2cf41c04d136e8_EOF
+          GH_AW_PROMPT_6fb07afdff2cf58a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_dc2cf41c04d136e8_EOF'
+          cat << 'GH_AW_PROMPT_6fb07afdff2cf58a_EOF'
           </system>
           {{#runtime-import .github/workflows/glossary-maintainer.md}}
-          GH_AW_PROMPT_dc2cf41c04d136e8_EOF
+          GH_AW_PROMPT_6fb07afdff2cf58a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -487,15 +487,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1f587f5823d8679e_EOF'
-          {"create_pull_request":{"draft":false,"expires":48,"labels":["documentation","glossary"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1f587f5823d8679e_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8023658bab84c7d2_EOF'
+          {"create_pull_request":{"draft":false,"expires":48,"labels":["area/documentation","type/automation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[docs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_8023658bab84c7d2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[docs] \". Labels [\"documentation\" \"glossary\"] will be automatically added."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[docs] \". Labels [\"area/documentation\" \"type/automation\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -702,7 +702,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_86597b49cb915f83_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b6e5576aa0d92c1c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -743,7 +743,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_86597b49cb915f83_EOF
+          GH_AW_MCP_CONFIG_b6e5576aa0d92c1c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1530,7 +1530,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.pythonhosted.org,anaconda.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,binstar.org,bootstrap.pypa.io,bun.sh,cdn.jsdelivr.net,codeload.github.com,conda.anaconda.org,conda.binstar.org,deb.nodesource.com,deno.land,docs.github.com,esm.sh,files.pythonhosted.org,get.pnpm.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,jsr.io,lfs.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,objects.githubusercontent.com,patch-diff.githubusercontent.com,pip.pypa.io,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.yarnpkg.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"draft\":false,\"expires\":48,\"labels\":[\"documentation\",\"glossary\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[docs] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"draft\":false,\"expires\":48,\"labels\":[\"area/documentation\",\"type/automation\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[docs] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/glossary-maintainer.md
+++ b/.github/workflows/glossary-maintainer.md
@@ -34,7 +34,7 @@ safe-outputs:
   create-pull-request:
     expires: 2d
     title-prefix: "[docs] "
-    labels: [documentation, glossary]
+    labels: [area/documentation, type/automation]
     draft: false
     protected-files: fallback-to-issue
   noop:

--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"92737466a3dd2a2abf3554fbe800e0d33bf94aa576e5151e00a07b2173bb8793","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"305dc0bcb8b315b1f54fe92f26b2fc7742b73e1186e6eb5937f268aa1edb7ec7","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -194,24 +194,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_56ca2b7dde9e1841_EOF'
+          cat << 'GH_AW_PROMPT_aa88e3e97a29d4ae_EOF'
           <system>
-          GH_AW_PROMPT_56ca2b7dde9e1841_EOF
+          GH_AW_PROMPT_aa88e3e97a29d4ae_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_56ca2b7dde9e1841_EOF'
+          cat << 'GH_AW_PROMPT_aa88e3e97a29d4ae_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_56ca2b7dde9e1841_EOF
+          GH_AW_PROMPT_aa88e3e97a29d4ae_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_56ca2b7dde9e1841_EOF'
+          cat << 'GH_AW_PROMPT_aa88e3e97a29d4ae_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_56ca2b7dde9e1841_EOF
+          GH_AW_PROMPT_aa88e3e97a29d4ae_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_56ca2b7dde9e1841_EOF'
+          cat << 'GH_AW_PROMPT_aa88e3e97a29d4ae_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -240,12 +240,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_56ca2b7dde9e1841_EOF
+          GH_AW_PROMPT_aa88e3e97a29d4ae_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_56ca2b7dde9e1841_EOF'
+          cat << 'GH_AW_PROMPT_aa88e3e97a29d4ae_EOF'
           </system>
           {{#runtime-import .github/workflows/link-checker.md}}
-          GH_AW_PROMPT_56ca2b7dde9e1841_EOF
+          GH_AW_PROMPT_aa88e3e97a29d4ae_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -475,15 +475,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0424b18ec6203bf1_EOF'
-          {"create_pull_request":{"draft":false,"if_no_changes":"warn","labels":["documentation","automated"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[link-checker] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0424b18ec6203bf1_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_847bbefe5b92d2f5_EOF'
+          {"create_pull_request":{"draft":false,"if_no_changes":"warn","labels":["area/documentation","type/automation"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[link-checker] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_847bbefe5b92d2f5_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[link-checker] \". Labels [\"documentation\" \"automated\"] will be automatically added."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[link-checker] \". Labels [\"area/documentation\" \"type/automation\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -690,7 +690,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6b652e48fd514463_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_3f059ab9c7ba5d56_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -731,7 +731,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6b652e48fd514463_EOF
+          GH_AW_MCP_CONFIG_3f059ab9c7ba5d56_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1475,7 +1475,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,*.pythonhosted.org,anaconda.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,binstar.org,bootstrap.pypa.io,bun.sh,cdn.jsdelivr.net,codeload.github.com,conda.anaconda.org,conda.binstar.org,deb.nodesource.com,deno.land,docs.github.com,esm.sh,files.pythonhosted.org,get.pnpm.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,jsr.io,lfs.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,objects.githubusercontent.com,patch-diff.githubusercontent.com,pip.pypa.io,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.yarnpkg.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"draft\":false,\"if_no_changes\":\"warn\",\"labels\":[\"documentation\",\"automated\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[link-checker] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"draft\":false,\"if_no_changes\":\"warn\",\"labels\":[\"area/documentation\",\"type/automation\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[link-checker] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -103,7 +103,7 @@ tools:
 safe-outputs:
   create-pull-request:
     title-prefix: "[link-checker] "
-    labels: [documentation, automated]
+    labels: [area/documentation, type/automation]
     draft: false
     protected-files: fallback-to-issue
     if-no-changes: "warn"

--- a/.github/workflows/markdown-linter.lock.yml
+++ b/.github/workflows/markdown-linter.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"75ea52e8351451b6675c7d4e4423608ee26326032c08a742f430b4cf906d7493","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5cb7bb174bd27ada2941498ee8e3d1bf09dad6fdef48cfcfa95b7776801cf435","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"},{"repo":"super-linter/super-linter","sha":"9e863354e3ff62e0727d37183162c4a88873df41","version":"v8.6.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -198,21 +198,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_6305b1460b86e5d7_EOF'
+          cat << 'GH_AW_PROMPT_5c42e5b0be8e6de7_EOF'
           <system>
-          GH_AW_PROMPT_6305b1460b86e5d7_EOF
+          GH_AW_PROMPT_5c42e5b0be8e6de7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6305b1460b86e5d7_EOF'
+          cat << 'GH_AW_PROMPT_5c42e5b0be8e6de7_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_6305b1460b86e5d7_EOF
+          GH_AW_PROMPT_5c42e5b0be8e6de7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_6305b1460b86e5d7_EOF'
+          cat << 'GH_AW_PROMPT_5c42e5b0be8e6de7_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -241,13 +241,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6305b1460b86e5d7_EOF
+          GH_AW_PROMPT_5c42e5b0be8e6de7_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6305b1460b86e5d7_EOF'
+          cat << 'GH_AW_PROMPT_5c42e5b0be8e6de7_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/markdown-linter.md}}
-          GH_AW_PROMPT_6305b1460b86e5d7_EOF
+          GH_AW_PROMPT_5c42e5b0be8e6de7_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -488,15 +488,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0e6cb0dc6a013ba7_EOF'
-          {"create_issue":{"expires":48,"labels":["automation","code-quality"],"max":1,"title_prefix":"[linter] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0e6cb0dc6a013ba7_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_18bc5e0df61ccfb7_EOF'
+          {"create_issue":{"expires":48,"labels":["type/automation","type/tech-debt"],"max":1,"title_prefix":"[linter] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_18bc5e0df61ccfb7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[linter] \". Labels [\"automation\" \"code-quality\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[linter] \". Labels [\"type/automation\" \"type/tech-debt\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -698,7 +698,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9f1d3a8be700fd5a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_6cfac171bb2e3e90_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -739,7 +739,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9f1d3a8be700fd5a_EOF
+          GH_AW_MCP_CONFIG_6cfac171bb2e3e90_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1421,7 +1421,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":48,\"labels\":[\"automation\",\"code-quality\"],\"max\":1,\"title_prefix\":\"[linter] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":48,\"labels\":[\"type/automation\",\"type/tech-debt\"],\"max\":1,\"title_prefix\":\"[linter] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/markdown-linter.md
+++ b/.github/workflows/markdown-linter.md
@@ -14,8 +14,8 @@ safe-outputs:
   create-issue:
     expires: 2d
     labels:
-    - automation
-    - code-quality
+    - type/automation
+    - type/tech-debt
     title-prefix: "[linter] "
   noop: null
 steps:

--- a/.github/workflows/msbuild-quality-review.lock.yml
+++ b/.github/workflows/msbuild-quality-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e9984c823cf24f03182d3981017bdf385996f22aa7ca5872a2f068c0a59b2d3a","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"eb250bd0a70e2fe4b6bbccee90206fd6dc9ea697f61996b60f5049bc63e6235c","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -191,23 +191,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_bff405802a9d7bf4_EOF'
+          cat << 'GH_AW_PROMPT_950585e3526dee89_EOF'
           <system>
-          GH_AW_PROMPT_bff405802a9d7bf4_EOF
+          GH_AW_PROMPT_950585e3526dee89_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bff405802a9d7bf4_EOF'
+          cat << 'GH_AW_PROMPT_950585e3526dee89_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_bff405802a9d7bf4_EOF
+          GH_AW_PROMPT_950585e3526dee89_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_bff405802a9d7bf4_EOF'
+          cat << 'GH_AW_PROMPT_950585e3526dee89_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_bff405802a9d7bf4_EOF
+          GH_AW_PROMPT_950585e3526dee89_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_bff405802a9d7bf4_EOF'
+          cat << 'GH_AW_PROMPT_950585e3526dee89_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -236,13 +236,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_bff405802a9d7bf4_EOF
+          GH_AW_PROMPT_950585e3526dee89_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bff405802a9d7bf4_EOF'
+          cat << 'GH_AW_PROMPT_950585e3526dee89_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/msbuild-review-shared.md}}
           {{#runtime-import .github/workflows/msbuild-quality-review.md}}
-          GH_AW_PROMPT_bff405802a9d7bf4_EOF
+          GH_AW_PROMPT_950585e3526dee89_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -446,16 +446,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_50c7a1b99a0edb93_EOF'
-          {"create_issue":{"expires":168,"labels":["automation","msbuild","code-quality"],"max":1,"title_prefix":"[msbuild-quality] "},"create_pull_request":{"draft":true,"labels":["automation","msbuild","code-quality"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[msbuild-quality] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_50c7a1b99a0edb93_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b8a89feccab19370_EOF'
+          {"create_issue":{"expires":168,"labels":["type/automation","area/mtp-msbuild","type/tech-debt"],"max":1,"title_prefix":"[msbuild-quality] "},"create_pull_request":{"draft":true,"labels":["type/automation","area/mtp-msbuild","type/tech-debt"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[msbuild-quality] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_b8a89feccab19370_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[msbuild-quality] \". Labels [\"automation\" \"msbuild\" \"code-quality\"] will be automatically added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[msbuild-quality] \". Labels [\"automation\" \"msbuild\" \"code-quality\"] will be automatically added. PRs will be created as drafts."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[msbuild-quality] \". Labels [\"type/automation\" \"area/mtp-msbuild\" \"type/tech-debt\"] will be automatically added.",
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[msbuild-quality] \". Labels [\"type/automation\" \"area/mtp-msbuild\" \"type/tech-debt\"] will be automatically added. PRs will be created as drafts."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -698,7 +698,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_eae2fed5b5bdf0ab_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8b97dd231603d6f8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -739,7 +739,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_eae2fed5b5bdf0ab_EOF
+          GH_AW_MCP_CONFIG_8b97dd231603d6f8_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1484,7 +1484,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,ci.dot.net,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,dist.nuget.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":168,\"labels\":[\"automation\",\"msbuild\",\"code-quality\"],\"max\":1,\"title_prefix\":\"[msbuild-quality] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"automation\",\"msbuild\",\"code-quality\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[msbuild-quality] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":168,\"labels\":[\"type/automation\",\"area/mtp-msbuild\",\"type/tech-debt\"],\"max\":1,\"title_prefix\":\"[msbuild-quality] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"area/mtp-msbuild\",\"type/tech-debt\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[msbuild-quality] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/perf-improver.lock.yml
+++ b/.github/workflows/perf-improver.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6941194e97cbf7fe781e106fbe402ae2b9202c1a3fdb132a81d8ab6eaa8f5303","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6a98786d1f78dc7b455a1323c5e8cbc45e4b5e49a51d0ebd1e5acdbf0b2d0f0a","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -260,25 +260,25 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_50f6c8f0a68e47da_EOF'
+          cat << 'GH_AW_PROMPT_a734822b57bca78c_EOF'
           <system>
-          GH_AW_PROMPT_50f6c8f0a68e47da_EOF
+          GH_AW_PROMPT_a734822b57bca78c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_50f6c8f0a68e47da_EOF'
+          cat << 'GH_AW_PROMPT_a734822b57bca78c_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:4), update_issue, create_pull_request(max:4), push_to_pull_request_branch(max:4), missing_tool, missing_data, noop
-          GH_AW_PROMPT_50f6c8f0a68e47da_EOF
+          GH_AW_PROMPT_a734822b57bca78c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_50f6c8f0a68e47da_EOF'
+          cat << 'GH_AW_PROMPT_a734822b57bca78c_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_50f6c8f0a68e47da_EOF
+          GH_AW_PROMPT_a734822b57bca78c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_50f6c8f0a68e47da_EOF'
+          cat << 'GH_AW_PROMPT_a734822b57bca78c_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -307,7 +307,7 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_50f6c8f0a68e47da_EOF
+          GH_AW_PROMPT_a734822b57bca78c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -315,10 +315,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_50f6c8f0a68e47da_EOF'
+          cat << 'GH_AW_PROMPT_a734822b57bca78c_EOF'
           </system>
           {{#runtime-import .github/workflows/perf-improver.md}}
-          GH_AW_PROMPT_50f6c8f0a68e47da_EOF
+          GH_AW_PROMPT_a734822b57bca78c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -556,17 +556,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_996e256009a3f663_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["automation","performance"],"max":4,"title_prefix":"[perf-improver] "},"create_pull_request":{"draft":true,"labels":["automation","performance"],"max":4,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[perf-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max":4,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[perf-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*","title_prefix":"[perf-improver] "}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_996e256009a3f663_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_833f912729eeeee8_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["type/automation","area/performance"],"max":4,"title_prefix":"[perf-improver] "},"create_pull_request":{"draft":true,"labels":["type/automation","area/performance"],"max":4,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[perf-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max":4,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[perf-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*","title_prefix":"[perf-improver] "}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_833f912729eeeee8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[perf-improver] \". Labels [\"automation\" \"performance\"] will be automatically added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 4 pull request(s) can be created. Title will be prefixed with \"[perf-improver] \". Labels [\"automation\" \"performance\"] will be automatically added. PRs will be created as drafts.",
+                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[perf-improver] \". Labels [\"type/automation\" \"area/performance\"] will be automatically added.",
+                "create_pull_request": " CONSTRAINTS: Maximum 4 pull request(s) can be created. Title will be prefixed with \"[perf-improver] \". Labels [\"type/automation\" \"area/performance\"] will be automatically added. PRs will be created as drafts.",
                 "push_to_pull_request_branch": " CONSTRAINTS: Maximum 4 push(es) can be made. The target pull request title must start with \"[perf-improver] \".",
                 "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated. Target: *. The target issue title must start with \"[perf-improver] \"."
               },
@@ -907,7 +907,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9522631eef537043_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_841cd4c70b6bd37f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -948,7 +948,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9522631eef537043_EOF
+          GH_AW_MCP_CONFIG_841cd4c70b6bd37f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1861,7 +1861,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.gradle-enterprise.cloud,*.pythonhosted.org,*.vsblob.vsassets.io,adoptium.net,anaconda.org,api.adoptium.net,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.foojay.io,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.apache.org,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,binstar.org,bootstrap.pypa.io,builds.dotnet.microsoft.com,bun.sh,cdn.azul.com,cdn.jsdelivr.net,central.sonatype.com,ci.dot.net,conda.anaconda.org,conda.binstar.org,crates.io,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,develocity.apache.org,dist.nuget.org,dl.google.com,dlcdn.apache.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,download.eclipse.org,download.java.net,download.oracle.com,downloads.gradle-dn.com,esm.sh,files.pythonhosted.org,ge.spockframework.org,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,gradle.org,host.docker.internal,index.crates.io,jcenter.bintray.com,jdk.java.net,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,maven-central.storage-download.googleapis.com,maven.apache.org,maven.google.com,maven.oracle.com,maven.pkg.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,pkgs.dev.azure.com,plugins-artifacts.gradle.org,plugins.gradle.org,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.gradle.org,repo.grails.org,repo.maven.apache.org,repo.spring.io,repo.yarnpkg.com,repo1.maven.org,repository.apache.org,s.symcb.com,s.symcd.com,scans-in.gradle.com,security.ubuntu.com,services.gradle.org,sh.rustup.rs,skimdb.npmjs.com,static.crates.io,static.rust-lang.org,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.java.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"automation\",\"performance\"],\"max\":4,\"title_prefix\":\"[perf-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"automation\",\"performance\"],\"max\":4,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[perf-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":4,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[perf-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\",\"title_prefix\":\"[perf-improver] \"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"type/automation\",\"area/performance\"],\"max\":4,\"title_prefix\":\"[perf-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"area/performance\"],\"max\":4,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[perf-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":4,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[perf-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\",\"title_prefix\":\"[perf-improver] \"}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/perf-improver.md
+++ b/.github/workflows/perf-improver.md
@@ -52,7 +52,7 @@ safe-outputs:
   create-pull-request:
     draft: true
     title-prefix: "[perf-improver] "
-    labels: [automation, performance]
+    labels: [type/automation, area/performance]
     max: 4
     protected-files: fallback-to-issue
   push-to-pull-request-branch:
@@ -61,7 +61,7 @@ safe-outputs:
     max: 4
   create-issue:
     title-prefix: "[perf-improver] "
-    labels: [automation, performance]
+    labels: [type/automation, area/performance]
     max: 4
   update-issue:
     target: "*"

--- a/.github/workflows/pr-fix.lock.yml
+++ b/.github/workflows/pr-fix.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7bcdd37113de11d4b41f605d203617bfed27da59956dabd8d07a39348bd81dbe","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"87b3fa109f0bbc30c16bf366387a9132e67c61fdcaf3d5e13765de64c74cbd8f","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -243,23 +243,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e546fcd8ce3f666c_EOF'
+          cat << 'GH_AW_PROMPT_5332ed887332d6ee_EOF'
           <system>
-          GH_AW_PROMPT_e546fcd8ce3f666c_EOF
+          GH_AW_PROMPT_5332ed887332d6ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e546fcd8ce3f666c_EOF'
+          cat << 'GH_AW_PROMPT_5332ed887332d6ee_EOF'
           <safe-output-tools>
           Tools: add_comment, create_issue, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_e546fcd8ce3f666c_EOF
+          GH_AW_PROMPT_5332ed887332d6ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_e546fcd8ce3f666c_EOF'
+          cat << 'GH_AW_PROMPT_5332ed887332d6ee_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_e546fcd8ce3f666c_EOF
+          GH_AW_PROMPT_5332ed887332d6ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e546fcd8ce3f666c_EOF'
+          cat << 'GH_AW_PROMPT_5332ed887332d6ee_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -288,7 +288,7 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e546fcd8ce3f666c_EOF
+          GH_AW_PROMPT_5332ed887332d6ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -296,10 +296,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_e546fcd8ce3f666c_EOF'
+          cat << 'GH_AW_PROMPT_5332ed887332d6ee_EOF'
           </system>
           {{#runtime-import .github/workflows/pr-fix.md}}
-          GH_AW_PROMPT_e546fcd8ce3f666c_EOF
+          GH_AW_PROMPT_5332ed887332d6ee_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -509,16 +509,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7c6b33bb2f639ced_EOF'
-          {"add_comment":{"max":1},"create_issue":{"labels":["automation","pr-fix"],"max":1,"title_prefix":"[pr-fix] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_7c6b33bb2f639ced_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4a7c2ce9b0522af5_EOF'
+          {"add_comment":{"max":1},"create_issue":{"labels":["type/automation","type/pr-fix"],"max":1,"title_prefix":"[pr-fix] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_4a7c2ce9b0522af5_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[pr-fix] \". Labels [\"automation\" \"pr-fix\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[pr-fix] \". Labels [\"type/automation\" \"type/pr-fix\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -760,7 +760,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_190487f56a40b05c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_4de04ae6957f1a8d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -804,7 +804,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_190487f56a40b05c_EOF
+          GH_AW_MCP_CONFIG_4de04ae6957f1a8d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1608,7 +1608,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_issue\":{\"labels\":[\"automation\",\"pr-fix\"],\"max\":1,\"title_prefix\":\"[pr-fix] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"create_issue\":{\"labels\":[\"type/automation\",\"type/pr-fix\"],\"max\":1,\"title_prefix\":\"[pr-fix] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-fix.md
+++ b/.github/workflows/pr-fix.md
@@ -27,7 +27,7 @@ safe-outputs:
   push-to-pull-request-branch:
   create-issue:
     title-prefix: "[pr-fix] "
-    labels: [automation, pr-fix]
+    labels: [type/automation, type/pr-fix]
   add-comment:
 
 timeout-minutes: 20

--- a/.github/workflows/repository-quality-improver.lock.yml
+++ b/.github/workflows/repository-quality-improver.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0a3cb0886a8db1bda0cb36c9862a7dafe3f21ef54f06cdfa00cf92664e9e0680","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0103e3cfd48879a0a0e59c2ffcad46f5949ded51b5e07605f8b127ba990ce545","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -193,21 +193,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_413f1edda6035b39_EOF'
+          cat << 'GH_AW_PROMPT_c701a618b5707d0a_EOF'
           <system>
-          GH_AW_PROMPT_413f1edda6035b39_EOF
+          GH_AW_PROMPT_c701a618b5707d0a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt_multi.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_413f1edda6035b39_EOF'
+          cat << 'GH_AW_PROMPT_c701a618b5707d0a_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_413f1edda6035b39_EOF
+          GH_AW_PROMPT_c701a618b5707d0a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_413f1edda6035b39_EOF'
+          cat << 'GH_AW_PROMPT_c701a618b5707d0a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -236,12 +236,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_413f1edda6035b39_EOF
+          GH_AW_PROMPT_c701a618b5707d0a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_413f1edda6035b39_EOF'
+          cat << 'GH_AW_PROMPT_c701a618b5707d0a_EOF'
           </system>
           {{#runtime-import .github/workflows/repository-quality-improver.md}}
-          GH_AW_PROMPT_413f1edda6035b39_EOF
+          GH_AW_PROMPT_c701a618b5707d0a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -470,15 +470,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e7f9326b739511eb_EOF'
-          {"create_issue":{"expires":48,"labels":["quality","automated-analysis"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e7f9326b739511eb_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e8b15a01f3d603cd_EOF'
+          {"create_issue":{"expires":48,"labels":["type/tech-debt","type/automation"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_e8b15a01f3d603cd_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [\"quality\" \"automated-analysis\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [\"type/tech-debt\" \"type/automation\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -680,7 +680,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_5008bec2ce196f82_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_dbbe2c6fb891f1e9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -721,7 +721,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5008bec2ce196f82_EOF
+          GH_AW_MCP_CONFIG_dbbe2c6fb891f1e9_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1402,7 +1402,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":48,\"labels\":[\"quality\",\"automated-analysis\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":48,\"labels\":[\"type/tech-debt\",\"type/automation\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/repository-quality-improver.md
+++ b/.github/workflows/repository-quality-improver.md
@@ -23,7 +23,7 @@ tools:
 safe-outputs:
   create-issue:
     expires: 2d
-    labels: [quality, automated-analysis]
+    labels: [type/tech-debt, type/automation]
     max: 1
 
 timeout-minutes: 20

--- a/.github/workflows/shared/msbuild-review-shared.md
+++ b/.github/workflows/shared/msbuild-review-shared.md
@@ -22,13 +22,13 @@ safe-outputs:
   # budget for a single weekly report plus an optional draft PR with safe fixes.
   create-issue:
     title-prefix: "[msbuild-quality] "
-    labels: [automation, msbuild, code-quality]
+    labels: [type/automation, area/mtp-msbuild, type/tech-debt]
     max: 1
     expires: 7d
   create-pull-request:
     draft: true
     title-prefix: "[msbuild-quality] "
-    labels: [automation, msbuild, code-quality]
+    labels: [type/automation, area/mtp-msbuild, type/tech-debt]
     max: 1
     protected-files: fallback-to-issue
   # NOTE: Consumers must also define this explicitly until workflow import/merge

--- a/.github/workflows/test-improver.lock.yml
+++ b/.github/workflows/test-improver.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c96dcaf50a17232d1c98ccd23022fcf39f868d6211dd69a065274a12b2de4469","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"294f9a6356918cd06e02e0cef1a07b50a4cfb207110f853d673c07cbbf4b6937","compiler_version":"v0.75.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"f889c9c3c06adeaabccefc06e29c42733ee05dff","version":"v0.75.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51","digest":"sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.51@sha256:2c0e5a1d6c805fb2a78ce97a6ff44265b7ffc1621fd41e0e00d9948df9fb62ce"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51","digest":"sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.51@sha256:92a400817e8a34260fb49074402ca24a6e5222c2171844a1c5d7b203caee33c0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51","digest":"sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.51@sha256:9f95539f18b025f2ae3919dcd1b939712a2cc1427fd747c7e2f2630a64732423"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.17","digest":"sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.17@sha256:1be0cd19153261e499c1183a730b1ec8db56eeca94b0cb5dd7ddcdbe2654bf32"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -260,25 +260,25 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_166ec02ab2a64428_EOF'
+          cat << 'GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF'
           <system>
-          GH_AW_PROMPT_166ec02ab2a64428_EOF
+          GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_166ec02ab2a64428_EOF'
+          cat << 'GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:4), update_issue, create_pull_request(max:4), push_to_pull_request_branch(max:4), missing_tool, missing_data, noop
-          GH_AW_PROMPT_166ec02ab2a64428_EOF
+          GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_166ec02ab2a64428_EOF'
+          cat << 'GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_166ec02ab2a64428_EOF
+          GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_166ec02ab2a64428_EOF'
+          cat << 'GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -307,7 +307,7 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_166ec02ab2a64428_EOF
+          GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
@@ -315,10 +315,10 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_push_to_pr_branch_guidance.md"
           fi
-          cat << 'GH_AW_PROMPT_166ec02ab2a64428_EOF'
+          cat << 'GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF'
           </system>
           {{#runtime-import .github/workflows/test-improver.md}}
-          GH_AW_PROMPT_166ec02ab2a64428_EOF
+          GH_AW_PROMPT_a45b88d1bfd3a4a4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -556,17 +556,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_00c7b7880bd29a33_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["automation","testing"],"max":4,"title_prefix":"[test-improver] "},"create_pull_request":{"draft":true,"labels":["automation","testing"],"max":4,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[test-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max":4,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[test-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*","title_prefix":"[test-improver] "}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_00c7b7880bd29a33_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_165221bd4ce3fde1_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"create_issue":{"labels":["type/automation","type/test-gap"],"max":4,"title_prefix":"[test-improver] "},"create_pull_request":{"draft":true,"labels":["type/automation","type/test-gap"],"max":4,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue","title_prefix":"[test-improver] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":102400,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max":4,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"target":"*","title_prefix":"[test-improver] "},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*","title_prefix":"[test-improver] "}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_165221bd4ce3fde1_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[test-improver] \". Labels [\"automation\" \"testing\"] will be automatically added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 4 pull request(s) can be created. Title will be prefixed with \"[test-improver] \". Labels [\"automation\" \"testing\"] will be automatically added. PRs will be created as drafts.",
+                "create_issue": " CONSTRAINTS: Maximum 4 issue(s) can be created. Title will be prefixed with \"[test-improver] \". Labels [\"type/automation\" \"type/test-gap\"] will be automatically added.",
+                "create_pull_request": " CONSTRAINTS: Maximum 4 pull request(s) can be created. Title will be prefixed with \"[test-improver] \". Labels [\"type/automation\" \"type/test-gap\"] will be automatically added. PRs will be created as drafts.",
                 "push_to_pull_request_branch": " CONSTRAINTS: Maximum 4 push(es) can be made. The target pull request title must start with \"[test-improver] \".",
                 "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated. Target: *. The target issue title must start with \"[test-improver] \"."
               },
@@ -907,7 +907,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_7d38c7b8e7f277e2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_c1d7ec68c6a95e94_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -948,7 +948,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7d38c7b8e7f277e2_EOF
+          GH_AW_MCP_CONFIG_c1d7ec68c6a95e94_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1861,7 +1861,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.gradle-enterprise.cloud,*.pythonhosted.org,*.vsblob.vsassets.io,adoptium.net,anaconda.org,api.adoptium.net,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.foojay.io,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.apache.org,archive.ubuntu.com,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,binstar.org,bootstrap.pypa.io,builds.dotnet.microsoft.com,bun.sh,cdn.azul.com,cdn.jsdelivr.net,central.sonatype.com,ci.dot.net,conda.anaconda.org,conda.binstar.org,crates.io,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,develocity.apache.org,dist.nuget.org,dl.google.com,dlcdn.apache.org,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,download.eclipse.org,download.java.net,download.oracle.com,downloads.gradle-dn.com,esm.sh,files.pythonhosted.org,ge.spockframework.org,get.pnpm.io,github.com,googleapis.deno.dev,googlechromelabs.github.io,gradle.org,host.docker.internal,index.crates.io,jcenter.bintray.com,jdk.java.net,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,maven-central.storage-download.googleapis.com,maven.apache.org,maven.google.com,maven.oracle.com,maven.pkg.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,pkgs.dev.azure.com,plugins-artifacts.gradle.org,plugins.gradle.org,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.anaconda.com,repo.continuum.io,repo.gradle.org,repo.grails.org,repo.maven.apache.org,repo.spring.io,repo.yarnpkg.com,repo1.maven.org,repository.apache.org,s.symcb.com,s.symcd.com,scans-in.gradle.com,security.ubuntu.com,services.gradle.org,sh.rustup.rs,skimdb.npmjs.com,static.crates.io,static.rust-lang.org,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.java.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"automation\",\"testing\"],\"max\":4,\"title_prefix\":\"[test-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"automation\",\"testing\"],\"max\":4,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[test-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":4,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[test-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\",\"title_prefix\":\"[test-improver] \"}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":10,\"target\":\"*\"},\"create_issue\":{\"labels\":[\"type/automation\",\"type/test-gap\"],\"max\":4,\"title_prefix\":\"[test-improver] \"},\"create_pull_request\":{\"draft\":true,\"labels\":[\"type/automation\",\"type/test-gap\"],\"max\":4,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"fallback-to-issue\",\"title_prefix\":\"[test-improver] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"push_to_pull_request_branch\":{\"if_no_changes\":\"warn\",\"max\":4,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"target\":\"*\",\"title_prefix\":\"[test-improver] \"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\",\"title_prefix\":\"[test-improver] \"}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-improver.md
+++ b/.github/workflows/test-improver.md
@@ -52,7 +52,7 @@ safe-outputs:
   create-pull-request:
     draft: true
     title-prefix: "[test-improver] "
-    labels: [automation, testing]
+    labels: [type/automation, type/test-gap]
     max: 4
     protected-files: fallback-to-issue
   push-to-pull-request-branch:
@@ -61,7 +61,7 @@ safe-outputs:
     max: 4
   create-issue:
     title-prefix: "[test-improver] "
-    labels: [automation, testing]
+    labels: [type/automation, type/test-gap]
     max: 4
   update-issue:
     target: "*"

--- a/eng/migrate-labels.ps1
+++ b/eng/migrate-labels.ps1
@@ -1,0 +1,581 @@
+<#
+.SYNOPSIS
+    Migrates the microsoft/testfx GitHub label taxonomy to the lowercase
+    "prefix/name" convention (area/, type/, external/, state/, resolution/,
+    needs/, priority/).
+
+.DESCRIPTION
+    Migration is performed in phases that minimize the risk of losing
+    issue/PR associations:
+
+      Preflight   List labels that are neither in the target taxonomy nor
+                  mapped in the migration table. Abort unless -Force.
+      Phase 1     Atomic 1:1 renames using ``gh label edit --name``. This
+                  preserves all associations natively and incidentally
+                  creates the target label.
+      Phase 2     Many-to-one merges. For each old label that needs to be
+                  merged into an already-existing target, list every issue
+                  and PR carrying the old label and re-label them. The
+                  source label is only deleted after every relabel
+                  succeeded AND the source label has zero remaining items.
+      Phase 3     Create any target labels that no phase-1 rename created.
+                  Update the color/description of any target label whose
+                  attributes drifted.
+      Phase 4     Pure deletions (legacy labels that have no replacement).
+      Postflight  Verify no migrated source label still exists, and no
+                  current label is outside the target taxonomy.
+
+    Run with -DryRun to print actions without mutating anything.
+
+.PARAMETER Repo
+    GitHub repo in OWNER/NAME form. Default: microsoft/testfx.
+
+.PARAMETER DryRun
+    Print actions without calling the GitHub API.
+
+.PARAMETER Force
+    Continue even if preflight finds labels that are not covered by the
+    migration map. (They will be left untouched.)
+
+.EXAMPLE
+    pwsh ./eng/migrate-labels.ps1 -DryRun
+    pwsh ./eng/migrate-labels.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Repo = 'microsoft/testfx',
+    [switch] $DryRun,
+    [switch] $Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Color palette (one source of truth per prefix)
+# ---------------------------------------------------------------------------
+$Color = @{
+    Area        = '0052CC'   # blue
+    Type        = '1D76DB'   # lighter blue
+    External    = 'C5DEF5'   # pale blue
+    State       = '0E8A16'   # green
+    Resolution  = 'CCCCCC'   # gray
+    Needs       = 'FBCA04'   # yellow
+    PriorityP0  = 'B60205'   # red
+    PriorityP1  = 'D93F0B'   # red-orange
+    PriorityP2  = 'FBCA04'   # yellow
+    PriorityP3  = '0E8A16'   # green
+    Dependencies = '0366D6'
+    AutoMerge   = '0E8A16'
+    HelpWanted  = '008672'   # GitHub default "help wanted" green
+    Breaking    = 'B60205'
+    Flaky       = 'B60205'
+    AI          = 'BFD4F2'
+}
+
+# ---------------------------------------------------------------------------
+# Target taxonomy: name -> @{ Color; Description }
+# ---------------------------------------------------------------------------
+$Targets = [ordered]@{
+    # area/*
+    'area/agentic-workflows'   = @{ Color = $Color.Area; Description = 'GitHub agentic workflow definitions under .github/workflows/*.md.' }
+    'area/analyzers'           = @{ Color = $Color.Area; Description = 'MSTest.Analyzers Roslyn analyzers and code fixes.' }
+    'area/assertion'           = @{ Color = $Color.Area; Description = 'Assert / StringAssert / CollectionAssert APIs.' }
+    'area/branding'            = @{ Color = $Color.Area; Description = 'Product branding, naming, icons.' }
+    'area/deployment-item'     = @{ Color = $Color.Area; Description = '[DeploymentItem] support.' }
+    'area/documentation'       = @{ Color = $Color.Area; Description = 'Repository or user-facing documentation.' }
+    'area/dump'                = @{ Color = $Color.Area; Description = 'CrashDump / HangDump extensions.' }
+    'area/fixtures'            = @{ Color = $Color.Area; Description = 'Test class / assembly initialization & cleanup.' }
+    'area/infrastructure'      = @{ Color = $Color.Area; Description = 'Build, CI, repo infrastructure.' }
+    'area/localization'        = @{ Color = $Color.Area; Description = 'Localized resources / xlf.' }
+    'area/mstest'              = @{ Color = $Color.Area; Description = 'MSTest framework (not analyzers or assertions).' }
+    'area/mstest-sdk'          = @{ Color = $Color.Area; Description = 'MSTest.Sdk MSBuild SDK.' }
+    'area/mtp'                 = @{ Color = $Color.Area; Description = 'Microsoft.Testing.Platform core library.' }
+    'area/mtp-extensions'      = @{ Color = $Color.Area; Description = 'MTP extensions (TrxReport, Retry, HtmlReport, ...).' }
+    'area/mtp-migration'       = @{ Color = $Color.Area; Description = 'Tracks the MTP migration campaign (replaces mtp-migration-challenge).' }
+    'area/mtp-msbuild'         = @{ Color = $Color.Area; Description = 'MTP MSBuild integration.' }
+    'area/mtp-vstest-bridge'   = @{ Color = $Color.Area; Description = 'MTP <-> VSTest bridge.' }
+    'area/native-aot'          = @{ Color = $Color.Area; Description = 'Native AOT compatibility.' }
+    'area/parameterized-tests' = @{ Color = $Color.Area; Description = 'DataRow / DynamicData / parameterized tests.' }
+    'area/performance'         = @{ Color = $Color.Area; Description = 'Runtime / build performance / efficiency.' }
+    'area/server-mode-jsonrpc' = @{ Color = $Color.Area; Description = 'MTP server mode - JSON RPC transport.' }
+    'area/server-mode-pipe'    = @{ Color = $Color.Area; Description = 'MTP server mode - named pipe transport.' }
+    'area/terminal-reporter'   = @{ Color = $Color.Area; Description = 'Console / terminal test reporter.' }
+    'area/test-framework'      = @{ Color = $Color.Area; Description = 'TestFramework public API and extensions.' }
+    'area/timeout'             = @{ Color = $Color.Area; Description = '[Timeout] handling.' }
+    'area/trx'                 = @{ Color = $Color.Area; Description = 'TRX report extension.' }
+    'area/uwp'                 = @{ Color = $Color.Area; Description = 'Universal Windows Platform support.' }
+    'area/winui'               = @{ Color = $Color.Area; Description = 'WinUI support.' }
+
+    # type/*
+    'type/announcement'        = @{ Color = $Color.Type;     Description = 'Announcement to the community.' }
+    'type/automation'          = @{ Color = $Color.Type;     Description = 'Created or maintained by an agentic workflow.' }
+    'type/ai-inspected'        = @{ Color = $Color.AI;       Description = 'Reviewed or generated with AI assistance.' }
+    'type/breaking-change'     = @{ Color = $Color.Breaking; Description = 'Behavioral or API breaking change.' }
+    'type/bug'                 = @{ Color = $Color.Type;     Description = 'Something is not working as intended.' }
+    'type/discussion'          = @{ Color = $Color.Type;     Description = 'Open discussion / brainstorming.' }
+    'type/feature'             = @{ Color = $Color.Type;     Description = 'New capability or enhancement.' }
+    'type/flaky-test'          = @{ Color = $Color.Flaky;    Description = 'Tracks flaky tests in CI.' }
+    'type/partner-request'     = @{ Color = $Color.Type;     Description = 'Request from a partner team.' }
+    'type/pr-fix'              = @{ Color = $Color.Type;     Description = 'Created by the pr-fix agentic workflow.' }
+    'type/qa'                  = @{ Color = $Color.Type;     Description = 'Created by the adhoc-qa agentic workflow.' }
+    'type/question'            = @{ Color = $Color.Type;     Description = 'Question or request for clarification.' }
+    'type/regression'          = @{ Color = $Color.Breaking; Description = 'Regression from a previous release.' }
+    'type/rfc'                 = @{ Color = $Color.Type;     Description = 'Request for comments.' }
+    'type/tech-debt'           = @{ Color = $Color.Type;     Description = 'Code health, refactoring, simplification.' }
+    'type/test-gap'            = @{ Color = $Color.Type;     Description = 'Missing or insufficient tests.' }
+
+    # external/*
+    'external/azdo'            = @{ Color = $Color.External; Description = 'Blocked on Azure DevOps.' }
+    'external/code-coverage'   = @{ Color = $Color.External; Description = 'Blocked on the code coverage tooling.' }
+    'external/dotnet-sdk'      = @{ Color = $Color.External; Description = 'Blocked on the .NET SDK.' }
+    'external/dotnet-test'     = @{ Color = $Color.External; Description = 'Blocked on `dotnet test` integration.' }
+    'external/fakes'           = @{ Color = $Color.External; Description = 'Blocked on Microsoft Fakes.' }
+    'external/nuget'           = @{ Color = $Color.External; Description = 'Blocked on NuGet.' }
+    'external/nunit'           = @{ Color = $Color.External; Description = 'Blocked on NUnit.' }
+    'external/other'           = @{ Color = $Color.External; Description = 'Caused by an external issue that needs to be solved first.' }
+    'external/test-explorer'   = @{ Color = $Color.External; Description = 'Blocked on the VS Test Explorer.' }
+    'external/tunit'           = @{ Color = $Color.External; Description = 'Blocked on TUnit.' }
+    'external/vstest'          = @{ Color = $Color.External; Description = 'Blocked on VSTest.' }
+    'external/xunit'           = @{ Color = $Color.External; Description = 'Blocked on xUnit.' }
+
+    # state/*
+    'state/approved'           = @{ Color = $Color.State; Description = 'Proposal approved; ready for implementation.' }
+    'state/blocked'            = @{ Color = $Color.State; Description = 'Cannot progress until a blocker is resolved.' }
+    'state/cannot-reproduce'   = @{ Color = $Color.State; Description = 'Maintainers cannot reproduce the issue.' }
+    'state/in-pr'              = @{ Color = $Color.State; Description = 'A PR is open for this issue.' }
+    'state/needs-approval'     = @{ Color = $Color.State; Description = 'Awaiting maintainer approval to proceed.' }
+    'state/stale'              = @{ Color = $Color.State; Description = 'No recent activity.' }
+
+    # resolution/*
+    'resolution/by-design'     = @{ Color = $Color.Resolution; Description = 'Closed: behavior is by design.' }
+    'resolution/duplicate'     = @{ Color = $Color.Resolution; Description = 'Closed: duplicate of another issue.' }
+    'resolution/fixed'         = @{ Color = $Color.Resolution; Description = 'Closed: fix has been merged.' }
+    'resolution/pending-release' = @{ Color = $Color.Resolution; Description = 'Fixed; awaiting next release.' }
+    'resolution/wont-fix'      = @{ Color = $Color.Resolution; Description = 'Closed: will not be fixed.' }
+
+    # needs/*
+    'needs/attention'          = @{ Color = $Color.Needs; Description = 'Needs maintainer attention.' }
+    'needs/author-feedback'    = @{ Color = $Color.Needs; Description = 'Waiting on the original author.' }
+    'needs/design'             = @{ Color = $Color.Needs; Description = 'Needs design / proposal before implementation.' }
+    'needs/info'               = @{ Color = $Color.Needs; Description = 'Needs more information from the reporter.' }
+    'needs/triage'             = @{ Color = $Color.Needs; Description = 'Needs triage by a maintainer.' }
+
+    # priority/*
+    'priority/0'               = @{ Color = $Color.PriorityP0; Description = 'Critical priority.' }
+    'priority/1'               = @{ Color = $Color.PriorityP1; Description = 'High priority.' }
+    'priority/2'               = @{ Color = $Color.PriorityP2; Description = 'Medium priority.' }
+    'priority/3'               = @{ Color = $Color.PriorityP3; Description = 'Low priority.' }
+
+    # standalone (kept as-is - GitHub UI surfaces have implicit hooks)
+    'dependencies'             = @{ Color = $Color.Dependencies; Description = 'Updates to dependency manifests.' }
+    'auto-merge'               = @{ Color = $Color.AutoMerge;    Description = 'PR is enabled for auto-merge.' }
+    'help wanted'              = @{ Color = $Color.HelpWanted;   Description = 'Up for grabs; can be claimed by commenting.' }
+
+    # explicitly kept (not in the new taxonomy but still in use)
+    'sprint'                   = @{ Color = 'BFD4F2'; Description = 'Tracks sprint work items.' }
+    'cla-already-signed'       = @{ Color = '009800'; Description = '(Managed by the CLA bot.)' }
+    'cla-not-required'         = @{ Color = '009800'; Description = '(Managed by the CLA bot.)' }
+    'cla-required'             = @{ Color = 'E11D21'; Description = '(Managed by the CLA bot.)' }
+    'cla-signed'               = @{ Color = '207DE5'; Description = '(Managed by the CLA bot.)' }
+}
+
+# ---------------------------------------------------------------------------
+# Old label -> new label mapping
+#   - String value: rename / merge into that target
+#   - $null:        delete the old label (no replacement)
+# All keys must refer to labels that currently exist in the repo (or are
+# silently skipped). Keys with non-null values must point at a key in $Targets.
+# ---------------------------------------------------------------------------
+$Migration = [ordered]@{
+    # Dependabot grouping
+    '.NET'                          = 'dependencies'
+    'dotnet_sdk_package_manager'    = 'dependencies'
+    'javascript'                    = 'dependencies'
+
+    # Area
+    'agentic-workflows'             = 'area/agentic-workflows'
+    'Area: Analyzers'               = 'area/analyzers'
+    'Area: Assertion'               = 'area/assertion'
+    'Area: Branding'                = 'area/branding'
+    'Area: DeploymentItem'          = 'area/deployment-item'
+    'Area: Documentation'           = 'area/documentation'
+    'documentation'                 = 'area/documentation'
+    'Area: Dump'                    = 'area/dump'
+    'Area: Fixtures'                = 'area/fixtures'
+    'Area: Infrastructure'          = 'area/infrastructure'
+    'Area: Localization'            = 'area/localization'
+    'Area: MSTest'                  = 'area/mstest'
+    'Area: MSTest.SDK'              = 'area/mstest-sdk'
+    'Area: MTP'                     = 'area/mtp'
+    'Area: MTP Extensions'          = 'area/mtp-extensions'
+    'mtp-migration-challenge'       = 'area/mtp-migration'
+    'Area: MTP MSBuild'             = 'area/mtp-msbuild'
+    'msbuild'                       = 'area/mtp-msbuild'
+    'Area: MTP VSTest Bridge'       = 'area/mtp-vstest-bridge'
+    'Area: Native AOT'              = 'area/native-aot'
+    'Area: Parameterized tests'     = 'area/parameterized-tests'
+    'Area: Performance'             = 'area/performance'
+    'performance'                   = 'area/performance'
+    'efficiency'                    = 'area/performance'
+    'green-software'                = 'area/performance'
+    'Area: Server Mode - JSON RPC'  = 'area/server-mode-jsonrpc'
+    'Area: Server Mode - Pipe'      = 'area/server-mode-pipe'
+    'Area: Terminal reporter'       = 'area/terminal-reporter'
+    'Area: TestFramework'           = 'area/test-framework'
+    'Area: Timeout'                 = 'area/timeout'
+    'Area: TRX'                     = 'area/trx'
+    'Area: UWP'                     = 'area/uwp'
+    'Area: WinUI'                   = 'area/winui'
+
+    # Type
+    'Announcement'                  = 'type/announcement'
+    'automated'                     = 'type/automation'
+    'automated-analysis'            = 'type/automation'
+    'automation'                    = 'type/automation'
+    'ai-inspected'                  = 'type/ai-inspected'
+    'Breaking :bangbang:'           = 'type/breaking-change'
+    'Discussion'                    = 'type/discussion'
+    'enhancement'                   = 'type/feature'
+    'Flaky-Test'                    = 'type/flaky-test'
+    'Partner request'               = 'type/partner-request'
+    'Question'                      = 'type/question'
+    'Regression'                    = 'type/regression'
+    'RFC'                           = 'type/rfc'
+    'Test Gap'                      = 'type/test-gap'
+    'testing'                       = 'type/test-gap'
+    'code-health'                   = 'type/tech-debt'
+    'codehealth'                    = 'type/tech-debt'
+    'code-quality'                  = 'type/tech-debt'
+    'maintainability'               = 'type/tech-debt'
+    'quality'                       = 'type/tech-debt'
+    'refactoring'                   = 'type/tech-debt'
+
+    # External
+    'External: .NET SDK'            = 'external/dotnet-sdk'
+    'External: AzDO'                = 'external/azdo'
+    'External: Code Coverage'       = 'external/code-coverage'
+    'External: dotnet test'         = 'external/dotnet-test'
+    'External: Fakes'               = 'external/fakes'
+    'External: NuGet'               = 'external/nuget'
+    'External: NUnit'               = 'external/nunit'
+    'External: Other'               = 'external/other'
+    'External: Test Explorer'       = 'external/test-explorer'
+    'External: TUnit'               = 'external/tunit'
+    'External: VSTest'              = 'external/vstest'
+    'External: xUnit'               = 'external/xunit'
+
+    # State
+    'In-PR'                         = 'state/in-pr'
+    'State: Approved'               = 'state/approved'
+    'State: Blocked'                = 'state/blocked'
+    "State: Can't Reproduce"        = 'state/cannot-reproduce'
+    'State: In-PR'                  = 'state/in-pr'
+    'State: Needs Approval'         = 'state/needs-approval'
+    'State: No Recent Activity'     = 'state/stale'
+
+    # Resolution
+    'Resolution: By Design'         = 'resolution/by-design'
+    'Resolution: Duplicate'         = 'resolution/duplicate'
+    'Resolution: Fixed'             = 'resolution/fixed'
+    'Resolution: Pending release'   = 'resolution/pending-release'
+    "State: Won't Fix"              = 'resolution/wont-fix'
+
+    # Needs
+    'Needs: Additional Info'        = 'needs/info'
+    'Needs: Attention :wave:'       = 'needs/attention'
+    'Needs: Author Feedback'        = 'needs/author-feedback'
+    'Needs: Design'                 = 'needs/design'
+    'Needs: Triage :mag:'           = 'needs/triage'
+
+    # Priority
+    'pri:1'                         = 'priority/1'
+
+    # Standalone normalization - canonicalize on the GH default "help wanted"
+    'Help-Wanted'                   = 'help wanted'
+
+    # Merge `glossary` (used only by the now-replaced glossary-maintainer workflow)
+    # into the broader docs area, preserving discoverability.
+    'glossary'                      = 'area/documentation'
+
+    # Pure deletions (legacy / niche / superseded with very few items)
+    'Area: Expecto'                 = $null
+    'build'                         = $null
+    'cross-platform'                = $null
+}
+
+# Labels to keep untouched: not in the new taxonomy but kept on purpose.
+# (Listing them explicitly so the preflight check doesn't flag them.)
+$Keep = @(
+    'daily-status'
+    'lean-squad'
+    'ported-from-ta-repo'
+    'report'
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Invoke-Gh {
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $Args)
+    if ($DryRun) {
+        Write-Host "    [dry-run] gh $($Args -join ' ')" -ForegroundColor DarkGray
+        return $null
+    }
+    & gh @Args
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh command failed (exit $LASTEXITCODE): gh $($Args -join ' ')"
+    }
+}
+
+function Get-AllLabels {
+    $json = & gh label list --repo $Repo --limit 500 --json name,color,description
+    if ($LASTEXITCODE -ne 0) { throw "Failed to list labels on $Repo (exit $LASTEXITCODE)" }
+    return ($json | ConvertFrom-Json)
+}
+
+function Get-LabelByName {
+    param($Labels, [string] $Name)
+    return ($Labels | Where-Object { $_.name -eq $Name } | Select-Object -First 1)
+}
+
+# Lists every issue and PR (state=all) with the given label and returns
+# their numbers. Throws if either gh invocation fails.
+function Get-ItemsWithLabel {
+    param([string] $Label)
+
+    $issueJson = & gh issue list --repo $Repo --label $Label --state all --limit 5000 --json number
+    if ($LASTEXITCODE -ne 0) { throw "Failed to list issues with label '$Label'" }
+
+    $prJson = & gh pr list --repo $Repo --label $Label --state all --limit 5000 --json number
+    if ($LASTEXITCODE -ne 0) { throw "Failed to list PRs with label '$Label'" }
+
+    $issues = @($issueJson | ConvertFrom-Json | ForEach-Object { $_.number })
+    $prs    = @($prJson    | ConvertFrom-Json | ForEach-Object { $_.number })
+    return @($issues + $prs | Sort-Object -Unique)
+}
+
+function Merge-LabelInto {
+    param(
+        [string] $From,
+        [string] $To
+    )
+
+    $items = Get-ItemsWithLabel -Label $From
+    $count = $items.Count
+    Write-Host "    found $count item(s) with '$From'" -ForegroundColor DarkGray
+    if ($count -ge 5000) {
+        throw "Label '$From' has >=5000 items - pagination support required, refusing to proceed."
+    }
+
+    $failures = @()
+    foreach ($n in $items) {
+        try {
+            Invoke-Gh issue edit $n --repo $Repo --add-label $To --remove-label $From | Out-Null
+        }
+        catch {
+            $failures += [pscustomobject]@{ Number = $n; Error = $_.Exception.Message }
+            Write-Host "    ! failed to relabel #${n}: $($_.Exception.Message)" -ForegroundColor Red
+        }
+    }
+
+    if ($failures.Count -gt 0) {
+        throw "$($failures.Count) item(s) failed to migrate from '$From' to '$To'; refusing to delete '$From'."
+    }
+
+    if (-not $DryRun) {
+        # GitHub's label-based issue/PR search is index-backed and may lag a few
+        # seconds after edits. Retry a few times before giving up.
+        $remaining = @()
+        $maxAttempts = 6
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            $remaining = Get-ItemsWithLabel -Label $From
+            if ($remaining.Count -eq 0) { break }
+            if ($attempt -lt $maxAttempts) {
+                Start-Sleep -Seconds (2 * $attempt)
+            }
+        }
+        if ($remaining.Count -gt 0) {
+            throw "Label '$From' still has $($remaining.Count) item(s) after relabel + $maxAttempts retries; refusing to delete."
+        }
+    }
+
+    Invoke-Gh label delete $From --repo $Repo --yes | Out-Null
+}
+
+function Ensure-Target {
+    param(
+        [string] $Name,
+        [Parameter()] $Existing
+    )
+    $spec = $Targets[$Name]
+    if (-not $spec) { throw "No target spec for '$Name'" }
+    $current = Get-LabelByName -Labels $Existing -Name $Name
+    if ($current) {
+        $colorDrift = $current.color.ToLowerInvariant() -ne $spec.Color.ToLowerInvariant()
+        $descDrift  = ($current.description ?? '') -ne $spec.Description
+        if ($colorDrift -or $descDrift) {
+            Write-Host "  ~ updating '$Name' (color/description)" -ForegroundColor Yellow
+            Invoke-Gh label edit $Name --repo $Repo --color $spec.Color --description $spec.Description | Out-Null
+        }
+    } else {
+        Write-Host "  + creating '$Name'" -ForegroundColor Green
+        Invoke-Gh label create $Name --repo $Repo --color $spec.Color --description $spec.Description | Out-Null
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Preflight: list labels not covered by the migration map or target taxonomy
+# ---------------------------------------------------------------------------
+Write-Host "=== Preflight ===" -ForegroundColor Cyan
+$existing = Get-AllLabels
+$existingNames = @($existing | ForEach-Object { $_.name })
+
+# Validate the script's mapping integrity.
+foreach ($old in @($Migration.Keys)) {
+    $new = $Migration[$old]
+    if ($null -ne $new -and -not $Targets.Contains($new)) {
+        throw "Migration target '$new' (for '$old') is not defined in `$Targets."
+    }
+}
+
+$uncovered = @()
+foreach ($name in $existingNames) {
+    if ($Targets.Contains($name)) { continue }
+    if ($Migration.Contains($name)) { continue }
+    if ($Keep -contains $name) { continue }
+    $uncovered += $name
+}
+if ($uncovered.Count -gt 0) {
+    Write-Host ("  ! {0} existing label(s) are not covered by the migration:" -f $uncovered.Count) -ForegroundColor Yellow
+    foreach ($n in ($uncovered | Sort-Object)) { Write-Host "      - $n" -ForegroundColor Yellow }
+    if (-not $Force) {
+        throw "Aborting: re-run with -Force to ignore these uncovered labels."
+    }
+    Write-Host "  (continuing because -Force was specified)" -ForegroundColor Yellow
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: atomic 1:1 renames (preserves all associations via gh)
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Phase 1: atomic 1:1 renames ===" -ForegroundColor Cyan
+foreach ($old in @($Migration.Keys)) {
+    $new = $Migration[$old]
+    if ($null -eq $new) { continue }
+    $oldLabel = Get-LabelByName -Labels $existing -Name $old
+    if (-not $oldLabel) { continue }
+    $newLabel = Get-LabelByName -Labels $existing -Name $new
+    if ($newLabel) { continue }  # target already exists -> merge in phase 2
+
+    $spec = $Targets[$new]
+    Write-Host "  > renaming '$old' -> '$new'" -ForegroundColor Magenta
+    Invoke-Gh label edit $old --repo $Repo --name $new --color $spec.Color --description $spec.Description | Out-Null
+
+    # Reflect the rename in the in-memory cache so subsequent iterations
+    # see the new label as existing (this matters when several old labels
+    # all merge into the same target).
+    if (-not $DryRun) {
+        $oldLabel.name = $new
+        $oldLabel.color = $spec.Color
+        $oldLabel.description = $spec.Description
+    } else {
+        # Dry-run simulation: pretend the rename happened.
+        $existing += [pscustomobject]@{ name = $new; color = $spec.Color; description = $spec.Description }
+        $existing = @($existing | Where-Object { $_.name -ne $old })
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: many-to-one merges
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Phase 2: many-to-one merges ===" -ForegroundColor Cyan
+if (-not $DryRun) { $existing = Get-AllLabels }
+foreach ($old in @($Migration.Keys)) {
+    $new = $Migration[$old]
+    if ($null -eq $new) { continue }
+    $oldLabel = Get-LabelByName -Labels $existing -Name $old
+    if (-not $oldLabel) { continue }
+    $newLabel = Get-LabelByName -Labels $existing -Name $new
+    if (-not $newLabel) { continue }  # shouldn't happen after phase 1
+
+    Write-Host "  m merging '$old' -> '$new'" -ForegroundColor Magenta
+    if ($DryRun) {
+        Write-Host "    [dry-run] would relabel every issue/PR with '$old' and delete '$old'" -ForegroundColor DarkGray
+        $existing = @($existing | Where-Object { $_.name -ne $old })
+        continue
+    }
+
+    # Make sure the target has the canonical color/description first.
+    Ensure-Target -Name $new -Existing $existing
+    Merge-LabelInto -From $old -To $new
+    $existing = Get-AllLabels
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: ensure remaining target labels exist (color/description)
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Phase 3: ensure target taxonomy ===" -ForegroundColor Cyan
+if (-not $DryRun) { $existing = Get-AllLabels }
+foreach ($name in @($Targets.Keys)) {
+    Ensure-Target -Name $name -Existing $existing
+}
+
+# ---------------------------------------------------------------------------
+# Phase 4: pure deletions
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Phase 4: pure deletions ===" -ForegroundColor Cyan
+if (-not $DryRun) { $existing = Get-AllLabels }
+foreach ($old in @($Migration.Keys)) {
+    $new = $Migration[$old]
+    if ($null -ne $new) { continue }
+    $oldLabel = Get-LabelByName -Labels $existing -Name $old
+    if (-not $oldLabel) { continue }
+
+    $items = if ($DryRun) { @() } else { Get-ItemsWithLabel -Label $old }
+    Write-Host "  - deleting '$old' ($($items.Count) item(s) will lose this label)" -ForegroundColor Red
+    Invoke-Gh label delete $old --repo $Repo --yes | Out-Null
+}
+
+# ---------------------------------------------------------------------------
+# Postflight audit
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Postflight audit ===" -ForegroundColor Cyan
+if ($DryRun) {
+    Write-Host "  (skipped in dry-run)" -ForegroundColor DarkGray
+    return
+}
+$final = Get-AllLabels
+$finalNames = @($final | ForEach-Object { $_.name })
+
+$leftover = @($Migration.Keys | Where-Object { $finalNames -contains $_ })
+if ($leftover.Count -gt 0) {
+    Write-Host "  ! migration source labels still present:" -ForegroundColor Red
+    foreach ($n in $leftover) { Write-Host "      - $n" -ForegroundColor Red }
+} else {
+    Write-Host "  OK no migration source labels remain" -ForegroundColor Green
+}
+
+$missing = @($Targets.Keys | Where-Object { $finalNames -notcontains $_ })
+if ($missing.Count -gt 0) {
+    Write-Host "  ! target labels missing from repo:" -ForegroundColor Red
+    foreach ($n in $missing) { Write-Host "      - $n" -ForegroundColor Red }
+} else {
+    Write-Host "  OK every target label exists" -ForegroundColor Green
+}
+
+$orphans = @($finalNames | Where-Object { -not $Targets.Contains($_) })
+if ($orphans.Count -gt 0) {
+    Write-Host "  i labels outside the target taxonomy (left alone):" -ForegroundColor Yellow
+    foreach ($n in ($orphans | Sort-Object)) {
+        $tag = if ($Keep -contains $n) { ' (preserved)' } else { '' }
+        Write-Host "      - $n$tag" -ForegroundColor Yellow
+    }
+}
+
+Write-Host ""
+Write-Host "Done." -ForegroundColor Cyan

--- a/eng/migrate-labels.ps1
+++ b/eng/migrate-labels.ps1
@@ -235,13 +235,19 @@ $Migration = [ordered]@{
     'automation'                    = 'type/automation'
     'ai-inspected'                  = 'type/ai-inspected'
     'Breaking :bangbang:'           = 'type/breaking-change'
+    'bug'                           = 'type/bug'
     'Discussion'                    = 'type/discussion'
     'enhancement'                   = 'type/feature'
+    'feature-request'               = 'type/feature'
     'Flaky-Test'                    = 'type/flaky-test'
     'Partner request'               = 'type/partner-request'
+    'pr-fix'                        = 'type/pr-fix'
+    'qa'                            = 'type/qa'
     'Question'                      = 'type/question'
     'Regression'                    = 'type/regression'
     'RFC'                           = 'type/rfc'
+    'Type: RFC'                     = 'type/rfc'
+    'test'                          = 'type/test-gap'
     'Test Gap'                      = 'type/test-gap'
     'testing'                       = 'type/test-gap'
     'code-health'                   = 'type/tech-debt'
@@ -282,10 +288,12 @@ $Migration = [ordered]@{
     "State: Won't Fix"              = 'resolution/wont-fix'
 
     # Needs
+    'need-triage'                   = 'needs/triage'
     'Needs: Additional Info'        = 'needs/info'
     'Needs: Attention :wave:'       = 'needs/attention'
     'Needs: Author Feedback'        = 'needs/author-feedback'
     'Needs: Design'                 = 'needs/design'
+    'Needs: Triage'                 = 'needs/triage'
     'Needs: Triage :mag:'           = 'needs/triage'
 
     # Priority


### PR DESCRIPTION
## Summary

This PR migrates the repository's GitHub labels from a mix of styles (`Area: Title Case`, `kebab-case`, `State: ...`, `Breaking :bangbang:`, ...) to an idiomatic `prefix/lowercase-kebab` (kubernetes / dotnet-runtime style) taxonomy. Many existing labels also default to the `ededed` gray color, which makes the issue list visually noisy and hard to scan.

### Target taxonomy (one color per prefix)

| Prefix | Color | Examples |
|---|---|---|
| `area/*` | 0052CC blue | `area/analyzers`, `area/mtp`, `area/test-framework` |
| `type/*` | 1D76DB | `type/bug`, `type/feature`, `type/automation`, `type/tech-debt`, `type/test-gap` |
| `external/*` | C5DEF5 | `external/azdo`, `external/vstest`, `external/nuget` |
| `state/*` | 0E8A16 green | `state/in-pr`, `state/blocked`, `state/stale` |
| `resolution/*` | CCCCCC | `resolution/fixed`, `resolution/wont-fix`, `resolution/duplicate` |
| `needs/*` | FBCA04 yellow | `needs/triage`, `needs/author-feedback` |
| `priority/*` | red->green gradient | `priority/0` ... `priority/3` |
| Standalone | varies | `dependencies`, `auto-merge`, `help wanted` (kept verbatim for GH UI surfacing) |

### What is in this PR

1. **Agentic workflow `.md` files** updated so nightly runs emit the new labels (and the `.lock.yml` files were regenerated with `gh aw compile --strict`).
2. **`.github/ISSUE_TEMPLATE/*.md`** updated to reference the new labels.
3. **`.github/policies/*.yml`** updated for both individual label names and the `labelSync` `Area:`/`Type:` prefix patterns (now `area/` / `type/`).
4. **`eng/migrate-labels.ps1`** - script that performs the live migration in 4 safe phases:
   - **Preflight** - fails (unless `-Force`) if any current label is not covered by the migration map or kept-as-is list.
   - **Phase 1: atomic 1:1 renames** - uses `gh label edit --name` so all existing issue/PR associations are preserved natively.
   - **Phase 2: many-to-one merges** - for each old label whose target already exists, re-labels every issue/PR, aborts before deletion if any item failed, verifies zero remaining associations, then deletes the source.
   - **Phase 3: ensure target taxonomy** - creates any remaining targets and normalizes colors/descriptions.
   - **Phase 4: pure deletions** - for the handful of legacy labels with very few items (`Area: Expecto`, `build`, `cross-platform`).
   - **Postflight audit** - verifies no migration source labels remain and lists any labels left outside the target taxonomy.

### Labels intentionally left untouched

- `sprint` (199 items, active project metadata)
- `cla-already-signed` / `cla-not-required` / `cla-required` / `cla-signed` (managed by the central CLA bot)
- `daily-status`, `lean-squad`, `ported-from-ta-repo`, `report` (historical metadata, low risk to keep; can be cleaned up later)

### Migration plan

The migration script will be executed against `microsoft/testfx` immediately after this PR is opened (rename ops only need a single round-trip per label via the GitHub API, and 1:1 renames preserve all issue/PR associations).
