### PR TITLE
Add MSTEST0066: [Ignore] should have a justification message

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -237,4 +237,7 @@
   <data name="AvoidAssertAreEqualOnCollectionsEquivalentFix" xml:space="preserve">
     <value>Replace with `Assert.{0}`</value>
   </data>
+  <data name="AddIgnoreJustificationFix" xml:space="preserve">
+    <value>Add a placeholder justification to '[Ignore]'</value>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/IgnoreShouldHaveJustificationFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/IgnoreShouldHaveJustificationFixer.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+
+using Analyzer.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// Code fixer for <see cref="IgnoreShouldHaveJustificationAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(IgnoreShouldHaveJustificationFixer))]
+[Shared]
+public sealed class IgnoreShouldHaveJustificationFixer : CodeFixProvider
+{
+    // Placeholder reason inserted by the code fix. Intentionally calls for action so it doesn't
+    // get accidentally committed as-is.
+    private const string PlaceholderJustification = "TODO: explain why this is ignored";
+
+    /// <inheritdoc />
+    public override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(DiagnosticIds.IgnoreShouldHaveJustificationRuleId);
+
+    /// <inheritdoc />
+    public override FixAllProvider GetFixAllProvider()
+        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        Diagnostic diagnostic = context.Diagnostics[0];
+        TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        SyntaxNode? node = root.FindNode(diagnosticSpan);
+        AttributeSyntax? attributeSyntax = node as AttributeSyntax ?? node?.FirstAncestorOrSelf<AttributeSyntax>();
+        if (attributeSyntax is null)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: CodeFixResources.AddIgnoreJustificationFix,
+                createChangedDocument: c => AddJustificationAsync(context.Document, attributeSyntax, c),
+                equivalenceKey: nameof(IgnoreShouldHaveJustificationFixer)),
+            diagnostic);
+    }
+
+    private static async Task<Document> AddJustificationAsync(Document document, AttributeSyntax attributeSyntax, CancellationToken cancellationToken)
+    {
+        SyntaxNode root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        AttributeArgumentSyntax justificationArgument = SyntaxFactory.AttributeArgument(
+            SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(PlaceholderJustification)));
+
+        AttributeArgumentListSyntax existingArgumentList = attributeSyntax.ArgumentList ?? SyntaxFactory.AttributeArgumentList();
+
+        AttributeArgumentListSyntax newArgumentList;
+        if (existingArgumentList.Arguments.Count == 0)
+        {
+            newArgumentList = existingArgumentList.WithArguments(SyntaxFactory.SingletonSeparatedList(justificationArgument));
+        }
+        else
+        {
+            // Replace the first positional argument (the message) with the placeholder.
+            // Empty / null literals on the first positional argument are the only cases we get here.
+            AttributeArgumentSyntax firstArgument = existingArgumentList.Arguments[0];
+            newArgumentList = existingArgumentList.WithArguments(existingArgumentList.Arguments.Replace(firstArgument, justificationArgument));
+        }
+
+        AttributeSyntax newAttribute = attributeSyntax.WithArgumentList(newArgumentList);
+        return document.WithSyntaxRoot(root.ReplaceNode(attributeSyntax, newAttribute));
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Přidat parametry [CallerFilePath] a [CallerLineNumber]</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Přidat [TestClass]</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Fügen Sie die Parameter „[CallerFilePath]“ und „[CallerLineNumber]“ hinzu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">"[TestClass]" hinzufügen</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Agregar los parámetros "[CallerFilePath]" y "[CallerLineNumber]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Agregar '[TestClass]'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Ajoutez les paramètres « [CallerFilePath] » et « [CallerLineNumber] »</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Ajouter '[TestClass]'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Aggiungere i parametri '[CallerFilePath]' e '[CallerLineNumber]'</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Aggiungi '[TestClass]'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">'[CallerFilePath]' パラメーターと '[CallerLineNumber]' パラメーターを追加する</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">'[TestClass]' の追加</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">'[CallerFilePath]'와 '[CallerLineNumber]' 매개변수 추가</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">'[TestClass]' 추가</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Dodaj parametry „[CallerFilePath]” i „[CallerLineNumber]”</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Dodaj element „[TestClass]”</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Adicionar os parâmetros "[CallerFilePath]" e "[CallerLineNumber]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Adicionar '[TestClass]'</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Добавить параметры "[CallerFilePath]" и "[CallerLineNumber]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">Добавить "[TestClass]"</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">'[CallerFilePath]' ve '[CallerLineNumber]' parametrelerini ekleyin</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">'[TestClass]' Ekle</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">添加参数‘[CallerFilePath]’和‘[CallerLineNumber]’</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">添加 “[TestClass]”</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">新增 '[CallerFilePath]' 和 '[CallerLineNumber]' 參數</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddIgnoreJustificationFix">
+        <source>Add a placeholder justification to '[Ignore]'</source>
+        <target state="new">Add a placeholder justification to '[Ignore]'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AddTestClassFix">
         <source>Add '[TestClass]'</source>
         <target state="translated">新增 '[TestClass]'</target>

