### PR TITLE
Add opt-in random test order to MSTest adapter (#7089)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -230,7 +230,10 @@ internal class TestExecutionManager
             return;
         }
 
-        int seed = MSTestSettings.CurrentSettings.RandomTestOrderSeed ?? new Random().Next();
+        // Use Guid.NewGuid().GetHashCode() rather than new Random() so that consecutive runs do not
+        // collide on the same seed on .NET Framework targets (where Random() is time-seeded with low
+        // resolution). The user can still pin the seed via RandomTestOrderSeed for reproducibility.
+        int seed = MSTestSettings.CurrentSettings.RandomTestOrderSeed ?? Guid.NewGuid().GetHashCode();
         _testOrderRandom = new Random(seed);
 
         frameworkHandle.SendMessage(

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -49,6 +49,12 @@ internal class TestExecutionManager
     private TestRunCancellationToken? _testRunCancellationToken;
 
     /// <summary>
+    /// Random number generator used to shuffle test execution order when <see cref="MSTestSettings.RandomizeTestOrder"/> is enabled.
+    /// Mutated only on the source-processing thread before parallel workers are started.
+    /// </summary>
+    private Random? _testOrderRandom;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="TestExecutionManager"/> class.
     /// </summary>
     public TestExecutionManager()
@@ -198,14 +204,48 @@ internal class TestExecutionManager
     /// <param name="isDeploymentDone">Indicates if deployment is done.</param>
     internal virtual async Task ExecuteTestsAsync(IEnumerable<TestCase> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, bool isDeploymentDone)
     {
-        var testsBySource = from test in tests
-                            group test by test.Source into testGroup
-                            select new { Source = testGroup.Key, Tests = testGroup };
+        InitializeRandomTestOrder(frameworkHandle);
+
+        var testsBySource = (from test in tests
+                             group test by test.Source into testGroup
+                             select new { Source = testGroup.Key, Tests = (IEnumerable<TestCase>)testGroup }).ToArray();
+
+        if (_testOrderRandom is { } random)
+        {
+            Shuffle(random, testsBySource);
+        }
 
         foreach (var group in testsBySource)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
             await ExecuteTestsInSourceAsync(group.Tests, runContext, frameworkHandle, group.Source, isDeploymentDone).ConfigureAwait(false);
+        }
+    }
+
+    private void InitializeRandomTestOrder(IMessageLogger frameworkHandle)
+    {
+        if (!MSTestSettings.CurrentSettings.RandomizeTestOrder)
+        {
+            _testOrderRandom = null;
+            return;
+        }
+
+        int seed = MSTestSettings.CurrentSettings.RandomTestOrderSeed ?? new Random().Next();
+        _testOrderRandom = new Random(seed);
+
+        frameworkHandle.SendMessage(
+            TestMessageLevel.Informational,
+            string.Format(CultureInfo.CurrentCulture, Resource.RandomTestOrderBanner, seed));
+    }
+
+    private static void Shuffle<T>(Random random, T[] items)
+    {
+        // Fisher-Yates shuffle. The array is mutated in place so that callers see a fully
+        // materialized, deterministic order before any parallel work starts.
+        for (int i = items.Length - 1; i > 0; i--)
+        {
+            int j = random.Next(i + 1);
+            (items[i], items[j]) = (items[j], items[i]);
         }
     }
 
@@ -339,6 +379,11 @@ internal class TestExecutionManager
         int parallelWorkers = sourceSettings.Workers;
         ExecutionScope parallelScope = sourceSettings.Scope;
         TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filterExpression, t, _testMethodFilter))];
