### PR TITLE
Flush AppInsights telemetry once at end of ingest loop

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightTelemetryClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightTelemetryClient.cs
@@ -24,8 +24,8 @@ internal sealed class AppInsightTelemetryClient : ITelemetryClient
     }
 
     public void TrackEvent(string eventName, Dictionary<string, string> properties, Dictionary<string, double> metrics)
-    {
-        _telemetryClient.TrackEvent(eventName, properties, metrics);
-        _telemetryClient.Flush();
-    }
+        => _telemetryClient.TrackEvent(eventName, properties, metrics);
+
+    public void Flush()
+        => _telemetryClient.Flush();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
@@ -246,6 +246,25 @@ internal sealed partial class AppInsightsProvider :
         {
             // This is expected when the test application is shutting down or if flush timeout.
         }
+        finally
+        {
+            // Single best-effort flush at end-of-loop so all queued events ship in one network
+            // round-trip rather than one per event. Per-event flushing previously serialized the
+            // ingest loop on the AppInsights ingestion call and, on slow Linux CI networks, could
+            // exhaust the 3-second Dispose timeout before later payloads (e.g. mstest sessionexit)
+            // were even read from the channel.
+            try
+            {
+                _client?.Flush();
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsEnabled(LogLevel.Error))
+                {
+                    await _logger.LogErrorAsync("Error during telemetry flush.", ex).ConfigureAwait(false);
+                }
+            }
+        }
     }
 
     private static double ToUnixTimeNanoseconds(DateTimeOffset value) =>

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/ITelemetryClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/ITelemetryClient.cs
@@ -6,4 +6,12 @@ namespace Microsoft.Testing.Extensions.Telemetry;
 internal interface ITelemetryClient
 {
     void TrackEvent(string eventName, Dictionary<string, string> properties, Dictionary<string, double> metrics);
+
+    /// <summary>
+    /// Forces any buffered telemetry events to be sent to the ingestion endpoint. This is intended
+    /// to be called once during shutdown rather than per-event: per-event flushing serializes the
+    /// ingest loop on the network round-trip and can block subsequent events from being processed
+    /// within the shutdown timeout.
+    /// </summary>
+    void Flush();
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
@@ -217,4 +217,78 @@ public sealed class AppInsightsProviderTests
         Assert.IsTrue(capturedProperties.TryGetValue("my.bool", out string? value), "Expected 'my.bool' property in tracked event.");
         Assert.AreEqual(TelemetryProperties.True, value);
     }
