### PR TITLE
[efficiency-improver] perf: avoid double IEnumerable enumeration in DynamicDataShouldBeValidAnalyzer

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/DynamicDataShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DynamicDataShouldBeValidAnalyzer.cs
@@ -185,14 +185,14 @@ public sealed class DynamicDataShouldBeValidAnalyzer : DiagnosticAnalyzer
                 return (potentialProperty, false);
             }
 
-            IEnumerable<ISymbol> candidateMethods = potentialMembers.Where(m => m.Kind == SymbolKind.Method);
-            if (candidateMethods.Count() > 1)
+            var candidateMethods = potentialMembers.Where(m => m.Kind == SymbolKind.Method).ToImmutableArray();
+            if (candidateMethods.Length > 1)
             {
                 // If there are multiple methods with the same name, report a diagnostic. This is not a supported scenario.
                 return (null, true);
             }
 
-            return (candidateMethods.FirstOrDefault() ?? potentialMembers[0], false);
+            return (candidateMethods.IsEmpty ? potentialMembers[0] : candidateMethods[0], false);
         }
     }
 


### PR DESCRIPTION
🤖 *This PR was created by Efficiency Improver, an automated AI assistant focused on reducing energy consumption and computational footprint.*

## Goal and Rationale

In `DynamicDataShouldBeValidAnalyzer.TryGetMemberCore`, `candidateMethods` was typed as `IEnumerable<ISymbol>` (a deferred LINQ query). The code then called `.Count() > 1` (first traversal) followed by `.FirstOrDefault()` (second traversal) — enumerating the filtered sequence twice for every `[DynamicData]` attribute analyzed at compile time.

## Focus Area
**Code-Level Efficiency** — redundant IEnumerable enumeration in a Roslyn analyzer hot path.

## Approach

Materialize the deferred LINQ query once with `.ToImmutableArray()`, then use `.Length` and array indexer access — both O(1) with no further traversal:

**Before:**
```csharp
IEnumerable<ISymbol> candidateMethods = potentialMembers.Where(m => m.Kind == SymbolKind.Method);
if (candidateMethods.Count() > 1)   // traversal #1
{
    return (null, true);
}
return (candidateMethods.FirstOrDefault() ?? potentialMembers[0], false);  // traversal #2
```

**After:**
```csharp
var candidateMethods = potentialMembers.Where(m => m.Kind == SymbolKind.Method).ToImmutableArray();
if (candidateMethods.Length > 1)   // O(1)
{
    return (null, true);
}
return (candidateMethods.IsEmpty ? potentialMembers[0] : candidateMethods[0], false);  // O(1)
```

## Energy Efficiency Evidence

**Proxy metric**: CPU instruction count — fewer instructions per LINQ enumeration = fewer CPU cycles = lower power draw.

**Call frequency**: This code runs on every method annotated with `[DynamicData]` during Roslyn compilation. In large test suites, this analyzer fires hundreds or thousands of times per build. Eliminating one full IEnumerable traversal per invocation compounds across the entire build.

**Green Software Foundation — Hardware Efficiency**: removing the redundant traversal reduces the total CPU work per build, making better use of the underlying hardware per compilation functional unit.

## Trade-offs

None. The result is semantically identical. The code is also slightly clearer — the `.Length` check on a materialized array is more readable than `.Count() > 1` on a lazy query.

## Test Status

✅ Build succeeded  
✅ All unit tests passed (`./build.sh -test`)




> Generated by [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/26696012701) · sonnet46 1.6M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26696012701, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/26696012701 -->

<!-- gh-aw-workflow-id: efficiency-improver -->