### PR TITLE
Convert AOT/trim pragma suppressions to attributes so they propagate to consumers

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.cs
@@ -307,15 +307,13 @@ internal
     /// </summary>
     /// <param name="path">The path of the assembly.</param>
     /// <returns>The loaded <see cref="Assembly"/>.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = "AssemblyResolver is part of the legacy reflection-mode loader and is not used in source-generator / Native AOT execution mode.")]
 #if NETFRAMEWORK
     protected virtual
 #else
     private static
 #endif
-    // This whole class is not used in source generator mode.
-#pragma warning disable IL2026 // Members attributed with RequiresUnreferencedCode may break when trimming
     Assembly LoadAssemblyFrom(string path) => Assembly.LoadFrom(path);
-#pragma warning restore IL2026 // Members attributed with RequiresUnreferencedCode may break when trimming
 
 #if NETFRAMEWORK
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs
@@ -240,6 +240,8 @@ internal static class MethodInfoExtensions
     //
     // [DataRow(0, "Hello")]
     // public void TestMethod<T1, T2>(T2 p0, T1, p1) { }
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed.", Justification = "Generic test methods with substituted type arguments are part of MSTest's reflection-mode adapter. Native AOT support relies on MSTest source-generated metadata, not on this code path.")]
+    [UnconditionalSuppressMessage("Aot", "IL3050:Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT", Justification = "Generic test methods with substituted type arguments are part of MSTest's reflection-mode adapter. Native AOT support relies on MSTest source-generated metadata, not on this code path.")]
     private static MethodInfo ConstructGenericMethod(MethodInfo methodInfo, object?[]? arguments)
     {
         DebugEx.Assert(methodInfo.IsGenericMethod, "ConstructGenericMethod should only be called for a generic method.");

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/DataSerializationHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/DataSerializationHelper.cs
@@ -12,6 +12,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 
 internal static class DataSerializationHelper
 {
+    private const string DataContractSerializationJustification =
+        "Data contract serialization is used for cross-process VSTest payloads. " +
+        "This should be safe as long as our generator mentions getting fields / properties of the target type. " +
+        "https://github.com/dotnet/runtime/issues/71350#issuecomment-1168140551";
+
     private static readonly ConcurrentDictionary<string, DataContractJsonSerializer> SerializerCache = new();
     private static readonly DataContractJsonSerializerSettings SerializerSettings = new()
     {
@@ -30,6 +35,8 @@ internal static class DataSerializationHelper
     /// </summary>
     /// <param name="data">Data array to serialize.</param>
     /// <returns>Serialized array.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = DataContractSerializationJustification)]
+    [UnconditionalSuppressMessage("Aot", "IL3050:Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT", Justification = DataContractSerializationJustification)]
     public static string?[]? Serialize(object?[]? data)
     {
         if (data == null)
@@ -61,14 +68,7 @@ internal static class DataSerializationHelper
 #endif
 
             using var memoryStream = new MemoryStream();
-            // This should be safe as long as our generator mentions
-            // getting fields / properties of the target type. https://github.com/dotnet/runtime/issues/71350#issuecomment-1168140551
-            // Not the best solution, maybe we can replace this with System.Text.Json, but the we need one generator calling the other.
-#pragma warning disable IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning disable IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
             serializer.WriteObject(memoryStream, data[i]);
-#pragma warning restore IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning restore IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
             byte[] serializerData = memoryStream.ToArray();
 
             serializedData[dataIndex] = Encoding.UTF8.GetString(serializerData, 0, serializerData.Length);
@@ -82,6 +82,8 @@ internal static class DataSerializationHelper
     /// </summary>
     /// <param name="serializedData">Serialized data array to deserialize.</param>
     /// <returns>Deserialized array.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = DataContractSerializationJustification)]
+    [UnconditionalSuppressMessage("Aot", "IL3050:Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT", Justification = DataContractSerializationJustification)]
     public static object?[]? Deserialize(string?[]? serializedData)
     {
         if (serializedData == null || serializedData.Length % 2 != 0)
@@ -111,14 +113,7 @@ internal static class DataSerializationHelper
 
             byte[] serializedDataBytes = Encoding.UTF8.GetBytes(serializedValue);
             using var memoryStream = new MemoryStream(serializedDataBytes);
-            // This should be safe as long as our generator mentions
-            // getting fields / properties of the target type. https://github.com/dotnet/runtime/issues/71350#issuecomment-1168140551
-            // Not the best solution, maybe we can replace this with System.Text.Json, but the we need one generator calling the other.
-#pragma warning disable IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning disable IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
             data[i] = serializer.ReadObject(memoryStream);
-#pragma warning restore IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning restore IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
             // For some reason, we don't get SerializationSurrogateProvider.GetDeserializedObject to be called by .NET runtime.
             // So we manually call it.
             data[i] = SerializationSurrogateProvider.GetDeserializedObject(data[i]!);
@@ -128,26 +123,20 @@ internal static class DataSerializationHelper
     }
 
     private static DataContractJsonSerializer GetSerializer(string assemblyQualifiedName)
-        => SerializerCache.GetOrAdd(
-            assemblyQualifiedName,
-            // This should be safe as long as our generator mentions
-            // getting fields / properties of the target type. https://github.com/dotnet/runtime/issues/71350#issuecomment-1168140551
-            // Not the best solution, maybe we can replace this with System.Text.Json, but the we need one generator calling the other.
-#pragma warning disable IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning disable IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
-            _ => new DataContractJsonSerializer(PlatformServiceProvider.Instance.ReflectionOperations.GetType(assemblyQualifiedName) ?? typeof(object), SerializerSettings));
-#pragma warning restore IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning restore IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
+        => SerializerCache.GetOrAdd(assemblyQualifiedName, CreateSerializerForAssemblyQualifiedName);
 
     private static DataContractJsonSerializer GetSerializer(Type type)
-        => SerializerCache.GetOrAdd(
-            type.AssemblyQualifiedName!,
-            // This should be safe as long as our generator mentions
-            // getting fields / properties of the target type. https://github.com/dotnet/runtime/issues/71350#issuecomment-1168140551
-            // Not the best solution, maybe we can replace this with System.Text.Json, but the we need one generator calling the other.
-#pragma warning disable IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning disable IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
-            _ => new DataContractJsonSerializer(type, SerializerSettings));
+        => SerializerCache.GetOrAdd(type.AssemblyQualifiedName!, _ => CreateSerializerForType(type));
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = DataContractSerializationJustification)]
+    [UnconditionalSuppressMessage("Aot", "IL3050:Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT", Justification = DataContractSerializationJustification)]
+    private static DataContractJsonSerializer CreateSerializerForAssemblyQualifiedName(string assemblyQualifiedName)
+        => new(PlatformServiceProvider.Instance.ReflectionOperations.GetType(assemblyQualifiedName) ?? typeof(object), SerializerSettings);
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = DataContractSerializationJustification)]
+    [UnconditionalSuppressMessage("Aot", "IL3050:Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT", Justification = DataContractSerializationJustification)]
+    private static DataContractJsonSerializer CreateSerializerForType(Type type)
+        => new(type, SerializerSettings);
 
     [DataContract]
     private sealed class SurrogatedDateOnly
