### PR TITLE
Fix MSTEST0066 false positive for [Ignore(IgnoreMessage = "...")]

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/IgnoreShouldHaveJustificationFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/IgnoreShouldHaveJustificationFixer.cs
@@ -64,24 +64,29 @@ public sealed class IgnoreShouldHaveJustificationFixer : CodeFixProvider
     {
         SyntaxNode root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-        AttributeArgumentSyntax justificationArgument = SyntaxFactory.AttributeArgument(
-            SyntaxFactory.LiteralExpression(
-                SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(PlaceholderJustification)));
+        LiteralExpressionSyntax justificationLiteral = SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression,
+            SyntaxFactory.Literal(PlaceholderJustification));
 
         AttributeArgumentListSyntax existingArgumentList = attributeSyntax.ArgumentList ?? SyntaxFactory.AttributeArgumentList();
 
         AttributeArgumentListSyntax newArgumentList;
         if (existingArgumentList.Arguments.Count == 0)
         {
-            newArgumentList = existingArgumentList.WithArguments(SyntaxFactory.SingletonSeparatedList(justificationArgument));
+            // [Ignore] or [Ignore()] - add a positional message argument.
+            newArgumentList = existingArgumentList.WithArguments(
+                SyntaxFactory.SingletonSeparatedList(SyntaxFactory.AttributeArgument(justificationLiteral)));
         }
         else
         {
-            // Replace the first positional argument (the message) with the placeholder.
-            // Empty / null literals on the first positional argument are the only cases we get here.
+            // Replace the first argument's value with the placeholder, preserving any
+            // named-argument syntax. This handles both [Ignore("")] (positional) and
+            // [Ignore(IgnoreMessage = "")] (named) - in either case we keep the existing
+            // form and only swap the empty/null literal for the placeholder string.
             AttributeArgumentSyntax firstArgument = existingArgumentList.Arguments[0];
-            newArgumentList = existingArgumentList.WithArguments(existingArgumentList.Arguments.Replace(firstArgument, justificationArgument));
+            AttributeArgumentSyntax updatedFirstArgument = firstArgument.WithExpression(justificationLiteral);
+            newArgumentList = existingArgumentList.WithArguments(
+                existingArgumentList.Arguments.Replace(firstArgument, updatedFirstArgument));
         }
 
         AttributeSyntax newAttribute = attributeSyntax.WithArgumentList(newArgumentList);

--- a/src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs
@@ -132,14 +132,26 @@ public sealed class IgnoreShouldHaveJustificationAnalyzer : DiagnosticAnalyzer
 
     private static bool HasJustification(AttributeData ignoreAttribute)
     {
-        // Parameterless [Ignore] - no justification.
-        if (ignoreAttribute.ConstructorArguments.Length == 0)
+        // First positional argument of IgnoreAttribute(string? message) is the justification when provided.
+        if (ignoreAttribute.ConstructorArguments.Length > 0
+            && ignoreAttribute.ConstructorArguments[0].Value is string positionalMessage
+            && !string.IsNullOrWhiteSpace(positionalMessage))
         {
-            return false;
+            return true;
         }
 
-        // First positional argument of IgnoreAttribute(string? message) is the justification.
-        TypedConstant messageArgument = ignoreAttribute.ConstructorArguments[0];
-        return messageArgument.Value is string message && !string.IsNullOrWhiteSpace(message);
+        // The IgnoreMessage property (inherited from ConditionBaseAttribute) can also carry the
+        // justification when applied via named-argument syntax: [Ignore(IgnoreMessage = "...")].
+        foreach (KeyValuePair<string, TypedConstant> namedArgument in ignoreAttribute.NamedArguments)
+        {
+            if (namedArgument.Key == "IgnoreMessage"
+                && namedArgument.Value.Value is string namedMessage
+                && !string.IsNullOrWhiteSpace(namedMessage))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreShouldHaveJustificationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreShouldHaveJustificationAnalyzerTests.cs
@@ -323,4 +323,204 @@ public sealed class IgnoreShouldHaveJustificationAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithNamedIgnoreMessage_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore(IgnoreMessage = "Tracked by #12345")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasIgnoreWithNamedIgnoreMessage_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [Ignore(IgnoreMessage = "Disabled until feature ships")]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithEmptyPositionalAndValidNamedIgnoreMessage_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore("", IgnoreMessage = "Tracked by #12345")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithEmptyNamedIgnoreMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore(IgnoreMessage = "")|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore(IgnoreMessage = "TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithWhitespaceNamedIgnoreMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore(IgnoreMessage = "   ")|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore(IgnoreMessage = "TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasIgnoreWithNullNamedIgnoreMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            #nullable enable
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:Ignore(IgnoreMessage = null)|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            #nullable enable
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Ignore(IgnoreMessage = "TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasIgnoreWithEmptyNamedIgnoreMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [{|#0:Ignore(IgnoreMessage = "")|}]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [Ignore(IgnoreMessage = "TODO: explain why this is ignored")]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"), fixedCode);
+    }
 }


### PR DESCRIPTION
Fixes #8660.

`IgnoreAttribute` derives from `ConditionBaseAttribute` which exposes a public settable `IgnoreMessage` property, so `[Ignore(IgnoreMessage = ""..."")]` is a perfectly valid justified-ignore syntax. The analyzer previously only inspected the positional constructor argument and would falsely report MSTEST0066 against this form.

### Changes

- `IgnoreShouldHaveJustificationAnalyzer.HasJustification` now also accepts a non-empty `IgnoreMessage` named argument as a justification.
- `IgnoreShouldHaveJustificationFixer` preserves the existing named/positional argument syntax when swapping the empty/null literal for the `TODO: explain why this is ignored` placeholder, so `[Ignore(IgnoreMessage = """")]` becomes `[Ignore(IgnoreMessage = ""TODO: ..."")]` rather than degrading the named argument into a positional one.

### Tests

Added analyzer + code-fix coverage for:

- `[Ignore(IgnoreMessage = ""..."")]` on a test method - no diagnostic.
- `[Ignore(IgnoreMessage = ""..."")]` on a test class - no diagnostic.
- `[Ignore("""", IgnoreMessage = ""..."")]` - no diagnostic (named arg satisfies).
- `[Ignore(IgnoreMessage = """")]` / `""   ""` / `null` - diagnostic + code fix that produces `[Ignore(IgnoreMessage = ""TODO: ..."")]`.
- Same for the test-class scenario.

All 18 `IgnoreShouldHaveJustificationAnalyzerTests` pass locally.