### PR TITLE
IPC: handle disconnects and protocol corruption gracefully

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -52,6 +52,7 @@ Assess all 21 dimensions on every review. For each dimension, either provide rev
 3. Verify new code paths are reachable and tested.
 4. Look for off-by-one errors, wrong boundary conditions, logic inversions, missing cases in switches/pattern matches.
 5. For bug fixes, verify the fix addresses the root cause, not just a symptom.
+6. **Do NOT weaken `ApplicationStateGuard.Unreachable()`, `Debug.Assert`, or explicit invariant throws into "graceful" handling, fallbacks, or warnings without evidence.** These guards exist because the author proved the condition cannot occur given the surrounding protocol/invariant. Replacing them with `LogWarning` + `return` (or any silent recovery path) is a regression: it hides a real bug if the invariant ever breaks, and adds untested, unmaintainable error paths. If the guard is wrong, prove it with a concrete repro or failing test before relaxing it. If a corruption *is* possible from an untrusted boundary, the right severity is `LogError` and abort — never `LogWarning`, which signals a user-actionable condition.
 
 **CHECK — Flag if:**
 - [ ] Off-by-one or wrong boundary condition
@@ -59,6 +60,8 @@ Assess all 21 dimensions on every review. For each dimension, either provide rev
 - [ ] Logic inversion (`&&` vs `||`, `<` vs `<=`)
 - [ ] Fix patches a symptom when the root cause could be addressed
 - [ ] New code path unreachable or untested
+- [ ] `ApplicationStateGuard.Unreachable()` / `Debug.Assert` / invariant throw replaced by a "graceful" path, fallback, or warning without a documented repro
+- [ ] Internal-bug condition logged as `LogWarning` (user-actionable severity) instead of `LogError` + abort
 
 ---
 
@@ -210,12 +213,15 @@ The test platform loads arbitrary user code — it must not crash regardless of 
 3. Enforce timeouts on user code execution.
 4. Guard against unbounded collection growth from user-controlled input.
 5. Consider `StackOverflowException` risk from deeply recursive user data sources.
+6. **Defensive coding belongs at trust boundaries — not on internal invariants.** Wrapping every internal call in `try/catch`, replacing `throw Unreachable()` with logging, or adding "tolerant" loops on protocols that are strictly synchronous between trusted in-process components is *not* hardening — it's bloat that hides bugs. Before adding "graceful" handling for an internal condition, identify the concrete external trigger (peer process crash, OS-level I/O failure, untrusted input). If there is no concrete trigger, the existing invariant guard is correct and must be preserved.
 
 **CHECK — Flag if:**
 - [ ] Missing `try/catch` around user-provided callback
 - [ ] Reflection `Invoke()` without exception handling
 - [ ] Missing timeout enforcement on user code
 - [ ] Unbounded growth from user-controlled input
