### PR TITLE
Validate --server argument values and require --dotnet-test-pipe for dotnettestcli

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
@@ -26,6 +26,7 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
     public const string DiscoverTestsTextArgument = "text";
 
     private static readonly string SupportedDiscoverTestsValues = $"'{DiscoverTestsTextArgument}', '{DiscoverTestsJsonArgument}'";
+    private static readonly string SupportedServerProtocolValues = $"'{JsonRpcProtocolName}', '{DotnetTestCliProtocolName}'";
     public const string ResultDirectoryOptionKey = "results-directory";
     public const string IgnoreExitCodeOptionKey = "ignore-exit-code";
     public const string MinimumExpectedTestsOptionKey = "minimum-expected-tests";
@@ -111,6 +112,14 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
             && !DiscoverTestsTextArgument.Equals(arguments[0], StringComparison.OrdinalIgnoreCase))
         {
             return ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, PlatformResources.PlatformCommandLineDiscoverTestsInvalidArgument, arguments[0], SupportedDiscoverTestsValues));
+        }
+
+        if (commandOption.Name == ServerOptionKey
+            && arguments.Length == 1
+            && !JsonRpcProtocolName.Equals(arguments[0], StringComparison.OrdinalIgnoreCase)
+            && !DotnetTestCliProtocolName.Equals(arguments[0], StringComparison.OrdinalIgnoreCase))
+        {
+            return ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, PlatformResources.PlatformCommandLineServerInvalidArgument, arguments[0], SupportedServerProtocolValues));
         }
 
         if (commandOption.Name == ClientPortOptionKey
@@ -203,6 +212,18 @@ internal sealed class PlatformCommandLineProvider : ICommandLineOptionsProvider
             && commandLineOptions.IsOptionSet(MinimumExpectedTestsOptionKey))
         {
             return ValidationResult.InvalidTask(PlatformResources.PlatformCommandLineMinimumExpectedTestsIncompatibleDiscoverTests);
+        }
+
+        // The '--server dotnettestcli' protocol path requires '--dotnet-test-pipe' to connect to the
+        // dotnet test pipe. Without it, the dotnet test connection silently never activates and the
+        // application falls back to console mode, leading to confusing behavior. Both options are
+        // internal and are expected to be passed together by 'dotnet test'.
+        if (commandLineOptions.TryGetOptionArgumentList(ServerOptionKey, out string[]? serverProtocolArgs)
+            && serverProtocolArgs is { Length: 1 }
+            && DotnetTestCliProtocolName.Equals(serverProtocolArgs[0], StringComparison.OrdinalIgnoreCase)
+            && !commandLineOptions.IsOptionSet(DotNetTestPipeOptionKey))
+        {
+            return ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, PlatformResources.PlatformCommandLineDotnetTestCliRequiresPipe, DotnetTestCliProtocolName, DotNetTestPipeOptionKey));
         }
 
         if (commandLineOptions.IsOptionSet(DiagnosticFileLoggerSynchronousWriteOptionKey))

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
@@ -41,6 +41,10 @@ internal static partial class PlatformResources
 
     internal static string @PlatformCommandLineDiscoverTestsInvalidArgument => GetResourceString("PlatformCommandLineDiscoverTestsInvalidArgument");
 
+    internal static string @PlatformCommandLineServerInvalidArgument => GetResourceString("PlatformCommandLineServerInvalidArgument");
+
+    internal static string @PlatformCommandLineDotnetTestCliRequiresPipe => GetResourceString("PlatformCommandLineDotnetTestCliRequiresPipe");
+
     internal static string @PlatformCommandLineExitOnProcessExitSingleArgument => GetResourceString("PlatformCommandLineExitOnProcessExitSingleArgument");
 
     internal static string @PlatformCommandLineDiagnosticOptionIsMissing => GetResourceString("PlatformCommandLineDiagnosticOptionIsMissing");

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -456,6 +456,12 @@ The default is TestResults in the directory that contains the test application.<
   <data name="PlatformCommandLineServerOptionDescription" xml:space="preserve">
     <value>Enable the server mode.</value>
   </data>