+        if (_testOrderRandom is { } sourceRandom)
+        {
+            Shuffle(sourceRandom, testsToRun);
+        }
+
         UnitTestElement[] unitTestElements = [.. testsToRun.Select(e => e.ToUnitTestElementWithUpdatedSource(source))];
         // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain
         var testRunner = (UnitTestRunner)isolationHost.CreateInstanceForType(
@@ -382,11 +427,36 @@ internal class TestExecutionManager
                 switch (parallelScope)
                 {
                     case ExecutionScope.MethodLevel:
-                        queue = new ConcurrentQueue<IEnumerable<TestCase>>(parallelizableTestSet.Select(t => new[] { t }));
+                        if (_testOrderRandom is { } methodRandom)
+                        {
+                            IEnumerable<TestCase>[] methodChunks = [.. parallelizableTestSet.Select(t => (IEnumerable<TestCase>)[t])];
+                            Shuffle(methodRandom, methodChunks);
+                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(methodChunks);
+                        }
+                        else
+                        {
+                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(parallelizableTestSet.Select(t => new[] { t }));
+                        }
+
                         break;
 
                     case ExecutionScope.ClassLevel:
-                        queue = new ConcurrentQueue<IEnumerable<TestCase>>(parallelizableTestSet.GroupBy(t => t.GetPropertyValue(EngineConstants.TestClassNameProperty) as string));
+                        if (_testOrderRandom is { } classRandom)
+                        {
+                            IEnumerable<TestCase>[] classChunks =
+                            [
+                                .. parallelizableTestSet
+                                    .GroupBy(t => t.GetPropertyValue(EngineConstants.TestClassNameProperty) as string)
+                                    .Select(g => (IEnumerable<TestCase>)g.ToArray()),
+                            ];
+                            Shuffle(classRandom, classChunks);
+                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(classChunks);
+                        }
+                        else
+                        {
+                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(parallelizableTestSet.GroupBy(t => t.GetPropertyValue(EngineConstants.TestClassNameProperty) as string));
+                        }
+
                         break;
                 }
 
@@ -463,7 +533,7 @@ internal class TestExecutionManager
         UnitTestRunner testRunner,
         bool usesAppDomains)
     {
-        IEnumerable<TestCase> orderedTests = MSTestSettings.CurrentSettings.OrderTestsByNameInClass
+        IEnumerable<TestCase> orderedTests = MSTestSettings.CurrentSettings.OrderTestsByNameInClass && !MSTestSettings.CurrentSettings.RandomizeTestOrder
             ? tests.OrderBy(t => t.GetManagedType()).ThenBy(t => t.GetManagedMethod())
             : tests;
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
@@ -59,6 +59,11 @@ internal sealed partial class MSTestSettings
 
         CurrentSettings = settings;
         RunConfigurationSettings = runConfigurationSettings;
+
+        if (settings.RandomizeTestOrder && settings.OrderTestsByNameInClass)
+        {
+            logger?.SendMessage(TestMessageLevel.Warning, Resource.RandomTestOrderAndOrderTestsByNameInClassConflict);
+        }
 
         // Track configuration source for telemetry.
 #if !WINDOWS_UWP && !WIN_UI
@@ -144,6 +149,23 @@ internal sealed partial class MSTestSettings
         }
     }
 
+    private static void ParseSignedIntegerSetting(IConfiguration configuration, string key, IMessageLogger? logger, Action<int> setSetting)
+    {
+        if (configuration[$"mstest:{key}"] is not string value)
+        {
+            return;
+        }
+
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int result))
+        {
+            setSetting(result);
+        }
+        else
+        {
+            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
+        }
+    }
+
     /// <summary>
     /// Convert the parameter xml to TestSettings.
     /// </summary>
