### PR TITLE
[perf-improver] perf: convert InternalOnlyExtensions from array property to static readonly HashSet

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProvider.cs
@@ -19,7 +19,7 @@ internal sealed class ServiceProvider : IServiceProvider, ICloneable
     public bool AllowTestAdapterFrameworkRegistration { get; set; }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-    private static Type[] InternalOnlyExtensions =>
+    private static readonly HashSet<Type> InternalOnlyExtensions =
     [
         // TestHost
         typeof(ITestHostApplicationLifetime),


### PR DESCRIPTION
🤖 *This is an automated contribution from [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26714845615).*

## Goal and Rationale

`ServiceProvider.InternalOnlyExtensions` was declared as a **computed property** (using `=>`), causing a new `Type[5]` to be allocated on every call to `GetServicesInternal` when `skipInternalOnlyExtensions: true`. This method backs the public `IServiceProvider.GetService(Type)` API, so it is invoked frequently whenever extensions or consumers call service lookups.

Additionally, `Array.Contains` (via `IEnumerable<T>.Contains`) does a linear scan through the 5 elements.

## Approach

Change `private static Type[] InternalOnlyExtensions => [...]` to `private static readonly HashSet<Type> InternalOnlyExtensions = [...]`.

| Metric | Before | After |
|--------|--------|-------|
| `Type[]` allocated per `GetService` call | 1 (5-element array) | 0 |
| `Contains` complexity | O(n) | O(1) |
| Class-level allocation | none | 1× `HashSet<Type>` at startup |

## Trade-offs

- One `HashSet<Type>` is allocated at class initialization instead of per-call; this is negligible.
- No behavioral change — the same 5 types are excluded from public `GetService` lookups.

## Test Status

- `Microsoft.Testing.Platform.UnitTests` (net8.0): **992 passed, 0 failed, 3 skipped** ✅

## Reproducibility

```bash
./build.sh
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
```




> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26714845615) · sonnet46 3.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26714845615, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/26714845615 -->

<!-- gh-aw-workflow-id: perf-improver -->