### PR TITLE
[code-simplifier] Add IsTestClass extension and apply consistently across MSTest analyzers

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/Helpers/FixtureUtils.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/FixtureUtils.cs
@@ -82,6 +82,12 @@ internal static class FixtureUtils
     public static bool IsTestMethod(this ImmutableArray<AttributeData> methodAttributes, INamedTypeSymbol testMethodAttributeSymbol)
         => methodAttributes.Any(methodAttribute => methodAttribute.AttributeClass.Inherits(testMethodAttributeSymbol));
 
+    public static bool IsTestClass(this INamedTypeSymbol typeSymbol, INamedTypeSymbol testClassAttributeSymbol)
+        => typeSymbol.GetAttributes().IsTestClass(testClassAttributeSymbol);
+
+    public static bool IsTestClass(this ImmutableArray<AttributeData> typeAttributes, INamedTypeSymbol testClassAttributeSymbol)
+        => typeAttributes.Any(typeAttribute => typeAttribute.AttributeClass.Inherits(testClassAttributeSymbol));
+
     public static bool IsInheritanceModeSet(this IMethodSymbol methodSymbol, INamedTypeSymbol? inheritanceBehaviorSymbol,
         INamedTypeSymbol? classInitializeOrCleanupAttributeSymbol)
     {

--- a/src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs
@@ -82,23 +82,16 @@ public sealed class IgnoreShouldHaveJustificationAnalyzer : DiagnosticAnalyzer
     private static void AnalyzeType(SymbolAnalysisContext context, INamedTypeSymbol ignoreAttributeSymbol, INamedTypeSymbol testClassAttributeSymbol)
     {
         var typeSymbol = (INamedTypeSymbol)context.Symbol;
+        ImmutableArray<AttributeData> typeAttributes = typeSymbol.GetAttributes();
 
-        AttributeData? ignoreAttribute = null;
-        bool isTestClass = false;
-        foreach (AttributeData typeAttribute in typeSymbol.GetAttributes())
+        if (!typeAttributes.IsTestClass(testClassAttributeSymbol))
         {
-            if (typeAttribute.AttributeClass.Inherits(testClassAttributeSymbol))
-            {
-                isTestClass = true;
-            }
-
-            if (SymbolEqualityComparer.Default.Equals(typeAttribute.AttributeClass, ignoreAttributeSymbol))
-            {
-                ignoreAttribute = typeAttribute;
-            }
+            return;
         }
 
-        if (!isTestClass || ignoreAttribute is null)
+        AttributeData? ignoreAttribute = typeAttributes.FirstOrDefault(attribute =>
+            SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, ignoreAttributeSymbol));
+        if (ignoreAttribute is null)
         {
             return;
         }

--- a/src/Analyzers/MSTest.Analyzers/PublicMethodShouldBeTestMethodAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PublicMethodShouldBeTestMethodAnalyzer.cs
@@ -74,17 +74,7 @@ public sealed class PublicMethodShouldBeTestMethodAnalyzer : DiagnosticAnalyzer
         }
 
         INamedTypeSymbol containingTypeSymbol = context.Symbol.ContainingType;
-        bool isTestClass = false;
-        foreach (AttributeData classAttribute in containingTypeSymbol.GetAttributes())
-        {
-            if (classAttribute.AttributeClass.Inherits(testClassAttributeSymbol))
-            {
-                isTestClass = true;
-                break;
-            }
-        }
-
-        if (!isTestClass)
+        if (!containingTypeSymbol.IsTestClass(testClassAttributeSymbol))
         {
             return;
         }

--- a/src/Analyzers/MSTest.Analyzers/TestClassShouldHaveTestMethodAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestClassShouldHaveTestMethodAnalyzer.cs
@@ -63,17 +63,7 @@ public sealed class TestClassShouldHaveTestMethodAnalyzer : DiagnosticAnalyzer
     {
         var classSymbol = (INamedTypeSymbol)context.Symbol;
 
-        bool isTestClass = false;
-        foreach (AttributeData classAttribute in classSymbol.GetAttributes())
-        {
-            if (classAttribute.AttributeClass.Inherits(testClassAttributeSymbol))
-            {
-                isTestClass = true;
-                break;
-            }
-        }
-
-        if (!isTestClass)
+        if (!classSymbol.IsTestClass(testClassAttributeSymbol))
         {
             return;
         }

--- a/src/Analyzers/MSTest.Analyzers/TypeContainingTestMethodShouldBeATestClassAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TypeContainingTestMethodShouldBeATestClassAnalyzer.cs
@@ -62,15 +62,7 @@ public sealed class TypeContainingTestMethodShouldBeATestClassAnalyzer : Diagnos
             return;
         }
 