+
+    [TestMethod]
+    public async Task Dispose_FlushesTelemetryClientOnceAfterAllTrackedEvents()
+    {
+        // Regression: previously AppInsightTelemetryClient.TrackEvent called Flush() per event,
+        // which serialized the ingest loop on each network round-trip. On slow Linux CI a
+        // single slow flush could exhaust the 3-second dispose timeout before later payloads
+        // (e.g. mstest sessionexit) were ever read from the channel and ship their
+        // "Send telemetry event:" trace line. The fix removes per-event flushing and flushes
+        // exactly once after the ingest loop drains.
+        Mock<IEnvironment> environment = new();
+        Mock<IClock> clock = new();
+        Mock<IConfiguration> config = new();
+        Mock<ITelemetryInformation> telemetryInformation = new();
+
+        Mock<ILoggerFactory> loggerFactory = new();
+        loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+
+        List<string> trackedEvents = [];
+        int flushCallCount = 0;
+        using ManualResetEventSlim secondEventTracked = new(initialState: false);
+        Mock<ITelemetryClient> testTelemetryClient = new();
+        testTelemetryClient.Setup(x => x.TrackEvent(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, double>>()))
+            .Callback((string eventName, Dictionary<string, string> _, Dictionary<string, double> _) =>
+            {
+                lock (trackedEvents)
+                {
+                    trackedEvents.Add(eventName);
+                    if (trackedEvents.Count >= 2)
+                    {
+                        secondEventTracked.Set();
+                    }
+                }
+            });
+        testTelemetryClient.Setup(x => x.Flush())
+            .Callback(() => Interlocked.Increment(ref flushCallCount));
+
+        Mock<ITelemetryClientFactory> telemetryClientFactory = new();
+        telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Returns(testTelemetryClient.Object);
+
+        CancellationTokenSource cancellationTokenSource = new();
+        Mock<ITestApplicationCancellationTokenSource> testApplicationCancellationTokenSource = new();
+        testApplicationCancellationTokenSource.Setup(x => x.CancellationToken).Returns(cancellationTokenSource.Token);
+
+        AppInsightsProvider appInsightsProvider = new(
+            environment.Object,
+            testApplicationCancellationTokenSource.Object,
+            new SystemTask(),
+            loggerFactory.Object,
+            clock.Object,
+            config.Object,
+            telemetryInformation.Object,
+            telemetryClientFactory.Object,
+            "sessionId");
+
+        await appInsightsProvider.LogEventAsync("FirstEvent", new Dictionary<string, object>(), CancellationToken.None);
+        await appInsightsProvider.LogEventAsync("SecondEvent", new Dictionary<string, object>(), CancellationToken.None);
+
+        Assert.IsTrue(secondEventTracked.Wait(TimeSpan.FromSeconds(30), TestContext.CancellationToken), "Telemetry consumer did not invoke TrackEvent for both events within the timeout.");
+
+        // Flush must not have happened per-event: it should only occur during shutdown drain.
+        Assert.AreEqual(0, Volatile.Read(ref flushCallCount), "Flush should not be invoked per-event; only once during dispose drain.");
+
+#if NETCOREAPP
+        await appInsightsProvider.DisposeAsync();
+#else
+        appInsightsProvider.Dispose();
+#endif
+
+        Assert.HasCount(2, trackedEvents);
+        Assert.AreEqual("FirstEvent", trackedEvents[0]);
+        Assert.AreEqual("SecondEvent", trackedEvents[1]);
+        Assert.AreEqual(1, Volatile.Read(ref flushCallCount), "Flush should be invoked exactly once after the ingest loop drains.");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes intermittent failures of `MTP_RunTests_SendsTelemetryWithSettingsAndAttributes` on Linux CI.

`AppInsightTelemetryClient.TrackEvent` called `TelemetryClient.Flush()` after every event. ApplicationInsights' `Flush()` synchronously blocks on the network round-trip to `dc.services.visualstudio.com`, which serialized the ingest loop on each event. On slow Linux CI a single blocking flush could exhaust the 3-second `AppInsightsProvider.Dispose` timeout before later queued payloads (notably the MSTest `sessionexit` event) were even read from the channel, so their `Send telemetry event:` trace line never appeared in the diagnostic log.

## Failure evidence

Excerpt from the failing run's diag log:

- `Send telemetry event: dotnet/testingplatform/host/testhostbuilt` at `T+0.23s`
- Test session ends at `T+0.43s`
- `WARNING Telemetry task didn't flush after '3'` at `T+3.43s` (exactly 3s later — the ingest loop was stuck inside a single network flush)
- No `mstest/sessionexit` trace line anywhere — the test asserts on its presence

## Fix

- Remove the per-event `Flush()` from `AppInsightTelemetryClient.TrackEvent`.
- Add `Flush()` to `ITelemetryClient` and implement it as a thin pass-through on the concrete client.
- In `AppInsightsProvider.IngestLoopAsync`, perform a single best-effort `Flush()` in a `finally` block after the channel drains. The call is wrapped in try/catch so telemetry errors never crash the host, and intentionally does not observe `_flushTimeoutOrStop` (cancelling on shutdown would defeat the purpose of the drain).

## Tests

- Existing `AppInsightsProvider` unit tests continue to pass.
- Adds a regression test `Dispose_FlushesTelemetryClientOnceAfterAllTrackedEvents` that verifies:
  1. `Flush` is never invoked while events are still being tracked (no per-event flushing).
  2. After `Dispose`, `Flush` is invoked exactly once and all queued events were tracked in order.
