### PR TITLE
Use args passed to CreateBuilderAsync in GetCurrentExecutableInfo

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs
@@ -95,7 +95,7 @@ public sealed class TestApplication : ITestApplication
         }
 
         TestHostControllerInfo testHostControllerInfo = new(parseResult);
-        CurrentTestApplicationModuleInfo testApplicationModuleInfo = new(systemEnvironment, systemProcess);
+        CurrentTestApplicationModuleInfo testApplicationModuleInfo = new(systemEnvironment, systemProcess, args);
 
         // Create the UnhandledExceptionHandler that will be set inside the TestHostBuilder.
         LazyInitializer.EnsureInitialized(ref s_unhandledExceptionHandler, () => new UnhandledExceptionHandler(systemEnvironment, systemConsole, parseResult.IsOptionSet(PlatformCommandLineProvider.TestHostControllerPIDOptionKey)));
@@ -112,7 +112,7 @@ public sealed class TestApplication : ITestApplication
         }
 
         // All checks are fine, create the TestApplication.
-        return new TestApplicationBuilder(loggingState, createBuilderStart, testApplicationOptions, s_unhandledExceptionHandler);
+        return new TestApplicationBuilder(loggingState, createBuilderStart, testApplicationOptions, s_unhandledExceptionHandler, args);
     }
 
     private static async Task LogInformationAsync(

--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
@@ -38,9 +38,10 @@ internal sealed class TestApplicationBuilder : ITestApplicationBuilder
         ApplicationLoggingState loggingState,
         DateTimeOffset createBuilderStart,
         TestApplicationOptions testApplicationOptions,
-        IUnhandledExceptionsHandler unhandledExceptionsHandler)
+        IUnhandledExceptionsHandler unhandledExceptionsHandler,
+        string[] args)
     {
-        _testHostBuilder = new TestHostBuilder(new SystemFileSystem(), new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler(), new CurrentTestApplicationModuleInfo(new SystemEnvironment(), new SystemProcessHandler()));
+        _testHostBuilder = new TestHostBuilder(new SystemFileSystem(), new SystemRuntimeFeature(), new SystemEnvironment(), new SystemProcessHandler(), new CurrentTestApplicationModuleInfo(new SystemEnvironment(), new SystemProcessHandler(), args));
         _createBuilderStart = createBuilderStart;
         _loggingState = loggingState;
         _testApplicationOptions = testApplicationOptions;

--- a/src/Platform/Microsoft.Testing.Platform/Services/CurrentTestApplicationModuleInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/CurrentTestApplicationModuleInfo.cs
@@ -5,11 +5,24 @@ using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.Services;
 
-internal sealed class CurrentTestApplicationModuleInfo(IEnvironment environment, IProcessHandler process) : ITestApplicationModuleInfo
+internal sealed class CurrentTestApplicationModuleInfo : ITestApplicationModuleInfo
 {
-    private readonly IEnvironment _environment = environment;
-    private readonly IProcessHandler _process = process;
+    private readonly IEnvironment _environment;
+    private readonly IProcessHandler _process;
+    private readonly string[]? _commandLineArguments;
     private static readonly string[] MuxerExec = ["exec"];
+
+    public CurrentTestApplicationModuleInfo(IEnvironment environment, IProcessHandler process)
+        : this(environment, process, commandLineArguments: null)
+    {
+    }
+
+    public CurrentTestApplicationModuleInfo(IEnvironment environment, IProcessHandler process, string[]? commandLineArguments)
+    {
+        _environment = environment;
+        _process = process;
+        _commandLineArguments = commandLineArguments;
+    }
 
     public bool IsCurrentTestApplicationHostDotnetMuxer
     {
@@ -102,16 +115,49 @@ internal sealed class CurrentTestApplicationModuleInfo(IEnvironment environment,
     {
         bool isDotnetMuxer = IsCurrentTestApplicationHostDotnetMuxer;
         bool isAppHost = IsAppHostOrSingleFileOrNativeAot;
-        string[] commandLineArguments = _environment.GetCommandLineArgs();
-        IEnumerable<string> arguments = (isAppHost, isDotnetMuxer) switch
+
+        // Prefer the arguments that were passed to TestApplication.CreateBuilderAsync over
+        // Environment.GetCommandLineArgs(). This way a custom Main that mutates the args
+        // (e.g. injecting defaults) sees its modifications reflected when an extension such as
+        // the Retry extension needs to relaunch the test host with the same configuration.
+        // Environment.GetCommandLineArgs() is still consulted to recover the dll path for the
+        // dotnet/mono muxer cases since that information isn't part of the args passed to Main.
+        IEnumerable<string> arguments;
+        if (_commandLineArguments is { } passedArgs)
         {
-            // When executable
-            (true, _) => commandLineArguments.Skip(1),
-            // When dotnet
-            (_, true) => MuxerExec.Concat(commandLineArguments),
-            // Otherwise
-            _ => commandLineArguments,
-        };
+            if (isAppHost)
+            {
+                arguments = passedArgs;
+            }
+            else if (isDotnetMuxer)
+            {
+                string[] envArgs = _environment.GetCommandLineArgs();
+                arguments = envArgs.Length > 0
+                    ? [.. MuxerExec, envArgs[0], .. passedArgs]
+                    : [.. MuxerExec, .. passedArgs];
+            }
+            else
+            {
+                // Mono muxer: prepend the dll path (envArgs[0]) before user-supplied args.
+                string[] envArgs = _environment.GetCommandLineArgs();
+                arguments = envArgs.Length > 0
+                    ? [envArgs[0], .. passedArgs]
+                    : passedArgs;
+            }
+        }
+        else
+        {
+            string[] commandLineArguments = _environment.GetCommandLineArgs();
+            arguments = (isAppHost, isDotnetMuxer) switch
+            {
+                // When executable
+                (true, _) => commandLineArguments.Skip(1),
+                // When dotnet
+                (_, true) => MuxerExec.Concat(commandLineArguments),
+                // Otherwise
+                _ => commandLineArguments,
+            };
+        }
 
         return new ExecutableInfo(GetProcessPath(), arguments, GetCurrentTestApplicationDirectory());
     }

--- a/src/Platform/Microsoft.Testing.Platform/Services/CurrentTestApplicationModuleInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/CurrentTestApplicationModuleInfo.cs
@@ -21,7 +21,10 @@ internal sealed class CurrentTestApplicationModuleInfo : ITestApplicationModuleI
     {
         _environment = environment;
         _process = process;
-        _commandLineArguments = commandLineArguments;
+
+        // Take a snapshot so later mutations of the caller's array don't affect
+        // GetCurrentExecutableInfo (and ExecutableInfo.Arguments exposes IEnumerable<string>).
+        _commandLineArguments = commandLineArguments is null ? null : (string[])commandLineArguments.Clone();
     }
 
     public bool IsCurrentTestApplicationHostDotnetMuxer

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+[UnsupportedOSPlatform("browser")]
+public sealed class CurrentTestApplicationModuleInfoTests
+{
+    [TestMethod]
+    public void GetCurrentExecutableInfo_AppHost_NoPassedArgs_UsesEnvironmentArgsSkippingProcessPath()
+    {
+        Mock<IEnvironment> environment = CreateAppHostEnvironment(["myapp.exe", "--filter", "MyTest"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler());
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "--filter", "MyTest" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_AppHost_WithPassedArgs_UsesPassedArgsInsteadOfEnvironmentArgs()
+    {
+        // Simulate a custom Main that mutates args (e.g. inserting default options) before
+        // forwarding them to TestApplication.CreateBuilderAsync.
+        Mock<IEnvironment> environment = CreateAppHostEnvironment(["myapp.exe"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), ["--retry-failed-tests", "1"]);
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_AppHost_WithEmptyPassedArgs_ReturnsEmpty()
+    {
+        Mock<IEnvironment> environment = CreateAppHostEnvironment(["myapp.exe", "--filter", "MyTest"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), []);
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        Assert.IsEmpty(executable.Arguments);
+    }
+
+#if NETCOREAPP
+    [TestMethod]
+    public void GetCurrentExecutableInfo_DotnetMuxer_NoPassedArgs_PrependsExecToEnvironmentArgs()
+    {
+        Mock<IEnvironment> environment = CreateDotnetMuxerEnvironment(["myapp.dll", "--filter", "MyTest"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler());
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "exec", "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_DotnetMuxer_WithPassedArgs_KeepsDllPathAndUsesPassedArgs()
+    {
+        // For the dotnet muxer case we still need to know which dll to launch, so we recover that
+        // from Environment.GetCommandLineArgs()[0]. The args that follow come from the user.
+        Mock<IEnvironment> environment = CreateDotnetMuxerEnvironment(["myapp.dll"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), ["--retry-failed-tests", "1"]);
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "exec", "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+    }
+
+    private static Mock<IEnvironment> CreateDotnetMuxerEnvironment(string[] commandLineArgs)
+    {
+        Mock<IEnvironment> environment = new();
+        environment.SetupGet(e => e.ProcessPath).Returns(Path.Combine("some", "directory", "dotnet.exe"));
+        environment.Setup(e => e.GetCommandLineArgs()).Returns(commandLineArgs);
+        return environment;
+    }
+#endif
+
+    private static Mock<IEnvironment> CreateAppHostEnvironment(string[] commandLineArgs)
+    {
+        Mock<IEnvironment> environment = new();
+#if NETCOREAPP
+        environment.SetupGet(e => e.ProcessPath).Returns(Path.Combine("some", "directory", "myapp.exe"));
+#endif
+        environment.Setup(e => e.GetCommandLineArgs()).Returns(commandLineArgs);
+        return environment;
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
@@ -77,10 +77,86 @@ public sealed class CurrentTestApplicationModuleInfoTests
         CollectionAssert.AreEqual(new[] { "exec", "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
+    [TestMethod]
+    public void GetCurrentExecutableInfo_DotnetMuxer_WithPassedArgsAndEmptyEnvironmentArgs_FallsBackToExecPlusPassedArgs()
+    {
+        Mock<IEnvironment> environment = CreateDotnetMuxerEnvironment([]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), ["--retry-failed-tests", "1"]);
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "exec", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_MonoMuxer_NoPassedArgs_UsesEnvironmentArgsAsIs()
+    {
+        Mock<IEnvironment> environment = CreateMonoMuxerEnvironment(["myapp.dll", "--filter", "MyTest"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler());
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_MonoMuxer_WithPassedArgs_KeepsDllPathAndUsesPassedArgs()
+    {
+        // Same as the dotnet muxer case: we need to keep the dll path (envArgs[0]) so mono knows
+        // which assembly to run, but the rest of the arguments must come from the user-supplied args.
+        Mock<IEnvironment> environment = CreateMonoMuxerEnvironment(["myapp.dll", "--filter", "MyTest"]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), ["--retry-failed-tests", "1"]);
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_MonoMuxer_WithPassedArgsAndEmptyEnvironmentArgs_FallsBackToPassedArgs()
+    {
+        Mock<IEnvironment> environment = CreateMonoMuxerEnvironment([]);
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), ["--retry-failed-tests", "1"]);
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public void GetCurrentExecutableInfo_PassedArgsAreSnapshotted_CallerMutationDoesNotAffectResult()
+    {
+        // The constructor should take a defensive copy of the passed args so that later
+        // mutations of the caller's array don't change what GetCurrentExecutableInfo returns.
+        Mock<IEnvironment> environment = CreateAppHostEnvironment(["myapp.exe"]);
+        string[] passedArgs = ["--retry-failed-tests", "1"];
+
+        CurrentTestApplicationModuleInfo info = new(environment.Object, new SystemProcessHandler(), passedArgs);
+
+        passedArgs[0] = "--mutated";
+        passedArgs[1] = "999";
+
+        ExecutableInfo executable = info.GetCurrentExecutableInfo();
+
+        CollectionAssert.AreEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+    }
+
     private static Mock<IEnvironment> CreateDotnetMuxerEnvironment(string[] commandLineArgs)
     {
         Mock<IEnvironment> environment = new();
         environment.SetupGet(e => e.ProcessPath).Returns(Path.Combine("some", "directory", "dotnet.exe"));
+        environment.Setup(e => e.GetCommandLineArgs()).Returns(commandLineArgs);
+        return environment;
+    }
+
+    private static Mock<IEnvironment> CreateMonoMuxerEnvironment(string[] commandLineArgs)
+    {
+        Mock<IEnvironment> environment = new();
+        environment.SetupGet(e => e.ProcessPath).Returns(Path.Combine("some", "directory", "mono.exe"));
         environment.Setup(e => e.GetCommandLineArgs()).Returns(commandLineArgs);
         return environment;
     }


### PR DESCRIPTION
Fixes #5239.

Previously, `CurrentTestApplicationModuleInfo.GetCurrentExecutableInfo` derived its arguments from `Environment.GetCommandLineArgs()`. If a custom `Main` mutated the args before forwarding them to `TestApplication.CreateBuilderAsync` (for example, to inject `--retry-failed-tests 1` as a default), the platform options reflected the mutation but the executable info did not. Extensions like Retry that re-launch the test host using these arguments would then throw.

### Fix

`CurrentTestApplicationModuleInfo` now accepts the args passed to `CreateBuilderAsync` and uses them when computing `GetCurrentExecutableInfo`. The DLL path is still recovered from `Environment.GetCommandLineArgs()[0]` for the `dotnet`/`mono` muxer cases, preserving the existing behavior when running under `dotnet.exe`.

### Repro from the issue

```csharp
if (args.Length == 0)
{
    args = ["--retry-failed-tests", "1"];
}

var builder = await TestApplication.CreateBuilderAsync(args);
SelfRegisteredExtensions.AddSelfRegisteredExtensions(builder, args);
using var app = await builder.BuildAsync();
return await app.RunAsync();
```

With the fix, the Retry extension now sees `[--retry-failed-tests, 1]` in the executable info regardless of what was on the OS command line.

### Tests

Added `CurrentTestApplicationModuleInfoTests` covering the AppHost and dotnet muxer paths with and without user-passed args (5 new tests). 290 related unit tests continue to pass.
