### PR TITLE
Remove misleading TreeNodeFilter test added by PR #7415

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Requests/TreeNodeFilterTests.cs
@@ -81,21 +81,6 @@ public sealed class TreeNodeFilterTests
     }
 
     [TestMethod]
-    public void LiteralSegment_RequiresWildcardToMatchNodesWithAdditionalSuffix()
-    {
-        // Note: This documents a current limitation that often surprises users.
-        //       Path segments are matched against an anchored regex (^value$), so a literal
-        //       like 'MyTest1' will NOT match a node whose actual ID is 'MyTest1()' (e.g. when
-        //       a framework appends parameter/method-signature info to the displayed name).
-        //       Users observing this typically need to add a wildcard: '/*/*/*/(MyTest1*|MyTest2*)'.
-        //       See https://github.com/microsoft/testfx/issues/7300 for the user-facing report.
-        TreeNodeFilter filter = new("/*/*/*/(MyTest1|MyTest2)");
-
-        Assert.IsFalse(filter.MatchesFilter("/A/B/C/MyTest1()", new PropertyBag()));
-        Assert.IsFalse(filter.MatchesFilter("/A/B/C/MyTest2()", new PropertyBag()));
-    }
-
-    [TestMethod]
     public void FullPathOrInsideParenthesizedExpressions_IsNotSupported_ThrowsActionableMessage()
     {
         const string Filter = "(/*/*/*/MyTest1)|(/*/*/*/MyTest2)";


### PR DESCRIPTION
### Context

PR #7415 (commit `32a26954f`) addressed `--treenode-filter` issues reported in #7300:
- **Case 4** (`(/*/*/*/MyTest1)|(/*/*/*/MyTest2)` crashing with a confusing message) — correctly fixed with `FullPathOrInsideParenthesizedExpressions_IsNotSupported_ThrowsActionableMessage`.
- **Cases 1-3** (`/*/*/*/(MyTest1)` and friends silently matching zero tests) — hypothesised to be caused by the framework appending a parameter-list suffix (e.g. `MyTest1()`) to test node IDs, and "documented as a limitation" via `LiteralSegment_RequiresWildcardToMatchNodesWithAdditionalSuffix`.

### Why this is wrong

The premise behind the new "limitation" test is incorrect, and the test should not stay as-is referencing #7300:

1. **TUnit (the framework that surfaced the issue) does not append any suffix.** TUnit's `TestFilterService.BuildPath` emits clean `/{assembly}/{namespace}/{className}/{methodName}` paths — no `()`.
2. **MTP's `TreeNodeFilter` actually matches all the patterns from the issue.** A direct reflection probe against `Microsoft.Testing.Platform 2.0.2` (the version TUnit currently bundles) returned `True` for every failing case in the issue, including `/*/*/*/(MyTest1)` against `/YourTestProjectNameHere/YourTestProjectNameHere/MyTests/MyTest1`. The kept regression test `OrExpression_WorksForSinglePathSegmentInsideParentheses` already proves this.
3. **The real bug lives in TUnit's `MetadataFilterMatcher.ExtractFilterHints`.** It does a naive `filterString.Split('/')` and treats `parts[4]` as a literal method-name hint unless `IsWildcard` returns true. `IsWildcard` only checks for `*`/`?`, so `"(MyTest1)"` is treated as a literal method name; `AotTestDataCollector.CouldDescriptorMatch` then rejects every descriptor before MTP's filter ever sees them. Filed upstream as thomhurst/TUnit#6026.

### What this PR does

- Removes `LiteralSegment_RequiresWildcardToMatchNodesWithAdditionalSuffix`. Its only behavioural assertion (anchored-regex matching: `MyTest1` does not match `MyTest1()`) is already covered by `MatchWildcard_MatchesSubstrings` and is unrelated to #7300; the misleading comment and `#7300` link were the main reason it existed.
- Keeps the genuinely useful regression `OrExpression_WorksForSinglePathSegmentInsideParentheses` and the actionable-error test `FullPathOrInsideParenthesizedExpressions_IsNotSupported_ThrowsActionableMessage`.

### Validation

- `Microsoft.Testing.Platform.UnitTests` build: ✅
- `TreeNodeFilterTests` (filter `FullyQualifiedName~TreeNodeFilterTests`): 52 passed, 0 failed (was 53 before removal of the misleading test).

### Related

- Issue: #7300
- Original PR: #7415
- Upstream TUnit bug: thomhurst/TUnit#6026