+  <data name="PlatformCommandLineServerInvalidArgument" xml:space="preserve">
+    <value>'--server' received unexpected value '{0}'. Supported values are: {1}.</value>
+  </data>
+  <data name="PlatformCommandLineDotnetTestCliRequiresPipe" xml:space="preserve">
+    <value>'--server {0}' requires '--{1}' to be specified.</value>
+  </data>
   <data name="PlatformCommandLineSkipBuildersNumberCheckOptionDescription" xml:space="preserve">
     <value>For testing purposes</value>
   </data>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člověka) nebo „json“, která vypíše zjištěné testy jako dokument JSON na standardním výstupu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">testovací kanál dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Adresář, do kterého budou umístěny výsledky testu.
 Pokud zadaný adresář neexistuje, vytvoří se.
 Výchozí hodnota je TestResults v adresáři, který obsahuje testovací aplikaci.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „json“, um die ermittelten Tests als JSON-Dokument in der Standardausgabe auszugeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">dotnet-Testpipe.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Das Verzeichnis, in dem die Testergebnisse abgelegt werden.
 Wenn das angegebene Verzeichnis nicht vorhanden ist, wird es erstellt.
 Der Standardwert ist "TestResults" im Verzeichnis, das die Testanwendung enthält.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o "json" para imprimir las pruebas detectadas como un documento JSON en la salida estándar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">canalización de prueba de dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Directorio donde se van a colocar los resultados de las pruebas.
 Si el directorio especificado no existe, se crea.
 El valor predeterminado es TestResults en el directorio que contiene la aplicación de prueba.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Accepte éventuellement « text » (sortie lisible par l’humain par défaut) ou « json » pour imprimer les tests détectés sous forme de document JSON sur une sortie standard.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">canal de test dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Le répertoire dans lequel les résultats des tests vont être placés.
 Si le répertoire spécifié n’existe pas, il est créé.
 La valeur par défaut est TestResults dans le répertoire qui contient l’application de test.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per stampare i test individuati come documento JSON nell'output standard.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">pipe di test dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">La directory in cui verranno collocati i risultati del test.
 Se la directory specificata non esiste, viene creata.
 L’impostazione predefinita è TestResults nella directory che contiene l'applicazione di test.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 必要に応じて、'text' (既定の人間が判読できる出力) または 'json' を指定すると、検出されたテストを標準出力に JSON ドキュメントとして印刷します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">dotnet テスト パイプ。</target>
@@ -657,6 +662,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">テスト結果を配置するディレクトリ。
 指定したディレクトリが存在しない場合は、作成されます。
 既定値は、テスト アプリケーションを含むディレクトリ内の TestResults です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 필요에 따라 'text'(사람이 읽을 수 있는 기본 출력) 또는 'json'을 수락하여 검색된 테스트를 표준 출력의 JSON 문서로 인쇄합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">.NET 테스트 파이프입니다.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">테스트 결과를 배치할 디렉터리입니다.
 지정한 디렉터리가 없으면 만들어집니다.
 기본값은 테스트 애플리케이션을 포함하는 디렉터리의 TestResults입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowieka) lub "json", aby wydrukować odnalezione testy jako dokument JSON w przypadku standardowych danych wyjściowych.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">potok testu dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Katalog, w którym zostaną umieszczone wyniki testów.
 Jeśli określony katalog nie istnieje, zostanie on utworzony.
 Wartość domyślna to TestResults w katalogu zawierającym aplikację testową.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' para imprimir os testes descobertos como um documento JSON na saída padrão.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">pipe de teste dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">O diretório no qual os resultados do teste serão colocados.
 Se o diretório especificado não existir, ele será criado.
 O padrão é TestResults no diretório que contém o aplicativo de teste.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 Дополнительно принимает "text" (вывод по умолчанию в понятном для человека формате) или "json", чтобы вывести найденные тесты в виде документа JSON в стандартном выводе.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">тестовый канал dotnet.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Каталог, в котором будут размещены результаты теста.
 Если указанный каталог не существует, он будет создан.
 Значение по умолчанию — TestResults в каталоге, содержащем тестируемое приложение.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 İsteğe bağlı olarak, bulunan testleri standart çıktıda JSON belgesi olarak yazdırmak için 'text' (varsayılan, insanlar tarafından okunabilir çıktı) veya 'json' biçimi kabul edilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">dotnet test kanalı.</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">Test sonuçlarının yerleştirileceği dizin.
 Belirtilen dizin yoksa oluşturulur.
 Varsayılan değer, test uygulamasını içeren dizindeki TestResults'dır.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 (可选)接受 "text"(默认的人类可读输出)或 "json"，以便将发现的测试作为 JSON 文档打印到标准输出。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">dotnet 测试管道。</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">将要放置测试结果的目录。
 如果指定的目录不存在，则创建该目录。
 默认值是包含测试应用程序的目录中的 TestResults。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -553,6 +553,11 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
 此外可接受 'text' (預設的人類可讀輸出) 或 'json'，以在標準輸出上將找到的測試列印為 JSON 文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestCliRequiresPipe">
