### PR TITLE
[perf-improver] perf: replace Regex array in AnsiDetector with direct string comparisons

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiDetector.cs
@@ -12,27 +12,32 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 /// </summary>
 internal static class AnsiDetector
 {
-    private static readonly Regex[] TerminalsRegexes =
-    [
-        new("^xterm"), // xterm, PuTTY, Mintty
-        new("^rxvt"), // RXVT
-        new("^(?!eterm-color).*eterm.*"), // Accepts eterm, but not eterm-color, which does not support moving the cursor, see #9950.
-        new("^screen"), // GNU screen, tmux
-        new("tmux"), // tmux
-        new("^vt100"), // DEC VT series
-        new("^vt102"), // DEC VT series
-        new("^vt220"), // DEC VT series
-        new("^vt320"), // DEC VT series
-        new("ansi"), // ANSI
-        new("scoansi"), // SCO ANSI
-        new("cygwin"), // Cygwin, MinGW
-        new("linux"), // Linux console
-        new("konsole"), // Konsole
-        new("bvterm"), // Bitvise SSH Client
-        new("^st-256color"), // Suckless Simple Terminal, st
-        new("alacritty") // Alacritty
-    ];
-
     public static bool IsAnsiSupported(string? termType)
-        => !RoslynString.IsNullOrEmpty(termType) && TerminalsRegexes.Any(regex => regex.IsMatch(termType));
+    {
+        if (RoslynString.IsNullOrEmpty(termType))
+        {
+            return false;
+        }
+
+        // Each condition mirrors the original regex pattern but uses plain string operations,
+        // eliminating the 17 Regex allocations and their compilation cost.
+        return termType.StartsWith("xterm", StringComparison.Ordinal) // ^xterm — xterm, PuTTY, Mintty
+            || termType.StartsWith("rxvt", StringComparison.Ordinal) // ^rxvt — RXVT
+            || (termType.Contains("eterm", StringComparison.Ordinal) // ^(?!eterm-color).*eterm.* — eterm but not eterm-color (#9950)
+                && !termType.StartsWith("eterm-color", StringComparison.Ordinal))
+            || termType.StartsWith("screen", StringComparison.Ordinal) // ^screen — GNU screen, tmux
+            || termType.Contains("tmux", StringComparison.Ordinal) // tmux — tmux
+            || termType.StartsWith("vt100", StringComparison.Ordinal) // ^vt100 — DEC VT series
+            || termType.StartsWith("vt102", StringComparison.Ordinal) // ^vt102 — DEC VT series
+            || termType.StartsWith("vt220", StringComparison.Ordinal) // ^vt220 — DEC VT series
+            || termType.StartsWith("vt320", StringComparison.Ordinal) // ^vt320 — DEC VT series
+            || termType.Contains("ansi", StringComparison.Ordinal) // ansi — ANSI
+            || termType.Contains("scoansi", StringComparison.Ordinal) // scoansi — SCO ANSI
+            || termType.Contains("cygwin", StringComparison.Ordinal) // cygwin — Cygwin, MinGW
+            || termType.Contains("linux", StringComparison.Ordinal) // linux — Linux console
+            || termType.Contains("konsole", StringComparison.Ordinal) // konsole — Konsole
+            || termType.Contains("bvterm", StringComparison.Ordinal) // bvterm — Bitvise SSH Client
+            || termType.StartsWith("st-256color", StringComparison.Ordinal) // ^st-256color — Suckless Simple Terminal, st
+            || termType.Contains("alacritty", StringComparison.Ordinal); // alacritty — Alacritty
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiDetector.cs
@@ -23,21 +23,21 @@ internal static class AnsiDetector
         // eliminating the 17 Regex allocations and their compilation cost.
         return termType.StartsWith("xterm", StringComparison.Ordinal) // ^xterm — xterm, PuTTY, Mintty
             || termType.StartsWith("rxvt", StringComparison.Ordinal) // ^rxvt — RXVT
-            || (termType.Contains("eterm", StringComparison.Ordinal) // ^(?!eterm-color).*eterm.* — eterm but not eterm-color (#9950)
+            || (termType.IndexOf("eterm", StringComparison.Ordinal) >= 0 // ^(?!eterm-color).*eterm.* — eterm but not eterm-color (#9950)
                 && !termType.StartsWith("eterm-color", StringComparison.Ordinal))
             || termType.StartsWith("screen", StringComparison.Ordinal) // ^screen — GNU screen, tmux
-            || termType.Contains("tmux", StringComparison.Ordinal) // tmux — tmux
+            || termType.IndexOf("tmux", StringComparison.Ordinal) >= 0 // tmux — tmux
             || termType.StartsWith("vt100", StringComparison.Ordinal) // ^vt100 — DEC VT series
             || termType.StartsWith("vt102", StringComparison.Ordinal) // ^vt102 — DEC VT series
             || termType.StartsWith("vt220", StringComparison.Ordinal) // ^vt220 — DEC VT series
             || termType.StartsWith("vt320", StringComparison.Ordinal) // ^vt320 — DEC VT series
-            || termType.Contains("ansi", StringComparison.Ordinal) // ansi — ANSI
-            || termType.Contains("scoansi", StringComparison.Ordinal) // scoansi — SCO ANSI
-            || termType.Contains("cygwin", StringComparison.Ordinal) // cygwin — Cygwin, MinGW
-            || termType.Contains("linux", StringComparison.Ordinal) // linux — Linux console
-            || termType.Contains("konsole", StringComparison.Ordinal) // konsole — Konsole
-            || termType.Contains("bvterm", StringComparison.Ordinal) // bvterm — Bitvise SSH Client
+            || termType.IndexOf("ansi", StringComparison.Ordinal) >= 0 // ansi — ANSI
+            || termType.IndexOf("scoansi", StringComparison.Ordinal) >= 0 // scoansi — SCO ANSI
+            || termType.IndexOf("cygwin", StringComparison.Ordinal) >= 0 // cygwin — Cygwin, MinGW
+            || termType.IndexOf("linux", StringComparison.Ordinal) >= 0 // linux — Linux console
+            || termType.IndexOf("konsole", StringComparison.Ordinal) >= 0 // konsole — Konsole
+            || termType.IndexOf("bvterm", StringComparison.Ordinal) >= 0 // bvterm — Bitvise SSH Client
             || termType.StartsWith("st-256color", StringComparison.Ordinal) // ^st-256color — Suckless Simple Terminal, st
-            || termType.Contains("alacritty", StringComparison.Ordinal); // alacritty — Alacritty
+            || termType.IndexOf("alacritty", StringComparison.Ordinal) >= 0; // alacritty — Alacritty
     }
 }


### PR DESCRIPTION
🤖 *This is an automated contribution from [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26642752864).*

## Goal and Rationale

`AnsiDetector` held a `static readonly Regex[] TerminalsRegexes` field initialised with **17 `new Regex(...)` instances**. These were allocated (and in some runtimes compiled) at class-initialisation time, purely to perform very simple prefix/substring checks against a terminal-type string. Every pattern maps directly to a `StartsWith` or `Contains` call, so no regex engine is needed.

## Approach

Replace the `Regex[]` field and its `.Any(regex => regex.IsMatch(...))` loop with a single `bool` expression chaining `string.StartsWith` / `string.Contains` (all with `StringComparison.Ordinal`), preserving each original pattern's semantics exactly — including the negative-lookahead case (`^(?!eterm-color).*eterm.*` → `Contains("eterm") && !StartsWith("eterm-color")`).

## Performance Evidence

| Metric | Before | After |
|--------|--------|-------|
| `Regex` instances allocated at startup | 17 | 0 |
| Regex compilation work | yes (interpreted mode) | eliminated |
| `Regex[]` array allocation | 1 | 0 |

`IsAnsiSupported` is called once per process (from `NativeMethods`) so this is a startup-cost win. The method now allocates nothing and executes with pure string comparison instructions.

**Methodology**: code inspection + BenchmarkDotNet would show reduced allocations on first call; the key claim (17 fewer allocations) is directly verifiable from the diff.

## Trade-offs

- Slightly more verbose than the regex array, but each line has a comment mapping it back to the original regex.
- No behavioral change — all 17 patterns are preserved faithfully.

## Test Status

- `Microsoft.Testing.Platform.UnitTests` (net8.0): **992 passed, 0 failed, 3 skipped** ✅

## Reproducibility

```bash
./build.sh  # restore + build
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
```




> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26642752864) · sonnet46 4.4M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26642752864, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/26642752864 -->

<!-- gh-aw-workflow-id: perf-improver -->