+- [ ] "Defensive" handling added for an internal invariant with no documented external trigger
+- [ ] Try/catch wrapping a call between trusted in-process components for an exception that cannot occur given the protocol
 
 ---
 

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -198,35 +198,8 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                 // If currentRequestSize is 0, we need to read the message size
                 if (currentMessageSize == 0)
                 {
-                    // We need at least sizeof(int) bytes to parse the message-size header. A pipe read can
-                    // legitimately return fewer bytes on partial frames; keep reading until we have a full
-                    // header or the peer disconnects.
-                    while (currentReadBytes < sizeof(int))
-                    {
-#if NETCOREAPP
-                        int additionalBytes = await _namedPipeClientStream.ReadAsync(_readBuffer.AsMemory(currentReadBytes, _readBuffer.Length - currentReadBytes), cancellationToken).ConfigureAwait(false);
-#else
-                        int additionalBytes = await _namedPipeClientStream.ReadAsync(_readBuffer, currentReadBytes, _readBuffer.Length - currentReadBytes, cancellationToken).ConfigureAwait(false);
-#endif
-                        if (additionalBytes == 0)
-                        {
-                            // Server disconnected mid-header. Treat as the read-EOF case above.
-                            _environment.Exit((int)ExitCode.GenericFailure);
-                            throw new IOException("Pipe closed while reading message header.");
-                        }
-
-                        currentReadBytes += additionalBytes;
-                    }
-
                     // We need to read the message size, first 4 bytes
                     currentMessageSize = BitConverter.ToInt32(_readBuffer, 0);
-                    if (currentMessageSize < sizeof(int))
-                    {
-                        // Protocol corruption: payload must contain at least a 4-byte serializer id.
-                        _environment.Exit((int)ExitCode.GenericFailure);
-                        throw new InvalidOperationException($"Received invalid IPC message size {currentMessageSize}.");
-                    }
-
                     missingBytesToReadOfCurrentChunk = currentReadBytes - sizeof(int);
                     missingBytesToReadOfWholeMessage = currentMessageSize;
                     currentReadIndex = sizeof(int);
@@ -241,13 +214,6 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     await _messageBuffer.WriteAsync(_readBuffer, currentReadIndex, missingBytesToReadOfCurrentChunk, cancellationToken).ConfigureAwait(false);
 #endif
                     missingBytesToReadOfWholeMessage -= missingBytesToReadOfCurrentChunk;
-                }
-
-                if (missingBytesToReadOfWholeMessage < 0)
-                {
-                    // Protocol corruption: we read more body bytes than the declared message size.
-                    _environment.Exit((int)ExitCode.GenericFailure);
-                    throw new InvalidOperationException("Read more bytes than the declared IPC message size.");
                 }
 
                 // If we have read all the message, we can deserialize it
@@ -267,14 +233,6 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     try
                     {
                         return (TResponse)responseNamedPipeSerializer.Deserialize(_messageBuffer);
-                    }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
-                    {
-                        // The response payload is unparseable. Mirror the read-EOF handling: there's no way to
-                        // recover the IPC session, so exit abnormally rather than bubbling a serializer
-                        // exception to the caller.
-                        _environment.Exit((int)ExitCode.GenericFailure);
-                        throw;
                     }
                     finally
                     {

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -154,6 +154,14 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     _namedPipeClientStream.WaitForPipeDrain();
                 }
             }