@@ -153,6 +175,8 @@ internal sealed partial class MSTestSettings
     internal static void SetSettingsFromConfig(IConfiguration configuration, IMessageLogger? logger, MSTestSettings settings)
     {
         ParseBooleanSetting(configuration, "orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
+        ParseBooleanSetting(configuration, "execution:randomizeTestOrder", logger, value => settings.RandomizeTestOrder = value);
+        ParseSignedIntegerSetting(configuration, "execution:randomTestOrderSeed", logger, value => settings.RandomTestOrderSeed = value);
         ParseBooleanSetting(configuration, "output:captureTrace", logger, value => settings.CaptureDebugTraces = value);
         ParseBooleanSetting(configuration, "parallelism:enabled", logger, value => settings.DisableParallelization = !value);
         ParseBooleanSetting(configuration, "execution:mapInconclusiveToFailed", logger, value => settings.MapInconclusiveToFailed = value);

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -24,6 +24,8 @@ internal sealed partial class MSTestSettings
         CurrentSettings.MapInconclusiveToFailed = settings.MapInconclusiveToFailed;
         CurrentSettings.MapNotRunnableToFailed = settings.MapNotRunnableToFailed;
         CurrentSettings.OrderTestsByNameInClass = settings.OrderTestsByNameInClass;
+        CurrentSettings.RandomizeTestOrder = settings.RandomizeTestOrder;
+        CurrentSettings.RandomTestOrderSeed = settings.RandomTestOrderSeed;
         CurrentSettings.ParallelizationScope = settings.ParallelizationScope;
         CurrentSettings.ParallelizationWorkers = settings.ParallelizationWorkers;
         CurrentSettings.TestCleanupTimeout = settings.TestCleanupTimeout;
@@ -267,6 +269,30 @@ internal sealed partial class MSTestSettings
                         else
                         {
                             logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, orderTestsByNameInClass, "OrderTestsByNameInClass"));
+                        }
+
+                        break;
+                    case "RANDOMIZETESTORDER":
+                        string randomizeTestOrder = reader.ReadInnerXml();
+                        if (bool.TryParse(randomizeTestOrder, out result))
+                        {
+                            settings.RandomizeTestOrder = result;
+                        }
+                        else
+                        {
+                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, randomizeTestOrder, "RandomizeTestOrder"));
+                        }
+
+                        break;
+                    case "RANDOMTESTORDERSEED":
+                        string randomTestOrderSeed = reader.ReadInnerXml();
+                        if (int.TryParse(randomTestOrderSeed, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedRandomTestOrderSeed))
+                        {
+                            settings.RandomTestOrderSeed = parsedRandomTestOrderSeed;
+                        }
+                        else
+                        {
+                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, randomTestOrderSeed, "RandomTestOrderSeed"));
                         }
 
                         break;

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using DebuggerLaunchMode = Microsoft.VisualStudio.TestTools.UnitTesting.DebuggerLaunchMode;
@@ -46,6 +46,8 @@ internal sealed partial class MSTestSettings
         TestCleanupTimeout = 0;
         CooperativeCancellationTimeout = false;
         OrderTestsByNameInClass = false;
+        RandomizeTestOrder = false;
+        RandomTestOrderSeed = null;
         LaunchDebuggerOnAssertionFailure = DebuggerLaunchMode.Disabled;
     }
 
