### PR TITLE
Reject invalid runId in JSON-RPC requests with InvalidParams error

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -368,6 +368,11 @@ internal sealed partial class ServerTestHost : CommonHost, IServerTestHost, IDis
                 await SendErrorAsync(reqId: request.Id, errorCode: errorCode, message: errorMessage, data: null, cancellationToken).ConfigureAwait(false);
                 CompleteRequest(ref _clientToServerRequests, request.Id, completion => completion.TrySetCanceled());
             }
+            catch (JsonRpcException e)
+            {
+                await SendErrorAsync(reqId: request.Id, errorCode: e.ErrorCode, message: e.Message, data: null, cancellationToken).ConfigureAwait(false);
+                CompleteRequest(ref _clientToServerRequests, request.Id, completion => completion.SetException(e));
+            }
             catch (Exception e)
             {
                 await SendErrorAsync(reqId: request.Id, errorCode: 0, message: e.ToString(), data: null, cancellationToken).ConfigureAwait(false);
@@ -420,6 +425,11 @@ internal sealed partial class ServerTestHost : CommonHost, IServerTestHost, IDis
 
         switch (message.Method, message.Params)
         {
+            case (_, InvalidRequestParamsArgs invalidParams):
+                {
+                    throw new JsonRpcException(invalidParams.ErrorCode, invalidParams.ErrorMessage);
+                }
+
             case (JsonRpcMethods.Initialize, InitializeRequestArgs args):
                 {
                     _client = new(args.ClientInfo.Name, args.ClientInfo.Version);

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -371,7 +371,7 @@ internal sealed partial class ServerTestHost : CommonHost, IServerTestHost, IDis
             catch (JsonRpcException e)
             {
                 await SendErrorAsync(reqId: request.Id, errorCode: e.ErrorCode, message: e.Message, data: null, cancellationToken).ConfigureAwait(false);
-                CompleteRequest(ref _clientToServerRequests, request.Id, completion => completion.SetException(e));
+                CompleteRequest(ref _clientToServerRequests, request.Id, completion => completion.TrySetException(e));
             }
             catch (Exception e)
             {

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
@@ -425,12 +425,16 @@ internal sealed class Json
                             _ => null,
                         };
                     }
-                    catch (MessageFormatException ex)
+                    catch (Exception ex) when (ex is MessageFormatException or InvalidOperationException or JsonException)
                     {
                         // If params can't be deserialized for a request, capture the failure so
                         // we can later send back a properly coded JSON-RPC error using the request id.
                         // For notifications there's no one to respond to, but we still avoid
                         // crashing the message-handling loop by swallowing into the sentinel.
+                        // We catch the broader set of deserialization-related exceptions because the
+                        // request payload is untrusted client input and the lower-level helpers
+                        // (e.g. JsonElement.GetString() on a non-string element) can throw types
+                        // other than MessageFormatException.
                         @params = new InvalidRequestParamsArgs(ErrorCodes.InvalidParams, ex.Message);
                     }
                 }
@@ -501,7 +505,7 @@ internal sealed class Json
             string runId = json.Bind<string>(jsonElement, JsonRpcStrings.RunId);
             if (!Guid.TryParse(runId, out Guid result))
             {
-                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+                throw new MessageFormatException(JsonRpcStrings.InvalidRunIdErrorMessage);
             }
 
             json.TryArrayBind(jsonElement, out TestNode[]? testNodes, JsonRpcStrings.Tests);
@@ -518,7 +522,7 @@ internal sealed class Json
             string runId = json.Bind<string>(jsonElement, JsonRpcStrings.RunId);
             if (!Guid.TryParse(runId, out Guid result))
             {
-                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+                throw new MessageFormatException(JsonRpcStrings.InvalidRunIdErrorMessage);
             }
 
             json.TryArrayBind(jsonElement, out TestNode[]? testNodes, JsonRpcStrings.Tests);
@@ -643,21 +647,9 @@ internal sealed class Json
     }
 
     internal T Bind<T>(JsonElement element, string? property = null)