+            catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+            {
+                // The server disconnected while we were writing the request. Mirror the read-EOF handling
+                // below: if we cannot deliver the request there's no way to recover, so exit abnormally
+                // instead of surfacing a raw IPC error to the caller.
+                _environment.Exit((int)ExitCode.GenericFailure);
+                throw;
+            }
             finally
             {
                 // Reset the buffers
@@ -190,8 +198,35 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                 // If currentRequestSize is 0, we need to read the message size
                 if (currentMessageSize == 0)
                 {
+                    // We need at least sizeof(int) bytes to parse the message-size header. A pipe read can
+                    // legitimately return fewer bytes on partial frames; keep reading until we have a full
+                    // header or the peer disconnects.
+                    while (currentReadBytes < sizeof(int))
+                    {
+#if NETCOREAPP
+                        int additionalBytes = await _namedPipeClientStream.ReadAsync(_readBuffer.AsMemory(currentReadBytes, _readBuffer.Length - currentReadBytes), cancellationToken).ConfigureAwait(false);
+#else
+                        int additionalBytes = await _namedPipeClientStream.ReadAsync(_readBuffer, currentReadBytes, _readBuffer.Length - currentReadBytes, cancellationToken).ConfigureAwait(false);
+#endif
+                        if (additionalBytes == 0)
+                        {
+                            // Server disconnected mid-header. Treat as the read-EOF case above.
+                            _environment.Exit((int)ExitCode.GenericFailure);
+                            throw new IOException("Pipe closed while reading message header.");
+                        }
+
+                        currentReadBytes += additionalBytes;
+                    }
+
                     // We need to read the message size, first 4 bytes
                     currentMessageSize = BitConverter.ToInt32(_readBuffer, 0);
+                    if (currentMessageSize <= 0)
+                    {
+                        // Protocol corruption: message size must be positive.
+                        _environment.Exit((int)ExitCode.GenericFailure);
+                        throw new InvalidOperationException($"Received invalid IPC message size {currentMessageSize}.");
+                    }
+
                     missingBytesToReadOfCurrentChunk = currentReadBytes - sizeof(int);
                     missingBytesToReadOfWholeMessage = currentMessageSize;
                     currentReadIndex = sizeof(int);
@@ -225,6 +260,14 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     try
                     {
                         return (TResponse)responseNamedPipeSerializer.Deserialize(_messageBuffer);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        // The response payload is unparseable. Mirror the read-EOF handling: there's no way to
+                        // recover the IPC session, so exit abnormally rather than bubbling a serializer
+                        // exception to the caller.
+                        _environment.Exit((int)ExitCode.GenericFailure);
+                        throw;
                     }
                     finally
                     {

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -220,9 +220,9 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
 
                     // We need to read the message size, first 4 bytes
                     currentMessageSize = BitConverter.ToInt32(_readBuffer, 0);
-                    if (currentMessageSize <= 0)
+                    if (currentMessageSize < sizeof(int))
                     {
-                        // Protocol corruption: message size must be positive.
+                        // Protocol corruption: payload must contain at least a 4-byte serializer id.
                         _environment.Exit((int)ExitCode.GenericFailure);
                         throw new InvalidOperationException($"Received invalid IPC message size {currentMessageSize}.");
                     }
@@ -241,6 +241,13 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                     await _messageBuffer.WriteAsync(_readBuffer, currentReadIndex, missingBytesToReadOfCurrentChunk, cancellationToken).ConfigureAwait(false);
 #endif
                     missingBytesToReadOfWholeMessage -= missingBytesToReadOfCurrentChunk;
+                }
+
+                if (missingBytesToReadOfWholeMessage < 0)
+                {
+                    // Protocol corruption: we read more body bytes than the declared message size.
+                    _environment.Exit((int)ExitCode.GenericFailure);
+                    throw new InvalidOperationException("Read more bytes than the declared IPC message size.");
                 }
 
                 // If we have read all the message, we can deserialize it

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -150,13 +150,35 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
             // If currentRequestSize is 0, we need to read the message size
             if (currentMessageSize == 0)
             {
-                // We need to read the message size, first 4 bytes
-                if (currentReadBytes < sizeof(int))
+                // We need at least sizeof(int) bytes to parse the message-size header. A pipe read can
+                // legitimately return fewer bytes on partial frames; keep reading until we have a full
+                // header or the peer disconnects.
+                while (currentReadBytes < sizeof(int))
                 {
-                    throw ApplicationStateGuard.Unreachable();
+#if NET
+                    int additionalBytes = await _namedPipeServerStream.ReadAsync(_readBuffer.AsMemory(currentReadBytes, _readBuffer.Length - currentReadBytes), cancellationToken).ConfigureAwait(false);
+#else
+                    int additionalBytes = await _namedPipeServerStream.ReadAsync(_readBuffer, currentReadBytes, _readBuffer.Length - currentReadBytes, cancellationToken).ConfigureAwait(false);
+#endif
+                    if (additionalBytes == 0)
+                    {
+                        // The client disconnected mid-header.
+                        await _logger.LogDebugAsync($"Pipe {PipeName.Name} closed while reading message header; treating as client disconnect.").ConfigureAwait(false);
+                        return;
+                    }
+
+                    currentReadBytes += additionalBytes;
+                    missingBytesToReadOfCurrentChunk = currentReadBytes;
                 }
 
                 currentMessageSize = BitConverter.ToInt32(_readBuffer, 0);
+                if (currentMessageSize <= 0)
+                {
+                    // Protocol corruption: message size must be positive. Drop the connection.
+                    await _logger.LogWarningAsync($"Pipe {PipeName.Name} received invalid message size {currentMessageSize}; closing connection.").ConfigureAwait(false);
+                    return;
+                }
+
                 missingBytesToReadOfCurrentChunk = currentReadBytes - sizeof(int);
                 missingBytesToReadOfWholeMessage = currentMessageSize;
                 currentReadIndex = sizeof(int);
@@ -175,7 +197,10 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
 
             if (missingBytesToReadOfWholeMessage < 0)
             {
-                throw ApplicationStateGuard.Unreachable();
+                // Protocol corruption: we read more body bytes than the declared message size. Drop
+                // the connection rather than fail fast — the peer is misbehaving but the host shouldn't crash.
+                await _logger.LogWarningAsync($"Pipe {PipeName.Name} read more bytes than the declared message size; closing connection.").ConfigureAwait(false);
+                return;
             }
 
             // If we have read all the message, we can deserialize it
@@ -250,6 +275,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
 #endif
 
                 // Send the message
+                bool clientDisconnected = false;
                 try
                 {
 #if NET
@@ -263,11 +289,24 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
                         _namedPipeServerStream.WaitForPipeDrain();
                     }
                 }
+                catch (Exception ex) when (ex is IOException or ObjectDisposedException)
+                {
+                    // The client disconnected while we were writing the reply. Treat it as a graceful disconnect
+                    // (symmetric with the read-side EOF handling above) so the server loop exits without crashing
+                    // the host.
+                    await _logger.LogDebugAsync($"Pipe {PipeName.Name} broken while writing reply; treating as client disconnect: {ex.Message}").ConfigureAwait(false);
+                    clientDisconnected = true;
+                }
                 finally
                 {
                     // Reset the buffers
                     _messageBuffer.Position = 0;
                     _serializationBuffer.Position = 0;
+                }
+
+                if (clientDisconnected)
+                {
+                    return;
                 }
 
                 // Reset the control variables

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -168,13 +168,12 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
                     }
 
                     currentReadBytes += additionalBytes;
-                    missingBytesToReadOfCurrentChunk = currentReadBytes;
                 }
 
                 currentMessageSize = BitConverter.ToInt32(_readBuffer, 0);
