### PR TITLE
Fix MD060 table-column-style violations in pre-existing docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@ Solution files: `TestFx.slnx` is the full solution; `MSTest.slnf`, `Microsoft.Te
 Always use the repo-local toolchain via the build scripts — they restore the pinned .NET SDK from `global.json` into `.dotnet/` (or reuse a matching `DOTNET_INSTALL_DIR`) and prepend that `dotnet` location to `PATH`.
 
 | Task | Windows | Linux/macOS |
-|---|---|---|
+| --- | --- | --- |
 | Restore + build (Debug) | `.\build.cmd` | `./build.sh` |
 | Release build | `.\build.cmd -c Release` | `./build.sh -c Release` |
 | Produce NuGet packages | `.\build.cmd -pack` | `./build.sh -pack` |

--- a/docs/RFCs/013-Microsoft-Extensions-Bridges.md
+++ b/docs/RFCs/013-Microsoft-Extensions-Bridges.md
@@ -16,7 +16,7 @@ The first bridge delivered with this RFC is `Microsoft.Testing.Extensions.Loggin
 MTP today ships its own slim implementations of:
 
 | Concern | MTP namespace | Equivalent in BCL ecosystem |
-|---|---|---|
+| --- | --- | --- |
 | Logging | `Microsoft.Testing.Platform.Logging` | `Microsoft.Extensions.Logging` |
 | Configuration | `Microsoft.Testing.Platform.Configurations` | `Microsoft.Extensions.Configuration` |
 | Service location | `Microsoft.Testing.Platform.Services.ServiceProvider` | `Microsoft.Extensions.DependencyInjection` |
@@ -44,7 +44,7 @@ The current "homegrown core + opt-in bridge extensions" pattern satisfies both c
 ## Phasing
 
 | Phase | Package | Status |
-|---|---|---|
+| --- | --- | --- |
 | 1 | `Microsoft.Testing.Extensions.Logging` | This RFC |
 | 2 | `Microsoft.Testing.Extensions.Configuration` | Future |
 | 3 | `Microsoft.Testing.Extensions.DependencyInjection` | Future |
@@ -113,7 +113,7 @@ Microsoft.Extensions.Logging.LoggerFactory → user's MEL providers
 ### Semantic mapping
 
 | MTP concept | Mapped MEL concept | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `LogLevel.Trace…Critical/None` (0..6) | `Microsoft.Extensions.Logging.LogLevel.Trace…Critical/None` | Same numeric values; mapped via explicit `switch` for safety/AOT |
 | `ILogger.Log<TState>(level, state, ex, formatter)` | `ILogger.Log<TState>(level, EventId.None, state, ex, formatter)` | `EventId` defaults to `None` |
 | `ILogger.LogAsync<TState>(...)` | Synchronous `Log` + `Task.CompletedTask` | MEL has no async API |

--- a/docs/RFCs/015-Command-Line-Option-Mappings.md
+++ b/docs/RFCs/015-Command-Line-Option-Mappings.md
@@ -22,7 +22,7 @@ dotnet test --logger trx --logger "console;verbosity=detailed" --collect "XPlat 
 In MTP, each of these capabilities is exposed by a distinct extension that registers its own option(s):
 
 | VSTest | MTP equivalent |
-|---|---|
+| --- | --- |
 | `--logger trx` | `--report-trx` (`Microsoft.Testing.Extensions.TrxReport`) |
 | `--logger "console;verbosity=detailed"` | `--output detailed` (`Microsoft.Testing.Platform`) |
 | `--collect "XPlat Code Coverage"` | `--coverage` (`Microsoft.Testing.Extensions.CodeCoverage`) |
@@ -285,7 +285,7 @@ Other rules are inherently **runtime** because the `Map` delegate is opaque at r
 ### Interaction with existing surfaces
 
 | Surface | Behaviour |
-|---|---|
+| --- | --- |
 | `ICommandLineOptions.IsOptionSet("report-trx")` | Returns `true` if the user passed `--report-trx` *or* `--logger trx`. Providers don't need to know which path was taken. |
 | `ICommandLineOptions.TryGetOptionArgumentList` | Same — the canonical option is what providers query. |
 | `--help` | Help renderer adds a new section, **VSTest-style options (compatibility)**, listing every mapping with its description. Canonical options remain the primary listing. |