-    {
-        if (property is not null)
-        {
-            try
-            {
-                element = element.GetProperty(property);
-            }
-            catch (KeyNotFoundException ex)
-            {
-                throw new KeyNotFoundException($"Key '{property}' was not found in the dictionary.", ex);
-            }
-        }
-
-        return Deserialize<T>(element);
-    }
+        => property is not null && !element.TryGetProperty(property, out element)
+            ? throw new MessageFormatException($"'{property}' field is missing")
+            : Deserialize<T>(element);
 
     internal bool TryBind<T>(JsonElement element, out T? value, string? property = null)
     {

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
@@ -405,24 +405,37 @@ internal sealed class Json
 
             if (json.TryBind(jsonElement, out string? method, JsonRpcStrings.Method))
             {
+                bool hasId = json.TryBind(jsonElement, out int id, JsonRpcStrings.Id);
+
                 object? @params = null;
                 if (jsonElement.TryGetProperty(JsonRpcStrings.Params, out JsonElement value))
                 {
-                    // Parse the specific methods
-                    @params = method switch
+                    try
                     {
-                        JsonRpcMethods.Initialize => json.Bind<InitializeRequestArgs>(value),
-                        JsonRpcMethods.TestingDiscoverTests => json.Bind<DiscoverRequestArgs>(value),
-                        JsonRpcMethods.TestingRunTests => json.Bind<RunRequestArgs>(value),
-                        JsonRpcMethods.CancelRequest => json.Bind<CancelRequestArgs>(value),
-                        JsonRpcMethods.Exit => json.Bind<ExitRequestArgs>(value),
+                        // Parse the specific methods
+                        @params = method switch
+                        {
+                            JsonRpcMethods.Initialize => json.Bind<InitializeRequestArgs>(value),
+                            JsonRpcMethods.TestingDiscoverTests => json.Bind<DiscoverRequestArgs>(value),
+                            JsonRpcMethods.TestingRunTests => json.Bind<RunRequestArgs>(value),
+                            JsonRpcMethods.CancelRequest => json.Bind<CancelRequestArgs>(value),
+                            JsonRpcMethods.Exit => json.Bind<ExitRequestArgs>(value),
 
-                        // Note: Let the server report unknown RPC request back to the client.
-                        _ => null,
-                    };
+                            // Note: Let the server report unknown RPC request back to the client.
+                            _ => null,
+                        };
+                    }
+                    catch (MessageFormatException ex)
+                    {
+                        // If params can't be deserialized for a request, capture the failure so
+                        // we can later send back a properly coded JSON-RPC error using the request id.
+                        // For notifications there's no one to respond to, but we still avoid
+                        // crashing the message-handling loop by swallowing into the sentinel.
+                        @params = new InvalidRequestParamsArgs(ErrorCodes.InvalidParams, ex.Message);
+                    }
                 }
 
-                return json.TryBind(jsonElement, out int id, JsonRpcStrings.Id)
+                return hasId
                     ? new RequestMessage(id, method!, @params)
                     : new NotificationMessage(method!, @params);
             }
