### PR TITLE
[perf-improver] perf: cache distinct processors in AsynchronousMessageBus to eliminate per-drain allocation

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
@@ -24,6 +24,8 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
     private readonly Dictionary<Type, List<IAsyncConsumerDataProcessor>> _dataTypeConsumers = [];
     private readonly IDataConsumer[] _dataConsumers;
     private readonly ITestApplicationCancellationTokenSource _testApplicationCancellationTokenSource;
+    private IAsyncConsumerDataProcessor[] _distinctProcessors = [];
+    private long[] _drainLastReceived = [];
     private bool _disabled;
 
     public AsynchronousMessageBus(
@@ -75,6 +77,9 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
                 asyncMultiProducerMultiConsumerDataProcessors.Add(asyncMultiProducerMultiConsumerDataProcessor);
             }
         }
+
+        _distinctProcessors = [.. _consumerProcessor.Values];
+        _drainLastReceived = new long[_distinctProcessors.Length];
     }
 
     public override async Task PublishAsync(IDataProducer dataProducer, IData data)
@@ -142,10 +147,9 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
         }
 
         var stopwatch = Stopwatch.StartNew();
-        var lastReceived = new Dictionary<IAsyncConsumerDataProcessor, long>();
-        foreach (IAsyncConsumerDataProcessor processor in _consumerProcessor.Values)
+        for (int i = 0; i < _distinctProcessors.Length; i++)
         {
-            lastReceived[processor] = processor.ReceivedCount;
+            _drainLastReceived[i] = _distinctProcessors[i].ReceivedCount;
         }
 
         for (int attempt = 0; attempt < maxAttempts; attempt++)
@@ -155,18 +159,18 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
                 return;
             }
 
-            foreach (IAsyncConsumerDataProcessor processor in _consumerProcessor.Values)
+            for (int i = 0; i < _distinctProcessors.Length; i++)
             {
-                await processor.DrainDataAsync().ConfigureAwait(false);
+                await _distinctProcessors[i].DrainDataAsync().ConfigureAwait(false);
             }
 
             bool anyNewlyReceived = false;
-            foreach (IAsyncConsumerDataProcessor processor in _consumerProcessor.Values)
+            for (int i = 0; i < _distinctProcessors.Length; i++)
             {
-                long currentReceived = processor.ReceivedCount;
-                if (currentReceived != lastReceived[processor])
+                long currentReceived = _distinctProcessors[i].ReceivedCount;
+                if (currentReceived != _drainLastReceived[i])
                 {
-                    lastReceived[processor] = currentReceived;
+                    _drainLastReceived[i] = currentReceived;
                     anyNewlyReceived = true;
                 }
             }
@@ -179,7 +183,7 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
 
         StringBuilder builder = new();
         builder.Append(CultureInfo.InvariantCulture, $"Publisher/Consumer loop detected during the drain after {stopwatch.Elapsed}.");
-        foreach (IAsyncConsumerDataProcessor processor in _consumerProcessor.Values)
+        foreach (IAsyncConsumerDataProcessor processor in _distinctProcessors)
         {
             builder.AppendLine();
             builder.Append(CultureInfo.InvariantCulture, $"Consumer '{processor.DataConsumer}' payload received {processor.ReceivedCount}.");
@@ -197,23 +201,17 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
 
         _disabled = true;
 
-        foreach (List<IAsyncConsumerDataProcessor> dataProcessors in _dataTypeConsumers.Values)
+        foreach (IAsyncConsumerDataProcessor processor in _distinctProcessors)
         {
-            foreach (IAsyncConsumerDataProcessor asyncMultiProducerMultiConsumerDataProcessor in dataProcessors)
-            {
-                await asyncMultiProducerMultiConsumerDataProcessor.CompleteAddingAsync().ConfigureAwait(false);
-            }
+            await processor.CompleteAddingAsync().ConfigureAwait(false);
         }
     }
 
     public override void Dispose()
     {
-        foreach (List<IAsyncConsumerDataProcessor> dataProcessors in _dataTypeConsumers.Values)
+        foreach (IAsyncConsumerDataProcessor processor in _distinctProcessors)
         {
-            foreach (IAsyncConsumerDataProcessor asyncMultiProducerMultiConsumerDataProcessor in dataProcessors)
-            {
-                asyncMultiProducerMultiConsumerDataProcessor.Dispose();
-            }
+            processor.Dispose();
         }
 
         _consumerProcessor.Clear();

--- a/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
@@ -214,6 +214,8 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
             processor.Dispose();
         }
 
+        _distinctProcessors = [];
+        _drainLastReceived = [];
         _consumerProcessor.Clear();
         _dataTypeConsumers.Clear();
     }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -91,6 +91,33 @@ public sealed class AsynchronousMessageBusTests
     }
 
     [TestMethod]
