### PR TITLE
Add two-stage Ctrl+C cancellation UX (#5345)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -85,6 +85,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
             () =>
             {
                 ConsoleLog(PlatformResources.CancellingTestSession);
+                ConsoleLog(PlatformResources.PressCtrlCAgainToForceExit);
                 return Task.CompletedTask;
             }).ConfigureAwait(false);
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -167,6 +167,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
         {
             terminal.AppendLine();
             terminal.AppendLine(PlatformResources.CancellingTestSession);
+            terminal.AppendLine(PlatformResources.PressCtrlCAgainToForceExit);
             terminal.AppendLine();
         });
     }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -127,7 +127,11 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
             // stdout, corrupting the JSON document. Route a single-line cancellation notice
             // to stderr instead so the user still gets feedback on Ctrl+C.
             await _policiesService.RegisterOnAbortCallbackAsync(
-                () => WriteToStandardErrorAsync(PlatformResources.CancellingTestSession)).ConfigureAwait(false);
+                async () =>
+                {
+                    await WriteToStandardErrorAsync(PlatformResources.CancellingTestSession).ConfigureAwait(false);
+                    await WriteToStandardErrorAsync(PlatformResources.PressCtrlCAgainToForceExit).ConfigureAwait(false);
+                }).ConfigureAwait(false);
         }
         else
         {

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -522,6 +522,9 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
   <data name="CancellingTestSession" xml:space="preserve">
     <value>Canceling the test session...</value>
   </data>
+  <data name="PressCtrlCAgainToForceExit" xml:space="preserve">
+    <value>Press Ctrl+C again to force exit.</value>
+  </data>
   <data name="DiagnosticFileLevelWithAsyncFlush" xml:space="preserve">
     <value>Diagnostic file (level '{0}' with async flush): {1}</value>
     <comment>0 level such as verbose,

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Může mít jenom jeden argument jako řetězec ve formátu &lt;value&gt;[h|m|s], kde value je hodnota datového typu float.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Proces měl být ukončen před tím, než jsme mohli určit tuto hodnotu.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Nimmt ein Argument als Zeichenfolge im Format &lt;value&gt;[h|m|s], wobei "value" auf "float" festgelegt ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Der Prozess hätte beendet werden müssen, bevor dieser Wert ermittelt werden kann</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Toma un argumento como cadena con el formato &lt;value&gt;[h|m|s] donde 'value' es float.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">El proceso debería haberse terminado para poder determinar este valor</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Prend un argument sous forme de chaîne au format &lt;value&gt;[h|m|s] où « value » est float.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Le processus aurait dû s’arrêter avant que nous puissions déterminer cette valeur</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Acquisisce un argomento come stringa nel formato &lt;value&gt;[h|m|s] dove 'value' è float.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Il processo dovrebbe essere terminato prima di poter determinare questo valore</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -686,6 +686,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 1 つの引数を文字列として &lt;value&gt;[h|m|s] の形式で使用します。この場合、'value' は float です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">この値を決定する前にプロセスを終了する必要があります</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 'value'가 float인 &lt;value&gt;[h|m|s] 형식의 문자열로 인수 하나를 사용합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">이 값을 결정하려면 프로세스가 종료되어야 합니다.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Pobiera jeden argument jako ciąg w formacie &lt;value&gt;[h|m|s], gdzie element „value” ma wartość zmiennoprzecinkową.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Proces powinien zakończyć się przed ustaleniem tej wartości</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Recebe um argumento como cadeia de caracteres no formato &lt;valor&gt;[h|m|s] em que 'valor' é float.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">O processo deve ter sido encerrado antes que possamos determinar esse valor</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Принимает один аргумент в виде строки в формате &lt;value&gt;[h|m|s], где "value" — число с плавающей точкой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Процесс должен быть завершен, прежде чем мы сможем определить это значение</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 Bir bağımsız değişkeni, 'value' değerinin kayan olduğu &lt;value&gt;[h|m|s] biçiminde dize olarak alır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">Bu değeri belirleyebilmemiz için süreçten çıkılmış olması gerekir</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 获取一个字符串形式的参数，格式为 &lt;value&gt;[h|m|s]，其中 "value" 为浮点型。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">在我们确定此值之前，流程应该已退出</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -685,6 +685,11 @@ Takes one argument as string in the format &lt;value&gt;[h|m|s] where 'value' is
 將一個引數作為字串，格式為 &lt;value&gt;[h|m|s]，其中 'value' 為 float。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PressCtrlCAgainToForceExit">
+        <source>Press Ctrl+C again to force exit.</source>
+        <target state="new">Press Ctrl+C again to force exit.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProcessHasNotYetExitedErrorMessage">
         <source>Process should have exited before we can determine this value</source>
         <target state="translated">在我們確定此值之前，流程應已結束</target>

--- a/src/Platform/Microsoft.Testing.Platform/Services/CTRLPlusCCancellationTokenSource.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/CTRLPlusCCancellationTokenSource.cs
@@ -8,16 +8,23 @@ namespace Microsoft.Testing.Platform.Services;
 
 internal sealed class CTRLPlusCCancellationTokenSource : ITestApplicationCancellationTokenSource, IDisposable
 {
-    private readonly CancellationTokenSource _cancellationTokenSource = new();
-    private readonly ILogger? _logger;
+    private const int StateIdle = 0;
+    private const int StateCancelling = 1;
+    private const int StateForcing = 2;
 
-    public CTRLPlusCCancellationTokenSource(IConsole? console = null, ILogger? logger = null)
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly IEnvironment _environment;
+    private readonly ILogger? _logger;
+    private int _state = StateIdle;
+
+    public CTRLPlusCCancellationTokenSource(IConsole? console = null, ILogger? logger = null, IEnvironment? environment = null)
     {
         if (console is not null && !IsCancelKeyPressNotSupported())
         {
             console.CancelKeyPress += OnConsoleCancelKeyPressed;
         }
 
+        _environment = environment ?? new SystemEnvironment();
         _logger = logger;
     }
 
@@ -40,7 +47,36 @@ internal sealed class CTRLPlusCCancellationTokenSource : ITestApplicationCancell
 
     private void OnConsoleCancelKeyPressed(object? sender, ConsoleCancelEventArgs e)
     {
+        // Suppress the runtime's default Ctrl+C handling so we control the exit code on
+        // both the first (cooperative) and the second (force-exit) press.
         e.Cancel = true;
+
+        // If cancellation is already in progress (from a previous Ctrl+C or from another source
+        // like a timeout), treat this Ctrl+C as a request to force-exit the process. This honors
+        // the contract advertised next to the "Cancelling..." message: "Press Ctrl+C again to
+        // force exit.".
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            if (Interlocked.Exchange(ref _state, StateForcing) == StateForcing)
+            {
+                // Another Ctrl+C already triggered the force-exit; suppress the duplicate.
+                return;
+            }
+
+            // We intentionally do not print an extra "Forcing exit..." message here because the
+            // IConsole abstraction has no stderr channel and writing to stdout would corrupt the
+            // JSON document produced by --list-tests json. The user already saw the
+            // "Press Ctrl+C again to force exit." hint, so the exit itself is the confirmation.
+            _environment.Exit((int)ExitCode.TestSessionAborted);
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _state, StateCancelling, StateIdle) != StateIdle)
+        {
+            // Another thread already transitioned the state; nothing to do.
+            return;
+        }
+
         try
         {
             _cancellationTokenSource.Cancel();

--- a/src/Platform/Microsoft.Testing.Platform/Services/CTRLPlusCCancellationTokenSource.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/CTRLPlusCCancellationTokenSource.cs
@@ -15,13 +15,16 @@ internal sealed class CTRLPlusCCancellationTokenSource : ITestApplicationCancell
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly IEnvironment _environment;
     private readonly ILogger? _logger;
+    private readonly IConsole? _subscribedConsole;
     private int _state = StateIdle;
+    private int _disposed;
 
     public CTRLPlusCCancellationTokenSource(IConsole? console = null, ILogger? logger = null, IEnvironment? environment = null)
     {
         if (console is not null && !IsCancelKeyPressNotSupported())
         {
             console.CancelKeyPress += OnConsoleCancelKeyPressed;
+            _subscribedConsole = console;
         }
 
         _environment = environment ?? new SystemEnvironment();
@@ -51,44 +54,56 @@ internal sealed class CTRLPlusCCancellationTokenSource : ITestApplicationCancell
         // both the first (cooperative) and the second (force-exit) press.
         e.Cancel = true;
 
-        // If cancellation is already in progress (from a previous Ctrl+C or from another source
-        // like a timeout), treat this Ctrl+C as a request to force-exit the process. This honors
-        // the contract advertised next to the "Cancelling..." message: "Press Ctrl+C again to
-        // force exit.".
-        if (_cancellationTokenSource.IsCancellationRequested)
+        // The state machine counts user Ctrl+C presses *independently* of external cancellation
+        // sources (timeout, max-failed-tests, explicit Cancel()). This honors the contract
+        // advertised next to the "Cancelling..." message ("Press Ctrl+C again to force exit.")
+        // regardless of who initiated the cancellation: the user must always press Ctrl+C twice
+        // to force-exit.
+        if (Interlocked.CompareExchange(ref _state, StateCancelling, StateIdle) == StateIdle)
         {
-            if (Interlocked.Exchange(ref _state, StateForcing) == StateForcing)
+            // First user Ctrl+C: cooperative cancellation. If the token was already cancelled
+            // by an external source this is effectively a no-op, but we still transitioned the
+            // state so the next press goes to force-exit.
+            try
             {
-                // Another Ctrl+C already triggered the force-exit; suppress the duplicate.
-                return;
+                _cancellationTokenSource.Cancel();
+            }
+            catch (AggregateException ex)
+            {
+                _logger?.LogWarning($"Exception during CTRLPlusCCancellationTokenSource cancel:\n{ex}");
             }
 
-            // We intentionally do not print an extra "Forcing exit..." message here because the
-            // IConsole abstraction has no stderr channel and writing to stdout would corrupt the
-            // JSON document produced by --list-tests json. The user already saw the
-            // "Press Ctrl+C again to force exit." hint, so the exit itself is the confirmation.
+            return;
+        }
+
+        // Second user Ctrl+C: force-exit. We intentionally do not print an extra
+        // "Forcing exit..." message here because the IConsole abstraction has no stderr channel
+        // and writing to stdout would corrupt the JSON document produced by --list-tests json.
+        // The user already saw the "Press Ctrl+C again to force exit." hint, so the exit itself
+        // is the confirmation. Any subsequent presses are suppressed by the StateForcing guard.
+        if (Interlocked.CompareExchange(ref _state, StateForcing, StateCancelling) == StateCancelling)
+        {
             _environment.Exit((int)ExitCode.TestSessionAborted);
-            return;
-        }
-
-        if (Interlocked.CompareExchange(ref _state, StateCancelling, StateIdle) != StateIdle)
-        {
-            // Another thread already transitioned the state; nothing to do.
-            return;
-        }
-
-        try
-        {
-            _cancellationTokenSource.Cancel();
-        }
-        catch (AggregateException ex)
-        {
-            _logger?.LogWarning($"Exception during CTRLPlusCCancellationTokenSource cancel:\n{ex}");
         }
     }
 
     public void Dispose()
-        => _cancellationTokenSource.Dispose();
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        // We stored the console reference only when subscription was actually performed
+        // (i.e. when CancelKeyPress is supported on this platform), so we can safely call -=
+        // on the same supported-platform paths.
+        if (_subscribedConsole is not null && !IsCancelKeyPressNotSupported())
+        {
+            _subscribedConsole.CancelKeyPress -= OnConsoleCancelKeyPressed;
+        }
+
+        _cancellationTokenSource.Dispose();
+    }
 
     public void Cancel()
         => _cancellationTokenSource.Cancel();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CTRLPlusCCancellationTokenSourceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CTRLPlusCCancellationTokenSourceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Platform.UnitTests;
@@ -37,7 +38,7 @@ public sealed class CTRLPlusCCancellationTokenSourceTests
     }
 
     [TestMethod]