@@ -486,7 +499,10 @@ internal sealed class Json
         _deserializers[typeof(DiscoverRequestArgs)] = new JsonElementDeserializer<DiscoverRequestArgs>((json, jsonElement) =>
         {
             string runId = json.Bind<string>(jsonElement, JsonRpcStrings.RunId);
-            _ = Guid.TryParse(runId, out Guid result);
+            if (!Guid.TryParse(runId, out Guid result))
+            {
+                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+            }
 
             json.TryArrayBind(jsonElement, out TestNode[]? testNodes, JsonRpcStrings.Tests);
             json.TryBind(jsonElement, out string? graphFilter, JsonRpcStrings.Filter);
@@ -500,7 +516,10 @@ internal sealed class Json
         _deserializers[typeof(RunRequestArgs)] = new JsonElementDeserializer<RunRequestArgs>((json, jsonElement) =>
         {
             string runId = json.Bind<string>(jsonElement, JsonRpcStrings.RunId);
-            _ = Guid.TryParse(runId, out Guid result);
+            if (!Guid.TryParse(runId, out Guid result))
+            {
+                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+            }
 
             json.TryArrayBind(jsonElement, out TestNode[]? testNodes, JsonRpcStrings.Tests);
             json.TryBind(jsonElement, out string? graphFilter, JsonRpcStrings.Filter);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcException.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcException.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.ServerMode;
+
+/// <summary>
+/// Exception used to surface a JSON-RPC error from request handling so that the
+/// server message loop can convert it into a properly coded JSON-RPC error
+/// response instead of a generic exception payload.
+/// </summary>
+internal sealed class JsonRpcException : Exception
+{
+    public JsonRpcException(int errorCode, string message)
+        : base(message)
+        => ErrorCode = errorCode;
+
+    public int ErrorCode { get; }
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcMethods.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/JsonRpcMethods.cs
@@ -51,6 +51,9 @@ internal static class JsonRpcStrings
     public const string Tests = "tests";
     public const string Filter = "filter";
 
+    // Shared error messages
+    public const string InvalidRunIdErrorMessage = "'" + RunId + "' field is not a valid Guid";
+
     // Test change message and test change properties
     internal const string Parent = "parent";
     internal const string Node = "node";

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
@@ -59,6 +59,13 @@ internal sealed record CancelRequestArgs(int CancelRequestId);
 
 internal sealed record ExitRequestArgs;
 
+/// <summary>
+/// Sentinel params type used when a request's params failed to deserialize.
+/// The request reaches the handler so a proper JSON-RPC error can be sent back
+/// using the request's id rather than crashing the message-handling loop.
+/// </summary>
+internal sealed record InvalidRequestParamsArgs(int ErrorCode, string ErrorMessage);
+
 internal sealed record ClientInfo(string Name, string Version);
 
 internal sealed record ClientCapabilities(bool DebuggerProvider);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
@@ -482,22 +482,30 @@ internal static class SerializerUtilities
                             ? null
                             : GetIdFromJson(idObj) ?? throw new MessageFormatException("id field should be a string or an int");
 
-                // TODO: Should we be forgiving in the deserialization (if it throws)?
-                // This way we'd be able to send an ErrorMessage back to the client,
-                // rather than send a log notification.
-
-                // Parse the specific methods
-                object? @params = method switch
+                object? @params;
+                try
                 {
-                    JsonRpcMethods.Initialize => Deserialize<InitializeRequestArgs>(paramsObj),
-                    JsonRpcMethods.TestingDiscoverTests => Deserialize<DiscoverRequestArgs>(paramsObj),
-                    JsonRpcMethods.TestingRunTests => Deserialize<RunRequestArgs>(paramsObj),
-                    JsonRpcMethods.CancelRequest => Deserialize<CancelRequestArgs>(paramsObj),
-                    JsonRpcMethods.Exit => Deserialize<ExitRequestArgs>(paramsObj),
+                    // Parse the specific methods
+                    @params = method switch
+                    {
+                        JsonRpcMethods.Initialize => Deserialize<InitializeRequestArgs>(paramsObj),
+                        JsonRpcMethods.TestingDiscoverTests => Deserialize<DiscoverRequestArgs>(paramsObj),
+                        JsonRpcMethods.TestingRunTests => Deserialize<RunRequestArgs>(paramsObj),
+                        JsonRpcMethods.CancelRequest => Deserialize<CancelRequestArgs>(paramsObj),
+                        JsonRpcMethods.Exit => Deserialize<ExitRequestArgs>(paramsObj),
 
-                    // Note: Let the server report unknown RPC request back to the client.
-                    _ => null,
-                };
+                        // Note: Let the server report unknown RPC request back to the client.
+                        _ => null,
+                    };
+                }
+                catch (MessageFormatException ex)
+                {
+                    // If params can't be deserialized for a request, capture the failure so
+                    // we can later send back a properly coded JSON-RPC error using the request id.
+                    // For notifications there's no one to respond to, but we still avoid
+                    // crashing the message-handling loop by swallowing into the sentinel.
+                    @params = new InvalidRequestParamsArgs(ErrorCodes.InvalidParams, ex.Message);
+                }
 
                 return id.HasValue
                     ? new RequestMessage(id.Value, method, @params)
@@ -587,7 +595,11 @@ internal static class SerializerUtilities
 
         Deserializers[typeof(DiscoverRequestArgs)] = new ObjectDeserializer<DiscoverRequestArgs>(properties =>
         {
-            _ = Guid.TryParse(GetRequiredPropertyFromJson<string>(properties, JsonRpcStrings.RunId), out Guid runId);
+            string runIdString = GetRequiredPropertyFromJson<string>(properties, JsonRpcStrings.RunId);
+            if (!Guid.TryParse(runIdString, out Guid runId))
+            {
+                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+            }
 
             var testsJson = GetOptionalPropertyFromJson(properties, JsonRpcStrings.Tests) as ICollection<object>;
 
@@ -600,7 +612,11 @@ internal static class SerializerUtilities
 
         Deserializers[typeof(RunRequestArgs)] = new ObjectDeserializer<RunRequestArgs>(properties =>
         {
-            _ = Guid.TryParse(GetRequiredPropertyFromJson<string>(properties, JsonRpcStrings.RunId), out Guid runId);
+            string runIdString = GetRequiredPropertyFromJson<string>(properties, JsonRpcStrings.RunId);
+            if (!Guid.TryParse(runIdString, out Guid runId))
+            {
+                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+            }
 
             var testsJson = GetOptionalPropertyFromJson(properties, JsonRpcStrings.Tests) as ICollection<object>;
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
@@ -498,12 +498,15 @@ internal static class SerializerUtilities
                         _ => null,
                     };
                 }
-                catch (MessageFormatException ex)
+                catch (Exception ex) when (ex is MessageFormatException or InvalidCastException)
                 {
                     // If params can't be deserialized for a request, capture the failure so
                     // we can later send back a properly coded JSON-RPC error using the request id.
                     // For notifications there's no one to respond to, but we still avoid
                     // crashing the message-handling loop by swallowing into the sentinel.
+                    // We catch the broader set of deserialization-related exceptions because the
+                    // request payload is untrusted client input and the lower-level helpers can
+                    // throw types other than MessageFormatException.
                     @params = new InvalidRequestParamsArgs(ErrorCodes.InvalidParams, ex.Message);
                 }
 
@@ -598,7 +601,7 @@ internal static class SerializerUtilities
             string runIdString = GetRequiredPropertyFromJson<string>(properties, JsonRpcStrings.RunId);
             if (!Guid.TryParse(runIdString, out Guid runId))
             {
-                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+                throw new MessageFormatException(JsonRpcStrings.InvalidRunIdErrorMessage);
             }
 
             var testsJson = GetOptionalPropertyFromJson(properties, JsonRpcStrings.Tests) as ICollection<object>;
@@ -615,7 +618,7 @@ internal static class SerializerUtilities
             string runIdString = GetRequiredPropertyFromJson<string>(properties, JsonRpcStrings.RunId);
             if (!Guid.TryParse(runIdString, out Guid runId))
             {
-                throw new MessageFormatException($"'{JsonRpcStrings.RunId}' field is not a valid Guid");
+                throw new MessageFormatException(JsonRpcStrings.InvalidRunIdErrorMessage);
             }
 
             var testsJson = GetOptionalPropertyFromJson(properties, JsonRpcStrings.Tests) as ICollection<object>;
@@ -762,7 +765,14 @@ internal static class SerializerUtilities
         => properties.TryGetValue(propertyName, out object? propObj) ? propObj : null;
 
     private static T GetRequiredPropertyFromJson<T>(IDictionary<string, object?> properties, string propertyName)
-        => (T)(GetOptionalPropertyFromJson(properties, propertyName) ?? throw new MessageFormatException($"'{propertyName}' field is missing"));
+    {
+        object? value = GetOptionalPropertyFromJson(properties, propertyName)
+            ?? throw new MessageFormatException($"'{propertyName}' field is missing");
+
+        return value is T typed
+            ? typed
+            : throw new MessageFormatException($"'{propertyName}' field has wrong type (expected {typeof(T).Name})");
+    }
 
     private static int? GetIdFromJson(object? idObj)
         => idObj switch

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -101,6 +101,54 @@ public sealed class FormatterUtilitiesTests
         }
     }
 
+    [DataRow(typeof(DiscoverRequestArgs))]
+    [DataRow(typeof(RunRequestArgs))]
+    [TestMethod]
+    public void Deserialize_InvalidRunId_ThrowsMessageFormatException(Type type)
+    {
+        const string json = """
+            {
+                "runId": "not-a-guid"
+            }
+            """;
+
+        Assert.Throws<MessageFormatException>(() => Deserialize(type, json));
+    }
+
+    [DataRow("testing/discoverTests")]
+    [DataRow("testing/runTests")]
+    [TestMethod]
+    public void DeserializeRpcMessage_InvalidRunId_CapturesInvalidParamsSentinel(string method)
+    {
+        string json = $$"""
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "{{method}}",
+                "params": {
+                    "runId": "not-a-guid"
+                }
+            }
+            """;
+
+#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
+#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
+        RpcMessage msg = _formatter.Deserialize<RpcMessage>(json
+#if NETCOREAPP
+            .AsMemory()
+#endif
+            );
+#pragma warning restore SA1111 // Closing parenthesis should be on line of last parameter
+#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+
+        var request = (RequestMessage)msg;
+        Assert.AreEqual(42, request.Id);
+        Assert.AreEqual(method, request.Method);
+        var invalid = (InvalidRequestParamsArgs)request.Params!;
+        Assert.AreEqual(ErrorCodes.InvalidParams, invalid.ErrorCode);
+        Assert.Contains("runId", invalid.ErrorMessage);
+    }
+
     private static void AssertRequestArgs<TRequestArgs>(Type type, TRequestArgs actualRequest, TRequestArgs expectedRequest)
         where TRequestArgs : RequestArgsBase
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -115,6 +115,41 @@ public sealed class FormatterUtilitiesTests
         Assert.Throws<MessageFormatException>(() => Deserialize(type, json));
     }
 
+    [DataRow("testing/discoverTests", "\"runId\": 42")]
+    [DataRow("testing/runTests", "\"runId\": 42")]
+    [DataRow("testing/discoverTests", "")]
+    [DataRow("testing/runTests", "")]
+    [TestMethod]
+    public void DeserializeRpcMessage_InvalidRunIdShape_CapturesInvalidParamsSentinel(string method, string runIdProperty)
+    {
+        string json = $$"""
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "{{method}}",
+                "params": {
+                    {{runIdProperty}}
+                }
+            }
+            """;
+
+#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
+#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
+        RpcMessage msg = _formatter.Deserialize<RpcMessage>(json
+#if NETCOREAPP
+            .AsMemory()
+#endif
+            );
+#pragma warning restore SA1111 // Closing parenthesis should be on line of last parameter
+#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+
+        var request = (RequestMessage)msg;
+        Assert.AreEqual(42, request.Id);
+        Assert.AreEqual(method, request.Method);
+        var invalid = (InvalidRequestParamsArgs)request.Params!;
+        Assert.AreEqual(ErrorCodes.InvalidParams, invalid.ErrorCode);
+    }
+
     [DataRow("testing/discoverTests")]
     [DataRow("testing/runTests")]
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
@@ -222,8 +222,10 @@ public sealed class ServerTests
         Assert.AreEqual(0, result);
     }
 
+    [DataRow(JsonRpcMethods.TestingDiscoverTests)]
+    [DataRow(JsonRpcMethods.TestingRunTests)]
     [TestMethod]
-    public async Task DiscoveryRequestWithInvalidRunId_ReturnsInvalidParamsError()
+    public async Task RequestWithInvalidRunId_ReturnsInvalidParamsError(string method)
     {
         using var server = TcpServer.Create();
 
@@ -265,18 +267,18 @@ public sealed class ServerTests
         using CancellationTokenSource cancellationTokenSource = new(TimeoutHelper.DefaultHangTimeSpanTimeout);
         await WaitForMessage(messageHandler, rpcMessage => rpcMessage is ResponseMessage, "Wait initialize", cancellationTokenSource.Token);
 
-        // Send a malformed discoverTests request with an invalid runId.
-        const string malformedDiscoverMessage = """
+        // Send a malformed request with an invalid runId.
+        string malformedMessage = $$"""
             {
                 "jsonrpc": "2.0",
                 "id": 2,
-                "method": "testing/discoverTests",
+                "method": "{{method}}",
                 "params": {
                     "runId": "not-a-guid"
                 }
             }
             """;
-        await WriteMessageAsync(writer, malformedDiscoverMessage);
+        await WriteMessageAsync(writer, malformedMessage);
 
         RpcMessage? msg = await WaitForMessage(messageHandler, rpcMessage => rpcMessage is ErrorMessage, "Wait invalid-runId error", cancellationTokenSource.Token);
         var error = (ErrorMessage)msg!;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/ServerTests.cs
@@ -192,7 +192,7 @@ public sealed class ServerTests
                 "id": 2,
                 "method": "testing/discoverTests",
                 "params": {
-                    "runId": "Run1"
+                    "runId": "00000000-0000-0000-0000-000000000001"
                 }
             }
             """;
@@ -216,6 +216,74 @@ public sealed class ServerTests
         var error = (ErrorMessage)msg!;
         Assert.AreEqual(ErrorCodes.RequestCanceled, error.ErrorCode);
 
+        await WriteMessageAsync(writer, """{ "jsonrpc": "2.0", "method": "exit", "params": { } }""");
+
+        int result = await serverTask;
+        Assert.AreEqual(0, result);
+    }
+
+    [TestMethod]
+    public async Task DiscoveryRequestWithInvalidRunId_ReturnsInvalidParamsError()
+    {
+        using var server = TcpServer.Create();
+
+        string[] args = ["--no-banner", "--server", "--client-port", $"{server.Port}", "--internal-testingplatform-skipbuildercheck"];
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new MockTestAdapter());
+        var testApplication = (TestApplication)await builder.BuildAsync();
+        testApplication.ServiceProvider.GetRequiredService<SystemConsole>().SuppressOutput();
+        Task<int> serverTask = Task.Run(testApplication.RunAsync);
+
+        using CancellationTokenSource timeout = new(TimeoutHelper.DefaultHangTimeSpanTimeout);
+        using TcpClient client = await server.WaitForConnectionAsync(timeout.Token);
+        using NetworkStream stream = client.GetStream();
+        using StreamWriter writer = new(stream, Encoding.UTF8);
+        TcpMessageHandler messageHandler = new(
+                client,
+                clientToServerStream: client.GetStream(),
+                serverToClientStream: client.GetStream(),
+                FormatterUtilities.CreateFormatter());
+
+        const string initializeMessage = """
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "processId": 32,
+                    "clientInfo": { "name": "testingplatform-unittests", "version": "1.0.0" },
+                    "capabilities": {
+                        "testing": {
+                            "debuggerProvider": true
+                        }
+                    }
+                }
+            }
+            """;
+        await WriteMessageAsync(writer, initializeMessage);
+
+        using CancellationTokenSource cancellationTokenSource = new(TimeoutHelper.DefaultHangTimeSpanTimeout);
+        await WaitForMessage(messageHandler, rpcMessage => rpcMessage is ResponseMessage, "Wait initialize", cancellationTokenSource.Token);
+
+        // Send a malformed discoverTests request with an invalid runId.
+        const string malformedDiscoverMessage = """
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "testing/discoverTests",
+                "params": {
+                    "runId": "not-a-guid"
+                }
+            }
+            """;
+        await WriteMessageAsync(writer, malformedDiscoverMessage);
+
+        RpcMessage? msg = await WaitForMessage(messageHandler, rpcMessage => rpcMessage is ErrorMessage, "Wait invalid-runId error", cancellationTokenSource.Token);
+        var error = (ErrorMessage)msg!;
+        Assert.AreEqual(2, error.Id);
+        Assert.AreEqual(ErrorCodes.InvalidParams, error.ErrorCode);
+
+        // The server should still be alive and able to handle the exit notification after the rejection.
         await WriteMessageAsync(writer, """{ "jsonrpc": "2.0", "method": "exit", "params": { } }""");
 
         int result = await serverTask;


### PR DESCRIPTION
Fixes #8423.

## Problem

When a client sends a JSON-RPC request (`testing/discoverTests` or `testing/runTests`) with a malformed `runId` value (e.g., a non-GUID string), the deserializer silently coerced it to `Guid.Empty` via `Guid.TryParse`. This hid the protocol violation from the client and could cause hard-to-diagnose downstream behavior.

## Fix

- `DiscoverRequestArgs` and `RunRequestArgs` deserializers in both `Json.cs` (System.Text.Json) and `SerializerUtilities.cs` (Jsonite) now throw `MessageFormatException` when `runId` cannot be parsed as a `Guid`.
- The `RpcMessage` deserializer now parses `id` first, then wraps the per-method params deserialization in a `try/catch`. On failure, it embeds an `InvalidRequestParamsArgs(ErrorCode, ErrorMessage)` sentinel in `Params` so the message can flow through to the request handler without crashing the server's message-handling loop.
- `ServerTestHost.HandleRequestCoreAsync` detects the sentinel and throws a new `JsonRpcException` carrying the proper error code; `HandleRequestAsync` catches it and sends a JSON-RPC `InvalidParams` (-32602) error response to the client.

## Tests

- Added `FormatterUtilitiesTests` coverage for invalid `runId` on both args types (per-args deserializer throws; full `RpcMessage` deserializer captures sentinel).
- Added a `ServerTests` integration test that sends a malformed request, asserts an `InvalidParams` error is returned, and verifies the server cleanly handles the subsequent `exit` notification (i.e., the loop is still alive).
- Fixed pre-existing `DiscoveryRequestCanBeCanceled` test that used an invalid `runId` of `Run1` (now uses a valid GUID).
