### PR TITLE
Surface still-running extensions during MTP shutdown (refs #5345)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -250,6 +250,8 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
             return;
         }
 
+        IShutdownProgressReporter? shutdownProgressReporter = serviceProvider.GetService<IShutdownProgressReporter>();
+
         // First, we call OnTestSessionFinishingAsync on all non-consumers.
         bool hasNonDataConsumers = false;
         foreach (ITestSessionLifetimeHandler testSessionLifetimeHandler in testSessionLifetimeHandlersContainer.TestSessionLifetimeHandlers)
@@ -272,6 +274,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
             hasNonDataConsumers = true;
 
             using (otelService?.StartActivity(testSessionLifetimeHandler.Uid, testSessionLifetimeHandler.ToOTelTags()))
+            using (shutdownProgressReporter?.Track(testSessionLifetimeHandler.Uid, testSessionLifetimeHandler.DisplayName, nameof(ITestSessionLifetimeHandler.OnTestSessionFinishingAsync)))
             {
                 await testSessionLifetimeHandler.OnTestSessionFinishingAsync(testSessionContext).ConfigureAwait(false);
             }
@@ -294,6 +297,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
             }
 
             using (otelService?.StartActivity(testSessionLifetimeHandler.Uid, testSessionLifetimeHandler.ToOTelTags()))
+            using (shutdownProgressReporter?.Track(testSessionLifetimeHandler.Uid, testSessionLifetimeHandler.DisplayName, nameof(ITestSessionLifetimeHandler.OnTestSessionFinishingAsync)))
             {
                 await testSessionLifetimeHandler.OnTestSessionFinishingAsync(testSessionContext).ConfigureAwait(false);
             }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
@@ -182,6 +182,15 @@ internal sealed partial class TestHostBuilder
         serviceProvider.TryAddService(context.ProxyOutputDevice);
         serviceProvider.TryAddService(context.ProxyOutputDevice.OriginalOutputDevice);
 
+        // Reports extensions/consumers that have not yet completed once the test-application
+        // cancellation token is signalled. Registered after the output device so it can use it.
+        ShutdownProgressReporter shutdownProgressReporter = new(
+            context.TestApplicationCancellationTokenSource,
+            context.ProxyOutputDevice,
+            context.LoggerFactory,
+            systemClock);
+        serviceProvider.AddService(shutdownProgressReporter);
+
         context.TestFrameworkCapabilities = TestFramework!.TestFrameworkCapabilitiesFactory(serviceProvider);
         if (context.TestFrameworkCapabilities is IAsyncInitializableExtension testFrameworkCapabilitiesAsyncInitializable)
         {

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.Framework.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.Framework.cs
@@ -111,7 +111,8 @@ internal sealed partial class TestHostBuilder
             serviceProvider.GetTestApplicationCancellationTokenSource(),
             serviceProvider.GetTask(),
             serviceProvider.GetLoggerFactory(),
-            serviceProvider.GetEnvironment());
+            serviceProvider.GetEnvironment(),
+            serviceProvider.GetService<IShutdownProgressReporter>());
         await concreteMessageBusService.InitAsync().ConfigureAwait(false);
         testFrameworkBuilderData.MessageBusProxy.SetBuiltMessageBus(concreteMessageBusService);
 

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -175,7 +175,8 @@ internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposab
                 ServiceProvider.GetTestApplicationCancellationTokenSource(),
                 ServiceProvider.GetTask(),
                 ServiceProvider.GetLoggerFactory(),
-                ServiceProvider.GetEnvironment());
+                ServiceProvider.GetEnvironment(),
+                ServiceProvider.GetService<IShutdownProgressReporter>());
             await concreteMessageBusService.InitAsync().ConfigureAwait(false);
             ((MessageBusProxy)ServiceProvider.GetMessageBus()).SetBuiltMessageBus(concreteMessageBusService);
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
@@ -24,6 +24,7 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
     private readonly Dictionary<Type, List<IAsyncConsumerDataProcessor>> _dataTypeConsumers = [];
     private readonly IDataConsumer[] _dataConsumers;
     private readonly ITestApplicationCancellationTokenSource _testApplicationCancellationTokenSource;