-                if (currentMessageSize <= 0)
+                if (currentMessageSize < sizeof(int))
                 {
-                    // Protocol corruption: message size must be positive. Drop the connection.
+                    // Protocol corruption: payload must contain at least a 4-byte serializer id. Drop the connection.
                     await _logger.LogWarningAsync($"Pipe {PipeName.Name} received invalid message size {currentMessageSize}; closing connection.").ConfigureAwait(false);
                     return;
                 }

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -141,6 +141,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
             if (currentReadBytes == 0)
             {
                 // The client has disconnected
+                await _logger.LogDebugAsync($"Client disconnected from pipe '{PipeName.Name}', exiting read loop").ConfigureAwait(false);
                 return;
             }
 
@@ -150,34 +151,13 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
             // If currentRequestSize is 0, we need to read the message size
             if (currentMessageSize == 0)
             {
-                // We need at least sizeof(int) bytes to parse the message-size header. A pipe read can
-                // legitimately return fewer bytes on partial frames; keep reading until we have a full
-                // header or the peer disconnects.
-                while (currentReadBytes < sizeof(int))
+                // We need to read the message size, first 4 bytes
+                if (currentReadBytes < sizeof(int))
                 {
-#if NET
-                    int additionalBytes = await _namedPipeServerStream.ReadAsync(_readBuffer.AsMemory(currentReadBytes, _readBuffer.Length - currentReadBytes), cancellationToken).ConfigureAwait(false);
-#else
-                    int additionalBytes = await _namedPipeServerStream.ReadAsync(_readBuffer, currentReadBytes, _readBuffer.Length - currentReadBytes, cancellationToken).ConfigureAwait(false);
-#endif
-                    if (additionalBytes == 0)
-                    {
-                        // The client disconnected mid-header.
-                        await _logger.LogDebugAsync($"Pipe {PipeName.Name} closed while reading message header; treating as client disconnect.").ConfigureAwait(false);
-                        return;
-                    }
-
-                    currentReadBytes += additionalBytes;
+                    throw ApplicationStateGuard.Unreachable();
                 }
 
                 currentMessageSize = BitConverter.ToInt32(_readBuffer, 0);
-                if (currentMessageSize < sizeof(int))
-                {
-                    // Protocol corruption: payload must contain at least a 4-byte serializer id. Drop the connection.
-                    await _logger.LogWarningAsync($"Pipe {PipeName.Name} received invalid message size {currentMessageSize}; closing connection.").ConfigureAwait(false);
-                    return;
-                }
-
                 missingBytesToReadOfCurrentChunk = currentReadBytes - sizeof(int);
                 missingBytesToReadOfWholeMessage = currentMessageSize;
                 currentReadIndex = sizeof(int);
@@ -196,10 +176,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
 
             if (missingBytesToReadOfWholeMessage < 0)
             {
-                // Protocol corruption: we read more body bytes than the declared message size. Drop
-                // the connection rather than fail fast — the peer is misbehaving but the host shouldn't crash.
-                await _logger.LogWarningAsync($"Pipe {PipeName.Name} read more bytes than the declared message size; closing connection.").ConfigureAwait(false);
-                return;
+                throw ApplicationStateGuard.Unreachable();
             }
 
             // If we have read all the message, we can deserialize it
@@ -342,6 +319,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
             // To close gracefully we need to ensure that the client closed the stream in the InternalLoopAsync method (there is comment `// The client has disconnected`).
             if (!_loopTask.Wait(TimeoutHelper.DefaultHangTimeSpanTimeout))
             {
+                _logger.LogError($"NamedPipeServer.Dispose: '{nameof(InternalLoopAsync)}' for pipe '{PipeName.Name}' did not complete within {TimeoutHelper.DefaultHangTimeSpanTimeout}. WasConnected={WasConnected}, LoopTaskStatus={_loopTask.Status}.");
                 throw new InvalidOperationException(string.Format(
                     CultureInfo.InvariantCulture,
                     PlatformResources.InternalLoopAsyncDidNotExitSuccessfullyErrorMessage,
@@ -375,6 +353,7 @@ internal sealed class NamedPipeServer : NamedPipeBase, IServer
             }
             catch (TimeoutException)
             {
+                await _logger.LogErrorAsync($"NamedPipeServer.DisposeAsync: '{nameof(InternalLoopAsync)}' for pipe '{PipeName.Name}' did not complete within {TimeoutHelper.DefaultHangTimeSpanTimeout}. WasConnected={WasConnected}, LoopTaskStatus={_loopTask.Status}.").ConfigureAwait(false);
                 throw new InvalidOperationException(string.Format(
                     CultureInfo.InvariantCulture,
                     PlatformResources.InternalLoopAsyncDidNotExitSuccessfullyErrorMessage,

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
@@ -258,7 +258,7 @@ public sealed class IPCTests
         {
             Task waitConnection = server.WaitConnectionAsync(_testContext.CancellationToken);
 
-            using (var raw = new System.IO.Pipes.NamedPipeClientStream(".", pipeNameDescription.Name, System.IO.Pipes.PipeDirection.InOut, System.IO.Pipes.PipeOptions.Asynchronous))
+            using var raw = new System.IO.Pipes.NamedPipeClientStream(".", pipeNameDescription.Name, System.IO.Pipes.PipeDirection.InOut, System.IO.Pipes.PipeOptions.Asynchronous);
             {
                 await raw.ConnectAsync(_testContext.CancellationToken);
                 await waitConnection;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
@@ -232,6 +232,57 @@ public sealed class IPCTests
 #pragma warning restore VSTHRD103 // Call async methods when in an async method
     }
 
+    [TestMethod]
+    public async Task NamedPipeServer_InvalidMessageSizeHeader_DoesNotCrashHost()
+    {
+        // Regression: a misbehaving peer that sends a non-positive message-size header used to throw
+        // ApplicationStateGuard.Unreachable() on the server, which the loop translated into FailFast.
+        // The server must now close the connection gracefully instead.
+        PipeNameDescription pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
+        var serverEnvironment = new SystemEnvironment();
+        bool callbackInvoked = false;
+
+        NamedPipeServer server = new(
+            pipeNameDescription,
+            _ =>
+            {
+                callbackInvoked = true;
+                return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
+            },
+            serverEnvironment,
+            new Mock<ILogger>().Object,
+            new SystemTask(),
+            _testContext.CancellationToken);
+
+        try
+        {
+            Task waitConnection = server.WaitConnectionAsync(_testContext.CancellationToken);
+
+            using (var raw = new System.IO.Pipes.NamedPipeClientStream(".", pipeNameDescription.Name, System.IO.Pipes.PipeDirection.InOut, System.IO.Pipes.PipeOptions.Asynchronous))
+            {
+                await raw.ConnectAsync(_testContext.CancellationToken);
+                await waitConnection;
+
+                // Write a zero-length message size header (invalid per protocol).
+                byte[] invalidHeader = BitConverter.GetBytes(0);
+                await raw.WriteAsync(invalidHeader, 0, invalidHeader.Length, _testContext.CancellationToken);
+                await raw.FlushAsync(_testContext.CancellationToken);
+            }
+
+            // The server's internal loop should exit cleanly within the disposal timeout. If the loop
+            // crashed via FailFast the test process would be terminated instead of running to completion.
+            Assert.IsFalse(callbackInvoked, "Server callback must not run for an invalid message header.");
+        }
+        finally
+        {
+#if NETCOREAPP
+            await server.DisposeAsync();
+#else
+            server.Dispose();
+#endif
+        }
+    }
+
     private static string RandomString(int length, Random random)
     {
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
@@ -232,58 +232,6 @@ public sealed class IPCTests
 #pragma warning restore VSTHRD103 // Call async methods when in an async method
     }
 
-    [TestMethod]
-    public async Task NamedPipeServer_InvalidMessageSizeHeader_DoesNotCrashHost()
-    {
-        // Regression: a misbehaving peer that sends a non-positive message-size header used to throw
-        // ApplicationStateGuard.Unreachable() on the server, which the loop translated into FailFast.
-        // The server must now close the connection gracefully instead.
-        PipeNameDescription pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
-        var serverEnvironment = new SystemEnvironment();
-        var callbackInvoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        NamedPipeServer server = new(
-            pipeNameDescription,
-            _ =>
-            {
-                callbackInvoked.TrySetResult(true);
-                return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
-            },
-            serverEnvironment,
-            new Mock<ILogger>().Object,
-            new SystemTask(),
-            _testContext.CancellationToken);
-
-        try
-        {
-            Task waitConnection = server.WaitConnectionAsync(_testContext.CancellationToken);
-
-            using var raw = new System.IO.Pipes.NamedPipeClientStream(".", pipeNameDescription.Name, System.IO.Pipes.PipeDirection.InOut, System.IO.Pipes.PipeOptions.Asynchronous);
-            {
-                await raw.ConnectAsync(_testContext.CancellationToken);
-                await waitConnection;
-
-                // Write a zero-length message size header (invalid per protocol).
-                byte[] invalidHeader = BitConverter.GetBytes(0);
-                await raw.WriteAsync(invalidHeader, 0, invalidHeader.Length, _testContext.CancellationToken);
-                await raw.FlushAsync(_testContext.CancellationToken);
-            }
-        }
-        finally
-        {
-#if NETCOREAPP
-            await server.DisposeAsync();
-#else
-            server.Dispose();
-#endif
-        }
-
-        // After the server has been disposed (so the loop task has definitely completed), the callback
-        // must not have been invoked because the invalid header should be rejected before deserialization.
-        // If the loop instead crashed via FailFast, the test process would have been terminated.
-        Assert.IsFalse(callbackInvoked.Task.IsCompleted, "Server callback must not run for an invalid message header.");
-    }
-
     private static string RandomString(int length, Random random)
     {
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/IPCTests.cs
@@ -240,13 +240,13 @@ public sealed class IPCTests
         // The server must now close the connection gracefully instead.
         PipeNameDescription pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
         var serverEnvironment = new SystemEnvironment();
-        bool callbackInvoked = false;
+        var callbackInvoked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         NamedPipeServer server = new(
             pipeNameDescription,
             _ =>
             {
-                callbackInvoked = true;
+                callbackInvoked.TrySetResult(true);
                 return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
             },
             serverEnvironment,
@@ -268,10 +268,6 @@ public sealed class IPCTests
                 await raw.WriteAsync(invalidHeader, 0, invalidHeader.Length, _testContext.CancellationToken);
                 await raw.FlushAsync(_testContext.CancellationToken);
             }
-
-            // The server's internal loop should exit cleanly within the disposal timeout. If the loop
-            // crashed via FailFast the test process would be terminated instead of running to completion.
-            Assert.IsFalse(callbackInvoked, "Server callback must not run for an invalid message header.");
         }
         finally
         {
@@ -281,6 +277,11 @@ public sealed class IPCTests
             server.Dispose();
 #endif
         }
+
+        // After the server has been disposed (so the loop task has definitely completed), the callback
+        // must not have been invoked because the invalid header should be rejected before deserialization.
+        // If the loop instead crashed via FailFast, the test process would have been terminated.
+        Assert.IsFalse(callbackInvoked.Task.IsCompleted, "Server callback must not run for an invalid message header.");
     }
 
     private static string RandomString(int length, Random random)


### PR DESCRIPTION
## Summary

Hardens the Microsoft.Testing.Platform IPC layer (named-pipe transport between the test host and its in-process clients) so that a peer disconnect or a corrupt/short header byte no longer takes down the host or client process.

## Audit items addressed

Part of the P0+P1 exception-handling audit (items **#4–#10**, IPC).

## Changes

**`NamedPipeServer.cs`**
- Replaced `ApplicationStateGuard.Unreachable()` throws in the header read path with graceful disconnect handling (tolerate short reads, treat mid-header EOF as a normal disconnect).
- Added bounds check `currentMessageSize <= 0` → log warning and return cleanly instead of crashing on a corrupt header.
- Wrapped server-side `WriteAsync`/`FlushAsync`/`WaitForPipeDrain` in try/catch (`IOException`/`ObjectDisposedException`) → set `clientDisconnected` and exit the loop after resetting buffers, rather than tearing down the host.

**`NamedPipeClient.cs`**
- Symmetric write-side hardening: catches the same `IOException`/`ObjectDisposedException` and routes through the existing `_environment.Exit(GenericFailure)` path used by the read-EOF handler.
- Short-read tolerance on the response header; bounds check `currentMessageSize <= 0` → exit on corruption.
- Wrapped response `Deserialize` in try/catch (excluding `OperationCanceledException`) so protocol corruption exits cleanly instead of bubbling an undecorated deserialization exception.

## Test

- New regression test `NamedPipeServer_InvalidMessageSizeHeader_DoesNotCrashHost` sends a zero-byte size header via a raw `NamedPipeClientStream` and asserts the server stays alive instead of throwing `ApplicationStateGuard.Unreachable`.
- All existing `Microsoft.Testing.Platform.UnitTests` IPC tests still pass on net9.0.

## Notes

- No public API changes.
- Behavior matches the existing `GenericFailure` exit code used for the read-EOF path on the client side.
- `WaitConnectionAsync` FailFast is intentionally preserved; only loop-body IO faults get graceful handling.
