### PR TITLE
Suppress failure-tracking issues from Build Failure Analysis workflows

### DIFF
--- a/.github/workflows/build-failure-analysis-command.lock.yml
+++ b/.github/workflows/build-failure-analysis-command.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"123f8a7f1e3e690a8a209afc8f5b12d3544a07d19f022ebf13c95b5d2ec4ff53","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cdf7e6dd50799a6020e37115183a80c698040971ea601872f5f10f6fc7484afc","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7","version":"v5.2.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"9f050961da586148d135e113d8bb025185cdf2b8","version":"v0.75.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.18"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -250,20 +250,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ab46a950539f61cb_EOF'
+          cat << 'GH_AW_PROMPT_d129ae11e5fa59d9_EOF'
           <system>
-          GH_AW_PROMPT_ab46a950539f61cb_EOF
+          GH_AW_PROMPT_d129ae11e5fa59d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ab46a950539f61cb_EOF'
+          cat << 'GH_AW_PROMPT_d129ae11e5fa59d9_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_ab46a950539f61cb_EOF
+          GH_AW_PROMPT_d129ae11e5fa59d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_ab46a950539f61cb_EOF'
+          cat << 'GH_AW_PROMPT_d129ae11e5fa59d9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -292,16 +292,16 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ab46a950539f61cb_EOF
+          GH_AW_PROMPT_d129ae11e5fa59d9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_ab46a950539f61cb_EOF'
+          cat << 'GH_AW_PROMPT_d129ae11e5fa59d9_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis-command.md}}
-          GH_AW_PROMPT_ab46a950539f61cb_EOF
+          GH_AW_PROMPT_d129ae11e5fa59d9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -556,9 +556,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1efdeefeba05bbac_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5068ae042e1283c8_EOF'
           {"add_comment":{"hide_older_comments":true,"max":1},"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1efdeefeba05bbac_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5068ae042e1283c8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -790,7 +790,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_54f7170c39ed0273_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_46d2e953909d7ce5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -831,7 +831,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_54f7170c39ed0273_EOF
+          GH_AW_MCP_CONFIG_46d2e953909d7ce5_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1222,7 +1222,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "30"

--- a/.github/workflows/build-failure-analysis-command.md
+++ b/.github/workflows/build-failure-analysis-command.md
@@ -148,6 +148,9 @@ tools:
     - "NuGet.Mcp.Server"
 
 safe-outputs:
+  # Match build-failure-analysis.md: suppress tracking-issue spam from
+  # transient AI service flakes (see issue #8685 and comments there).
+  report-failure-as-issue: false
   add-comment:
     max: 1
     hide-older-comments: true

--- a/.github/workflows/build-failure-analysis.lock.yml
+++ b/.github/workflows/build-failure-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e8e7e2f12b0172c988dc12b40e9689da82008a000bc8515735f3b5bfdddb1285","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"455b908fb91e2873c51b4690c39505ae86cc92158666b7e14a6083907c1cd383","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7","version":"v5.2.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"9f050961da586148d135e113d8bb025185cdf2b8","version":"v0.75.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.18"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -249,20 +249,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_8f519c9da6ee60d9_EOF'
+          cat << 'GH_AW_PROMPT_d01b03d1807f525c_EOF'
           <system>
-          GH_AW_PROMPT_8f519c9da6ee60d9_EOF
+          GH_AW_PROMPT_d01b03d1807f525c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8f519c9da6ee60d9_EOF'
+          cat << 'GH_AW_PROMPT_d01b03d1807f525c_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request_review_comment(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_8f519c9da6ee60d9_EOF
+          GH_AW_PROMPT_d01b03d1807f525c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_8f519c9da6ee60d9_EOF'
+          cat << 'GH_AW_PROMPT_d01b03d1807f525c_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -291,13 +291,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_8f519c9da6ee60d9_EOF
+          GH_AW_PROMPT_d01b03d1807f525c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_8f519c9da6ee60d9_EOF'
+          cat << 'GH_AW_PROMPT_d01b03d1807f525c_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-failure-analysis-shared.md}}
           {{#runtime-import .github/workflows/build-failure-analysis.md}}
-          GH_AW_PROMPT_8f519c9da6ee60d9_EOF
+          GH_AW_PROMPT_d01b03d1807f525c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -549,9 +549,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c54032c1df47564f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d63b713a200ed2d5_EOF'
           {"add_comment":{"hide_older_comments":true,"max":1},"create_pull_request_review_comment":{"max":10,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c54032c1df47564f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d63b713a200ed2d5_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -783,7 +783,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_fdde8dcda439a71a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_18f7fc77e234b36e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -824,7 +824,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fdde8dcda439a71a_EOF
+          GH_AW_MCP_CONFIG_18f7fc77e234b36e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1214,7 +1214,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "30"

--- a/.github/workflows/build-failure-analysis.md
+++ b/.github/workflows/build-failure-analysis.md
@@ -172,6 +172,12 @@ tools:
     - "NuGet.Mcp.Server"
 
 safe-outputs:
+  # The agent runs on every PR (gh-aw has no agent-job-level `if:` hook), so a
+  # transient AI service flake on an otherwise-successful build would
+  # otherwise spam tracking issues (see issue #8685). Suppress those: the
+  # workflow is advisory, and run-level failures are still visible in the
+  # Actions UI for anyone who wants to investigate.
+  report-failure-as-issue: false
   add-comment:
     max: 1
     hide-older-comments: true


### PR DESCRIPTION
Stops the `Build Failure Analysis` workflow from spamming tracking issues (e.g. #8685) when its AI agent flakes on otherwise-successful builds.

## Why

The workflow runs on every PR. gh-aw does not expose a job-level `if:` hook to gate the auto-generated Copilot CLI step, so the agent is invoked unconditionally; on successful builds it simply noops. Upstream the Copilot/AI service is intermittently flaky and returns "Failed to get response from the AI model"; when that happens during a noop call, the run is marked failed and the gh-aw safe-output machinery auto-files a `[aw] Build Failure Analysis failed` tracking issue.

Example flake: https://github.com/microsoft/testfx/actions/runs/26727721772 -- build succeeded (0 errors), the binlog-mcp / NuGet MCP / dump-binlog steps correctly skipped (they are gated on `steps.build.outcome == ''failure''`), but `Execute GitHub Copilot CLI` still ran, retried 4 outer x 5 inner times, and exited 1 with "Last error: Unknown error".

## What

Adds `safe-outputs.report-failure-as-issue: false` to both:
- `.github/workflows/build-failure-analysis.md`
- `.github/workflows/build-failure-analysis-command.md`

This is the gh-aw-sanctioned switch for exactly this scenario (the auto-generated tracking-issue body links to it as "Stop reporting this workflow as a failure"). The compiled change in both `.lock.yml` files is a single env-var flip (`GH_AW_FAILURE_REPORT_AS_ISSUE: "true" -> "false"`), plus the usual frontmatter-hash and prompt-heredoc-marker churn.

The workflow stays advisory: real analyses still post PR comments / inline suggestion blocks on legit build failures, and any run-level failures remain visible in the Actions UI for anyone who wants to investigate.

## Out of scope

A deeper fix (split the build into a separate job and gate the agent job on `needs.build.outputs.outcome == ''failure''`) would also save the wasted AI API calls on successful builds, but: gh-aw applies the top-level `if:` to the `activation` job rather than the `agent` job (see `.github/workflows/adhoc-qa.{md,lock.yml}`), `NuGet.Mcp.Server` would need to be installed on both jobs, and `GH_AW_BINLOG_PATH` would become invalid across jobs. That refactor can land separately if needed; this PR focuses on stopping the immediate issue spam.

Lock files regenerated with `gh aw compile --strict` (v0.75.4, the version pinned for the rest of the BFA lock files).