@@ -160,6 +162,25 @@ internal sealed partial class MSTestSettings
     /// Gets a value indicating whether tests should be ordered by name in the class.
     /// </summary>
     internal bool OrderTestsByNameInClass { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether tests should be executed in a random order to help expose hidden dependencies between tests.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, the adapter shuffles assemblies, parallel chunks and individual tests using <see cref="RandomTestOrderSeed"/>
+    /// (or an auto-generated seed). Tests marked with <c>[DoNotParallelize]</c> are still executed after the parallelizable set,
+    /// but their relative order is also randomized. When this option is enabled, <see cref="OrderTestsByNameInClass"/> is ignored.
+    /// </remarks>
+    internal bool RandomizeTestOrder { get; private set; }
+
+    /// <summary>
+    /// Gets the seed used to randomize test execution order when <see cref="RandomizeTestOrder"/> is enabled.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/>, the adapter generates a seed at run time and reports it in the run output so that the same
+    /// order can be reproduced by setting this value to the reported seed.
+    /// </remarks>
+    internal int? RandomTestOrderSeed { get; private set; }
 
     /// <summary>
     /// Gets a value specifying when to launch the debugger on assertion failure.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
@@ -320,6 +320,14 @@ but received {4} argument(s), with types '{5}'.</value>
     <value>Test Parallelization enabled for {0} (Workers: {1}, Scope: {2})</value>
     <comment>{Locked="Workers"}{Locked="Scope"}</comment>
   </data>
+  <data name="RandomTestOrderBanner" xml:space="preserve">
+    <value>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</value>
+    <comment>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</comment>
+  </data>
+  <data name="RandomTestOrderAndOrderTestsByNameInClassConflict" xml:space="preserve">
+    <value>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</value>
+    <comment>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</comment>
+  </data>
   <data name="UTA_AssemblyCleanupMethodWasUnsuccesful" xml:space="preserve">
     <value>Assembly Cleanup method {0}.{1} failed. Error Message: {2}. StackTrace: {3}</value>
   </data>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
@@ -270,6 +270,16 @@ byl však přijat tento počet argumentů: {4} s typy {5}.</target>
         <target state="translated">V sestavení je načtena starší verze balíčku MSTestV2. Zjišťování testů může selhat při zjišťování všech testů dat, pokud jsou závislé na souboru .runsettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Položka runsettings &lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt; se v operačních systémech jiných než Windows nepodporuje.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
@@ -270,6 +270,16 @@ aber empfing {4} Argument(e) mit den Typen „{5}“.</target>
         <target state="translated">Eine ältere Version des MSTestV2-Pakets wird in die Assembly geladen. Bei der Testermittlung werden möglicherweise nicht alle Datentests ermittelt, wenn sie von der Datei ".runsettings" abhängen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Der Eintrag "&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;" der Ausführungseinstellungen wird auf Nicht-Windows-Betriebssystemen nicht unterstützt.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
@@ -270,6 +270,16 @@ pero recibió {4} argumentos, con los tipos '{5}'.</target>
         <target state="translated">Hay una versión anterior del paquete MSTestV2 cargada en el ensamblado. Es posible que la detección de pruebas no detecte todas las pruebas de datos si dependen del archivo ".runsettings".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">La entrada runsettings "&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;" no se admite en sistemas operativos que no son de Windows.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
@@ -270,6 +270,16 @@ mais a reçu {4} argument(s), avec les types « {5} ».</target>
         <target state="translated">Une version antérieure du package MSTestV2 est chargée dans l’assembly. La découverte de tests risque de ne pas découvrir tous les tests de données s’ils dépendent du fichier '.runsettings'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">L’entrée Runsettings « &lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt; » n’est pas prise en charge sur les systèmes d’exploitation non Windows.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
@@ -270,6 +270,16 @@ ma ha ricevuto {4} argomenti, con tipi '{5}'.</target>
         <target state="translated">Nell'assembly è caricata una versione precedente del pacchetto MSTestV2. L'individuazione dei test potrebbe non riuscire a individuare tutti i test dei dati se dipendono dal file '.runsettings'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">La voce Runsettings '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' non è supportata nei sistemi operativi non Windows.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
@@ -271,6 +271,16 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">古いバージョンの MSTestV2 パッケージがアセンブリに読み込まれています。`.runsettings` ファイルに依存している場合、テスト検出ですべてのデータ テストを検出できない可能性があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Runsettings エントリ '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' は、Windows OS 以外ではサポートされていません。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
@@ -270,6 +270,16 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">이전 버전 MSTestV2 패키지가 어셈블리에 로드되어 테스트 검색이 '.runsettings' 파일에 종속된 경우 모든 데이터 테스트를 검색하지 못할 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Runsettings 항목 '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;'는 Windows 이외의 OS에서는 지원되지 않습니다.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
@@ -270,6 +270,16 @@ ale odebrał argumenty {4} z typami „{5}”.</target>
         <target state="translated">Starsza wersja pakietu MSTestV2 jest załadowana do zestawu. Odnajdywanie testów może nie odnaleźć wszystkich testów danych, jeśli zależą od pliku „.runsettings”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Wpis runsettings „&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;” nie jest obsługiwany w systemach operacyjnych innych niż Windows.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
@@ -270,6 +270,16 @@ mas {4} argumentos recebidos, com tipos '{5}'.</target>
         <target state="translated">Uma versão mais antiga do pacote MSTestV2 é carregada no assembly, a descoberta de teste pode falhar ao descobrir todos os testes de dados se eles dependerem do arquivo `.runsettings`.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Não há suporte para a entrada runsettings "&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;" em sistemas operacionais que não sejam Windows.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
@@ -270,6 +270,16 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">В сборку загружена старая версия пакета MSTestV2. При обнаружении тестов могут быть обнаружены не все тесты данных, если они зависят от файла ".runsettings".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">Запись Runsettings "&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;" не поддерживается в ОС, отличных от Windows.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
@@ -270,6 +270,16 @@ ancak, '{5}' türünde {4} bağımsız değişken aldı.</target>
         <target state="translated">Montaja MSTestV2 paketinin daha eski bir sürümü yüklenir, test keşfi, `.runsettings` dosyasına bağlılarsa tüm veri testlerini keşfetmede başarısız olabilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">'&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' çalışma ayarları girişi Windows dışı işletim sistemlerinde desteklenmiyor.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
@@ -270,6 +270,16 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">程序集中加载了 MSTestV2 包的较旧版本，如果测试发现依赖于“.runsettings”文件，则它们可能无法发现所有数据测试。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">非 Windows 操作系统不支持 Runsettings 条目 "&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;"。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
@@ -270,6 +270,16 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">元件中已載入舊版的 MSTestV2 套件，如果測試探索相依於 '.runsettings' 檔案，則測試探索可能無法探索所有資料測試。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RandomTestOrderAndOrderTestsByNameInClassConflict">
+        <source>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</source>
+        <target state="new">Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</target>
+        <note>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</note>
+      </trans-unit>
+      <trans-unit id="RandomTestOrderBanner">
+        <source>Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</source>
+        <target state="new">Random test order enabled (Seed: {0}). Set 'RandomTestOrderSeed' to reproduce this order.</target>
+        <note>{Locked="Seed"}{Locked="RandomTestOrderSeed"}</note>
+      </trans-unit>
       <trans-unit id="STAIsOnlySupportedOnWindowsWarning">
         <source>Runsettings entry '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;' is not supported on non-Windows OSes.</source>
         <target state="translated">非 Windows OS 不支援 Runsettings 項目 '&lt;ExecutionApartmentState&gt;STA&lt;/ExecutionApartmentState&gt;'。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Telemetry/MSTestTelemetryDataCollector.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Telemetry/MSTestTelemetryDataCollector.cs
@@ -393,6 +393,8 @@ internal sealed class MSTestTelemetryDataCollector
         metrics["mstest.setting.treat_discovery_warnings_as_errors"] = AsTelemetryBool(settings.TreatDiscoveryWarningsAsErrors);
         metrics["mstest.setting.consider_empty_data_source_as_inconclusive"] = AsTelemetryBool(settings.ConsiderEmptyDataSourceAsInconclusive);
         metrics["mstest.setting.order_tests_by_name"] = AsTelemetryBool(settings.OrderTestsByNameInClass);
+        metrics["mstest.setting.randomize_test_order"] = AsTelemetryBool(settings.RandomizeTestOrder);
+        metrics["mstest.setting.random_test_order_seed_provided"] = AsTelemetryBool(settings.RandomTestOrderSeed.HasValue);
         metrics["mstest.setting.capture_debug_traces"] = AsTelemetryBool(settings.CaptureDebugTraces);
     }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -803,6 +803,84 @@ public class TestExecutionManagerTests : TestContainer
         }
     }
 