@@ -235,6 +224,4 @@ internal static class DataSerializationHelper
             return type;
         }
     }
-#pragma warning restore IL3050 // IL3050: Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT
-#pragma warning restore IL2026 // IL2026: Members attributed with RequiresUnreferencedCode may break when trimming
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ManagedNameHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ManagedNameHelper.cs
@@ -112,6 +112,7 @@ internal static class ManagedNameHelper
     /// More information about <paramref name="managedTypeName"/> and <paramref name="managedMethodName"/> can be found in
     /// <see href="https://github.com/microsoft/vstest/blob/main/docs/RFCs/0017-Managed-TestCase-Properties.md">the RFC</see>.
     /// </remarks>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = "Reflection-based name resolution is used by the legacy VSTest bridge for managed-name lookup. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public static MethodInfo GetMethod(Assembly assembly, string managedTypeName, string managedMethodName)
     {
         Type type = assembly.GetType(managedTypeName, throwOnError: false, ignoreCase: false)
@@ -128,6 +129,7 @@ internal static class ManagedNameHelper
         return method ?? throw new InvalidManagedNameException();
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based name resolution is used by the legacy VSTest bridge for managed-name lookup. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     private static MethodInfo? FindMethod(Type type, string methodName, int methodArity, string[]? parameterTypes)
     {
         bool Filter(MemberInfo mbr, object? param)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs
@@ -48,47 +48,50 @@ internal sealed class ReflectionOperations : MarshalByRefObject, IReflectionOper
     public object[] GetCustomAttributes(Assembly assembly, Type type)
         => assembly.GetCustomAttributes(type, inherit: true);
 
-#pragma warning disable IL2070 // this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.
-#pragma warning disable IL2026 // Members attributed with RequiresUnreferencedCode may break when trimming
-#pragma warning disable IL2067 // 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.
-#pragma warning disable IL2057 // Unrecognized value passed to the typeName parameter of 'System.Type.GetType(String)'
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public ConstructorInfo[] GetDeclaredConstructors(Type classType)
         => classType.GetConstructors(DeclaredOnlyLookup);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public MethodInfo[] GetDeclaredMethods(Type classType)
         => classType.GetMethods(DeclaredOnlyLookup);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public PropertyInfo[] GetDeclaredProperties(Type type)
         => type.GetProperties(DeclaredOnlyLookup);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public Type[] GetDefinedTypes(Assembly assembly)
         => assembly.GetTypes();
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public MethodInfo[] GetRuntimeMethods(Type type)
         => type.GetMethods(Everything);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public MethodInfo? GetRuntimeMethod(Type declaringType, string methodName, Type[] parameters, bool includeNonPublic)
         => includeNonPublic
             ? declaringType.GetMethod(methodName, Everything, null, parameters, null)
             : declaringType.GetMethod(methodName, parameters);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public PropertyInfo? GetRuntimeProperty(Type classType, string testContextPropertyName, bool includeNonPublic)
         => includeNonPublic
             ? classType.GetProperty(testContextPropertyName, Everything)
             : classType.GetProperty(testContextPropertyName);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:Unrecognized value passed to the typeName parameter of 'System.Type.GetType(String)'.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public Type? GetType(string typeName)
         => Type.GetType(typeName);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:Members attributed with RequiresUnreferencedCode may break when trimming", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public Type? GetType(Assembly assembly, string typeName)
         => assembly.GetType(typeName);
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Reflection-based discovery/execution is the MSTest reflection-mode adapter path. Native AOT support relies on MSTest source-generated reflection metadata, not on this code path.")]
     public object? CreateInstance(Type type, object?[] parameters)
         => Activator.CreateInstance(type, parameters);
-#pragma warning restore IL2070 // this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.
-#pragma warning restore IL2026 // Members attributed with RequiresUnreferencedCode may break when trimming
-#pragma warning restore IL2067 // 'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.
-#pragma warning restore IL2057 // Unrecognized value passed to the typeName parameter of 'System.Type.GetType(String)'
 
     /// <summary>
     /// Checks to see if a member or type is decorated with the given attribute, or an attribute that derives from it. e.g. [MyTestClass] from [TestClass] will match if you look for [TestClass]. The inherit parameter does not impact this checking.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHost.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHost.cs
@@ -350,6 +350,7 @@ internal class TestSourceHost : ITestSourceHost
     /// <returns>
     /// A list of path.
     /// </returns>
+    [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Assembly.Location is explicitly checked for empty before use; in single-file/Native AOT scenarios it returns empty and the affected blocks are skipped.")]
     internal virtual List<string> GetResolutionPaths(string sourceFileName, bool isPortableMode)
     {
         List<string> resolutionPaths =
@@ -380,7 +381,6 @@ internal class TestSourceHost : ITestSourceHost
 
         // We check for the empty path, and in single file mode, or on source gen mode we don't allow
         // loading dependencies than from the current folder, which is what the default loader handles by itself.
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
         if (!string.IsNullOrEmpty(typeof(TestSourceHost).Assembly.Location))
         {
             // Adding adapter folder to resolution paths
@@ -398,7 +398,6 @@ internal class TestSourceHost : ITestSourceHost
                 resolutionPaths.Add(Path.GetDirectoryName(typeof(AssemblyHelper).Assembly.Location)!);
             }
         }
-#pragma warning restore IL3000 // Avoid accessing Assembly file path when publishing as a single file
 
         return resolutionPaths;
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
@@ -117,6 +117,7 @@ internal sealed class TestMethodFilter
     /// <param name="context">Discovery context.</param>
     /// <param name="logger">The logger to log exception messages too.</param>
     /// <returns>Filter expression.</returns>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "GetTestCaseFilter is part of the VSTest discovery contract on the concrete DiscoveryContext type; the runtime guarantees the method exists on supported hosts.")]
     private ITestCaseFilterExpression? GetTestCaseFilterFromDiscoveryContext(IDiscoveryContext context, IMessageLogger logger)
     {
         try

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
@@ -136,6 +136,7 @@ internal abstract class DeploymentUtilityBase
     /// <param name="deploymentDirectory">The deployment directory.</param>
     /// <param name="resultsDirectory">Root results directory.</param>
     /// <returns>Returns a list of deployment warnings.</returns>
+    [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Deployment is a reflection-mode/legacy adapter feature; in single-file/Native AOT scenarios Assembly.Location returns an empty string and the comparison falls through without error.")]
     protected IEnumerable<string> Deploy(IList<DeploymentItem> deploymentItems, string testSourceHandler, string deploymentDirectory, string resultsDirectory)
     {
         Ensure.NotNullOrWhiteSpace(deploymentDirectory);
@@ -194,9 +195,7 @@ internal abstract class DeploymentUtilityBase
                     // Ignore the test platform files.
                     string tempFile = Path.GetFileName(fileToDeploy);
                     // We throw when we run in source gen mode.
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
                     string assemblyName = Path.GetFileName(GetType().Assembly.Location);
-#pragma warning restore IL3000 // Avoid accessing Assembly file path when publishing as a single file
                     if (tempFile.Equals(assemblyName, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
@@ -149,9 +149,7 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
         CancellationToken cancellationToken)
         => ExecuteRequestWithRequestCountGuardAsync(async () =>
         {
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
             string[] testAssemblyPaths = [.. _getTestAssemblies().Select(GetAssemblyPath)];
-#pragma warning restore IL3000 // Avoid accessing Assembly file path when publishing as a single file
             switch (request)
             {
                 case DiscoverTestExecutionRequest discoverRequest:
@@ -184,12 +182,10 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     /// <see cref="Assembly.Location"/> returns an empty string (e.g. on Android CoreCLR
     /// where assemblies are memory-mapped).
     /// </summary>
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
+    [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Empty Assembly.Location is handled explicitly by falling back to the assembly simple name; see method body.")]
     internal static string GetAssemblyPath(Assembly assembly)
     {
-#pragma warning disable IL3000 // Avoid accessing Assembly file path when publishing as a single file
         string location = assembly.Location;
-#pragma warning restore IL3000 // Avoid accessing Assembly file path when publishing as a single file
         if (!string.IsNullOrEmpty(location))
         {
             return location;
@@ -204,7 +200,6 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
 
         return name + ".dll";
     }
-#pragma warning restore IL3000 // Avoid accessing Assembly file path when publishing as a single file
 
     private async Task ExecuteRequestWithRequestCountGuardAsync(Func<Task> asyncFunc)
     {

--- a/src/TestFramework/TestFramework/Internal/ReflectionTestMethodInfo.cs
+++ b/src/TestFramework/TestFramework/Internal/ReflectionTestMethodInfo.cs
@@ -47,6 +47,12 @@ internal sealed class ReflectionTestMethodInfo : MethodInfo
 
     public override bool IsDefined(Type attributeType, bool inherit) => _methodInfo.IsDefined(attributeType, inherit);
 
+#if NET5_0_OR_GREATER
+    [RequiresUnreferencedCode("The native code for the generic method instantiation might not be available at runtime.")]
+#endif
+#if NET7_0_OR_GREATER
+    [RequiresDynamicCode("The native code for the generic method instantiation might not be available at runtime.")]
+#endif
     public override MethodInfo MakeGenericMethod(params Type[] typeArguments) => new ReflectionTestMethodInfo(_methodInfo.MakeGenericMethod(typeArguments), DisplayName);
 
     public override Type[] GetGenericArguments() => _methodInfo.GetGenericArguments();

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrimTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrimTests.cs
@@ -134,8 +134,13 @@ public class UnitTest1
             .PatchCodeWithReplace("$TargetFramework$", tfm),
             addPublicFeeds: true);
 
+        // Do NOT pass warnAsError: true here. The reflection-mode adapter still depends on the
+        // vstest Microsoft.TestPlatform.ObjectModel submodule and on System.Private.DataContractSerialization
+        // internals, both of which emit trim warnings that are outside this repo's control. Promoting them
+        // to errors would fail the publish with NETSDK1144 before we get a chance to inspect the warning list.
         DotnetMuxerResult result = await DotnetCli.RunAsync(
             $"publish {generator.TargetAssetPath} -r {RID} -f {tfm}",
+            warnAsError: false,
             cancellationToken: TestContext.CancellationToken);
 
         // Files in MSTest's own source whose trim warnings are suppressed by this PR.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrimTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrimTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 
 namespace MSTest.Acceptance.IntegrationTests;
 
@@ -59,6 +60,105 @@ System.Console.WriteLine("This project validates trim/AOT compatibility via dotn
         await DotnetCli.RunAsync(
             $"publish {generator.TargetAssetPath} -r {RID} -f {tfm}",
             cancellationToken: TestContext.CancellationToken);
+    }
+
+    // Source code for a project that references MSTest.TestAdapter (the reflection-mode adapter)
+    // and runs trim analysis with TrimmerRootAssembly to scan the full surface of the assemblies
+    // we own. Used by Publish_WithTestAdapter_DoesNotSurfaceWarningsFromSuppressedSources.
+    //
+    // Note: We do not enable TreatWarningsAsErrors here because the reflection-mode adapter still
+    // depends on the vstest Microsoft.TestPlatform.ObjectModel submodule and on
+    // System.Private.DataContractSerialization internals, both of which emit trim warnings that
+    // are outside this repo's control. The test instead asserts that specific source files we
+    // suppressed in this repo no longer appear in publish output.
+    private const string TrimAnalysisWithTestAdapterSourceCode = """
+#file MSTestTrimAnalysisWithTestAdapter.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>$TargetFramework$</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <EnableMSTestRunner>true</EnableMSTestRunner>
+        <PublishTrimmed>true</PublishTrimmed>
+        <!-- Show individual trim warnings instead of a single IL2104 per assembly -->
+        <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+        <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    </ItemGroup>
+    <!-- Force the trimmer to analyze the full surface of the assemblies modified in this PR
+         so we catch trim warnings that would not be caught by only testing reachable code paths. -->
+    <ItemGroup>
+        <TrimmerRootAssembly Include="MSTestAdapter.PlatformServices" />
+        <TrimmerRootAssembly Include="Microsoft.Testing.Extensions.VSTestBridge" />
+        <TrimmerRootAssembly Include="MSTest.TestFramework" />
+    </ItemGroup>
+</Project>
+
+#file UnitTest1.cs
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyTests;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestMethod1()
+    {
+    }
+}
+""";
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
+    public async Task Publish_WithTestAdapter_DoesNotSurfaceWarningsFromSuppressedSources(string tfm)
+    {
+        // Regression test for the suppressions added in https://github.com/microsoft/testfx/pull/8686.
+        //
+        // Before that PR, the listed source files emitted trim warnings (IL20xx/IL30xx) when a
+        // downstream consumer published a trimmed project that referenced MSTest.TestAdapter.
+        // The original C# `#pragma warning disable ILxxxx` directives in those files only
+        // silenced the compile-time warning during MSTest's own build; they did NOT propagate to
+        // the IL, so the linker still emitted the warnings at the consumer's publish time.
+        //
+        // After converting those pragmas to [UnconditionalSuppressMessage] / [RequiresUnreferencedCode]
+        // / [RequiresDynamicCode] attributes, the suppressions are honored by the IL trimmer and
+        // these source-file references should no longer appear in publish output.
+        using TestAsset generator = await TestAsset.GenerateAssetAsync(
+            $"MSTestTrimAnalysisWithTestAdapter_{tfm}",
+            TrimAnalysisWithTestAdapterSourceCode
+            .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+            .PatchCodeWithReplace("$TargetFramework$", tfm),
+            addPublicFeeds: true);
+
+        DotnetMuxerResult result = await DotnetCli.RunAsync(
+            $"publish {generator.TargetAssetPath} -r {RID} -f {tfm}",
+            cancellationToken: TestContext.CancellationToken);
+
+        // Files in MSTest's own source whose trim warnings are suppressed by this PR.
+        // The trimmer includes source file paths in its IL2xxx/IL3xxx warnings, so the absence
+        // of these file names in publish output is evidence that the suppression attributes work.
+        string[] suppressedSourceFiles =
+        [
+            "TestSourceHost.cs",
+            "DeploymentUtilityBase.cs",
+            "ReflectionOperations.cs",
+            "AssemblyResolver.cs",
+            "DataSerializationHelper.cs",
+            "ManagedNameHelper.cs",
+            "MethodInfoExtensions.cs",
+            "TestMethodFilter.cs",
+            "SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs",
+            "ReflectionTestMethodInfo.cs",
+        ];
+
+        foreach (string fileName in suppressedSourceFiles)
+        {
+            result.AssertOutputDoesNotContain(fileName);
+        }
     }
 
     public TestContext TestContext { get; set; }


### PR DESCRIPTION
## Motivation

PR #8586 enables a Native AOT integration test that exercises `MSTest.TestAdapter`. When that test publishes with `PublishAot=true` + `MSBuildTreatWarningsAsErrors=true` + `TrimmerSingleWarn=false`, the ILC trim/AOT analyzer surfaces every individual warning from MSTest's libraries as an error.

Many of those warnings are already suppressed in source via `#pragma warning disable ILxxxx` — but the C# `#pragma` only silences the **compile-time** warning. It has **no effect** on the linker/ILC analyzer warnings that fire at a downstream consumer's publish time. To silence those, suppressions must be expressed as attributes (`[UnconditionalSuppressMessage]`, `[RequiresUnreferencedCode]`, `[RequiresDynamicCode]`) that survive into the IL where ILC can see them.

This PR is a focused mechanical conversion of MSTest's existing `IL` pragmas to attribute form, addressing ~31 of the warnings #8586 currently surfaces. It is independent of #8586 and can land first.

## Changes (product code)

| File | Change |
|---|---|
| `TestFramework/Internal/ReflectionTestMethodInfo.cs` | Add `[RequiresUnreferencedCode]` (NET5+) and `[RequiresDynamicCode]` (NET7+) on the `MakeGenericMethod` override to match the base member's annotations (fixes IL2046 / IL3051) |
| `MSTestAdapter.PlatformServices/Services/TestSourceHost.cs` | `[UnconditionalSuppressMessage("SingleFile", "IL3000")]` on `GetResolutionPaths` |
| `MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs` | Same on `Deploy` |
| `Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs` | Same on `GetAssemblyPath` |
| `MSTestAdapter.PlatformServices/AssemblyResolver.cs` | `[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026")]` on `LoadAssemblyFrom` |
| `MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs` | Per-method suppressions (10 methods) for IL2026/IL2057/IL2070 |
| `MSTestAdapter.PlatformServices/Helpers/DataSerializationHelper.cs` | Lambdas extracted to named methods so attributes apply (ILC reports on the generated method, not the source-level enclosing method); per-method `[UnconditionalSuppressMessage]` for IL2026/IL3050 |
| `MSTestAdapter.PlatformServices/Helpers/ManagedNameHelper.cs` | Per-method suppressions for IL2026 / IL2070 |
| `MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs` | Per-method suppression for IL2060 / IL3050 on `ConstructGenericMethod` |
| `MSTestAdapter.PlatformServices/TestMethodFilter.cs` | `[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072")]` on `GetTestCaseFilterFromDiscoveryContext` |

## What the attributes actually do for end users

`[UnconditionalSuppressMessage("...", "ILxxxx")]` does two things at different times:
- **At MSTest's build time:** silences the C# warning at the source location (same as the old `#pragma`).
- **At the end user's `dotnet publish /p:PublishTrimmed=true` (or `PublishAot=true`) time:** the suppression is baked into IL metadata, so ILC's analyzer reads it and stops reporting the corresponding warning from MSTest's assemblies into the consumer's build output.

Important caveat — these attributes do **not** make the reflection-mode adapter trim/AOT-*safe* at runtime. They only stop the analyzer noise. MSTest's source-generator path remains the only AOT-safe entry point. The justifications make that explicit.

`[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` on `ReflectionTestMethodInfo.MakeGenericMethod` do the opposite — they *propagate* a requirement to callers, matching the base `MethodInfo.MakeGenericMethod` annotations and restoring override consistency (which itself was an analyzer error: IL2046/IL3051).

## New acceptance test

This PR also adds `MSTest.Acceptance.IntegrationTests.TrimTests.Publish_WithTestAdapter_DoesNotSurfaceWarningsFromSuppressedSources`. It:

- generates a project referencing `MSTest.TestAdapter` + `MSTest.TestFramework` + `Microsoft.Testing.Platform`,
- enables `PublishTrimmed=true` + `TrimmerSingleWarn=false`,
- uses `<TrimmerRootAssembly>` to force trim analysis of the full surface of the assemblies we changed (`MSTestAdapter.PlatformServices`, `Microsoft.Testing.Extensions.VSTestBridge`, `MSTest.TestFramework`),
- asserts that the source files we suppressed (`TestSourceHost.cs`, `DeploymentUtilityBase.cs`, `ReflectionOperations.cs`, etc.) no longer appear in publish output.

The trimmer includes source-file paths in its IL2xxx/IL3xxx messages, so absence ≡ the suppression attributes are being honored. The test does **not** enable `TreatWarningsAsErrors` because out-of-scope warnings (vstest submodule, `System.Private.DataContractSerialization` internals) would otherwise fail it; the assertions on specific source-file names are scoped to MSTest's own code.

## Out of scope (deferred)

These warnings from the same #8586 test output are intentionally **not** addressed here:

- `MSTestSourceGeneratedReflectionMetadata.g.cs` IL2070 — belongs in the source generator emitter (fix in #8586 or a generator-side follow-up).
- `Microsoft.TestPlatform.ObjectModel` warnings (`TestObject.cs`, `TestProperty.cs`, `CustomKeyValueConverter.cs`, `CustomStringArrayConverter.cs`) — that's the vstest submodule, not this repo.
- Transitive DataContract IL3050 warnings emitted from inside `System.Private.DataContractSerialization`.
- Broader interface-level refactor (e.g. propagating `[RequiresUnreferencedCode]` onto `IReflectionOperations`) — out of scope for a mechanical conversion.

## Local validation

- Release builds of `MSTestAdapter.PlatformServices`, `TestFramework`, `Microsoft.Testing.Extensions.VSTestBridge` and the acceptance test project all build with 0 warnings / 0 errors.
- The new acceptance test will run in CI.

