### PR TITLE
Skip MSTEST0065 when expected/actual is null literal

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
 using MSTest.Analyzers.Helpers;
+using MSTest.Analyzers.RoslynAnalyzerHelpers;
 
 namespace MSTest.Analyzers;
 
@@ -74,6 +75,17 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             return;
         }
 
+        // When either argument is the null literal, MSTEST0037 (UseProperAssertMethods) already triggers
+        // and suggests the more meaningful Assert.IsNull / Assert.IsNotNull replacement. Reporting
+        // MSTEST0065 in that case is a false positive because CollectionAssert.AreEqual / Assert.AreSequenceEqual
+        // are not the user's intent — they are performing a null check.
+        // The first parameter is "expected" on Assert.AreEqual and "notExpected" on Assert.AreNotEqual.
+        string firstParameterName = targetMethod.Name == "AreEqual" ? "expected" : "notExpected";
+        if (HasNullLiteralArgument(invocation, firstParameterName) || HasNullLiteralArgument(invocation, "actual"))
+        {
+            return;
+        }
+
         string methodName = $"Assert.{targetMethod.Name}";
         string comparedTypeDisplay = comparedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule, methodName, comparedTypeDisplay));
@@ -82,6 +94,12 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
     private static bool ShouldReport(ITypeSymbol comparedType, INamedTypeSymbol genericEnumerableSymbol)
         => comparedType.SpecialType != SpecialType.System_String
             && ImplementsGenericEnumerable(comparedType, genericEnumerableSymbol);
+
+    private static bool HasNullLiteralArgument(IInvocationOperation invocation, string parameterName)
+    {
+        IArgumentOperation? argument = invocation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == parameterName);
+        return argument?.Value.WalkDownConversion() is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } };
+    }
 
     private static bool ImplementsGenericEnumerable(ITypeSymbol type, INamedTypeSymbol genericEnumerableSymbol)
     {

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -75,10 +75,13 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             return;
         }
 
-        // When either argument is the null literal, MSTEST0037 (UseProperAssertMethods) already triggers
-        // and suggests the more meaningful Assert.IsNull / Assert.IsNotNull replacement. Reporting
-        // MSTEST0065 in that case is a false positive because CollectionAssert.AreEqual / Assert.AreSequenceEqual
-        // are not the user's intent — they are performing a null check.
+        // When either argument is the null literal, the user is performing a null check rather than
+        // a collection equality check, so suggesting CollectionAssert.AreEqual / Assert.AreSequenceEqual
+        // would be misleading.
+        // When null is in the expected/notExpected position, MSTEST0037 (UseProperAssertMethods) already
+        // triggers and proposes the correct Assert.IsNull / Assert.IsNotNull replacement.
+        // When null is in the actual position, MSTEST0037 does not currently fire, but suppressing
+        // MSTEST0065 is still correct because CollectionAssert guidance is not what the user wants.
         // The first parameter is "expected" on Assert.AreEqual and "notExpected" on Assert.AreNotEqual.
         string firstParameterName = targetMethod.Name == "AreEqual" ? "expected" : "notExpected";
         if (HasNullLiteralArgument(invocation, firstParameterName) || HasNullLiteralArgument(invocation, "actual"))

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -322,6 +322,31 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenUsingAssertAreNotEqualWithCollectionExpectedAndNullActual_DoNotReportDiagnostic()
+    {
+        // Same rationale for Assert.AreNotEqual(x, null): the user is performing a null check, not a
+        // collection comparison, so suggesting CollectionAssert.AreNotEqual would be misleading.
+        string code = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Dictionary<string, int>? dictionary = new();
+                    Assert.AreNotEqual(dictionary, null);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task CodeFix_Ordered_ForAreEqual()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -222,8 +222,12 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenUsingAssertAreEqualOnNullableListNulls_ReportDiagnostic()
+    public async Task WhenUsingAssertAreEqualOnNullableListNulls_DoNotReportDiagnostic()
     {
+        // When an argument is the null literal, MSTEST0037 (UseProperAssertMethods) already
+        // triggers and suggests Assert.IsNull / Assert.IsNotNull, which is the correct fix.
+        // MSTEST0065 must stay quiet to avoid a redundant (and misleading) suggestion to switch
+        // to CollectionAssert.AreEqual / Assert.AreSequenceEqual.
         string code = """
             #nullable enable
             using System.Collections.Generic;
@@ -235,12 +239,86 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
                 [TestMethod]
                 public void MyTestMethod()
                 {
-                    {|#0:Assert.AreEqual<List<int>?>(null, null)|};
+                    Assert.AreEqual<List<int>?>(null, null);
                 }
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "List<int>?"));
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithNullExpectedAndCollectionActual_DoNotReportDiagnostic()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/8655.
+        // Assert.AreEqual(null, dictionary) is a null check that MSTEST0037 already catches and
+        // converts to Assert.IsNull(dictionary). MSTEST0065 must not report it.
+        string code = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Dictionary<string, int>? dictionary = null;
+                    Assert.AreEqual(null, dictionary);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithCollectionExpectedAndNullActual_DoNotReportDiagnostic()
+    {
+        // Symmetric variant of the issue above: null is in the actual position.
+        string code = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Dictionary<string, int>? dictionary = null;
+                    Assert.AreEqual(dictionary, null);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreNotEqualWithNullExpectedAndCollectionActual_DoNotReportDiagnostic()
+    {
+        // Same rationale for Assert.AreNotEqual(null, x): MSTEST0037 converts it to Assert.IsNotNull(x).
+        string code = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Dictionary<string, int>? dictionary = new();
+                    Assert.AreNotEqual(null, dictionary);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes #8655.

### Problem

[MSTEST0065](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0065) (`AvoidAssertAreEqualOnCollections`) fires on calls like:

```csharp
Dictionary<string, int>? dictionary = ...;
Assert.AreEqual(null, dictionary);
```

because the generic type argument inferred for `Assert.AreEqual<T>` is a collection type. The suggested fix — switch to `CollectionAssert.AreEqual` / `Assert.AreSequenceEqual` — is not what the user wants: they are performing a null check, not a collection comparison.

[MSTEST0037](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0037) (`UseProperAssertMethods`) already triggers on the same call and proposes the correct `Assert.IsNull(dictionary)` (or `Assert.IsNotNull` for `AreNotEqual`) replacement. MSTEST0065 reporting it is redundant and misleading.

### Fix

In `AvoidAssertAreEqualOnCollectionsAnalyzer`, skip reporting when either the `expected` / `notExpected` or `actual` argument is the `null` literal. This is detected via `ILiteralOperation { ConstantValue: { HasValue: true, Value: null } }` after walking down conversions, matching the pattern used by other MSTest analyzers (see `UseProperAssertMethodsAnalyzer.NullChecks.cs`).

### Tests

- Replaced the existing `WhenUsingAssertAreEqualOnNullableListNulls_ReportDiagnostic` test (which asserted on the now-suppressed case) with a `...DoNotReportDiagnostic` version explaining the rationale.
- Added regression tests covering `Assert.AreEqual(null, dictionary)`, `Assert.AreEqual(dictionary, null)`, and `Assert.AreNotEqual(null, dictionary)`.

`dotnet test` for `MSTest.Analyzers.UnitTests` passes (1091/1091 tests).