-        bool isTestClass = false;
-        foreach (AttributeData classAttribute in namedTypeSymbol.GetAttributes())
-        {
-            if (classAttribute.AttributeClass.Inherits(testClassAttributeSymbol))
-            {
-                isTestClass = true;
-                break;
-            }
-        }
+        bool isTestClass = namedTypeSymbol.IsTestClass(testClassAttributeSymbol);
 
         if (isTestClass)
         {

--- a/src/Analyzers/MSTest.Analyzers/UseConditionBaseWithTestClassAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseConditionBaseWithTestClassAnalyzer.cs
@@ -53,21 +53,13 @@ public sealed class UseConditionBaseWithTestClassAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol testClassAttributeSymbol, INamedTypeSymbol conditionBaseAttributeSymbol)
     {
-        INamedTypeSymbol? conditionBaseAttribute = null;
-        bool isTestClass = false;
-        foreach (AttributeData attribute in context.Symbol.GetAttributes())
-        {
-            if (attribute.AttributeClass.Inherits(testClassAttributeSymbol))
-            {
-                isTestClass = true;
-            }
-            else if (attribute.AttributeClass.Inherits(conditionBaseAttributeSymbol))
-            {
-                conditionBaseAttribute = attribute.AttributeClass;
-            }
-        }
+        ImmutableArray<AttributeData> typeAttributes = context.Symbol.GetAttributes();
 
-        if (conditionBaseAttribute is not null && !isTestClass)
+        INamedTypeSymbol? conditionBaseAttribute = typeAttributes
+            .FirstOrDefault(attribute => attribute.AttributeClass.Inherits(conditionBaseAttributeSymbol))
+            ?.AttributeClass;
+
+        if (conditionBaseAttribute is not null && !typeAttributes.IsTestClass(testClassAttributeSymbol))
         {
             context.ReportDiagnostic(context.Symbol.CreateDiagnostic(UseConditionBaseWithTestClassRule, conditionBaseAttribute.Name));
         }


### PR DESCRIPTION
## Code Simplification - 2026-05-29

Follow-up to #8674 which introduced `IsTestMethod` extension methods in `FixtureUtils.cs`. This PR adds analogous `IsTestClass` extensions and applies them to replace the repetitive `isTestClass` bool + `foreach` pattern across five analyzer files.

### Files Simplified

- `src/Analyzers/MSTest.Analyzers/Helpers/FixtureUtils.cs` — Added `IsTestClass(INamedTypeSymbol, ...)` and `IsTestClass(ImmutableArray<AttributeData>, ...)` extension methods, mirroring the existing `IsTestMethod` pair
- `src/Analyzers/MSTest.Analyzers/IgnoreShouldHaveJustificationAnalyzer.cs` — Replaced manual foreach + bool in `AnalyzeType` with `IsTestClass` + `FirstOrDefault`
- `src/Analyzers/MSTest.Analyzers/PublicMethodShouldBeTestMethodAnalyzer.cs` — Replaced 8-line foreach + bool block with single `IsTestClass` call
- `src/Analyzers/MSTest.Analyzers/TestClassShouldHaveTestMethodAnalyzer.cs` — Same simplification
- `src/Analyzers/MSTest.Analyzers/TypeContainingTestMethodShouldBeATestClassAnalyzer.cs` — Same simplification
- `src/Analyzers/MSTest.Analyzers/UseConditionBaseWithTestClassAnalyzer.cs` — Combined both attribute checks using `FirstOrDefault` + `IsTestClass`

### Improvements Made

1. **Reduced Duplication** — The `isTestClass = false; foreach { if Inherits { isTestClass = true; break; } }` pattern appeared in 5 files; it is now a single extension method call
2. **Applied Project Standards** — Consistent with the `IsTestMethod` refactoring from #8674
3. **Improved Clarity** — Intent is expressed directly: `if (!type.IsTestClass(...))` reads more clearly than the expanded loop

### Changes Based On

Recent changes from:
- #8674 — Deduplicate test-method attribute detection across MSTest analyzers (the original refactoring that this follows up on)

### Testing

- ✅ All MSTest.Analyzers.UnitTests pass (`dotnet run` against `net8.0`)
- ✅ Build succeeds with 0 warnings
- ✅ No functional changes — behavior is identical

### Review Focus

Please verify:
- Functionality is preserved in all five modified analyzers
- The new `IsTestClass` extensions follow the same pattern as `IsTestMethod`

---

*Automated by Code Simplifier Agent*


<!-- gh-aw-tracker-id: code-simplifier -->




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item was blocked because it doesn't meet the GitHub integrity level.
>
> - [#8671](https://github.com/microsoft/testfx/pull/8671) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/26642104607) · sonnet46 3.9M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-05-30T14:28:57.758Z --> on May 30, 2026, 2:28 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26642104607, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/26642104607 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->