-    public void CtrlC_WhileCancellationAlreadyTriggeredExternally_TriggersForceExit()
+    public void CtrlC_AfterExternalCancel_DoesNotForceExit_ButSecondCtrlCDoes()
     {
         var console = new CancelableConsole();
         var environment = new RecordingEnvironment();
@@ -46,8 +47,13 @@ public sealed class CTRLPlusCCancellationTokenSourceTests
         // Simulate cancellation from another source (timeout, max-failed-tests, etc.).
         source.Cancel();
 
+        // The user has not yet seen the "Press Ctrl+C again to force exit." hint, so the first
+        // user Ctrl+C must not force-exit — it should be treated as the first cooperative press.
         console.FireCancelKeyPress();
+        Assert.IsNull(environment.ExitCode, "First user Ctrl+C must not force-exit even when cancellation was already requested externally.");
 
+        // The second user Ctrl+C should then force-exit.
+        console.FireCancelKeyPress();
         Assert.AreEqual((int)ExitCode.TestSessionAborted, environment.ExitCode);
     }
 
@@ -67,6 +73,78 @@ public sealed class CTRLPlusCCancellationTokenSourceTests
         Assert.AreEqual((int)ExitCode.TestSessionAborted, environment.ExitCode);
     }
 
+    [TestMethod]
+    public void FirstCtrlC_WhenCancelCallbackThrows_LogsWarningAndSuppressesException()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        var logger = new RecordingLogger();
+        using var source = new CTRLPlusCCancellationTokenSource(console, logger, environment);
+
+        // Registering a throwing callback on the token causes CancellationTokenSource.Cancel()
+        // to throw AggregateException, exercising the catch/log path in OnConsoleCancelKeyPressed.
+        source.CancellationToken.Register(() => throw new InvalidOperationException("boom"));
+
+        console.FireCancelKeyPress();
+
+        Assert.IsTrue(source.CancellationToken.IsCancellationRequested);
+        Assert.IsNull(environment.ExitCode, "First Ctrl+C must not force-exit even when the cancel callback throws.");
+        Assert.AreEqual(1, logger.WarningCount, "The AggregateException must be logged as a warning.");
+        Assert.IsNotNull(logger.LastWarning);
+        Assert.Contains("CTRLPlusCCancellationTokenSource cancel", logger.LastWarning!);
+    }
+
+    [TestMethod]
+    public void ConcurrentFirstCtrlC_OnlyTransitionsStateOnce_AndAllPressesCombinedNeverExitMoreThanOnce()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        using var source = new CTRLPlusCCancellationTokenSource(console, logger: null, environment);
+
+        // Registering a callback on the token lets us count how many times the underlying
+        // CancellationTokenSource.Cancel() was actually invoked. The state machine guarantees
+        // only the first thread that wins the StateIdle -> StateCancelling transition calls
+        // Cancel(), so the callback must fire exactly once even under heavy contention.
+        int cancelCallbackInvocations = 0;
+        source.CancellationToken.Register(() => Interlocked.Increment(ref cancelCallbackInvocations));
+
+        Parallel.For(0, 16, _ => console.FireCancelKeyPress());
+
+        Assert.IsTrue(source.CancellationToken.IsCancellationRequested);
+        Assert.AreEqual(1, cancelCallbackInvocations, "Only the thread that wins the state transition must call Cancel().");
+        Assert.AreEqual(1, environment.ExitCallCount, "Across many concurrent presses Exit() must be called at most once.");
+    }
+
+    [TestMethod]
+    public void Constructor_WithNullConsole_DoesNotCrash_AndCancelStillWorks()
+    {
+        var environment = new RecordingEnvironment();
+        using var source = new CTRLPlusCCancellationTokenSource(console: null, logger: null, environment);
+
+        source.Cancel();
+
+        Assert.IsTrue(source.CancellationToken.IsCancellationRequested);
+        Assert.IsNull(environment.ExitCode, "Without a console there is no Ctrl+C handler and Exit must never be called.");
+    }
+
+    [TestMethod]
+    public void Dispose_UnsubscribesCancelKeyPressHandler()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        var source = new CTRLPlusCCancellationTokenSource(console, logger: null, environment);
+
+        source.Dispose();
+
+        // After disposal the handler must be detached so a late Ctrl+C cannot touch the disposed
+        // CancellationTokenSource (which would throw ObjectDisposedException).
+        Assert.IsFalse(console.HasCancelKeyPressSubscribers);
+
+        // Firing the event after dispose must be a no-op.
+        console.FireCancelKeyPress();
+        Assert.IsNull(environment.ExitCode);
+    }
+
     private sealed class CancelableConsole : IConsole
     {
         public event ConsoleCancelEventHandler? CancelKeyPress;
@@ -80,6 +158,8 @@ public sealed class CTRLPlusCCancellationTokenSourceTests
         public int WindowWidth => int.MaxValue;
 
         public bool IsOutputRedirected => false;
+
+        public bool HasCancelKeyPressSubscribers => CancelKeyPress is not null;
 
         public void FireCancelKeyPress()
         {
@@ -181,6 +261,32 @@ public sealed class CTRLPlusCCancellationTokenSourceTests
 
             // The real implementation never returns; ours does, so subsequent presses still
             // observe ExitCallCount accurately for the test.
+        }
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        private int _warningCount;
+
+        public int WarningCount => _warningCount;
+
+        public string? LastWarning { get; private set; }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                Interlocked.Increment(ref _warningCount);
+                LastWarning = formatter(state, exception);
+            }
+        }
+
+        public Task LogAsync<TState>(LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Log(logLevel, state, exception, formatter);
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CTRLPlusCCancellationTokenSourceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CTRLPlusCCancellationTokenSourceTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class CTRLPlusCCancellationTokenSourceTests
+{
+    [TestMethod]
+    public void FirstCtrlC_CancelsToken_AndDoesNotExitProcess()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        using var source = new CTRLPlusCCancellationTokenSource(console, logger: null, environment);
+
+        console.FireCancelKeyPress();
+
+        Assert.IsTrue(source.CancellationToken.IsCancellationRequested);
+        Assert.IsNull(environment.ExitCode, "Environment.Exit must not be called on the first Ctrl+C press.");
+    }
+
+    [TestMethod]
+    public void SecondCtrlC_TriggersForceExit_WithTestSessionAbortedExitCode()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        using var source = new CTRLPlusCCancellationTokenSource(console, logger: null, environment);
+
+        console.FireCancelKeyPress();
+        console.FireCancelKeyPress();
+
+        Assert.IsTrue(source.CancellationToken.IsCancellationRequested);
+        Assert.AreEqual((int)ExitCode.TestSessionAborted, environment.ExitCode);
+    }
+
+    [TestMethod]
+    public void CtrlC_WhileCancellationAlreadyTriggeredExternally_TriggersForceExit()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        using var source = new CTRLPlusCCancellationTokenSource(console, logger: null, environment);
+
+        // Simulate cancellation from another source (timeout, max-failed-tests, etc.).
+        source.Cancel();
+
+        console.FireCancelKeyPress();
+
+        Assert.AreEqual((int)ExitCode.TestSessionAborted, environment.ExitCode);
+    }
+
+    [TestMethod]
+    public void RepeatedCtrlC_AfterForceExit_DoesNotCallExitAgain()
+    {
+        var console = new CancelableConsole();
+        var environment = new RecordingEnvironment();
+        using var source = new CTRLPlusCCancellationTokenSource(console, logger: null, environment);
+
+        console.FireCancelKeyPress();
+        console.FireCancelKeyPress();
+        console.FireCancelKeyPress();
+        console.FireCancelKeyPress();
+
+        Assert.AreEqual(1, environment.ExitCallCount);
+        Assert.AreEqual((int)ExitCode.TestSessionAborted, environment.ExitCode);
+    }
+
+    private sealed class CancelableConsole : IConsole
+    {
+        public event ConsoleCancelEventHandler? CancelKeyPress;
+
+        public int BufferHeight => int.MaxValue;
+
+        public int BufferWidth => int.MaxValue;
+
+        public int WindowHeight => int.MaxValue;
+
+        public int WindowWidth => int.MaxValue;
+
+        public bool IsOutputRedirected => false;
+
+        public void FireCancelKeyPress()
+        {
+            ConsoleCancelEventHandler? handler = CancelKeyPress;
+            handler?.Invoke(this, CreateConsoleCancelEventArgs());
+        }
+
+        public void Clear() => throw new NotImplementedException();
+
+        public ConsoleColor GetForegroundColor() => ConsoleColor.White;
+
+        public void SetForegroundColor(ConsoleColor color)
+        {
+            // do nothing
+        }
+
+        public void Write(string? value)
+        {
+            // do nothing
+        }
+
+        public void Write(char value)
+        {
+            // do nothing
+        }
+
+        public void WriteLine()
+        {
+            // do nothing
+        }
+
+        public void WriteLine(string? value)
+        {
+            // do nothing
+        }
+
+        // ConsoleCancelEventArgs has no public constructor; use reflection to instantiate it
+        // for the purposes of the test.
+        private static ConsoleCancelEventArgs CreateConsoleCancelEventArgs()
+        {
+            ConstructorInfo? constructor = typeof(ConsoleCancelEventArgs).GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: [typeof(ConsoleSpecialKey)],
+                modifiers: null);
+
+            Assert.IsNotNull(constructor, "Failed to locate internal ConsoleCancelEventArgs constructor.");
+            return (ConsoleCancelEventArgs)constructor.Invoke([ConsoleSpecialKey.ControlC]);
+        }
+    }
+
+    private sealed class RecordingEnvironment : IEnvironment
+    {
+        public int? ExitCode { get; private set; }
+
+        public int ExitCallCount { get; private set; }
+
+        public string CommandLine => string.Empty;
+
+        public string MachineName => string.Empty;
+
+        public string NewLine => Environment.NewLine;
+
+        public int ProcessId => 0;
+
+        public string OsVersion => string.Empty;
+
+#if NETCOREAPP
+        public string? ProcessPath => null;
+#endif
+
+        public string[] GetCommandLineArgs() => [];
+
+        public string? GetEnvironmentVariable(string name) => null;
+
+        public IDictionary GetEnvironmentVariables() => new Dictionary<string, string>();
+
+        public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => string.Empty;
+
+        public void FailFast(string? message, Exception? exception)
+        {
+            // do nothing
+        }
+
+        public void FailFast(string? message)
+        {
+            // do nothing
+        }
+
+        public void SetEnvironmentVariable(string variable, string? value)
+        {
+            // do nothing
+        }
+
+        public void Exit(int exitCode)
+        {
+            ExitCode = exitCode;
+            ExitCallCount++;
+
+            // The real implementation never returns; ours does, so subsequent presses still
+            // observe ExitCallCount accurately for the test.
+        }
+    }
+}