+    private readonly IShutdownProgressReporter? _shutdownProgressReporter;
     private IAsyncConsumerDataProcessor[] _distinctProcessors = [];
     private long[] _drainLastReceived = [];
     private bool _disabled;
@@ -34,11 +35,23 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
         ITask task,
         ILoggerFactory loggerFactory,
         IEnvironment environment)
+        : this(dataConsumers, testApplicationCancellationTokenSource, task, loggerFactory, environment, shutdownProgressReporter: null)
+    {
+    }
+
+    public AsynchronousMessageBus(
+        IDataConsumer[] dataConsumers,
+        ITestApplicationCancellationTokenSource testApplicationCancellationTokenSource,
+        ITask task,
+        ILoggerFactory loggerFactory,
+        IEnvironment environment,
+        IShutdownProgressReporter? shutdownProgressReporter)
     {
         _dataConsumers = dataConsumers;
         _testApplicationCancellationTokenSource = testApplicationCancellationTokenSource;
         _task = task;
         _environment = environment;
+        _shutdownProgressReporter = shutdownProgressReporter;
         _logger = loggerFactory.CreateLogger<AsynchronousMessageBus>();
         _isTraceLoggingEnabled = _logger.IsEnabled(LogLevel.Trace);
     }
@@ -161,7 +174,11 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
 
             for (int i = 0; i < _distinctProcessors.Length; i++)
             {
-                await _distinctProcessors[i].DrainDataAsync().ConfigureAwait(false);
+                IAsyncConsumerDataProcessor processor = _distinctProcessors[i];
+                using (_shutdownProgressReporter?.Track(processor.DataConsumer.Uid, processor.DataConsumer.DisplayName, nameof(IAsyncConsumerDataProcessor.DrainDataAsync)))
+                {
+                    await processor.DrainDataAsync().ConfigureAwait(false);
+                }
             }
 
             bool anyNewlyReceived = false;

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -535,6 +535,10 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
   <data name="PressCtrlCAgainToForceExit" xml:space="preserve">
     <value>Press Ctrl+C again to force exit.</value>
   </data>
