### PR TITLE
Refactor TestClassModelBuilder.BuildAttributes to a LINQ pipeline

### DIFF
--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -117,17 +117,11 @@ internal static class TestClassModelBuilder
             return EquatableArray<AttributeApplicationModel>.Empty;
         }
 
-        ImmutableArray<AttributeApplicationModel>.Builder builder = ImmutableArray.CreateBuilder<AttributeApplicationModel>(attributes.Length);
-        foreach (AttributeData attribute in attributes)
-        {
-            AttributeApplicationModel? model = BuildAttribute(attribute);
-            if (model is not null)
-            {
-                builder.Add(model);
-            }
-        }
-
-        return new EquatableArray<AttributeApplicationModel>(builder.ToImmutable());
+        return attributes
+            .Select(BuildAttribute)
+            .Where(static model => model is not null)
+            .Select(static model => model!)
+            .ToEquatableArray();
     }
 
     private static AttributeApplicationModel? BuildAttribute(AttributeData attribute)

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -119,8 +119,7 @@ internal static class TestClassModelBuilder
 
         return attributes
             .Select(BuildAttribute)
-            .Where(static model => model is not null)
-            .Select(static model => model!)
+            .WhereNotNull()
             .ToEquatableArray();
     }
 

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
@@ -131,7 +131,13 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>
 
 internal static class EquatableArrayExtensions
 {
+    private static readonly Func<object?, bool> NotNullTest = x => x is not null;
+
     public static EquatableArray<T> ToEquatableArray<T>(this IEnumerable<T> source)
         where T : IEquatable<T>
         => new(source.ToImmutableArray());
+
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
+        where T : class
+        => source.Where((Func<T?, bool>)NotNullTest)!;
 }


### PR DESCRIPTION
Address code-quality bot feedback on PR #8574: replace the manual `foreach` + `ImmutableArray<AttributeApplicationModel>.Builder` loop in `TestClassModelBuilder.BuildAttributes` with an explicit `Select` / `Where` / `Select` / `ToEquatableArray` LINQ pipeline.

See discussion: https://github.com/microsoft/testfx/pull/8574#discussion_r3299121414.

No behavior change; no new imports needed (`System.Linq` is already imported and `ToEquatableArray` accepts `IEnumerable<T>`).
