### PR TITLE
[link-checker] Fix broken documentation links

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -250,7 +250,7 @@ See full log [of v3.10.5...v3.11.0](https://github.com/microsoft/testfx/compare/
 * MSTEST0037: Recognize IsTrue(collection.\[Count|Length] \[==|>|!=] 0) patterns and cleanup by @Youssef1313 in [#6416](https://github.com/microsoft/testfx/pull/6416)
 * Improve collection.Count/Length detection in MSTEST0037 by @Youssef1313 in [#6428](https://github.com/microsoft/testfx/pull/6428)
 * Add analyzer for Assert APIs with format parameters (MSTEST0053) by @Copilot in [#6294](https://github.com/microsoft/testfx/pull/6294)
-* Add analyzer and codefix to move from `TestContext.CancellationTokenSource.Token` to `TestContext.CancellationToken` by @Copilot in [#6429](https://github.com/microsoft/testfx/)pull/6429
+* Add analyzer and codefix to move from `TestContext.CancellationTokenSource.Token` to `TestContext.CancellationToken` by @Copilot in [#6429](https://github.com/microsoft/testfx/pull/6429
 * Add analyzer for ignoring string method return values (MSTEST0055) by @Copilot in [#6482](https://github.com/microsoft/testfx/pull/6482)
 * Is subsetof return non subset values of the superset (relates to #662) by @AtolagbeMuiz in [#6292](https://github.com/microsoft/testfx/pull/6292)
 * Implement assert contains overload to accept non-generic collection by @AtolagbeMuiz in [#6417](https://github.com/microsoft/testfx/pull/6417)
@@ -1651,7 +1651,7 @@ See full log [of v3.2.1...v3.2.2](https://github.com/microsoft/testfx/compare/v3
 
 ## <a name="3.2.1" />[3.2.1] - 2024-02-13
 
-See full log [of v3.2.0...v.3.2.1](https://github.com/microsoft/testfx/compare/v3.2.0...v.3.2.1)
+See full log [of v3.2.0...v3.2.1](https://github.com/microsoft/testfx/compare/v3.2.0...v3.2.1)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -250,7 +250,7 @@ See full log [of v3.10.5...v3.11.0](https://github.com/microsoft/testfx/compare/
 * MSTEST0037: Recognize IsTrue(collection.\[Count|Length] \[==|>|!=] 0) patterns and cleanup by @Youssef1313 in [#6416](https://github.com/microsoft/testfx/pull/6416)
 * Improve collection.Count/Length detection in MSTEST0037 by @Youssef1313 in [#6428](https://github.com/microsoft/testfx/pull/6428)
 * Add analyzer for Assert APIs with format parameters (MSTEST0053) by @Copilot in [#6294](https://github.com/microsoft/testfx/pull/6294)
-* Add analyzer and codefix to move from `TestContext.CancellationTokenSource.Token` to `TestContext.CancellationToken` by @Copilot in [#6429](https://github.com/microsoft/testfx/pull/6429
+* Add analyzer and codefix to move from `TestContext.CancellationTokenSource.Token` to `TestContext.CancellationToken` by @Copilot in [#6429](https://github.com/microsoft/testfx/pull/6429)
 * Add analyzer for ignoring string method return values (MSTEST0055) by @Copilot in [#6482](https://github.com/microsoft/testfx/pull/6482)
 * Is subsetof return non subset values of the superset (relates to #662) by @AtolagbeMuiz in [#6292](https://github.com/microsoft/testfx/pull/6292)
 * Implement assert contains overload to accept non-generic collection by @AtolagbeMuiz in [#6417](https://github.com/microsoft/testfx/pull/6417)


### PR DESCRIPTION
## Summary

Fixed 2 malformed URLs found in `docs/Changelog.md` during the daily link check.

## Changes

| File | Broken URL | Fixed URL |
|------|-----------|-----------|
| `docs/Changelog.md` | `https://github.com/microsoft/testfx/)pull/6429` | `https://github.com/microsoft/testfx/pull/6429` |
| `docs/Changelog.md` | `https://github.com/microsoft/testfx/compare/v3.2.0...v.3.2.1` | `https://github.com/microsoft/testfx/compare/v3.2.0...v3.2.1` |

## Investigation Notes

The link checker found many other "broken" links, but they fall into categories that cannot be fixed:

- **False positives**: Many GitHub URLs like `https://github.com/Evangelink)` or PR links with trailing `)` are artefacts of the link checker capturing markdown punctuation (e.g., `[text](url)`) as part of the URL. The actual URLs are valid.
- **Unlisted NuGet packages**: Historical changelog entries reference alpha/pre-release NuGet package versions that are now unlisted (e.g., `MSTest.Engine/1.0.0-alpha.*`, `MSTest.Sdk/3.3.1`, etc.). These are expected and cannot be restored.
- **Old GitHub tags**: Compare links using old tag formats (e.g., `1.3.2...1.4.0-beta`) reference tags that no longer exist in the repository.
- **Non-existent repository**: `microsoft/testanywhere` compare links reference a repository that does not exist on GitHub.

These unfixable links have been documented in cache memory to avoid repeated investigation in future runs.




> Generated by [Daily Link Checker & Fixer](https://github.com/microsoft/testfx/actions/runs/26574088256) · sonnet46 1.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+link-checker%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/link-checker.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Daily Link Checker & Fixer, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26574088256, workflow_id: link-checker, run: https://github.com/microsoft/testfx/actions/runs/26574088256 -->

<!-- gh-aw-workflow-id: link-checker -->