+  <data name="ShutdownProgressStillWaitingPrefix" xml:space="preserve">
+    <value>Still waiting for: </value>
+    <comment>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</comment>
+  </data>
   <data name="DiagnosticFileLevelWithAsyncFlush" xml:space="preserve">
     <value>Diagnostic file (level '{0}' with async flush): {1}</value>
     <comment>0 level such as verbose,

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -765,6 +765,11 @@ Přebírá jeden argument jako časovou hodnotu s explicitní příponou jednotk
         <target state="translated">Instance typu ITestFramework by neměly být registrovány prostřednictvím poskytovatele služeb, ale prostřednictvím metody ITestApplicationBuilder.RegisterTestFramework.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Přeskočeno</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -765,6 +765,11 @@ Verwendet ein Argument als Zeitwert mit einem expliziten Einheitensuffix. Akzept
         <target state="translated">Instanzen vom Typ "ITestFramework" sollten nicht über den Dienstanbieter, sondern über "ITestApplicationBuilder.RegisterTestFramework" registriert werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Übersprungen</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -765,6 +765,11 @@ Toma un argumento como un valor de tiempo con un sufijo de unidad explícito. Lo
         <target state="translated">Las instancias de tipo "ITestFramework" no deben registrarse mediante el proveedor de servicios, sino mediante "ITestApplicationBuilder.RegisterTestFramework".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Omitida</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -765,6 +765,11 @@ Prend un argument correspondant à une valeur de temps avec un suffixe d’unit�
         <target state="translated">Les instances de type « ITestFramework » ne doivent pas être inscrites par le biais du fournisseur de services, mais par le biais de « ITestApplicationBuilder.RegisterTestFramework »</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Ignoré</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -765,6 +765,11 @@ Accetta un argomento come valore di ora con un suffisso di unità esplicito. I s
         <target state="translated">Le istanze di tipo 'ITestFramework' non devono essere registrate tramite il provider di servizi, ma tramite 'ITestApplicationBuilder.RegisterTestFramework'</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Ignorato</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -766,6 +766,11 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">'ITestFramework' 型のインスタンスは、サービス プロバイダーを介して登録することはできません。'ITestApplicationBuilder.RegisterTestFramework' を介して登録する必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">スキップ</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -765,6 +765,11 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">'ITestFramework' 형식의 인스턴스는 서비스 공급자를 통해 등록하지 않아야 하지만 'ITestApplicationBuilder.RegisterTestFramework'를 통해 등록해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">건너뜀</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -765,6 +765,11 @@ Przyjmuje jeden argument jako wartość czasu z jawnym sufiksem jednostki. Akcep
         <target state="translated">Wystąpienia typu „ITestFramework” nie powinny być rejestrowane za pośrednictwem dostawcy usług, ale za pośrednictwem elementu „ITestApplicationBuilder.RegisterTestFramework”</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Pominięto</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -765,6 +765,11 @@ Recebe um argumento como valor temporal, com um sufixo de unidade explícito. O
         <target state="translated">Instâncias do tipo "ITestFramework" não devem ser registradas por meio do provedor de serviços, mas por meio de "ITestApplicationBuilder.RegisterTestFramework"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Ignorado</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -765,6 +765,11 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">Экземпляры типа "ITestFramework" следует регистрировать не через поставщика услуг, а через "ITestApplicationBuilder.RegisterTestFramework"</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Пропущен</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -765,6 +765,11 @@ Açık bir birim soneki bulunan bir zaman değeri olarak bir bağımsız değiş
         <target state="translated">'ITestFramework' türündeki örnekler hizmet sağlayıcısı aracılığıyla değil, 'ITestApplicationBuilder.RegisterTestFramework' aracılığıyla kaydedilmelidir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">Atlandı</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -765,6 +765,11 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">不应通过服务提供商注册类型为“ITestFramework”的实例，而应通过“ITestApplicationBuilder.RegisterTestFramework”进行注册</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">已跳过</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -765,6 +765,11 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">類型 'ITestFramework' 的執行個體不應透過服務提供者註冊，而是透過 'ITestApplicationBuilder.RegisterTestFramework' 註冊</target>
         <note />
       </trans-unit>
+      <trans-unit id="ShutdownProgressStillWaitingPrefix">
+        <source>Still waiting for: </source>
+        <target state="new">Still waiting for: </target>
+        <note>Prefix for the message that lists extensions that have not yet completed their shutdown work. Each entry is formatted as "{DisplayName} ({Phase}, {Seconds}s)" and entries are separated by "; ".</note>
+      </trans-unit>
       <trans-unit id="Skipped">
         <source>Skipped</source>
         <target state="translated">略過</target>

--- a/src/Platform/Microsoft.Testing.Platform/Services/IShutdownProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IShutdownProgressReporter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Services;
+
+/// <summary>
+/// Tracks units of work that the platform is awaiting during shutdown so that, after
+/// cancellation has been requested, the user can be told which extensions are still
+/// running and how long each one has been blocking.
+/// </summary>
+/// <remarks>
+/// Implementations must be thread-safe. Callers wrap shutdown-relevant awaits with
+/// <c>using (reporter.Track(uid, displayName, phase)) { await ... }</c>; on the
+/// happy path (no cancellation) this is effectively a no-op beyond bookkeeping.
+/// </remarks>
+internal interface IShutdownProgressReporter
+{
+    /// <summary>
+    /// Registers a unit of in-flight work and returns a disposable that removes it.
+    /// </summary>
+    /// <param name="uid">Stable identifier of the extension / consumer being awaited.</param>
+    /// <param name="displayName">Human-readable name surfaced to the user.</param>
+    /// <param name="phase">Short label describing what we are awaiting (e.g. <c>OnTestSessionFinishingAsync</c>).</param>
+    /// <returns>A disposable that removes the tracker when the awaited work completes.</returns>
+    IDisposable Track(string uid, string displayName, string phase);
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
@@ -129,12 +129,11 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
             while (!stopToken.IsCancellationRequested)
             {
                 IReadOnlyList<TrackedWork> snapshot = Snapshot();
-                if (snapshot.Count == 0)
+                if (snapshot.Count > 0)
                 {
-                    return;
+                    await ReportAsync(snapshot, stopToken).ConfigureAwait(false);
                 }
 
-                await ReportAsync(snapshot, stopToken).ConfigureAwait(false);
                 await Task.Delay(_pollInterval, stopToken).ConfigureAwait(false);
             }
         }

