### PR TITLE
[efficiency-improver] perf: reduce redundant UTF-8 encoding in IPC BaseSerializer WriteField

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -221,8 +221,7 @@ internal abstract class BaseSerializer
 
     protected static void WriteStringSize(Stream stream, string str)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(str);
-        byte[] len = BitConverter.GetBytes(bytes.Length);
+        byte[] len = BitConverter.GetBytes(Encoding.UTF8.GetByteCount(str));
         stream.Write(len, 0, len.Length);
     }
 
@@ -299,8 +298,7 @@ internal abstract class BaseSerializer
         }
 
         WriteUShort(stream, id);
-        WriteStringSize(stream, value);
-        WriteStringValue(stream, value);
+        WriteString(stream, value);
     }
 
     protected static void WriteField(Stream stream, ushort id, long? value)

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -71,34 +71,6 @@ internal abstract class BaseSerializer
         }
     }
 
-    protected static void WriteStringValue(Stream stream, string str)
-    {
-        int stringutf8TotalBytes = Encoding.UTF8.GetByteCount(str);
-        byte[] bytes = ArrayPool<byte>.Shared.Rent(stringutf8TotalBytes);
-        try
-        {
-            Encoding.UTF8.GetBytes(str, bytes);
-            stream.Write(bytes, 0, stringutf8TotalBytes);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(bytes);
-        }
-    }
-
-    protected static void WriteStringSize(Stream stream, string str)
-    {
-        int stringutf8TotalBytes = Encoding.UTF8.GetByteCount(str);
-        Span<byte> len = stackalloc byte[sizeof(int)];
-
-        if (!BitConverter.TryWriteBytes(len, stringutf8TotalBytes))
-        {
-            throw ApplicationStateGuard.Unreachable();
-        }
-
-        stream.Write(len);
-    }
-
     protected static void WriteSize<T>(Stream stream)
         where T : struct
     {
@@ -211,18 +183,6 @@ internal abstract class BaseSerializer
         byte[] len = BitConverter.GetBytes(bytes.Length);
         stream.Write(len, 0, len.Length);
         stream.Write(bytes, 0, bytes.Length);
-    }
-
-    protected static void WriteStringValue(Stream stream, string str)
-    {
-        byte[] bytes = Encoding.UTF8.GetBytes(str);
-        stream.Write(bytes, 0, bytes.Length);
-    }
-
-    protected static void WriteStringSize(Stream stream, string str)
-    {
-        byte[] len = BitConverter.GetBytes(Encoding.UTF8.GetByteCount(str));
-        stream.Write(len, 0, len.Length);
     }
 
     protected static void WriteSize<T>(Stream stream)


### PR DESCRIPTION
🤖 *This PR was created by Efficiency Improver, an automated AI assistant focused on reducing energy consumption and computational footprint.*

## Goal and Rationale

In `BaseSerializer.WriteField(Stream, ushort, string?)`, the string was encoded to UTF-8 **twice** per call — once in `WriteStringSize` (to compute the length to write) and again in `WriteStringValue` (to write the bytes). Since both helpers together write identical bytes to `WriteString`, this PR replaces the pair with a single `WriteString` call.

Additionally, `WriteStringSize` in the `#else` (netstandard2.0) path was calling `Encoding.UTF8.GetBytes(str)` just to read `.Length`, allocating a full byte array that was immediately discarded. Fixed to use `Encoding.UTF8.GetByteCount(str)` instead.

## Focus Area
**Code-Level Efficiency** — redundant computation and unnecessary heap allocations in a hot IPC serialization path.

## Approach

`WriteStringSize` + `WriteStringValue` together write:
1. 4-byte length prefix
2. UTF-8-encoded string bytes

This is **identical** to what `WriteString` writes — the only difference was that each helper encoded the string independently.

**NETCOREAPP path** (before → after):
- Before: `WriteStringSize` (1× `GetByteCount`) + `WriteStringValue` (1× `GetByteCount` + 1× `GetBytes`) = **3 string scans**
- After: `WriteString` (1× `GetByteCount` + 1× `GetBytes`) = **2 string scans**

**netstandard2.0 (`#else`) path** (before → after):
- Before: `WriteStringSize` (1× `GetBytes` allocation, discarded) + `WriteStringValue` (1× `GetBytes` allocation + write) = **2 full encodings, 2 heap allocations**
- After: `WriteString` = **1 encoding, 1 heap allocation**

## Energy Efficiency Evidence

**Proxy metric**: memory allocation (fewer `byte[]` heap allocations = less GC pressure, less DRAM refresh energy) and CPU instruction count (fewer string traversals = fewer CPU cycles).

**Call frequency**: `WriteField(ushort, string?)` is called ~54 times in just the dotnet-test IPC serializers (`TestResultMessagesSerializer`, `DiscoveredTestMessagesSerializer`, `FileArtifactMessagesSerializer`, etc.). Every test result transmitted over IPC triggers multiple calls. In a large test suite with thousands of tests, the savings compound.

**Green Software Foundation — Hardware Efficiency**: eliminating redundant string traversals makes better use of the CPU cache; fewer allocations reduce GC-induced stop-the-world pauses that waste CPU cycles proportional to heap size.

## Trade-offs

None. The byte stream written to the IPC pipe is **identical** before and after — this is a pure implementation-detail change with no observable behavior difference. The resulting code is also simpler (fewer lines).

## Test Status

✅ Build succeeded  
✅ All unit tests passed (`./build.sh -test`)




> Generated by [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/26664877441) · sonnet46 4.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26664877441, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/26664877441 -->

<!-- gh-aw-workflow-id: efficiency-improver -->