### PR DESCRIPTION
Implements two-stage Ctrl+C cancellation UX requested in #5345.

## Behavior

- **First Ctrl+C** — unchanged cooperative cancellation; the test session is asked to stop gracefully so cleanup (file creation, disposers, etc.) can still run. A new hint line is now printed right after `Canceling the test session...`:
  > Press Ctrl+C again to force exit.
- **Second Ctrl+C** — calls `IEnvironment.Exit((int)ExitCode.TestSessionAborted)` (exit code `3`), forcing the process to terminate immediately if cooperative cancellation is taking too long.

## Implementation notes

- `CTRLPlusCCancellationTokenSource` now takes an optional `IEnvironment` (defaults to `SystemEnvironment`) and uses an `Interlocked` state machine (Idle → Cancelling → Forcing) so repeated presses are race-safe and idempotent.
- The hint is appended in all three places that render the cancel banner: `TerminalTestReporter.StartCancelling`, `SimplifiedConsoleOutputDeviceBase`, and the JSON-discovery branch of `TerminalOutputDevice` (which goes to stderr to keep stdout JSON clean).
- New localized string `PressCtrlCAgainToForceExit` added to `PlatformResources.resx` with all 13 XLF files regenerated via `UpdateXlf`.
- No `Forcing exit...` confirmation message is printed on the second press to avoid corrupting `--list-tests --output json` stdout; the exit itself is the confirmation.

## Tests

- Added `CTRLPlusCCancellationTokenSourceTests` with 4 cases covering first/second press, external-cancellation-then-Ctrl+C, and idempotency.
- Verified 132 cancellation/stop-policy/terminal-reporter tests still pass.

Fixes #5345.