--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 MSTEST0064 | Usage | Info | PreferAsyncAssertionAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0064)
 MSTEST0065 | Usage | Warning | AvoidAssertAreEqualOnCollectionsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0065)
+MSTEST0066 | Design | Info | IgnoreShouldHaveJustificationAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0066)

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -70,4 +70,5 @@ internal static class DiagnosticIds
     public const string TestClassConstructorShouldBeValidRuleId = "MSTEST0063";
     public const string PreferAsyncAssertionRuleId = "MSTEST0064";
     public const string AvoidAssertAreEqualOnCollectionsRuleId = "MSTEST0065";
+    public const string IgnoreShouldHaveJustificationRuleId = "MSTEST0066";
 }

--- a/src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// MSTEST0066: <inheritdoc cref="Resources.IgnoreShouldHaveJustificationTitle"/>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class IgnoreShouldHaveJustificationAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly LocalizableResourceString Title = new(nameof(Resources.IgnoreShouldHaveJustificationTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.IgnoreShouldHaveJustificationMessageFormat), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString Description = new(nameof(Resources.IgnoreShouldHaveJustificationDescription), Resources.ResourceManager, typeof(Resources));
+
+    internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        DiagnosticIds.IgnoreShouldHaveJustificationRuleId,
+        Title,
+        MessageFormat,
+        Description,
+        Category.Design,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingIgnoreAttribute, out INamedTypeSymbol? ignoreAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute, out INamedTypeSymbol? testMethodAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestClassAttribute, out INamedTypeSymbol? testClassAttributeSymbol))
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(
+                ctx => AnalyzeMethod(ctx, ignoreAttributeSymbol, testMethodAttributeSymbol),
+                SymbolKind.Method);
+
+            context.RegisterSymbolAction(
+                ctx => AnalyzeType(ctx, ignoreAttributeSymbol, testClassAttributeSymbol),
+                SymbolKind.NamedType);
+        });
+    }
+
+    private static void AnalyzeMethod(SymbolAnalysisContext context, INamedTypeSymbol ignoreAttributeSymbol, INamedTypeSymbol testMethodAttributeSymbol)
+    {
+        var methodSymbol = (IMethodSymbol)context.Symbol;
+
+        AttributeData? ignoreAttribute = null;
+        bool isTestMethod = false;
+        foreach (AttributeData methodAttribute in methodSymbol.GetAttributes())
+        {
+            if (methodAttribute.AttributeClass.Inherits(testMethodAttributeSymbol))
+            {
+                isTestMethod = true;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(methodAttribute.AttributeClass, ignoreAttributeSymbol))
+            {
+                ignoreAttribute = methodAttribute;
+            }
+        }
+
+        if (!isTestMethod || ignoreAttribute is null)
+        {
+            return;
+        }
+
+        ReportIfMissingJustification(context, ignoreAttribute, methodSymbol.Name);
+    }
+
+    private static void AnalyzeType(SymbolAnalysisContext context, INamedTypeSymbol ignoreAttributeSymbol, INamedTypeSymbol testClassAttributeSymbol)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+
+        AttributeData? ignoreAttribute = null;
+        bool isTestClass = false;
+        foreach (AttributeData typeAttribute in typeSymbol.GetAttributes())
+        {
+            if (typeAttribute.AttributeClass.Inherits(testClassAttributeSymbol))
+            {
+                isTestClass = true;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(typeAttribute.AttributeClass, ignoreAttributeSymbol))
+            {
+                ignoreAttribute = typeAttribute;
+            }
+        }
+
+        if (!isTestClass || ignoreAttribute is null)
+        {
+            return;
+        }
+
+        ReportIfMissingJustification(context, ignoreAttribute, typeSymbol.Name);
+    }
+
+    private static void ReportIfMissingJustification(SymbolAnalysisContext context, AttributeData ignoreAttribute, string targetName)
+    {
+        if (HasJustification(ignoreAttribute))
+        {
+            return;
+        }
+
+        if (ignoreAttribute.ApplicationSyntaxReference is { } syntaxReference)
+        {
+            context.ReportDiagnostic(syntaxReference.CreateDiagnostic(Rule, context.CancellationToken, targetName));
+        }
+        else
+        {
+            context.ReportDiagnostic(context.Symbol.CreateDiagnostic(Rule, targetName));
+        }
+    }
+
+    private static bool HasJustification(AttributeData ignoreAttribute)
+    {
+        // Parameterless [Ignore] - no justification.
+        if (ignoreAttribute.ConstructorArguments.Length == 0)
+        {
+            return false;
+        }
+
+        // First positional argument of IgnoreAttribute(string? message) is the justification.
+        TypedConstant messageArgument = ignoreAttribute.ConstructorArguments[0];
+        return messageArgument.Value is string message && !string.IsNullOrWhiteSpace(message);
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -765,4 +765,13 @@ The type declaring these methods should also respect the following rules:
   <data name="PreferAsyncAssertionDescription" xml:space="preserve">
     <value>When verifying exceptions from asynchronous code, use the async assertion methods instead of blocking the asynchronous operation with GetAwaiter().GetResult().</value>
   </data>
+  <data name="IgnoreShouldHaveJustificationTitle" xml:space="preserve">
+    <value>'[Ignore]' should specify a justification</value>
+  </data>
+  <data name="IgnoreShouldHaveJustificationMessageFormat" xml:space="preserve">
+    <value>'[Ignore]' should specify a message explaining why '{0}' is ignored</value>
+  </data>
+  <data name="IgnoreShouldHaveJustificationDescription" xml:space="preserve">
+    <value>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</value>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -522,6 +522,21 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="translated">Metody GlobalTestInitialize a GlobalTestCleanup by měly mít platné rozložení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Metody jako Contains, StartsWith a EndsWith vracejí logické hodnoty, které označují, jestli byla podmínka splněna. Ignorování těchto vrácených hodnot je pravděpodobně chyba.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -523,6 +523,21 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="translated">Die Methoden „GlobalTestInitialize“ und „GlobalTestCleanup“ müssen ein gültiges Layout aufweisen</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Methoden wie Contains, StartsWith und EndsWith geben boolesche Werte zurück, die angeben, ob die Bedingung erfüllt wurde. Das Ignorieren dieser Rückgabewerte ist wahrscheinlich ein Fehler.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -522,6 +522,21 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="translated">Los métodos GlobalTestInitialize y GlobalTestCleanup deben tener un diseño válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Los métodos como Contains, StartsWith y EndsWith devuelven valores booleanos que indican si se cumplió la condición. Ignorar estos valores devueltos probablemente sea un error.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -522,6 +522,21 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
         <target state="translated">Les méthodes GlobalTestInitialize et GlobalTestCleanup doivent avoir une structure valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Les méthodes telles que Contains, StartsWith et EndsWith retournent des valeurs booléennes qui indiquent si la condition a été remplie. Ignorer ces valeurs de retour est certainement une erreur.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -522,6 +522,21 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="translated">I metodi GlobalTestInitialize e GlobalTestCleanup devono avere un layout valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Metodi come Contains, StartsWith e EndsWith restituiscono valori booleani che indicano se la condizione è stata soddisfatta. Ignorare questi valori restituiti è probabilmente un errore.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -522,6 +522,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">GlobalTestInitialize および GlobalTestCleanup メソッドには有効なレイアウトが必要です</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Contains、StartsWith、EndsWith などのメソッドは、条件が満たされたかどうかを示すブール値を返します。これらの戻り値を無視するのは間違いである可能性が高いです。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -522,6 +522,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">GlobalTestInitialize 및 GlobalTestCleanup 메서드에는 유효한 레이아웃이 있어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Contains, StartsWith 및 EndsWith와 같은 메서드는 조건이 충족되었는지 여부를 나타내는 부울 값을 반환합니다. 이 반환 값을 무시하는 것은 아마 실수일 것입니다.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -522,6 +522,21 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="translated">Metody GlobalTestInitialize i GlobalTestCleanup powinny mieć prawidłowy układ</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Metody takie jak Contains, StartsWith i EndsWith zwracają wartości logiczne wskazujące, czy warunek został spełniony. Ignorowanie tych wartości zwrotnych jest prawdopodobnie błędem.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -522,6 +522,21 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <target state="translated">Os métodos GlobalTestInitialize e GlobalTestCleanup devem ter um layout válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Métodos como Contains, StartsWith e EndsWith retornam valores boolianos que indicam se a condição foi atendida. Ignorar esses valores retornados provavelmente é um erro.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -528,6 +528,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">Методы GlobalTestInitialize и GlobalTestCleanup должны использовать допустимый макет</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Такие методы, как Contains, StartsWith и EndsWith, возвращают логические значения, указывающие, выполнено ли условие. Игнорирование этих возвращаемых значений, скорее всего, является ошибкой.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -522,6 +522,21 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="translated">GlobalTestInitialize ve GlobalTestCleanup yöntemleri geçerli bir düzene sahip olmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Contains, StartsWith ve EndsWith gibi yöntemler, koşulun karşılanıp karşılanmadığını belirten boole değerleri döndürür. Bu dönüş değerlerini yok saymak büyük olasılıkla bir hataya yol açar.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -522,6 +522,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">GlobalTestInitialize 和 GlobalTestCleanup 方法应具有有效的布局</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Contains、StartsWith 和 EndsWith 等方法会返回指示是否满足条件的布尔值。忽略这些返回值可能是一个错误。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -522,6 +522,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">GlobalTestInitialize 和 GlobalTestCleanup 方法應具備有效的配置</target>
         <note />
       </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationDescription">
+        <source>An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</source>
+        <target state="new">An '[Ignore]' attribute applied to a test method or test class should include a non-empty message explaining why the test or class is ignored. A justification message makes it easier to triage skipped tests, helps reviewers understand the intent, and prevents tests from being silently disabled forever.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationMessageFormat">
+        <source>'[Ignore]' should specify a message explaining why '{0}' is ignored</source>
+        <target state="new">'[Ignore]' should specify a message explaining why '{0}' is ignored</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IgnoreShouldHaveJustificationTitle">
+        <source>'[Ignore]' should specify a justification</source>
+        <target state="new">'[Ignore]' should specify a justification</target>
+        <note />
+      </trans-unit>
       <trans-unit id="IgnoreStringMethodReturnValueDescription">
         <source>Methods like Contains, StartsWith, and EndsWith return boolean values that indicate whether the condition was met. Ignoring these return values is likely a mistake.</source>
         <target state="translated">Contains、StartsWith 和 EndsWith 等方法會傳回布林值，指出是否已符合條件。忽略這些傳回值可能導致錯誤。</target>

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreShouldHaveJustificationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreShouldHaveJustificationAnalyzerTests.cs
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
+    MSTest.Analyzers.IgnoreShouldHaveJustificationAnalyzer,
+    MSTest.Analyzers.IgnoreShouldHaveJustificationFixer>;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public sealed class IgnoreShouldHaveJustificationAnalyzerTests
+{
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithMessage_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore("Tracked by #12345")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasIgnoreWithMessage_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [Ignore("Disabled until feature ships")]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithoutMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore("TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithEmptyMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore("")|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore("TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithWhitespaceMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore("   ")|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore("TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithNullMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            #nullable enable
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore(null)|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            #nullable enable
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore("TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasIgnoreWithoutMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [{|#0:Ignore|}]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [Ignore("TODO: explain why this is ignored")]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasIgnoreWithEmptyMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [{|#0:Ignore("")|}]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [Ignore("TODO: explain why this is ignored")]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestMethodHasIgnore_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [Ignore]
+                public void RegularMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestClassHasIgnore_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [Ignore]
+            public class MyClass
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithCombinedAttributes_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod, {|#0:Ignore|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod, Ignore("TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **MSTEST0066: `[Ignore]` should have a justification message**.

This analyzer flags `[Ignore]` usages on test methods and test classes when no meaningful justification is provided:

- `[Ignore]` (parameterless)
- `[Ignore("""")]`
- `[Ignore(null)]`
- `[Ignore("" "")]` (whitespace-only)

It applies to `[TestMethod]` / `[TestClass]` and any attribute that inherits from them (e.g. `[DataTestMethod]`).

### Why a new rule?

MSTEST0015 (`TestMethodShouldNotBeIgnored`) is **disabled by default** and flags **any** `[Ignore]` usage on methods regardless of message. MSTEST0066 is complementary: it **allows** `[Ignore]` (a legitimate temporary state) but **requires** authors to document **why** the test/class is ignored. It also covers `[TestClass]`, which MSTEST0015 does not.

### Configuration

- Category: `Design`
- Severity: `Info`
- Enabled by default: `true` (included in `All` and `Recommended` modes)

### Code fix

A C# code fix inserts a placeholder so the author cannot miss the missing reason:

`[Ignore(""TODO: explain why this is ignored"")]`

### Tests

11 unit test cases covering positive flags (parameterless, empty, null literal, whitespace-only), valid messages (negative), combined attribute lists (`[TestMethod, Ignore]`), derived test attributes, and non-test method/class scenarios.
