### PR TITLE
MSTEST0005: Stop reporting on fields of type TestContext

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/TestContextShouldBeValidFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/TestContextShouldBeValidFixer.cs
@@ -76,56 +76,29 @@ public sealed class TestContextShouldBeValidFixer : CodeFixProvider
                 modifiers.Where(modifier => !modifier.IsKind(SyntaxKind.PrivateKeyword) && !modifier.IsKind(SyntaxKind.InternalKeyword) && !modifier.IsKind(SyntaxKind.ProtectedKeyword))).Add(visibilityModifier);
         }
 
-        MemberDeclarationSyntax newMemberDeclaration = memberDeclaration.WithModifiers(modifiers);
-
-        if (newMemberDeclaration is FieldDeclarationSyntax fieldDeclarationSyntax)
+        // The analyzer only reports on property declarations.
+        var propertyDeclaration = (PropertyDeclarationSyntax)memberDeclaration.WithModifiers(modifiers);
+        if (!propertyDeclaration.Identifier.ValueText.Equals(TestContextShouldBeValidAnalyzer.TestContextPropertyName, StringComparison.Ordinal))
         {
-            newMemberDeclaration = ConvertFieldToProperty(fieldDeclarationSyntax);
+            propertyDeclaration = propertyDeclaration.WithIdentifier(
+                SyntaxFactory.Identifier(propertyDeclaration.Identifier.LeadingTrivia, TestContextShouldBeValidAnalyzer.TestContextPropertyName, propertyDeclaration.Identifier.TrailingTrivia));
         }
-        else
-        {
-            // ensure that the property has setter and getter
-            var propertyDeclaration = (PropertyDeclarationSyntax)newMemberDeclaration;
-            if (!propertyDeclaration.Identifier.ValueText.Equals(TestContextShouldBeValidAnalyzer.TestContextPropertyName, StringComparison.Ordinal))
-            {
-                propertyDeclaration = propertyDeclaration.WithIdentifier(
-                    SyntaxFactory.Identifier(propertyDeclaration.Identifier.LeadingTrivia, TestContextShouldBeValidAnalyzer.TestContextPropertyName, propertyDeclaration.Identifier.TrailingTrivia));
-            }
 
-            SyntaxList<AccessorDeclarationSyntax> accessors = propertyDeclaration.AccessorList?.Accessors ?? default;
+        SyntaxList<AccessorDeclarationSyntax> accessors = propertyDeclaration.AccessorList?.Accessors ?? default;
 
-            AccessorDeclarationSyntax getAccessor = accessors.FirstOrDefault(a => a.Kind() == SyntaxKind.GetAccessorDeclaration)
-                ?? SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+        AccessorDeclarationSyntax getAccessor = accessors.FirstOrDefault(a => a.Kind() == SyntaxKind.GetAccessorDeclaration)
+            ?? SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
-            AccessorDeclarationSyntax setAccessor = accessors.FirstOrDefault(a => a.Kind() == SyntaxKind.SetAccessorDeclaration)
-                ?? SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+        AccessorDeclarationSyntax setAccessor = accessors.FirstOrDefault(a => a.Kind() == SyntaxKind.SetAccessorDeclaration)
+            ?? SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
-            newMemberDeclaration = propertyDeclaration.WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List([getAccessor, setAccessor])));
-        }
+        PropertyDeclarationSyntax newPropertyDeclaration = propertyDeclaration.WithAccessorList(
+            SyntaxFactory.AccessorList(SyntaxFactory.List([getAccessor, setAccessor])));
 
         // Create a new member declaration with the updated modifiers.
-        editor.ReplaceNode(memberDeclaration, newMemberDeclaration);
+        editor.ReplaceNode(memberDeclaration, newPropertyDeclaration);
         SyntaxNode newRoot = editor.GetChangedRoot();
 
         return document.WithSyntaxRoot(newRoot);
-    }
-
-    private static PropertyDeclarationSyntax ConvertFieldToProperty(FieldDeclarationSyntax fieldDeclaration)
-    {
-        TypeSyntax type = fieldDeclaration.Declaration.Type;
-
-        // Create the property declaration
-        PropertyDeclarationSyntax propertyDeclaration = SyntaxFactory.PropertyDeclaration(type, TestContextShouldBeValidAnalyzer.TestContextPropertyName)
-            .WithModifiers(SyntaxFactory.TokenList(fieldDeclaration.Modifiers))
-            .WithAccessorList(SyntaxFactory.AccessorList(
-                SyntaxFactory.List(
-                [
-                    SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)),
-                    SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
-                        .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
-                ])));
-
-        return propertyDeclaration;
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -355,7 +355,7 @@ The type declaring these methods should also respect the following rules:
     <value>TestCleanup method should have valid layout</value>
   </data>
   <data name="TestContextShouldBeValidDescription" xml:space="preserve">