+        <source>'--server {0}' requires '--{1}' to be specified.</source>
+        <target state="new">'--server {0}' requires '--{1}' to be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
         <target state="translated">dotnet 測試管道。</target>
@@ -656,6 +661,11 @@ The default is TestResults in the directory that contains the test application.<
         <target state="translated">將放置測試結果的目錄。
 如果指定的目錄不存在，系統會建立該目錄。
 預設值是包含測試應用程式之目錄中的 TestResults。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineServerInvalidArgument">
+        <source>'--server' received unexpected value '{0}'. Supported values are: {1}.</source>
+        <target state="new">'--server' received unexpected value '{0}'. Supported values are: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineServerOptionDescription">

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestHelper.cs
@@ -10,5 +10,5 @@ internal static class DotnetTestHelper
     public static bool HasDotnetTestServerOption(this CommandLineHandler commandLineHandler) =>
         commandLineHandler.TryGetOptionArgumentList(PlatformCommandLineProvider.ServerOptionKey, out string[]? serverArgs) &&
         serverArgs.Length == 1 &&
-        serverArgs[0].Equals(PlatformCommandLineProvider.DotnetTestCliProtocolName, StringComparison.Ordinal);
+        serverArgs[0].Equals(PlatformCommandLineProvider.DotnetTestCliProtocolName, StringComparison.OrdinalIgnoreCase);
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/PlatformCommandLineProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/PlatformCommandLineProviderTests.cs
@@ -229,6 +229,115 @@ public sealed class PlatformCommandLineProviderTests
     }
 
     [TestMethod]