--- a/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Resources;
+
+namespace Microsoft.Testing.Platform.Services;
+
+/// <summary>
+/// Default <see cref="IShutdownProgressReporter"/>. Once the test-application
+/// cancellation token is signalled, a single background watchdog periodically
+/// reports the set of extensions/consumers that have not yet completed.
+/// </summary>
+internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOutputDeviceDataProducer, IDisposable
+{
+    internal static readonly TimeSpan DefaultQuietWindow = TimeSpan.FromSeconds(3);
+    internal static readonly TimeSpan DefaultPollInterval = TimeSpan.FromSeconds(1);
+
+    private readonly ConcurrentDictionary<long, TrackedWork> _inFlight = new();
+    private readonly ITestApplicationCancellationTokenSource _testApplicationCancellationTokenSource;
+    private readonly IOutputDevice? _outputDevice;
+    private readonly ILogger _logger;
+    private readonly IClock _clock;
+    private readonly TimeSpan _quietWindow;
+    private readonly TimeSpan _pollInterval;
+    private readonly CancellationTokenRegistration _registration;
+    private readonly CancellationTokenSource _watchdogStopSource = new();
+    private long _nextId;
+    private int _watchdogStarted;
+    private bool _disposed;
+
+    public ShutdownProgressReporter(
+        ITestApplicationCancellationTokenSource testApplicationCancellationTokenSource,
+        IOutputDevice? outputDevice,
+        ILoggerFactory loggerFactory,
+        IClock clock)
+        : this(testApplicationCancellationTokenSource, outputDevice, loggerFactory, clock, DefaultQuietWindow, DefaultPollInterval)
+    {
+    }
+
+    internal ShutdownProgressReporter(
+        ITestApplicationCancellationTokenSource testApplicationCancellationTokenSource,
+        IOutputDevice? outputDevice,
+        ILoggerFactory loggerFactory,
+        IClock clock,
+        TimeSpan quietWindow,
+        TimeSpan pollInterval)
+    {
+        _testApplicationCancellationTokenSource = testApplicationCancellationTokenSource;
+        _outputDevice = outputDevice;
+        _logger = loggerFactory.CreateLogger<ShutdownProgressReporter>();
+        _clock = clock;
+        _quietWindow = quietWindow;
+        _pollInterval = pollInterval;
+        _registration = _testApplicationCancellationTokenSource.CancellationToken.Register(OnCancellationRequested);
+    }
+
+    public string Uid => nameof(ShutdownProgressReporter);
+
+    public string Version => PlatformVersion.Version;
+
+    public string DisplayName => nameof(ShutdownProgressReporter);
+
+    public string Description => "Reports extensions still running during shutdown.";
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public IDisposable Track(string uid, string displayName, string phase)
+    {
+        if (_disposed)
+        {
+            return NoopDisposable.Instance;
+        }
+
+        long id = Interlocked.Increment(ref _nextId);
+        var work = new TrackedWork(uid, displayName, phase, _clock.UtcNow);
+        _inFlight[id] = work;
+        return new Releaser(this, id);
+    }
+
+    internal IReadOnlyList<TrackedWork> Snapshot()
+        => _inFlight.Values.OrderByDescending(w => w.StartedAt).ToArray();
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _registration.Dispose();
+        try
+        {
+            _watchdogStopSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        _watchdogStopSource.Dispose();
+    }
+
+    private void OnCancellationRequested()
+    {
+        if (Interlocked.CompareExchange(ref _watchdogStarted, 1, 0) != 0)
+        {
+            return;
+        }
+
+        // Fire-and-forget watchdog. The process is shutting down, so we accept the unobserved task.
+        _ = Task.Run(() => RunWatchdogAsync(_watchdogStopSource.Token));
+    }
+
+    private async Task RunWatchdogAsync(CancellationToken stopToken)
+    {
+        try
+        {
+            // Quiet window: give extensions a chance to drain before reporting anything.
+            await Task.Delay(_quietWindow, stopToken).ConfigureAwait(false);
+
+            while (!stopToken.IsCancellationRequested)
+            {
+                IReadOnlyList<TrackedWork> snapshot = Snapshot();
+                if (snapshot.Count == 0)
+                {
+                    return;
+                }
+
+                await ReportAsync(snapshot).ConfigureAwait(false);
+                await Task.Delay(_pollInterval, stopToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on dispose / process exit.
+        }
+        catch (Exception ex)
+        {
+            // Never let the watchdog crash the process; just log if possible.
+            try
+            {
+                await _logger.LogWarningAsync($"Shutdown progress watchdog failed: {ex}").ConfigureAwait(false);
+            }
+            catch
+            {
+                // Swallow - we are during shutdown.
+            }
+        }
+    }
+
+    private async Task ReportAsync(IReadOnlyList<TrackedWork> snapshot)
+    {
+        DateTimeOffset now = _clock.UtcNow;
+        StringBuilder builder = new();
+        builder.Append(PlatformResources.ShutdownProgressStillWaitingPrefix);
+        for (int i = 0; i < snapshot.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append("; ");
+            }
+
+            TrackedWork work = snapshot[i];
+            int elapsedSeconds = Math.Max(1, (int)Math.Round((now - work.StartedAt).TotalSeconds));
+            builder.Append(CultureInfo.CurrentCulture, $"{work.DisplayName} ({work.Phase}, {elapsedSeconds}s)");
+        }
+
+        string message = builder.ToString();
+
+        try
+        {
+            await _logger.LogInformationAsync(message).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Logging during shutdown is best-effort.
+        }
+
+        if (_outputDevice is not null)
+        {
+            try
+            {
+                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(message), _watchdogStopSource.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on dispose.
+            }
+            catch
+            {
+                // Output during shutdown is best-effort.
+            }
+        }
+    }
+
+    internal readonly record struct TrackedWork(string Uid, string DisplayName, string Phase, DateTimeOffset StartedAt);
+
+    private sealed class Releaser(ShutdownProgressReporter owner, long id) : IDisposable
+    {
+        private int _released;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                owner._inFlight.TryRemove(id, out _);
+            }
+        }
+    }
+
+    private sealed class NoopDisposable : IDisposable
+    {
+        public static readonly NoopDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
@@ -111,8 +111,12 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
             return;
         }
 