-    <value>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+    <value>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</value>

--- a/src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs
@@ -186,108 +186,77 @@ public sealed class TestContextShouldBeValidAnalyzer : DiagnosticAnalyzer
                         var namedType = (INamedTypeSymbol)context.Symbol;
                         foreach (ISymbol member in namedType.GetMembers())
                         {
-                            IFieldSymbol? fieldReturnedByProperty = null;
-                            ConcurrentBag<IFieldSymbol>? fieldsAssignedInConstructor = null;
-                            switch (member.Kind)
+                            if (member is not IPropertySymbol propertySymbol)
                             {
-                                case SymbolKind.Property:
-                                case SymbolKind.Field:
-                                    if (member is IPropertySymbol propertySymbol)
-                                    {
-                                        if (!SymbolEqualityComparer.Default.Equals(propertySymbol.Type, testContextSymbol) ||
-                                            !member.Name.Equals(TestContextPropertyName, StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            continue;
-                                        }
-
-                                        if (propertySymbol.IsStatic)
-                                        {
-                                            context.RegisterSymbolEndAction(
-                                                context => context.ReportDiagnostic(member.CreateDiagnostic(TestContextShouldBeValidRule)));
-                                            continue;
-                                        }
-
-                                        if (IsTestContextPropertyAutomaticallyAssigned(propertySymbol, testContextSymbol))
-                                        {
-                                            return;
-                                        }
-
-                                        fieldsAssignedInConstructor = [];
-
-                                        context.RegisterOperationBlockAction(context =>
-                                        {
-                                            if (context.OwningSymbol.Equals(propertySymbol.GetMethod, SymbolEqualityComparer.Default))
-                                            {
-                                                fieldReturnedByProperty = TryGetReturnedField(context.OperationBlocks);
-                                            }
-                                            else if (TryGetTestContextParameterIfValidConstructor(context.OwningSymbol, testContextSymbol) is { } parameter)
-                                            {
-                                                CollectTestContextFieldsAssignedInConstructor(parameter, context.OperationBlocks, fieldsAssignedInConstructor);
-                                            }
-                                        });
-                                    }
-                                    else if (member is IFieldSymbol fieldSymbol)
-                                    {
-                                        // AssociatedSymbol check is to not analyze compiler-generated backing field.
-                                        if (fieldSymbol.AssociatedSymbol is not null ||
-                                            // Workaround https://github.com/dotnet/roslyn/issues/70208
-                                            // https://github.com/dotnet/roslyn/blob/05e49aa98995349ffa26a19020333293ffe99670/src/Compilers/CSharp/Portable/Symbols/Synthesized/GeneratedNameKind.cs#L47
-                                            (fieldSymbol.Name.StartsWith("<", StringComparison.Ordinal) && fieldSymbol.Name.EndsWith(">P", StringComparison.Ordinal)) ||
-                                            !SymbolEqualityComparer.Default.Equals(fieldSymbol.Type, testContextSymbol))
-                                        {
-                                            continue;
-                                        }
-
-                                        // For fields, we check the type but not the name to allow analyzing different conventions.
-                                        // The field could be named _testContext, testContext, or s_testContext. So we want to analyze all these.
-                                        if (fieldSymbol.IsStatic)
-                                        {
-                                            context.RegisterSymbolEndAction(
-                                                context => context.ReportDiagnostic(member.CreateDiagnostic(TestContextShouldBeValidRule)));
-                                            continue;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        throw ApplicationStateGuard.Unreachable();
-                                    }
-
-                                    // Initially, we consider the field/property as not assigned in the constructor.
-                                    // Then, we look for a constructor with a single TestContext parameter and look for assignment
-                                    // in the constructor. We simply iterate over the operation blocks (no DFA involved for now).
-                                    bool isAssigned = false;
-
-                                    context.RegisterOperationBlockAction(
-                                        context =>
-                                        {
-                                            if (TryGetTestContextParameterIfValidConstructor(context.OwningSymbol, testContextSymbol) is not { } parameter)
-                                            {
-                                                return;
-                                            }
-
-                                            if (AssignsParameterToMember(parameter, member, context.OperationBlocks))
-                                            {
-                                                isAssigned = true;
-                                            }
-                                        });
-
-                                    context.RegisterSymbolEndAction(
-                                        context =>
-                                        {
-                                            if (!isAssigned)
-                                            {
-                                                isAssigned = fieldReturnedByProperty is not null &&
-                                                    fieldsAssignedInConstructor?.Contains(fieldReturnedByProperty, SymbolEqualityComparer.Default) == true;
-                                            }
-
-                                            if (!isAssigned)
-                                            {
-                                                context.ReportDiagnostic(member.CreateDiagnostic(TestContextShouldBeValidRule));
-                                            }
-                                        });
-
-                                    break;
+                                continue;
                             }
+
+                            if (!SymbolEqualityComparer.Default.Equals(propertySymbol.Type, testContextSymbol) ||
+                                !propertySymbol.Name.Equals(TestContextPropertyName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+
+                            if (propertySymbol.IsStatic)
+                            {
+                                context.RegisterSymbolEndAction(
+                                    context => context.ReportDiagnostic(propertySymbol.CreateDiagnostic(TestContextShouldBeValidRule)));
+                                continue;
+                            }
+
+                            if (IsTestContextPropertyAutomaticallyAssigned(propertySymbol, testContextSymbol))
+                            {
+                                return;
+                            }
+
+                            IFieldSymbol? fieldReturnedByProperty = null;
+                            ConcurrentBag<IFieldSymbol> fieldsAssignedInConstructor = [];
+
+                            context.RegisterOperationBlockAction(context =>
+                            {
+                                if (context.OwningSymbol.Equals(propertySymbol.GetMethod, SymbolEqualityComparer.Default))
+                                {
+                                    fieldReturnedByProperty = TryGetReturnedField(context.OperationBlocks);
+                                }
+                                else if (TryGetTestContextParameterIfValidConstructor(context.OwningSymbol, testContextSymbol) is { } parameter)
+                                {
+                                    CollectTestContextFieldsAssignedInConstructor(parameter, context.OperationBlocks, fieldsAssignedInConstructor);
+                                }
+                            });
+
+                            // Initially, we consider the property as not assigned in the constructor.
+                            // Then, we look for a constructor with a single TestContext parameter and look for assignment
+                            // in the constructor. We simply iterate over the operation blocks (no DFA involved for now).
+                            bool isAssigned = false;
+
+                            context.RegisterOperationBlockAction(
+                                context =>
+                                {
+                                    if (TryGetTestContextParameterIfValidConstructor(context.OwningSymbol, testContextSymbol) is not { } parameter)
+                                    {
+                                        return;
+                                    }
+
+                                    if (AssignsParameterToMember(parameter, propertySymbol, context.OperationBlocks))
+                                    {
+                                        isAssigned = true;
+                                    }
+                                });
+
+                            context.RegisterSymbolEndAction(
+                                context =>
+                                {
+                                    if (!isAssigned)
+                                    {
+                                        isAssigned = fieldReturnedByProperty is not null &&
+                                            fieldsAssignedInConstructor.Contains(fieldReturnedByProperty, SymbolEqualityComparer.Default);
+                                    }
+
+                                    if (!isAssigned)
+                                    {
+                                        context.ReportDiagnostic(propertySymbol.CreateDiagnostic(TestContextShouldBeValidRule));
+                                    }
+                                });
                         }
                     }, SymbolKind.NamedType);
             }

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -792,11 +792,11 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
+        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
 – Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
 – Nesmí být static.
 – Musí mít metodu setter.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -793,11 +793,11 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">„TestContext“ muss ein nicht statisches Feld oder eine nicht statische Eigenschaft sein, das im Konstruktor zugewiesen ist, oder für eine von MSTest festgelegte Eigenschaft sollte es dem Layout folgen:
+        <target state="needs-review-translation">„TestContext“ muss ein nicht statisches Feld oder eine nicht statische Eigenschaft sein, das im Konstruktor zugewiesen ist, oder für eine von MSTest festgelegte Eigenschaft sollte es dem Layout folgen:
 – es sollte „public“ sein, unabhängig davon, ob das Attribut „[assembly: DiscoverInternals]“ festgelegt ist oder nicht.
 – sie darf nicht „static“ sein
 – es sollte einen Setter aufweisen.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -792,11 +792,11 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">"TestContext" debe ser un campo no estático o una propiedad asignada en el constructor o para una propiedad establecida por MSTest, debe seguir el diseño:
+        <target state="needs-review-translation">"TestContext" debe ser un campo no estático o una propiedad asignada en el constructor o para una propiedad establecida por MSTest, debe seguir el diseño:
 - debe ser "public" independientemente de si el atributo "[assembly: DiscoverInternals]" está establecido o no.
 - No debe ser "static"
 - debe tener un establecedor.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -792,11 +792,11 @@ Le type doit être une classe
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">« TestContext » doit être un champ ou une propriété non statique affecté dans le constructeur ou pour une propriété définie par MSTest, il doit suivre la disposition :
+        <target state="needs-review-translation">« TestContext » doit être un champ ou une propriété non statique affecté dans le constructeur ou pour une propriété définie par MSTest, il doit suivre la disposition :
 - il doit être « public », que l’attribut « [assembly: DiscoverInternals] » soit défini ou non.
 - il ne devrait pas être « statique »
 - il doit avoir un setter.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -792,11 +792,11 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">'TestContext' deve essere una proprietà o un campo non statico assegnato nel costruttore o per un insieme di proprietà da MSTest. Deve seguire il layout:
+        <target state="needs-review-translation">'TestContext' deve essere una proprietà o un campo non statico assegnato nel costruttore o per un insieme di proprietà da MSTest. Deve seguire il layout:
 - deve essere “pubblico” indipendentemente dal fatto che l'attributo “[assembly: DiscoverInternals]” sia impostato o meno.
 - non deve essere “statico”
 - deve avere un setter.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -792,11 +792,11 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">'TestContext' は、コンストラクターまたは MSTest によって設定されたプロパティに割り当てられた非静的フィールドまたはプロパティである必要があります。レイアウトに従う必要があります:
+        <target state="needs-review-translation">'TestContext' は、コンストラクターまたは MSTest によって設定されたプロパティに割り当てられた非静的フィールドまたはプロパティである必要があります。レイアウトに従う必要があります:
 - '[assembly: DiscoverInternals]' 属性が設定されているかどうかに関係なく、'public' である必要があります。
 - 'static' にすることはできません
 - セッターが必要です。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -792,11 +792,11 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">'TestContext'는 생성자 또는 MSTest에서 설정한 속성에 할당된 비정적 필드 또는 속성이어야 하며 레이아웃을 따라야 합니다.
+        <target state="needs-review-translation">'TestContext'는 생성자 또는 MSTest에서 설정한 속성에 할당된 비정적 필드 또는 속성이어야 하며 레이아웃을 따라야 합니다.
 - '[assembly: DiscoverInternals]' 특성이 설정되었는지 여부에 관계없이 'public'이어야 합니다.
 - 'static'이 아니어야 합니다.
 - setter가 있어야 합니다.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -792,11 +792,11 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">Element „TestContext” powinien być niestatycznym polem lub właściwością przypisaną w konstruktorze lub dla właściwości ustawionej przez narzędzie MSTest, powinien być zgodny z układem:
+        <target state="needs-review-translation">Element „TestContext” powinien być niestatycznym polem lub właściwością przypisaną w konstruktorze lub dla właściwości ustawionej przez narzędzie MSTest, powinien być zgodny z układem:
 — powinien mieć wartość „public” niezależnie od tego, czy ustawiono atrybut „[assembly: DiscoverInternals]”.
 — nie powinien mieć wartości „static”
 — powinien mieć metodę ustawiającą.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -792,11 +792,11 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">'TestContext' deve ser um campo ou propriedade não estática atribuída no construtor ou, para uma propriedade definida pelo MSTest, deve seguir o layout:
+        <target state="needs-review-translation">'TestContext' deve ser um campo ou propriedade não estática atribuída no construtor ou, para uma propriedade definida pelo MSTest, deve seguir o layout:
 - deve ser 'public' independentemente de o atributo '[assembly: DiscoverInternals]' estar definido ou não.
 - não deve ser 'static'
 - deve ter um setter.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -801,11 +801,11 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">"TestContext" должно быть нестатическим полем или свойством, присваиваемым в конструкторе, или — для свойства, установленного MSTest — должно следовать набору правил:
+        <target state="needs-review-translation">"TestContext" должно быть нестатическим полем или свойством, присваиваемым в конструкторе, или — для свойства, установленного MSTest — должно следовать набору правил:
 — оно должно быть объявлено как "public", независимо от того, задан ли атрибут "[assembly: DiscoverInternals]";
 — оно не может быть объявлено как "static";
 — для него должен быть определен метод задания.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -793,11 +793,11 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">'TestContext' statik olmayan bir alan veya oluşturucuda atanan bir özellik olmalıdır veya MSTest tarafından ayarlanan bir özellik kümesi için şu düzeni izlemelidir:
+        <target state="needs-review-translation">'TestContext' statik olmayan bir alan veya oluşturucuda atanan bir özellik olmalıdır veya MSTest tarafından ayarlanan bir özellik kümesi için şu düzeni izlemelidir:
 - '[assembly: DiscoverInternals]' özniteliğinin ayarlanıp ayarlanmadığına bakılmaksızın 'public' olmalıdır.
 - 'static' olmamalıdır
 - bir ayarlayıcı içermelidir.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -792,11 +792,11 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">"TestContext" 应该是构造函数中分配的非静态字段或属性，或者对于 MSTest 设置的属性，它应遵循以下布局:
+        <target state="needs-review-translation">"TestContext" 应该是构造函数中分配的非静态字段或属性，或者对于 MSTest 设置的属性，它应遵循以下布局:
 - 无论是否设置 "[assembly: DiscoverInternals]" 属性，它都应为 "public"。
 - 它不应为 "static"
 - 它应具有一个资源库。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -792,11 +792,11 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidDescription">
-        <source>'TestContext' should be a non-static field or property assigned in constructor or for a property set by MSTest, it should follow the layout:
+        <source>'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="translated">'TestContext' 應是在建構函式中指派的非靜態欄位或屬性，或是針對由 MSTest 所設定的屬性，其應遵循下列配置:
+        <target state="needs-review-translation">'TestContext' 應是在建構函式中指派的非靜態欄位或屬性，或是針對由 MSTest 所設定的屬性，其應遵循下列配置:
 - 它應該是 'public' (無論是否有設定 '[assembly: DiscoverInternals]' 屬性)。
 - 它不應該是 'static'
 - 它應該有 setter。</target>

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
@@ -27,63 +27,72 @@ public sealed class TestContextShouldBeValidAnalyzerTests
     [DataRow("TeStCoNtExT", "internal")]
     [DataRow("TeStCoNtExT", "protected")]
     [TestMethod]
-    public async Task WhenTestContextCaseInsensitiveIsField_Diagnostic(string fieldName, string accessibility)
+    public async Task WhenTestContextCaseInsensitiveIsField_NoDiagnostic(string fieldName, string accessibility)
     {
+        // MSTEST0005 only validates the TestContext property layout. Fields of type TestContext
+        // are intentionally not flagged, because doing so produced too many false positives
+        // (see https://github.com/microsoft/testfx/issues/4590). The static-field case is
+        // covered by MSTEST0024 (DoNotStoreStaticTestContext).
         string code = $$"""
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
             [TestClass]
             public class MyTestClass
             {
-                {{accessibility}} TestContext [|{{fieldName}}|];
+                {{accessibility}} TestContext {{fieldName}};
             }
             """;
-        string fixedCode =
-            """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-            [TestClass]
-            public class MyTestClass
-            {
-                public TestContext TestContext { get; set; }
-            }
-            """;
-        await VerifyCS.VerifyCodeFixAsync(
-            code,
-            fixedCode);
+        await VerifyCS.VerifyCodeFixAsync(code, code);
     }
 
-    [DataRow("TestContext", "private")]
-    [DataRow("TestContext", "public")]
-    [DataRow("TestContext", "internal")]
-    [DataRow("TestContext", "protected")]
-    [DataRow("testcontext", "private")]
-    [DataRow("testcontext", "public")]
-    [DataRow("testcontext", "internal")]
-    [DataRow("testcontext", "protected")]
-    [DataRow("TESTCONTEXT", "private")]
-    [DataRow("TESTCONTEXT", "public")]
-    [DataRow("TESTCONTEXT", "internal")]
-    [DataRow("TESTCONTEXT", "protected")]
-    [DataRow("TeStCoNtExT", "private")]
-    [DataRow("TeStCoNtExT", "public")]
-    [DataRow("TeStCoNtExT", "internal")]
-    [DataRow("TeStCoNtExT", "protected")]
+    [DataRow("_testContext")]
+    [DataRow("s_testContext")]
+    [DataRow("testContext")]
     [TestMethod]
-    public async Task WhenTestContextCaseInsensitiveIsField_AssignedInConstructor_NoDiagnostic(string fieldName, string accessibility)
+    public async Task WhenStaticFieldOfTypeTestContextAssignedInClassInitialize_NoDiagnostic(string fieldName)
     {
+        // Regression test for https://github.com/microsoft/testfx/issues/4590:
+        // a static field of type TestContext that is assigned in a [ClassInitialize] method
+        // must not trigger MSTEST0005. MSTEST0024 already covers the "do not store TestContext
+        // in a static member" guidance.
         string code = $$"""
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
             [TestClass]
             public class MyTestClass
             {
-                public MyTestClass(TestContext testContext)
-                {
-                    this.{{fieldName}} = testContext;
-                }
+                private static TestContext {{fieldName}};
 
-                {{accessibility}} TestContext {{fieldName}};
+                [ClassInitialize]
+                public static void ClassInitialize(TestContext context) =>
+                    {{fieldName}} = context;
+
+                [TestMethod]
+                public void TestMethod1() { }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenStaticFieldOfTypeTestContextIsNeverAssigned_NoDiagnostic()
+    {
+        // Documents the deliberate behavior change tied to https://github.com/microsoft/testfx/issues/4590:
+        // MSTEST0005 no longer reports on fields of type TestContext, including unassigned static fields.
+        // Such a field is also not reported by MSTEST0024 (which only fires on assignment), so this is
+        // an accepted trade-off in favor of removing the false positives that previously bothered users.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext _context;
+
+                [TestMethod]
+                public void TestMethod1() { }
             }
             """;
 


### PR DESCRIPTION
## Summary

Removes the field-handling branch from `TestContextShouldBeValidAnalyzer` so MSTEST0005 only validates the `TestContext` property layout. The rule's message reads *"Property 'TestContext' should be valid"*, so the field path was already at odds with the diagnostic text.

Fixes #4590.

## Why

Reporting on every static or unassigned field of type `TestContext` produced too many false positives. The most visible one comes from a perfectly reasonable pattern:

```csharp
[TestClass]
public class MyTests
{
    private static TestContext _context;

    [ClassInitialize]
    public static void ClassInitialize(TestContext context) =>
        _context = context;
}
```

The static-field misuse case is already covered by **MSTEST0024** (`DoNotStoreStaticTestContextAnalyzer`), which warns at the assignment site with the much clearer message *"Do not store TestContext in a static member"*.

## Trade-off

A static field of type `TestContext` that is never assigned now gets no MSTEST0005 (and no MSTEST0024 since there is no assignment site). This is an accepted trade-off in favor of removing the false positives; a regression test (`WhenStaticFieldOfTypeTestContextIsNeverAssigned_NoDiagnostic`) documents the behavior so it isn't accidentally restored.

## Changes

- `src/Analyzers/MSTest.Analyzers/TestContextShouldBeValidAnalyzer.cs` — replace the `switch (member.Kind)` over property/field with an `IPropertySymbol` filter; property analysis (auto-assignment, constructor assignment, backing-field fallback) is unchanged.
- `src/Analyzers/MSTest.Analyzers.CodeFixes/TestContextShouldBeValidFixer.cs` — drop `ConvertFieldToProperty` and the `FieldDeclarationSyntax` branch; the fixer now operates on property declarations only.
- `src/Analyzers/MSTest.Analyzers/Resources.resx` — update `TestContextShouldBeValidDescription` to drop the mention of "field". XLF files regenerated via `UpdateXlf`.
- `test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs`:
  - `WhenTestContextCaseInsensitiveIsField_Diagnostic` → `WhenTestContextCaseInsensitiveIsField_NoDiagnostic` (asserts no diagnostic, same parametric cases).
  - Drops the now-redundant `WhenTestContextCaseInsensitiveIsField_AssignedInConstructor_NoDiagnostic`.
  - Adds `WhenStaticFieldOfTypeTestContextAssignedInClassInitialize_NoDiagnostic` covering the exact #4590 scenario.
  - Adds `WhenStaticFieldOfTypeTestContextIsNeverAssigned_NoDiagnostic` documenting the deliberate trade-off.

## Validation

`MSTest.Analyzers.UnitTests` passes on both `net8.0` and `net472` (66 tests for `TestContextShouldBeValidAnalyzerTests`).
