### PR TITLE
[code-simplifier] simplify: cleanup in crash/hang dump CLI options from PR #8666

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpCommandLineProvider.cs
@@ -52,12 +52,12 @@ internal sealed class CrashDumpCommandLineProvider : CommandLineOptionsProviderB
 
     public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
         => IsCrashDumpMainOptionMissing(commandLineOptions)
-            ? ValidationResult.InvalidTask(CrashDumpResources.MissingCrashDumpMainOption)
-            : AreCrashReportOptionsMutuallyExclusive(commandLineOptions)
-            ? ValidationResult.InvalidTask(CrashDumpResources.CrashReportAndIfSupportedAreMutuallyExclusiveErrorMessage)
-            : IsCrashReportUnsupportedOnCurrentPlatform(commandLineOptions)
-            ? ValidationResult.InvalidTask(CrashDumpResources.CrashReportNotSupportedOnWindowsErrorMessage)
-            : ValidationResult.ValidTask;
+        ? ValidationResult.InvalidTask(CrashDumpResources.MissingCrashDumpMainOption)
+        : AreCrashReportOptionsMutuallyExclusive(commandLineOptions)
+        ? ValidationResult.InvalidTask(CrashDumpResources.CrashReportAndIfSupportedAreMutuallyExclusiveErrorMessage)
+        : IsCrashReportUnsupportedOnCurrentPlatform(commandLineOptions)
+        ? ValidationResult.InvalidTask(CrashDumpResources.CrashReportNotSupportedOnWindowsErrorMessage)
+        : ValidationResult.ValidTask;
 
     private static bool AreCrashReportOptionsMutuallyExclusive(ICommandLineOptions commandLineOptions)
         => commandLineOptions.IsOptionSet(CrashDumpCommandLineOptions.CrashReportOptionName) &&

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -113,12 +113,11 @@ internal sealed class HangDumpProcessLifetimeHandler : ITestHostProcessLifetimeH
             // supported value (see MapToSupportedDumpType) and emit a single informational
             // message so the CI log makes the substitution visible without breaking the run.
             string requested = dumpTypeIfSupported[0];
-            string mapped = HangDumpCommandLineProvider.MapToSupportedDumpType(requested);
-            _dumpType = mapped;
-            if (!string.Equals(mapped, requested, StringComparison.OrdinalIgnoreCase))
+            _dumpType = HangDumpCommandLineProvider.MapToSupportedDumpType(requested);
+            if (!string.Equals(_dumpType, requested, StringComparison.OrdinalIgnoreCase))
             {
                 await _outputDisplay.DisplayAsync(
-                    new FormattedTextOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.HangDumpTypeIfSupportedFallbackInfoMessage, requested, mapped)),
+                    new FormattedTextOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.HangDumpTypeIfSupportedFallbackInfoMessage, requested, _dumpType)),
                     cancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
## Code Simplification – 2026-05-31

Two small clean-ups applied to code merged today in #8666 (Add `--crash-report-if-supported` and `--hangdump-type-if-supported` options).

### Files Simplified

- `src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpCommandLineProvider.cs` – Fixed ternary operator indentation alignment (operators were indented 4 extra spaces relative to the method body)
- `src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs` – Removed the redundant `mapped` intermediate variable; assign directly to `_dumpType` and use it in the format string

### Improvements Made

1. **Formatting consistency**
   - The `?`/`:` chain in `ValidateCommandLineOptionsAsync` was indented at 12 spaces while the surrounding method body uses 8 – now aligned correctly, matching the rest of the file.

2. **Reduced intermediary variables**
   - `string mapped = MapToSupportedDumpType(requested); _dumpType = mapped;` → `_dumpType = MapToSupportedDumpType(requested);` — the separate `mapped` local was only used once for assignment and once in the format string; both usages now reference `_dumpType` directly.

### Changes Based On

- #8666 – Add --crash-report-if-supported and --hangdump-type-if-supported options (merged 2026-05-31)

### Testing

- ✅ All tests pass (`./build.sh -test`)
- ✅ Build succeeds with 0 warnings, 0 errors
- ✅ No functional changes – behavior is identical

---

*Automated by Code Simplifier Agent*


<!-- gh-aw-tracker-id: code-simplifier -->




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 4 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8708](https://github.com/microsoft/testfx/pull/8708) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8707](https://github.com/microsoft/testfx/pull/8707) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8697](https://github.com/microsoft/testfx/pull/8697) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8696](https://github.com/microsoft/testfx/pull/8696) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/26714176325) · sonnet46 4.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-01T13:55:17.482Z --> on Jun 1, 2026, 1:55 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26714176325, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/26714176325 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->