+        // Capture the token synchronously here so a concurrent Dispose() (which disposes
+        // _watchdogStopSource) cannot turn the Task.Run lambda into an ObjectDisposedException.
+        CancellationToken stopToken = _watchdogStopSource.Token;
+
         // Fire-and-forget watchdog. The process is shutting down, so we accept the unobserved task.
-        _ = Task.Run(() => RunWatchdogAsync(_watchdogStopSource.Token));
+        _ = Task.Run(() => RunWatchdogAsync(stopToken));
     }
 
     private async Task RunWatchdogAsync(CancellationToken stopToken)
@@ -130,7 +134,7 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
                     return;
                 }
 
-                await ReportAsync(snapshot).ConfigureAwait(false);
+                await ReportAsync(snapshot, stopToken).ConfigureAwait(false);
                 await Task.Delay(_pollInterval, stopToken).ConfigureAwait(false);
             }
         }
@@ -152,7 +156,7 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
         }
     }
 
-    private async Task ReportAsync(IReadOnlyList<TrackedWork> snapshot)
+    private async Task ReportAsync(IReadOnlyList<TrackedWork> snapshot, CancellationToken stopToken)
     {
         DateTimeOffset now = _clock.UtcNow;
         StringBuilder builder = new();
@@ -184,7 +188,7 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
         {
             try
             {
-                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(message), _watchdogStopSource.Token).ConfigureAwait(false);
+                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(message), stopToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ShutdownProgressReporter.cs
@@ -145,7 +145,7 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
             {
                 await _logger.LogWarningAsync($"Shutdown progress watchdog failed: {ex}").ConfigureAwait(false);
             }
-            catch
+            catch (Exception)
             {
                 // Swallow - we are during shutdown.
             }
@@ -175,7 +175,7 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
         {
             await _logger.LogInformationAsync(message).ConfigureAwait(false);
         }
-        catch
+        catch (Exception)
         {
             // Logging during shutdown is best-effort.
         }
@@ -190,7 +190,7 @@ internal sealed class ShutdownProgressReporter : IShutdownProgressReporter, IOut
             {
                 // Expected on dispose.
             }
-            catch
+            catch (Exception)
             {
                 // Output during shutdown is best-effort.
             }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ShutdownProgressReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ShutdownProgressReporterTests.cs
@@ -130,6 +130,31 @@ public sealed class ShutdownProgressReporterTests : IDisposable
         Assert.IsEmpty(reporter.Snapshot());
     }
 
+    [TestMethod]
+    public async Task Watchdog_EmitsForLateTracking_WhenQuietWindowElapsedWithNoWork()
+    {
+        // Repro: cancellation fires, the quiet window elapses with zero tracked work
+        // (e.g. extensions only start their shutdown handlers afterwards), then tracking
+        // begins. The watchdog must keep polling and report the late work instead of
+        // exiting after the first empty snapshot.
+        using ShutdownProgressReporter reporter = CreateReporter(quietWindow: TimeSpan.FromMilliseconds(40), pollInterval: TimeSpan.FromMilliseconds(30));
+
+        CancelTokenSource();
+
+        // Wait past the quiet window so the watchdog has observed at least one empty snapshot.
+        await Task.Delay(200, TestContext.CancellationToken);
+        Assert.IsEmpty(_outputDevice.Messages);
+
+        using IDisposable tracker = reporter.Track("uid-late", "Display Late", "Phase Late");
+
+        await WaitForMessageAsync(TimeSpan.FromSeconds(5));
+
+        IReadOnlyList<string> messages = _outputDevice.Messages;
+        Assert.IsGreaterThanOrEqualTo(1, messages.Count, $"Expected at least one message, got {messages.Count}");
+        Assert.Contains("Display Late", messages[0]);
+        Assert.Contains("Phase Late", messages[0]);
+    }
+
     private ShutdownProgressReporter CreateReporter(TimeSpan? quietWindow = null, TimeSpan? pollInterval = null)
         => new(
             _cancellationTokenSource.Object,

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ShutdownProgressReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ShutdownProgressReporterTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class ShutdownProgressReporterTests : IDisposable
+{
+    private readonly Mock<ITestApplicationCancellationTokenSource> _cancellationTokenSource = new();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly CapturingOutputDevice _outputDevice = new();
+    private readonly Mock<IClock> _clock = new();
+    private readonly DateTimeOffset _now = new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _cancellationTokenSource.SetupGet(x => x.CancellationToken).Returns(_cts.Token);
+        _clock.SetupGet(c => c.UtcNow).Returns(() => _now);
+    }
+
+    public void Dispose() => _cts.Dispose();
+
+    [TestMethod]
+    public void Track_AddsEntry_Snapshot_ReturnsIt()
+    {
+        using ShutdownProgressReporter reporter = CreateReporter();
+        IDisposable handle = reporter.Track("uid-1", "Display 1", "Phase 1");
+
+        IReadOnlyList<ShutdownProgressReporter.TrackedWork> snapshot = reporter.Snapshot();
+        Assert.HasCount(1, snapshot);
+        Assert.AreEqual("uid-1", snapshot[0].Uid);
+        Assert.AreEqual("Display 1", snapshot[0].DisplayName);
+        Assert.AreEqual("Phase 1", snapshot[0].Phase);
+
+        handle.Dispose();
+        Assert.IsEmpty(reporter.Snapshot());
+    }
+
+    [TestMethod]
+    public void Track_Dispose_IsIdempotent()
+    {
+        using ShutdownProgressReporter reporter = CreateReporter();
+        IDisposable handle = reporter.Track("uid-1", "Display 1", "Phase 1");
+
+        handle.Dispose();
+        handle.Dispose();
+
+        Assert.IsEmpty(reporter.Snapshot());
+    }
+
+    [TestMethod]
+    public async Task Watchdog_DoesNotEmit_BeforeCancellation()
+    {
+        using ShutdownProgressReporter reporter = CreateReporter(quietWindow: TimeSpan.FromMilliseconds(20), pollInterval: TimeSpan.FromMilliseconds(20));
+        using IDisposable tracker = reporter.Track("uid-1", "Display 1", "Phase 1");
+
+        await Task.Delay(120, TestContext.CancellationToken);
+
+        Assert.IsEmpty(_outputDevice.Messages);
+    }
+
+    [TestMethod]
+    public async Task Watchdog_EmitsAfterQuietWindow_WhenStillTracking()
+    {
+        using ShutdownProgressReporter reporter = CreateReporter(quietWindow: TimeSpan.FromMilliseconds(40), pollInterval: TimeSpan.FromMilliseconds(30));
+        using IDisposable tracker = reporter.Track("uid-1", "Display 1", "Phase 1");
+
+        CancelTokenSource();
+
+        await WaitForMessageAsync(TimeSpan.FromSeconds(5));
+
+        IReadOnlyList<string> messages = _outputDevice.Messages;
+        Assert.IsGreaterThanOrEqualTo(1, messages.Count, $"Expected at least one message, got {messages.Count}");
+        Assert.Contains("Display 1", messages[0]);
+        Assert.Contains("Phase 1", messages[0]);
+    }
+
+    [TestMethod]
+    public async Task Watchdog_DoesNotEmit_IfAllTrackersDisposedBeforeQuietWindow()
+    {
+        using ShutdownProgressReporter reporter = CreateReporter(quietWindow: TimeSpan.FromMilliseconds(100), pollInterval: TimeSpan.FromMilliseconds(30));
+        IDisposable handle = reporter.Track("uid-1", "Display 1", "Phase 1");
+
+        CancelTokenSource();
+        handle.Dispose();
+
+        await Task.Delay(300, TestContext.CancellationToken);
+
+        Assert.IsEmpty(_outputDevice.Messages);
+    }
+
+    [TestMethod]
+    public async Task Watchdog_StopsEmitting_OnceAllTrackersDisposed()
+    {
+        using ShutdownProgressReporter reporter = CreateReporter(quietWindow: TimeSpan.FromMilliseconds(20), pollInterval: TimeSpan.FromMilliseconds(20));
+        IDisposable handle = reporter.Track("uid-1", "Display 1", "Phase 1");
+
+        CancelTokenSource();
+        await WaitForMessageAsync(TimeSpan.FromSeconds(5));
+
+        handle.Dispose();
+        int countAfterDispose = _outputDevice.Messages.Count;
+
+        await Task.Delay(200, TestContext.CancellationToken);
+
+        // Allow at most one extra in-flight emission that was already running when we disposed.
+        Assert.IsLessThanOrEqualTo(countAfterDispose + 1, _outputDevice.Messages.Count);
+    }
+
+    [TestMethod]
+    public void Track_AfterDispose_ReturnsNoop()
+    {
+        ShutdownProgressReporter reporter = CreateReporter();
+        reporter.Dispose();
+
+        IDisposable handle = reporter.Track("uid-1", "Display 1", "Phase 1");
+        handle.Dispose();
+
+        Assert.IsEmpty(reporter.Snapshot());
+    }
+
+    private ShutdownProgressReporter CreateReporter(TimeSpan? quietWindow = null, TimeSpan? pollInterval = null)
+        => new(
+            _cancellationTokenSource.Object,
+            _outputDevice,
+            new NullLoggerFactory(),
+            _clock.Object,
+            quietWindow ?? ShutdownProgressReporter.DefaultQuietWindow,
+            pollInterval ?? ShutdownProgressReporter.DefaultPollInterval);
+
+#pragma warning disable VSTHRD103 // Call async methods when in an async method - CancellationTokenSource.CancelAsync is unavailable on net462.
+    private void CancelTokenSource() => _cts.Cancel();
+#pragma warning restore VSTHRD103
+
+    private async Task WaitForMessageAsync(TimeSpan timeout)
+    {
+        DateTime deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline && _outputDevice.Messages.Count == 0)
+        {
+            await Task.Delay(20, TestContext.CancellationToken);
+        }
+    }
+
+    private sealed class CapturingOutputDevice : IOutputDevice
+    {
+        private readonly List<string> _messages = [];
+
+        public IReadOnlyList<string> Messages
+        {
+            get
+            {
+                lock (_messages)
+                {
+                    return _messages.ToArray();
+                }
+            }
+        }
+
+        public Task DisplayAsync(IOutputDeviceDataProducer producer, IOutputDeviceData data, CancellationToken cancellationToken)
+        {
+            string? text = data switch
+            {
+                WarningMessageOutputDeviceData w => w.Message,
+                FormattedTextOutputDeviceData f => f.Text,
+                _ => data.ToString(),
+            };
+
+            lock (_messages)
+            {
+                _messages.Add(text ?? string.Empty);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NullLoggerFactory : ILoggerFactory
+    {
+        public ILogger CreateLogger(string categoryName) => NullLogger.Instance;
+    }
+
+    private sealed class NullLogger : ILogger
+    {
+        public static readonly NullLogger Instance = new();
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+
+        public Task LogAsync<TState>(LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes part of #5345 (incremental improvement, complementary to the phased-shutdown RFC in #8580).

### Problem

Today when a user hits `Ctrl+C` on a hanging MTP test run, the cancellation token gets signalled but the user has **no visibility** into _which_ extension or consumer is blocking the shutdown. The process just appears stuck.

### Approach

Add a small `IShutdownProgressReporter` service that:

1. Tracks units of in-flight shutdown work via `using (reporter.Track(uid, displayName, phase)) { await ... }`.
2. Once the test-application cancellation token fires, waits a short **quiet window** (3s) to avoid noise on clean shutdowns.
3. Then **periodically (every 1s)** emits a `Still waiting for: <Name1> (<Phase1>, <Ns>); <Name2> ...` warning through `IOutputDevice`.

The three known blocking await sites are now wrapped:

- `ITestSessionLifetimeHandler.OnTestSessionFinishingAsync` (non-consumer pass) — `CommonTestHost`
- `ITestSessionLifetimeHandler.OnTestSessionFinishingAsync` (consumer pass) — `CommonTestHost`
- `IAsyncConsumerDataProcessor.DrainDataAsync` per consumer — `AsynchronousMessageBus`

This is intentionally **complementary to #8580**. The RFC there proposes a full phased-shutdown protocol with a graceful timer and forced abort. The same trackers introduced here will feed the eventual `Force-killed because X didn't drain` message in that bigger work — but in the meantime this PR ships value independently with zero behavior change on the happy path.

### Limitations

- Does not surface slow user test code (only platform extensions/consumers expose `Uid`/`DisplayName`).
- Output uses `WarningMessageOutputDeviceData` (yellow text); coordination with the live progress line is best-effort.
- Strings are localized via `PlatformResources.resx` / regenerated `.xlf` files.

### Tests

7 new unit tests in `ShutdownProgressReporterTests` covering snapshot semantics, idempotent dispose, quiet-window behavior, post-cancellation emission, no-emit-if-all-disposed, and post-disposal `Track`. All pass on net9.0 and net462.

### Out of scope

- Server-mode / IPC progress propagation.
- CLI options to tune the quiet window or poll interval (constants for now).
- Acceptance-test coverage (would require a long-sleeping fake extension; deferring until the RFC lands).
