### PR TITLE
Disable failure-as-issue reporting for adhoc-qa workflow

### DIFF
--- a/.github/workflows/adhoc-qa.lock.yml
+++ b/.github/workflows/adhoc-qa.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"172588d3be9237566aafcd40fcb1c8d34e9a6a44ff3e48d8a6130d1ffcee596e","compiler_version":"v0.76.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"832feb0b0b2de359c74589d7d2373cf37e6369e383968c1276fef84b7f6021d2","compiler_version":"v0.76.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"46d564922b082d0db93244972e8005ea6904ee5f","version":"v0.76.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.55"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.19"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -220,23 +220,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_cdc4ef6948920676_EOF'
+          cat << 'GH_AW_PROMPT_36949136a5c51cd8_EOF'
           <system>
-          GH_AW_PROMPT_cdc4ef6948920676_EOF
+          GH_AW_PROMPT_36949136a5c51cd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cdc4ef6948920676_EOF'
+          cat << 'GH_AW_PROMPT_36949136a5c51cd8_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_discussion, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_cdc4ef6948920676_EOF
+          GH_AW_PROMPT_36949136a5c51cd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_cdc4ef6948920676_EOF'
+          cat << 'GH_AW_PROMPT_36949136a5c51cd8_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_cdc4ef6948920676_EOF
+          GH_AW_PROMPT_36949136a5c51cd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_cdc4ef6948920676_EOF'
+          cat << 'GH_AW_PROMPT_36949136a5c51cd8_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -265,12 +265,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_cdc4ef6948920676_EOF
+          GH_AW_PROMPT_36949136a5c51cd8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cdc4ef6948920676_EOF'
+          cat << 'GH_AW_PROMPT_36949136a5c51cd8_EOF'
           </system>
           {{#runtime-import .github/workflows/adhoc-qa.md}}
-          GH_AW_PROMPT_cdc4ef6948920676_EOF
+          GH_AW_PROMPT_36949136a5c51cd8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -481,9 +481,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_14e6b0ffcf5954f2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4de3c3c071ad32a8_EOF'
           {"add_comment":{"max":5,"target":"*"},"create_discussion":{"category":"q-a","expires":168,"fallback_to_issue":true,"max":1,"title_prefix":"[adhoc-qa] "},"create_pull_request":{"draft":true,"labels":["type/automation","type/qa"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"fallback-to-issue"},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_14e6b0ffcf5954f2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4de3c3c071ad32a8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -747,7 +747,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_3e6441cf543327f6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_acabc4ed84b2bda6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -788,7 +788,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3e6441cf543327f6_EOF
+          GH_AW_MCP_CONFIG_acabc4ed84b2bda6_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1169,7 +1169,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "15"

--- a/.github/workflows/adhoc-qa.md
+++ b/.github/workflows/adhoc-qa.md
@@ -41,6 +41,7 @@ network: defaults
 safe-outputs:
   noop:
     report-as-issue: false
+  report-failure-as-issue: false
   mentions: false
   allowed-github-references: []
   create-discussion:


### PR DESCRIPTION
Fixes #8703.

The `adhoc-qa` agentic workflow keeps creating spurious tracking issues (e.g. #8703) when the `copilot` engine terminates unexpectedly mid-run while reading shell output. These are environment/engine failures with no actionable code change for this repository, so the auto-filed issues are pure noise.

This PR adds `report-failure-as-issue: false` to the workflow's `safe-outputs` block (as suggested by the tip at the bottom of #8703 itself) and regenerates `adhoc-qa.lock.yml` via `gh aw compile adhoc-qa --strict` (gh-aw v0.76.1, matching the previously compiled version). The only meaningful runtime change is `GH_AW_FAILURE_REPORT_AS_ISSUE` flipping from `"true"` to `"false"`; the rest of the lock diff is expected heredoc/hash churn.