### PR TITLE
[test-improver] test: add abstract method edge case test for MSTEST0041 (UseDeploymentItemWithTestMethodOrTestClass)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests.cs
@@ -136,4 +136,22 @@ public sealed class UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenAbstractMethodHasDeploymentItemWithoutTestMethod_Diagnostic()
+    {
+        // Abstract classes are skipped (DeploymentItem is inherited), but abstract methods are not.
+        // An abstract method with [DeploymentItem] but no [TestMethod] is flagged as misuse.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public abstract class MyBaseClass
+            {
+                [DeploymentItem("")]
+                public abstract void [|SomeMethod|]();
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
🤖 *This PR was created by Test Improver, an automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`UseDeploymentItemWithTestMethodOrTestClassAnalyzer` (MSTEST0041) has a documented design decision — that abstract *methods* are treated differently from abstract *classes* — which was not covered by any test.

## Approach

Added 1 new test case:

| Test | Scenario |
|------|----------|
| `WhenAbstractMethodHasDeploymentItemWithoutTestMethod_Diagnostic` | Documents the design decision: abstract classes skip the check (inherited attributes), but abstract *methods* do not — an abstract method with `[DeploymentItem]` but no `[TestMethod]` is flagged |

The abstract method test is anchored in an existing code comment in the analyzer:
> `For now, we do the IsAbstract check specifically for classes and not methods. If we got a convincing feedback around a false positive for the attribute on an abstract method, we can adjust the check.`

A test that documents this intent makes future changes safer.

## Test Status

✅ Build succeeded
✅ All tests passed

## Trade-offs

Purely additive test changes — no production code modifications. This test follows the same `VerifyCS` pattern already established in the file.