+    public async Task IsValid_When_Server_HasNoArgument()
+    {
+        var provider = new PlatformCommandLineProvider();
+        CommandLineOption option = provider.GetCommandLineOptions().First(x => x.Name == PlatformCommandLineProvider.ServerOptionKey);
+
+        ValidationResult validateOptionsResult = await provider.ValidateOptionArgumentsAsync(option, []).ConfigureAwait(false);
+        Assert.IsTrue(validateOptionsResult.IsValid);
+    }
+
+    [TestMethod]
+    [DataRow("jsonrpc")]
+    [DataRow("JSONRPC")]
+    [DataRow("JsonRpc")]
+    [DataRow("dotnettestcli")]
+    [DataRow("DOTNETTESTCLI")]
+    [DataRow("DotnetTestCli")]
+    public async Task IsValid_When_Server_HasAcceptedArgument_AnyCasing(string argument)
+    {
+        var provider = new PlatformCommandLineProvider();
+        CommandLineOption option = provider.GetCommandLineOptions().First(x => x.Name == PlatformCommandLineProvider.ServerOptionKey);
+
+        ValidationResult validateOptionsResult = await provider.ValidateOptionArgumentsAsync(option, [argument]).ConfigureAwait(false);
+        Assert.IsTrue(validateOptionsResult.IsValid);
+    }
+
+    [TestMethod]
+    [DataRow("random")]
+    [DataRow("invalid")]
+    [DataRow("json")]
+    [DataRow("rpc")]
+    public async Task IsInvalid_When_Server_HasUnknownArgument(string argument)
+    {
+        var provider = new PlatformCommandLineProvider();
+        CommandLineOption option = provider.GetCommandLineOptions().First(x => x.Name == PlatformCommandLineProvider.ServerOptionKey);
+
+        ValidationResult validateOptionsResult = await provider.ValidateOptionArgumentsAsync(option, [argument]).ConfigureAwait(false);
+        Assert.IsFalse(validateOptionsResult.IsValid);
+        Assert.AreEqual(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                PlatformResources.PlatformCommandLineServerInvalidArgument,
+                argument,
+                $"'{PlatformCommandLineProvider.JsonRpcProtocolName}', '{PlatformCommandLineProvider.DotnetTestCliProtocolName}'"),
+            validateOptionsResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task IsValid_When_Server_DotnetTestCli_With_DotnetTestPipe()
+    {
+        var provider = new PlatformCommandLineProvider();
+        var options = new Dictionary<string, string[]>
+        {
+            { PlatformCommandLineProvider.ServerOptionKey, ["dotnettestcli"] },
+            { PlatformCommandLineProvider.DotNetTestPipeOptionKey, ["pipe-name"] },
+        };
+
+        ValidationResult validateOptionsResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(options)).ConfigureAwait(false);
+        Assert.IsTrue(validateOptionsResult.IsValid);
+    }
+
+    [TestMethod]
+    [DataRow("dotnettestcli")]
+    [DataRow("DotnetTestCli")]
+    public async Task IsInvalid_When_Server_DotnetTestCli_Without_DotnetTestPipe(string protocol)
+    {
+        var provider = new PlatformCommandLineProvider();
+        var options = new Dictionary<string, string[]>
+        {
+            { PlatformCommandLineProvider.ServerOptionKey, [protocol] },
+        };
+
+        ValidationResult validateOptionsResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(options)).ConfigureAwait(false);
+        Assert.IsFalse(validateOptionsResult.IsValid);
+        Assert.AreEqual(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                PlatformResources.PlatformCommandLineDotnetTestCliRequiresPipe,
+                PlatformCommandLineProvider.DotnetTestCliProtocolName,
+                PlatformCommandLineProvider.DotNetTestPipeOptionKey),
+            validateOptionsResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task IsValid_When_Server_JsonRpc_Without_DotnetTestPipe()
+    {
+        var provider = new PlatformCommandLineProvider();
+        var options = new Dictionary<string, string[]>
+        {
+            { PlatformCommandLineProvider.ServerOptionKey, ["jsonrpc"] },
+        };
+
+        ValidationResult validateOptionsResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(options)).ConfigureAwait(false);
+        Assert.IsTrue(validateOptionsResult.IsValid);
+    }
+
+    [TestMethod]
+    public async Task IsValid_When_Server_NoArgument_Without_DotnetTestPipe()
+    {
+        var provider = new PlatformCommandLineProvider();
+        var options = new Dictionary<string, string[]>
+        {
+            { PlatformCommandLineProvider.ServerOptionKey, [] },
+        };
+
+        ValidationResult validateOptionsResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(options)).ConfigureAwait(false);
+        Assert.IsTrue(validateOptionsResult.IsValid);
+    }
+
+    [TestMethod]
     public void IsListTestsJsonOutput_ReturnsTrueOnlyWhenJsonArgumentSet()
     {
         Assert.IsFalse(PlatformCommandLineProvider.IsListTestsJsonOutput(new TestCommandLineOptions([])));


### PR DESCRIPTION
Fixes #6879.

## Summary

The `--server` MTP CLI option previously accepted any string argument without validation, while only `jsonrpc` and `dotnettestcli` are actually meaningful protocol values. When the user (or a tool) passed something unexpected like `--server random`, the option silently fell through to the non-JSON-RPC code path (treated as `dotnettestcli`), with no error surfaced. This made misuse very hard to diagnose.

## Changes

* **Validate `--server <value>`** in `PlatformCommandLineProvider.ValidateOptionArgumentsAsync`. When an argument is provided, it must be `jsonrpc` or `dotnettestcli` (case-insensitive). Unknown values now produce a clear error:
  > `'--server' received unexpected value 'random'. Supported values are: 'jsonrpc', 'dotnettestcli'.`

* **Cross-option validation** in `ValidateCommandLineOptionsAsync`: `--server dotnettestcli` now requires `--dotnet-test-pipe` to also be specified. Without the pipe option, `DotnetTestConnection` never activates and the app silently fell back to console mode — the same kind of silent fallthrough as the original bug.

* **Consistency fix** in `DotnetTestHelper.HasDotnetTestServerOption`: changed `StringComparison.Ordinal` to `OrdinalIgnoreCase` for the `dotnettestcli` comparison so it matches the case-insensitive treatment elsewhere (`TestHostBuilder.CommonServices.cs` already uses `OrdinalIgnoreCase` for `jsonrpc`).

* **Tests**: 9 new tests in `PlatformCommandLineProviderTests` covering:
  - valid no argument
  - valid `jsonrpc` / `dotnettestcli` with any casing
  - invalid argument values (`random`, `invalid`, `json`, `rpc`)
  - cross-option requirement (`dotnettestcli` with/without `--dotnet-test-pipe`)
  - `jsonrpc` / no argument do not require `--dotnet-test-pipe`

## Validation

* `Microsoft.Testing.Platform.UnitTests` (net9.0): 981 passed / 2 skipped (same as baseline), including the 9 new tests.
