### PR TITLE
[link-checker] Fix broken documentation links

### DIFF
--- a/docs/RFCs/004-In-Assembly-Parallel-Execution.md
+++ b/docs/RFCs/004-In-Assembly-Parallel-Execution.md
@@ -89,8 +89,8 @@ Test lifecyle method semantics
 In-assembly parallel execution can be conditioned using the following means:
 
 1. as annotations in source code (as described in this document).
-2. as configuration properties set via a .runsettings file [\[see here for more\]](https://github.com/Microsoft/vstest-docs/blob/main/docs/configure.md).
-3. by passing runsettings arguments via the command line [\[see here for more\]](https://github.com/Microsoft/vstest-docs/blob/main/docs/RunSettingsArguments.md).
+2. as configuration properties set via a .runsettings file [\[see here for more\]](https://github.com/microsoft/vstest/blob/main/docs/configure.md).
+3. by passing runsettings arguments via the command line [\[see here for more\]](https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md).
 
 (3) overrides (2) which in turn overrides (1). The ```[DoNotParallelize]``` annotation may be applied only to source code, and hence remains unaffected by these rules - thus, even if in-assembly parallel execution in conditioned via (2) or (3), specific program elements can still opt-out safely.
 


### PR DESCRIPTION
## Summary

Fixed 2 broken documentation links in `docs/RFCs/004-In-Assembly-Parallel-Execution.md`.

### Links Fixed

The `microsoft/vstest-docs` repository has been consolidated into `microsoft/vstest`. Two links in the RFC were pointing to the old location:

| Old URL | New URL |
|---------|---------|
| `https://github.com/Microsoft/vstest-docs/blob/main/docs/configure.md` | `https://github.com/microsoft/vstest/blob/main/docs/configure.md` |
| `https://github.com/Microsoft/vstest-docs/blob/main/docs/RunSettingsArguments.md` | `https://github.com/microsoft/vstest/blob/main/docs/RunSettingsArguments.md` |

### Other Broken Links (Not Fixed)

The following categories of broken links were identified but are not actionable:

- **Historical NuGet version links** in CHANGELOG files — old package versions are unlisted on NuGet.org but the historical records are accurate
- **Historical GitHub comparison links** — old tags/refs no longer exist but are accurate historical records  
- **`microsoft/testanywhere` comparison links** — repo no longer public; historical CHANGELOG entries
- **`localhost:5050`** — intentional developer example URL
- **Azure DevOps build badge** — old CI badge URL no longer accessible




> Generated by [Daily Link Checker & Fixer](https://github.com/microsoft/testfx/actions/runs/26636619194) · sonnet46 1.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+link-checker%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/link-checker.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Daily Link Checker & Fixer, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26636619194, workflow_id: link-checker, run: https://github.com/microsoft/testfx/actions/runs/26636619194 -->

<!-- gh-aw-workflow-id: link-checker -->