### PR TITLE
Disable MSTEST0067 by default

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,4 +8,4 @@ Rule ID | Category | Severity | Notes
 MSTEST0064 | Usage | Info | PreferAsyncAssertionAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0064)
 MSTEST0065 | Usage | Warning | AvoidAssertAreEqualOnCollectionsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0065)
 MSTEST0066 | Design | Info | IgnoreShouldHaveJustificationAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0066)
-MSTEST0067 | Usage | Info | AvoidThreadSleepAndTaskWaitInTestsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0067)
+MSTEST0067 | Usage | Disabled | AvoidThreadSleepAndTaskWaitInTestsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0067)

--- a/src/Analyzers/MSTest.Analyzers/AvoidThreadSleepAndTaskWaitInTestsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidThreadSleepAndTaskWaitInTestsAnalyzer.cs
@@ -30,7 +30,7 @@ public sealed class AvoidThreadSleepAndTaskWaitInTestsAnalyzer : DiagnosticAnaly
         Description,
         Category.Usage,
         DiagnosticSeverity.Info,
-        isEnabledByDefault: true);
+        isEnabledByDefault: false);
 
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }


### PR DESCRIPTION
Downgrades the effective severity of `MSTEST0067` (`AvoidThreadSleepAndTaskWaitInTestsAnalyzer`) by switching `isEnabledByDefault` from `true` to `false`.

### Why

`MSTEST0067` was introduced in #8646 with `DefaultSeverity = Info` and `isEnabledByDefault = true`. With those settings the `AnalyzerSeverityDecider` elevates it to **Warning** in `Recommended` mode (the default MSTest analysis mode) and in `All` mode — which is more intrusive than intended for this stylistic guidance.

Marking the rule as not enabled by default keeps the default severity at `Info` and ensures it only surfaces in `All` mode, where users explicitly opt into the most aggressive analyzer set. The rule remains fully available and can be turned on individually via `.editorconfig`.

### Changes

- `AvoidThreadSleepAndTaskWaitInTestsAnalyzer.cs`: `isEnabledByDefault: true` → `false`.
- `AnalyzerReleases.Unshipped.md`: severity column for `MSTEST0067` updated from `Info` to `Disabled` to match the convention used for other opt-in rules (e.g. `MSTEST0021`, `MSTEST0026`).