+    public async Task DisableAsync_WithConsumerSubscribedToMultipleDataTypes_ShouldCompleteProcessorOnce()
+    {
+        using MessageBusProxy proxy = new();
+        MultiTypeConsumer consumer = new();
+        using var asynchronousMessageBus = new AsynchronousMessageBus(
+            [consumer],
+            new CTRLPlusCCancellationTokenSource(),
+            new SystemTask(),
+            new NopLoggerFactory(),
+            new SystemEnvironment());
+        await asynchronousMessageBus.InitAsync();
+        proxy.SetBuiltMessageBus(asynchronousMessageBus);
+
+        DummyProducer producer = new("MultiTypeProducer", typeof(MultiTypeConsumer.DataTypeA), typeof(MultiTypeConsumer.DataTypeB));
+        await proxy.PublishAsync(producer, new MultiTypeConsumer.DataTypeA());
+        await proxy.PublishAsync(producer, new MultiTypeConsumer.DataTypeB());
+        await proxy.DrainDataAsync();
+
+        Assert.AreEqual(1, consumer.ReceivedTypeA);
+        Assert.AreEqual(1, consumer.ReceivedTypeB);
+
+        // DisableAsync must not throw even though the consumer is registered for 2 data types;
+        // the single backing processor must be completed exactly once (not once per data type).
+        await asynchronousMessageBus.DisableAsync();
+    }
+
+    [TestMethod]
     public async Task Consumers_ConsumeData_ShouldNotMissAnyPayload()
     {
         int totalConsumers = Environment.ProcessorCount;
@@ -390,5 +417,52 @@ public sealed class AsynchronousMessageBusTests
         public string ProducerId { get; }
 
         public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    }
+
+    private sealed class MultiTypeConsumer : IDataConsumer
+    {
+        public int ReceivedTypeA { get; private set; }
+
+        public int ReceivedTypeB { get; private set; }
+
+        public Type[] DataTypesConsumed => [typeof(DataTypeA), typeof(DataTypeB)];
+
+        public string Uid => nameof(MultiTypeConsumer);
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => string.Empty;
+
+        public string Description => string.Empty;
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+        public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+        {
+            if (value is DataTypeA)
+            {
+                ReceivedTypeA++;
+            }
+            else if (value is DataTypeB)
+            {
+                ReceivedTypeB++;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public sealed class DataTypeA : IData
+        {
+            public string DisplayName => nameof(DataTypeA);
+
+            public string? Description => nameof(DataTypeA);
+        }
+
+        public sealed class DataTypeB : IData
+        {
+            public string DisplayName => nameof(DataTypeB);
+
+            public string? Description => nameof(DataTypeB);
+        }
     }
 }


### PR DESCRIPTION
🤖 *This is an automated contribution from [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26685809280).*

## Goal and Rationale

`AsynchronousMessageBus.DrainDataAsync()` allocated a fresh `Dictionary<IAsyncConsumerDataProcessor, long>` on **every call** solely to track how many items each processor had received between drain rounds. Since the set of processors is fixed after `InitAsync`, this dictionary can be replaced with a cached array pair (`IAsyncConsumerDataProcessor[]` + `long[]`) allocated once.

Additionally, `DisableAsync` and `Dispose` iterated `_dataTypeConsumers.Values` with a nested loop — because a consumer subscribed to N data types appears in N separate lists, each processor was being completed/disposed N times. Using the deduplicated `_distinctProcessors` array fixes this.

## Approach

1. Add two new fields initialized at end of `InitAsync`:
   - `_distinctProcessors = [.. _consumerProcessor.Values]` — the unique set of processors
   - `_drainLastReceived = new long[_distinctProcessors.Length]` — reusable count snapshot

2. `DrainDataAsync`: replace `new Dictionary<IAsyncConsumerDataProcessor, long>()` + hash-table lookups with direct array indexing over `_distinctProcessors`.

3. `DisableAsync` / `Dispose`: replace double nested `foreach` over `_dataTypeConsumers.Values` with a single `foreach` over `_distinctProcessors`.

## Performance Evidence

| Metric | Before | After |
|--------|--------|-------|
| `Dictionary<IAsyncConsumerDataProcessor, long>` allocated per drain | 1 | 0 |
| Processor visits in `DisableAsync` (N consumers × M types) | N×M | N |
| Processor visits in `Dispose` (N consumers × M types) | N×M | N |
| Inner-loop access pattern in drain | hash-table lookup | array index (cache-friendly) |

`DrainDataAsync` is called once at the end of every test run. The dictionary allocation and hash operations are eliminated; the reused `long[]` snapshot costs only a stack read per iteration.

**Methodology**: code inspection + allocation diff (directly verifiable from the diff).

## Trade-offs

- Two new fields per `AsynchronousMessageBus` instance (one pointer + one pointer — negligible).
- No behavioral change for `DrainDataAsync`.
- `DisableAsync` / `Dispose` now call `CompleteAddingAsync` / `Dispose` **exactly once** per processor (vs. once per (processor, data-type) pair previously) — this is strictly more correct.

## Test Status

- `Microsoft.Testing.Platform.UnitTests` (net8.0): **992 passed, 0 failed, 3 skipped** ✅

## Reproducibility

```bash
./build.sh
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
```

> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26685809280) · sonnet46




> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26685809280) · sonnet46 3.1M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26685809280, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/26685809280 -->

<!-- gh-aw-workflow-id: perf-improver -->