### PR TITLE
Skip expert-reviewer agentic workflow on OneLocBuild localization PRs

### DIFF
--- a/.github/workflows/review-on-open.agent.lock.yml
+++ b/.github/workflows/review-on-open.agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e276ddf3f1158403d8daf390a97d66809d95301c0b6483058b1ea5b2e6cbf999","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6b9954e9bf8983971c619ec0eaff1f25e880bc5e398b1a4a632c06cdb6d2f03b","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49","digest":"sha256:9e4b936d4215af09fa412e12a5fc82f97f2cde4993eefc85980a900122fa9062","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49@sha256:9e4b936d4215af09fa412e12a5fc82f97f2cde4993eefc85980a900122fa9062"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49","digest":"sha256:b795506f6b4fd12694a29f964b4d38d2d29ac3aaafe3394131619ce36020b646","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49@sha256:b795506f6b4fd12694a29f964b4d38d2d29ac3aaafe3394131619ce36020b646"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49","digest":"sha256:f6c6998edfb9f58b6e12d3f148e6f2104747a7702d563a9e8b13d4b2ae6997dd","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49@sha256:f6c6998edfb9f58b6e12d3f148e6f2104747a7702d563a9e8b13d4b2ae6997dd"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -75,8 +75,10 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && ((github.event.pull_request.draft == false) && (github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.id == github.repository_id))
+      needs.pre_activation.outputs.activated == 'true' && ((github.event.pull_request.draft == false && !(
+      github.event.pull_request.user.login == 'dotnet-bot'
+      && startsWith(github.event.pull_request.title, 'Localized file check-in')
+      )) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -210,21 +212,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_de069ee2a63638d2_EOF'
+          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
           <system>
-          GH_AW_PROMPT_de069ee2a63638d2_EOF
+          GH_AW_PROMPT_35834297cdfc6352_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt_multi.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_de069ee2a63638d2_EOF'
+          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:30), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_de069ee2a63638d2_EOF
+          GH_AW_PROMPT_35834297cdfc6352_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_de069ee2a63638d2_EOF'
+          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -253,13 +255,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_de069ee2a63638d2_EOF
+          GH_AW_PROMPT_35834297cdfc6352_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_de069ee2a63638d2_EOF'
+          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/review-shared.md}}
           {{#runtime-import .github/workflows/review-on-open.agent.md}}
-          GH_AW_PROMPT_de069ee2a63638d2_EOF
+          GH_AW_PROMPT_35834297cdfc6352_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -484,9 +486,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f80fae7b7c948051_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_824a51814315adc6_EOF'
           {"add_comment":{"max":5},"create_pull_request_review_comment":{"max":30,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f80fae7b7c948051_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_824a51814315adc6_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -737,7 +739,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_23515b271c8a1b6f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_216c1064395b6fad_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -778,7 +780,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_23515b271c8a1b6f_EOF
+          GH_AW_MCP_CONFIG_216c1064395b6fad_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1372,7 +1374,10 @@ jobs:
 
   pre_activation:
     if: >
-      (github.event.pull_request.draft == false) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
+      (github.event.pull_request.draft == false && !(
+      github.event.pull_request.user.login == 'dotnet-bot'
+      && startsWith(github.event.pull_request.title, 'Localized file check-in')
+      )) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id)
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/review-on-open.agent.md
+++ b/.github/workflows/review-on-open.agent.md
@@ -13,8 +13,14 @@ on:
     types: [opened]
   roles: [admin, maintainer, write]
 
-# Skip draft PRs — only run for PRs opened as ready
-if: github.event.pull_request.draft == false
+# Skip draft PRs and OneLocBuild localization check-in PRs (authored by dotnet-bot)
+# — only run for human-authored PRs opened as ready.
+if: >
+  github.event.pull_request.draft == false
+  && !(
+    github.event.pull_request.user.login == 'dotnet-bot'
+    && startsWith(github.event.pull_request.title, 'Localized file check-in')
+  )
 
 permissions:
   contents: read


### PR DESCRIPTION
Stops the `expert-reviewer` agentic workflow from running on OneLocBuild localization check-in PRs (e.g. #8634), which are pure generated `.xlf` updates that don't benefit from expert review.

## Change

Extends the `if:` guard in `.github/workflows/review-on-open.agent.md` to also skip when both:

- `github.event.pull_request.user.login == 'dotnet-bot'`
- `startsWith(github.event.pull_request.title, 'Localized file check-in')`

This is the same detection pattern already used by `.github/workflows/enable-auto-merge.yml` for these PRs.

The recompiled `review-on-open.agent.lock.yml` is included in the commit (strict-mode compile, no warnings).

## What this does NOT fix

The `copilot-pull-request-reviewer[bot]` review on the same PR is GitHub's *Copilot code review* product. It is not driven by repo workflows and can only be filtered via repo Settings → Copilot (path filters in Code review settings, or Content exclusion for patterns like `**/xlf/**`). That has to be configured by an admin in the UI.

## Notes

- Slash-command `/review` (`review.agent.md`) is intentionally left alone — it's opt-in.
- `dotnet-maestro[bot]` dependency-flow PRs are NOT included in this skip; happy to extend if desired.