### PR TITLE
Fix flaky Dispose_FlushesTelemetryClientOnceAfterAllTrackedEvents test

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
@@ -242,6 +242,7 @@ public sealed class AppInsightsProviderTests
         List<string> trackedEvents = [];
         int flushCallCount = 0;
         using ManualResetEventSlim secondEventTracked = new(initialState: false);
+        using ManualResetEventSlim flushInvoked = new(initialState: false);
         Mock<ITelemetryClient> testTelemetryClient = new();
         testTelemetryClient.Setup(x => x.TrackEvent(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, double>>()))
             .Callback((string eventName, Dictionary<string, string> _, Dictionary<string, double> _) =>
@@ -256,7 +257,11 @@ public sealed class AppInsightsProviderTests
                 }
             });
         testTelemetryClient.Setup(x => x.Flush())
-            .Callback(() => Interlocked.Increment(ref flushCallCount));
+            .Callback(() =>
+            {
+                Interlocked.Increment(ref flushCallCount);
+                flushInvoked.Set();
+            });
 
         Mock<ITelemetryClientFactory> telemetryClientFactory = new();
         telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Returns(testTelemetryClient.Object);
@@ -289,6 +294,12 @@ public sealed class AppInsightsProviderTests
 #else
         appInsightsProvider.Dispose();
 #endif
+
+        // Dispose only waits up to 3 seconds for the ingest task to drain, and may proceed even
+        // before the task reaches its finally block (especially under thread-pool pressure on CI).
+        // Wait explicitly for the Flush callback so the assertions below are not racing the
+        // background continuation.
+        Assert.IsTrue(flushInvoked.Wait(TimeSpan.FromSeconds(30), TestContext.CancellationToken), "Flush was not invoked within the timeout after dispose.");
 
         Assert.HasCount(2, trackedEvents);
         Assert.AreEqual("FirstEvent", trackedEvents[0]);


### PR DESCRIPTION
## Problem

The `Dispose_FlushesTelemetryClientOnceAfterAllTrackedEvents` unit test was flaky on `net462` (and possible on other targets too):

```
Assertion failed. Expected values to be equal.
Flush should be invoked exactly once after the ingest loop drains.

expected: 1
actual:   0

Assert.AreEqual(1, Volatile.Read(ref flushCallCount))
```

## Root cause

`AppInsightsProvider.Dispose()` only waits up to **3 seconds** for the ingest task to drain, then proceeds regardless. Even when the wait succeeds, the `TaskCompletionSource(RunContinuationsAsynchronously)` continuation that drives the ingest loop into its `finally` block (where `_client.Flush()` runs) may still be queued on the thread pool. Under thread-pool pressure on CI, the assertion on `flushCallCount` ran **before** `Flush()` had actually executed.

## Fix

Test-only change. Signal explicitly via a `ManualResetEventSlim` from the mocked `Flush()` callback, and wait on it (with a generous 30s timeout) after `Dispose()` / `DisposeAsync()` so the assertions no longer race the background continuation.

## Verification

- 15× consecutive runs on `net462`: all passed.
- 10× consecutive runs on `net8.0`: all passed.

The production code is intentionally unchanged - the behavior under test is correct, only the test synchronization with the background ingest task needed to be reliable.