+    public async Task RunTestsWithRandomizeTestOrderAndFixedSeedShouldProduceDeterministicOrder()
+    {
+        static TestCase[] BuildTests() =>
+        [
+            GetTestCase(typeof(DummyTestClassForOrder), "TestA"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestB"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestC"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestD"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestE"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestF"),
+        ];
+
+        _runContext.MockRunSettings.Setup(rs => rs.SettingsXml).Returns(
+            """
+            <RunSettings>
+              <RunConfiguration>
+                <DisableAppDomain>True</DisableAppDomain>
+              </RunConfiguration>
+              <MSTest>
+                <RandomizeTestOrder>True</RandomizeTestOrder>
+                <RandomTestOrderSeed>12345</RandomTestOrderSeed>
+                <Parallelize>
+                  <Workers>1</Workers>
+                </Parallelize>
+              </MSTest>
+            </RunSettings>
+            """);
+
+        MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+
+        var firstHandle = new TestableFrameworkHandle();
+        var firstManager = new TestExecutionManager(EnvironmentWrapper.Instance, task => task());
+        await firstManager.RunTestsAsync(BuildTests(), _runContext, firstHandle, new TestRunCancellationToken());
+
+        var secondHandle = new TestableFrameworkHandle();
+        var secondManager = new TestExecutionManager(EnvironmentWrapper.Instance, task => task());
+        await secondManager.RunTestsAsync(BuildTests(), _runContext, secondHandle, new TestRunCancellationToken());
+
+        // Same seed must produce the same order across separate runs.
+        firstHandle.TestCaseStartList.Should().Equal(secondHandle.TestCaseStartList);
+        firstHandle.TestCaseStartList.Should().HaveCount(6);
+
+        // Order must differ from the original input (extremely unlikely with seed 12345 across 6 items;
+        // this guards against accidentally turning randomization off).
+        string[] originalOrder = ["TestA", "TestB", "TestC", "TestD", "TestE", "TestF"];
+        firstHandle.TestCaseStartList.Should().NotEqual(originalOrder);
+    }
+
+    public async Task RunTestsWithoutRandomizeTestOrderShouldPreserveInputOrder()
+    {
+        TestCase[] tests =
+        [
+            GetTestCase(typeof(DummyTestClassForOrder), "TestA"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestB"),
+            GetTestCase(typeof(DummyTestClassForOrder), "TestC"),
+        ];
+
+        _runContext.MockRunSettings.Setup(rs => rs.SettingsXml).Returns(
+            """
+            <RunSettings>
+              <RunConfiguration>
+                <DisableAppDomain>True</DisableAppDomain>
+              </RunConfiguration>
+              <MSTest>
+                <Parallelize>
+                  <Workers>1</Workers>
+                </Parallelize>
+              </MSTest>
+            </RunSettings>
+            """);
+
+        MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+
+        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+
+        _frameworkHandle.TestCaseStartList.Should().Equal("TestA", "TestB", "TestC");
+    }
+
     #endregion
 
     #region private methods
@@ -960,6 +1038,40 @@ public class TestExecutionManagerTests : TestContainer
 
         [TestMethod]
         public void TestMethod1() => ThreadIds.Add(Environment.CurrentManagedThreadId);
+    }
+
+    [DummyTestClass]
+    private sealed class DummyTestClassForOrder
+    {
+        [TestMethod]
+        public void TestA()
+        {
+        }
+
+        [TestMethod]
+        public void TestB()
+        {
+        }
+
+        [TestMethod]
+        public void TestC()
+        {
+        }
+
+        [TestMethod]
+        public void TestD()
+        {
+        }
+
+        [TestMethod]
+        public void TestE()
+        {
+        }
+
+        [TestMethod]
+        public void TestF()
+        {
+        }
     }
 
     [DummyTestClass]

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -258,6 +258,90 @@ public class MSTestSettingsTests : TestContainer
         adapterSettings.ParallelizationScope.HasValue.Should().BeFalse();
     }
 
