### PR TITLE
Fix bad merge in MSTest.Analyzers xlf files

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -796,10 +796,6 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
         <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
 – Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
 – Nesmí být static.

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -797,14 +797,10 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">„TestContext“ muss ein nicht statisches Feld oder eine nicht statische Eigenschaft sein, das im Konstruktor zugewiesen ist, oder für eine von MSTest festgelegte Eigenschaft sollte es dem Layout folgen:
+– es sollte „public“ sein, unabhängig davon, ob das Attribut „[assembly: DiscoverInternals]“ festgelegt ist oder nicht.
+– sie darf nicht „static“ sein
+– es sollte einen Setter aufweisen.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -796,14 +796,10 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">"TestContext" debe ser un campo no estático o una propiedad asignada en el constructor o para una propiedad establecida por MSTest, debe seguir el diseño:
+- debe ser "public" independientemente de si el atributo "[assembly: DiscoverInternals]" está establecido o no.
+- No debe ser "static"
+- debe tener un establecedor.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -796,14 +796,10 @@ Le type doit être une classe
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">« TestContext » doit être un champ ou une propriété non statique affecté dans le constructeur ou pour une propriété définie par MSTest, il doit suivre la disposition :
+- il doit être « public », que l’attribut « [assembly: DiscoverInternals] » soit défini ou non.
+- il ne devrait pas être « statique »
+- il doit avoir un setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -796,14 +796,10 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">'TestContext' deve essere una proprietà o un campo non statico assegnato nel costruttore o per un insieme di proprietà da MSTest. Deve seguire il layout:
+- deve essere “pubblico” indipendentemente dal fatto che l'attributo “[assembly: DiscoverInternals]” sia impostato o meno.
+- non deve essere “statico”
+- deve avere un setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -796,14 +796,10 @@ The type declaring these methods should also respect the following rules:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">'TestContext' は、コンストラクターまたは MSTest によって設定されたプロパティに割り当てられた非静的フィールドまたはプロパティである必要があります。レイアウトに従う必要があります:
+- '[assembly: DiscoverInternals]' 属性が設定されているかどうかに関係なく、'public' である必要があります。
+- 'static' にすることはできません
+- セッターが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -796,14 +796,10 @@ The type declaring these methods should also respect the following rules:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">'TestContext'는 생성자 또는 MSTest에서 설정한 속성에 할당된 비정적 필드 또는 속성이어야 하며 레이아웃을 따라야 합니다.
+- '[assembly: DiscoverInternals]' 특성이 설정되었는지 여부에 관계없이 'public'이어야 합니다.
+- 'static'이 아니어야 합니다.
+- setter가 있어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -796,14 +796,10 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">Element „TestContext” powinien być niestatycznym polem lub właściwością przypisaną w konstruktorze lub dla właściwości ustawionej przez narzędzie MSTest, powinien być zgodny z układem:
+— powinien mieć wartość „public” niezależnie od tego, czy ustawiono atrybut „[assembly: DiscoverInternals]”.
+— nie powinien mieć wartości „static”
+— powinien mieć metodę ustawiającą.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -796,14 +796,10 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">'TestContext' deve ser um campo ou propriedade não estática atribuída no construtor ou, para uma propriedade definida pelo MSTest, deve seguir o layout:
+- deve ser 'public' independentemente de o atributo '[assembly: DiscoverInternals]' estar definido ou não.
+- não deve ser 'static'
+- deve ter um setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -805,14 +805,10 @@ The type declaring these methods should also respect the following rules:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">"TestContext" должно быть нестатическим полем или свойством, присваиваемым в конструкторе, или — для свойства, установленного MSTest — должно следовать набору правил:
+— оно должно быть объявлено как "public", независимо от того, задан ли атрибут "[assembly: DiscoverInternals]";
+— оно не может быть объявлено как "static";
+— для него должен быть определен метод задания.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -797,14 +797,10 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">'TestContext' statik olmayan bir alan veya oluşturucuda atanan bir özellik olmalıdır veya MSTest tarafından ayarlanan bir özellik kümesi için şu düzeni izlemelidir:
+- '[assembly: DiscoverInternals]' özniteliğinin ayarlanıp ayarlanmadığına bakılmaksızın 'public' olmalıdır.
+- 'static' olmamalıdır
+- bir ayarlayıcı içermelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -796,14 +796,10 @@ The type declaring these methods should also respect the following rules:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">"TestContext" 应该是构造函数中分配的非静态字段或属性，或者对于 MSTest 设置的属性，它应遵循以下布局:
+- 无论是否设置 "[assembly: DiscoverInternals]" 属性，它都应为 "public"。
+- 它不应为 "static"
+- 它应具有一个资源库。</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -796,14 +796,10 @@ The type declaring these methods should also respect the following rules:
 - it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
 - it should not be 'static'
 - it should have a setter.</source>
-        <target state="new">'TestContext' should be a non-static property assigned in constructor or set by MSTest. To be set by MSTest, it should follow the layout:
-- it should be 'public' regardless of whether '[assembly: DiscoverInternals]' attribute is set or not.
-- it should not be 'static'
-- it should have a setter.</target>
-        <target state="needs-review-translation">TestContext musí být nestatické pole nebo vlastnost přiřazené v konstruktoru nebo pro vlastnost nastavenou přes MSTest. Musí se řídit následujícím rozložením:
-– Musí být public bez ohledu na to, jestli je nastavený atribut [assembly: DiscoverInternals].
-– Nesmí být static.
-– Musí mít metodu setter.</target>
+        <target state="needs-review-translation">'TestContext' 應是在建構函式中指派的非靜態欄位或屬性，或是針對由 MSTest 所設定的屬性，其應遵循下列配置:
+- 它應該是 'public' (無論是否有設定 '[assembly: DiscoverInternals]' 屬性)。
+- 它不應該是 'static'
+- 它應該有 setter。</target>
         <note />
       </trans-unit>
       <trans-unit id="TestContextShouldBeValidTitle">


### PR DESCRIPTION
## Problem

Two recent OneLocBuild check-ins corrupted the `TestContextShouldBeValidDescription` trans-unit in all 13 language xlf files for `MSTest.Analyzers`, breaking the build with:

```
xlf\Resources.cs.xlf : error : The element 'trans-unit' in namespace 'urn:oasis:names:tc:xliff:document:1.2' has invalid child element 'target' in namespace 'urn:oasis:names:tc:xliff:document:1.2'. List of possible elements expected: 'context-group, count-group, prop-group, note, alt-trans' in namespace 'urn:oasis:names:tc:xliff:document:1.2' as well as any element in namespace '##other'. [D:\a\_work\1\s\src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj]
```

### Root cause

- 41fd1ac8c (Localized file check-in #8631) added a stray `<target state=""new"">English text</target>` element, producing **two** `<target>` elements in a single `<trans-unit>`. This violates the xliff 1.2 schema and is what the compiler error above is about.
- c27a8f156 (Localized file check-in #8634) then overwrote the existing localized translation with the Czech text in all 12 non-Czech language files.

## Fix

Restore the `TestContextShouldBeValidDescription` trans-unit to its pristine pre-bad-merge state (taken from commit 561ebf79f) for all 13 affected files. This:

- Removes the duplicate `<target>` so each `<trans-unit>` has exactly one target (fixes the XSD validation error).
- Restores the proper per-language translation that was overwritten with Czech.

## Verification

- Built `MSTest.Analyzers.csproj` locally: 0 warnings, 0 errors.
- XML-parsed every `.xlf` file under `src/` and `test/` and verified that no `<trans-unit>` has more than one `<target>`.