@@ -337,7 +337,7 @@ Reject the proposal entirely and rely on documentation. This is the current stat
 ### Alternative 5 — Naming variants considered
 
 | Considered name | Why rejected |
-|---|---|
+| --- | --- |
 | `CommandLineAlias` | Misleading; "alias" implies a pure rename. (See **Naming** above.) |
 | `CommandLineOptionTransformation` | Accurate but evokes compiler passes / heavy machinery. |
 | `CommandLineOptionExpander` | Accurate for 1→N case but awkward for the 1→1 case. |
@@ -361,7 +361,7 @@ Reject the proposal entirely and rely on documentation. This is the current stat
 ## Phasing
 
 | Phase | Deliverable | Owner |
-|---|---|---|
+| --- | --- | --- |
 | 1 | Mapping infrastructure (`ICommandLineOptionMappingProvider`, parser integration, validation, help/info plumbing). | `Microsoft.Testing.Platform` |
 | 2 | First mapping shipped: `--logger trx` in `Microsoft.Testing.Extensions.TrxReport`. | TRX extension |
 | 3 | `--collect "XPlat Code Coverage"` / `--collect "Code Coverage"` in `Microsoft.Testing.Extensions.CodeCoverage`. | Code coverage extension |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -87,7 +87,7 @@ An automated agentic workflow (`.github/workflows/lean-squad.md`) that manages t
 An optional argument value for the MTP `--list-tests` command-line option that switches test discovery output from the default human-readable text to a machine-readable JSON document emitted on stdout. Introduced in [PR #8280](https://github.com/microsoft/testfx/pull/8280).
 
 | Invocation | Behavior |
-|---|---|
+| --- | --- |
 | `--list-tests` | Default human-readable text output (unchanged) |
 | `--list-tests text` | Explicit alias for the default text mode |
 | `--list-tests json` | JSON document on stdout; banner, progress, and per-test text are suppressed; errors go to stderr |

--- a/docs/microsoft.testing.platform/002-TestConfig-EnvironmentVariables.md
+++ b/docs/microsoft.testing.platform/002-TestConfig-EnvironmentVariables.md
@@ -115,21 +115,21 @@ internal sealed class TestConfigurationEnvironmentVariableProvider : ITestHostEn
 
 The `environmentVariables` section must be a **flat JSON object whose values are scalars**. Any deviation throws `FormatException` during the build phase with a message identifying the offending key and the configuration file path. Specifically:
 
-| JSON shape                                              | Behavior                                       |
-| ------------------------------------------------------- | ---------------------------------------------- |
-| `"environmentVariables": { "FOO": "bar" }`              | ✅ Sets `FOO=bar`                              |
-| `"environmentVariables": { "FOO": "" }`                 | ✅ Sets `FOO=""`                               |
-| `"environmentVariables": { "FOO": 42, "BAR": true }`    | ✅ Coerced to text: `FOO=42`, `BAR=True`       |
-| `"environmentVariables": { "FOO": null }`               | ⚠️ Runtime-dependent (see [Edge cases](#edge-cases-and-limitations)) |
-| `"environmentVariables": {}`                            | ✅ No-op; controller process model **not** triggered |
-| (section absent)                                        | ✅ No-op; controller process model **not** triggered |
-| `"environmentVariables": "oops"`                        | ❌ Throws – section must be a JSON object       |
-| `"environmentVariables": [1, 2]`                        | ❌ Throws – section must be a JSON object       |
-| `"environmentVariables": { "FOO": { "NESTED": "x" } }`  | ❌ Throws – nested objects not supported        |
-| `"environmentVariables": { "FOO": [1, 2] }`             | ❌ Throws – nested arrays not supported         |
-| `"environmentVariables": { "FOO": {} }`                 | ❌ Throws – nested empty objects not supported  |
-| `"environmentVariables": { "": "x" }`                   | ❌ Throws – empty variable names are invalid    |
-| `"environmentVariables": { "FOO=BAR": "x" }`            | ❌ Throws – `=` is not allowed in names         |
+| JSON shape | Behavior |
+| --- | --- |
+| `"environmentVariables": { "FOO": "bar" }` | ✅ Sets `FOO=bar` |
+| `"environmentVariables": { "FOO": "" }` | ✅ Sets `FOO=""` |
+| `"environmentVariables": { "FOO": 42, "BAR": true }` | ✅ Coerced to text: `FOO=42`, `BAR=True` |
+| `"environmentVariables": { "FOO": null }` | ⚠️ Runtime-dependent (see [Edge cases](#edge-cases-and-limitations)) |
+| `"environmentVariables": {}` | ✅ No-op; controller process model **not** triggered |
+| (section absent) | ✅ No-op; controller process model **not** triggered |
+| `"environmentVariables": "oops"` | ❌ Throws – section must be a JSON object |
+| `"environmentVariables": [1, 2]` | ❌ Throws – section must be a JSON object |
+| `"environmentVariables": { "FOO": { "NESTED": "x" } }` | ❌ Throws – nested objects not supported |
+| `"environmentVariables": { "FOO": [1, 2] }` | ❌ Throws – nested arrays not supported |
+| `"environmentVariables": { "FOO": {} }` | ❌ Throws – nested empty objects not supported |
+| `"environmentVariables": { "": "x" }` | ❌ Throws – empty variable names are invalid |
+| `"environmentVariables": { "FOO=BAR": "x" }` | ❌ Throws – `=` is not allowed in names |
 
 ### Precedence and ordering
 

--- a/docs/microsoft.testing.platform/ArtifactNamingHelper.md
+++ b/docs/microsoft.testing.platform/ArtifactNamingHelper.md
@@ -15,7 +15,7 @@ Resolves to: `MyTests_12345_2025-09-22_13-49-34.0000000_hang.dmp`
 ## Available Placeholders
 
 | Placeholder | Description | Example |
-|-------------|-------------|---------|
+| --- | --- | --- |
 | `{pname}` | Name of the process | `MyTests` |
 | `{pid}` | Process ID | `12345` |
 | `{asm}` | Assembly name (entry assembly, or `unknown` if unavailable) | `MyTests` |


### PR DESCRIPTION
Fixes MD060 (`table-column-style`) violations across six pre-existing markdown files. These errors were not caught by CI because the `DavidAnson/markdownlint-cli2-action@v18` action uses `markdownlint-cli2 v0.15.0` (`markdownlint v0.36.1`), and MD060 was added in markdownlint v0.40.0. Running `npx markdownlint-cli2 '**/*.md'` locally with a current version surfaced 62 errors, all MD060, all in files I'm not otherwise touching.

## What changed

Five files had separator rows written as `|---|---|---|` (no spaces around dashes) while their cell rows used the spaced `| value | value |` style — an inconsistency MD060 flags. The separators are normalized to `| --- | --- | --- |`.

- `.github/copilot-instructions.md`
- `docs/glossary.md`
- `docs/microsoft.testing.platform/ArtifactNamingHelper.md`
- `docs/RFCs/013-Microsoft-Extensions-Bridges.md`
- `docs/RFCs/015-Command-Line-Option-Mappings.md`

One file used `aligned` style with visual padding, but the alignment was broken by emoji widths in the cell text (✅/⚠️/❌ have non-monospace widths in markdown). Converted that table to compact (single-space) cell style:

- `docs/microsoft.testing.platform/002-TestConfig-EnvironmentVariables.md`

## Verification

```
`$ npx markdownlint-cli2 '**/*.md'
`markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
`Linting: 115 file(s)
`Summary: 0 error(s)
```

This PR is doc-only — no compiled artifacts, no behavior change. Splitting from #8599 to keep the workflow catalog focused.

> Note: bumping `DavidAnson/markdownlint-cli2-action` to a newer release (so CI catches MD060 going forward) is intentionally out of scope here — a version bump may surface additional rule violations from other newly-added rules and deserves its own focused PR.