+    public void RandomizeTestOrderShouldBeFalseByDefault()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+
+        adapterSettings.RandomizeTestOrder.Should().BeFalse();
+        adapterSettings.RandomTestOrderSeed.Should().BeNull();
+    }
+
+    public void RandomizeTestOrderShouldBeConsumedFromRunSettingsWhenSpecified()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+                <RandomizeTestOrder>True</RandomizeTestOrder>
+                <RandomTestOrderSeed>42</RandomTestOrderSeed>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+
+        adapterSettings.RandomizeTestOrder.Should().BeTrue();
+        adapterSettings.RandomTestOrderSeed.Should().Be(42);
+    }
+
+    public void RandomTestOrderSeedShouldAcceptNegativeValues()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+                <RandomTestOrderSeed>-7</RandomTestOrderSeed>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+
+        adapterSettings.RandomTestOrderSeed.Should().Be(-7);
+    }
+
+    public void RandomizeTestOrderShouldWarnWhenValueIsInvalid()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+                <RandomizeTestOrder>notabool</RandomizeTestOrder>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+
+        adapterSettings.RandomizeTestOrder.Should().BeFalse();
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'notabool' for runsettings entry 'RandomizeTestOrder', setting will be ignored."), Times.Once);
+    }
+
+    public void RandomTestOrderSeedShouldWarnWhenValueIsInvalid()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+                <RandomTestOrderSeed>notanint</RandomTestOrderSeed>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+
+        adapterSettings.RandomTestOrderSeed.Should().BeNull();
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'notanint' for runsettings entry 'RandomTestOrderSeed', setting will be ignored."), Times.Once);
+    }
+
     public void GetSettingsShouldThrowIfParallelizationWorkersIsNotInt()
     {
         string runSettingsXml =
@@ -1075,6 +1159,8 @@ public class MSTestSettingsTests : TestContainer
             { "mstest:execution:treatDiscoveryWarningsAsErrors", "true" },
             { "mstest:execution:considerEmptyDataSourceAsInconclusive", "true" },
             { "mstest:orderTestsByNameInClass", "true" },
+            { "mstest:execution:randomizeTestOrder", "true" },
+            { "mstest:execution:randomTestOrderSeed", "-12345" },
             { "mstest:output:captureTrace", "true" },
         };
 
@@ -1089,6 +1175,8 @@ public class MSTestSettingsTests : TestContainer
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
+        settings.RandomizeTestOrder.Should().BeTrue();
+        settings.RandomTestOrderSeed.Should().Be(-12345);
         settings.CaptureDebugTraces.Should().BeTrue();
         settings.CooperativeCancellationTimeout.Should().BeTrue();
         settings.MapInconclusiveToFailed.Should().BeTrue();

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -342,6 +342,51 @@ public class MSTestSettingsTests : TestContainer
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'notanint' for runsettings entry 'RandomTestOrderSeed', setting will be ignored."), Times.Once);
     }
 
+    public void PopulateSettingsShouldWarnWhenRandomizeTestOrderAndOrderTestsByNameInClassAreBothEnabled()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+                <RandomizeTestOrder>True</RandomizeTestOrder>
+                <OrderTestsByNameInClass>True</OrderTestsByNameInClass>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
+        _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+
+        MSTestSettings.CurrentSettings.RandomizeTestOrder.Should().BeTrue();
+        MSTestSettings.CurrentSettings.OrderTestsByNameInClass.Should().BeTrue();
+        _mockMessageLogger.Verify(
+            lm => lm.SendMessage(
+                TestMessageLevel.Warning,
+                "Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored."),
+            Times.Once);
+    }
+
+    public void PopulateSettingsShouldNotWarnWhenOnlyRandomizeTestOrderIsEnabled()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+              <MSTestV2>
+                <RandomizeTestOrder>True</RandomizeTestOrder>
+              </MSTestV2>
+            </RunSettings>
+            """;
+
+        _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
+        _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+
+        MSTestSettings.CurrentSettings.RandomizeTestOrder.Should().BeTrue();
+        MSTestSettings.CurrentSettings.OrderTestsByNameInClass.Should().BeFalse();
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Never);
+    }
+
     public void GetSettingsShouldThrowIfParallelizationWorkersIsNotInt()
     {
         string runSettingsXml =


### PR DESCRIPTION
Fixes #7089.

## What

Adds two new MSTest adapter settings:

- RandomizeTestOrder (bool, default false): when `true`, the adapter randomizes the order tests are scheduled in.
- RandomTestOrderSeed (int?, default `null`): optional seed for reproducibility. When not provided, a seed is auto-generated and the effective value is logged so runs can be reproduced.

Both XML runsettings (<MSTest><RandomizeTestOrder>true</RandomizeTestOrder>…) and `testconfig.json` (`mstest.execution.randomizeTestOrder` / `randomTestOrderSeed`) are supported.

When `RandomizeTestOrder` is enabled, `OrderTestsByNameInClass` is ignored and a warning is emitted if both are set.

## Why

Per the issue, this gives users a low-friction way to surface order-dependencies between tests. The seed is logged so a failing randomized run can be reproduced deterministically.

## Notes

- `[DoNotRandomize]` attribute support is intentionally deferred to a follow-up.
- Cross-project seed coordination (`dotnet test`) is also deferred.
- Randomization applies to:
  - the order in which the adapter walks test sources;
  - the order of tests inside each source;
  - the order parallel chunks are dispatched (method-level and class-level scopes).
- Thread interleaving in parallel mode is intrinsically non-deterministic; the docs on the property call this out.
- The shared `Random` is mutated only on the source-processing thread before workers start; all shuffled arrays are eagerly materialized (Fisher-Yates) so workers see a frozen order.

## Tests

- Unit tests for XML parsing (default value, valid value, negative seed, invalid value warning).
- `testconfig.json` parsing extended in the existing config test.
- Deterministic-shuffle test in `TestExecutionManagerTests` runs the same input twice with the same seed and asserts the two execution orders are identical (and differ from the input order).
- Full unit-test suite (836 tests) passes on `net9.0`.
