### PR TITLE
Reconcile vendored-sync drift for #8728-#8732

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -10,8 +10,8 @@
           "repo": "dotnet/runtime",
           "ref": "main",
           "path": "src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs",
-          "baseline_ref_sha": "39b9607807f29e48cae4652cd74735182b31182e",
-          "baseline_blob_sha": "ff64dbf87889bd5fe2f19e13dff9b762c9be2dc7",
+          "baseline_ref_sha": "906c53718074c669286fd5b0cd88bc7a56a0cd10",
+          "baseline_blob_sha": "78908b119ae07e92f7e89fe507eb0fc69b21fa99",
           "scope": "entire file; attribute scope changed to internal"
         }
       ]
@@ -19,15 +19,15 @@
     {
       "id": "source-gen-system-polyfills",
       "local_path": "src/Analyzers/MSTest.SourceGeneration/Helpers/SystemPolyfills.cs",
-      "notes": "Nullable attribute polyfills for source generator. Originally referenced retired dotnet/coreclr@60f1e626 -- successor file lives in dotnet/runtime with the same content.",
+      "notes": "Nullable attribute polyfills for source generator. Only NotNullWhenAttribute is mirrored locally; combined with a locally-defined IsExternalInit shim. Originally referenced retired dotnet/coreclr@60f1e626 -- successor file lives in dotnet/runtime with the same content.",
       "sources": [
         {
           "repo": "dotnet/runtime",
           "ref": "main",
           "path": "src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs",
-          "baseline_ref_sha": "39b9607807f29e48cae4652cd74735182b31182e",
-          "baseline_blob_sha": "ff64dbf87889bd5fe2f19e13dff9b762c9be2dc7",
-          "scope": "Nullable attribute types only; combined with locally-defined IsExternalInit"
+          "baseline_ref_sha": "906c53718074c669286fd5b0cd88bc7a56a0cd10",
+          "baseline_blob_sha": "78908b119ae07e92f7e89fe507eb0fc69b21fa99",
+          "scope": "NotNullWhenAttribute only; combined with locally-defined IsExternalInit"
         }
       ]
     },
@@ -64,15 +64,15 @@
     {
       "id": "platform-file-utilities-case-sensitivity",
       "local_path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs",
-      "notes": "Only GetIsFileSystemCaseSensitive is copied. Drift signal fires on the whole upstream file; reviewer should check whether changes touch the copied region (lines 41-59 at baseline).",
+      "notes": "Originally copied lines 41-59 (GetIsFileSystemCaseSensitive) from the runtime probe. Upstream has since replaced the probe with an OS-based check (OperatingSystem.IsWindows/MacOS/IOS/TvOS); we intentionally keep the file-system probe locally because (a) the platform targets netstandard2.0 where those APIs are not first-class, and (b) the probe better reflects mount-level case sensitivity. Drift signal fires on the whole upstream file; reviewer should check whether any new change affects the historical copied region.",
       "sources": [
         {
           "repo": "dotnet/runtime",
           "ref": "main",
           "path": "src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs",
-          "baseline_ref_sha": "73ba11f3015216b39cb866d9fb7d3d25e93489f2",
-          "baseline_blob_sha": "e5e97847ddd8e678112b31fa123932463170ccb5",
-          "scope": "lines 41-59 only (GetIsFileSystemCaseSensitive)"
+          "baseline_ref_sha": "906c53718074c669286fd5b0cd88bc7a56a0cd10",
+          "baseline_blob_sha": "0e1278fd1a2cab8dcbcf860f9297cf4eecca4600",
+          "scope": "originally lines 41-59 (GetIsFileSystemCaseSensitive); upstream has since rewritten the helper -- local copy intentionally diverges"
         }
       ]
     },
@@ -124,23 +124,23 @@
     {
       "id": "platform-response-file-helper",
       "local_path": "src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs",
-      "notes": "Core logic taken from command-line-api's CliParser and StringExtensions response-file parsing.",
+      "notes": "Core logic taken from command-line-api's CommandLineParser (formerly CliParser) and StringExtensions response-file parsing. Local copy intentionally omits recursive @file expansion.",
       "sources": [
         {
           "repo": "dotnet/command-line-api",
           "ref": "main",
-          "path": "src/System.CommandLine/Parsing/CliParser.cs",
-          "baseline_ref_sha": "feb61c7f328a2401d74f4317b39d02126cfdfe24",
-          "baseline_blob_sha": "d05b9f05521af2ed05f7f33cf319255820b338de",
-          "scope": "response-file expansion logic (around line 40)"
+          "path": "src/System.CommandLine/Parsing/CommandLineParser.cs",
+          "baseline_ref_sha": "fa1991f84bc8c384aa636a251398a40e56ee1702",
+          "baseline_blob_sha": "ee60fedddabe429d172756fe1b908309164bd805",
+          "scope": "SplitCommandLine implementation (around line 40); upstream file was renamed from CliParser.cs"
         },
         {
           "repo": "dotnet/command-line-api",
           "ref": "main",
           "path": "src/System.CommandLine/Parsing/StringExtensions.cs",
-          "baseline_ref_sha": "feb61c7f328a2401d74f4317b39d02126cfdfe24",
-          "baseline_blob_sha": "169070c5f707aee86c376bad6456e00183718763",
-          "scope": "ExpandResponseFile and string-splitting helpers (around line 349)"
+          "baseline_ref_sha": "fa1991f84bc8c384aa636a251398a40e56ee1702",
+          "baseline_blob_sha": "ab6be26ba8cd23058ee60df184a20ad607899eca",
+          "scope": "ExpandResponseFile/SplitLine helpers (around line 316)"
         }
       ]
     }

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs
@@ -4,8 +4,8 @@
 using Microsoft.Testing.Platform.Resources;
 
 // Most of the core logic is from:
-// - https://github.com/dotnet/command-line-api/blob/feb61c7f328a2401d74f4317b39d02126cfdfe24/src/System.CommandLine/Parsing/CliParser.cs#L40
-// - https://github.com/dotnet/command-line-api/blob/feb61c7f328a2401d74f4317b39d02126cfdfe24/src/System.CommandLine/Parsing/StringExtensions.cs#L349
+// - https://github.com/dotnet/command-line-api/blob/fa1991f84bc8c384aa636a251398a40e56ee1702/src/System.CommandLine/Parsing/CommandLineParser.cs#L40
+// - https://github.com/dotnet/command-line-api/blob/fa1991f84bc8c384aa636a251398a40e56ee1702/src/System.CommandLine/Parsing/StringExtensions.cs#L316
 internal static class ResponseFileHelper
 {
     internal static bool TryReadResponseFile(string rspFilePath, ICollection<string> errors, [NotNullWhen(true)] out string[]? newArguments)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs
@@ -9,7 +9,8 @@ internal static class FileUtilities
 
     /// <summary>
     /// Determines whether the file system is case sensitive.
-    /// Copied from https://github.com/dotnet/runtime/blob/73ba11f3015216b39cb866d9fb7d3d25e93489f2/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs#L41-L59 .
+    /// Originally copied from https://github.com/dotnet/runtime/blob/73ba11f3015216b39cb866d9fb7d3d25e93489f2/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs#L41-L59 .
+    /// Upstream has since replaced the probe with an OS-based check; we intentionally keep the probe implementation here.
     /// </summary>
     public static bool GetIsFileSystemCaseSensitive()
     {

--- a/src/Polyfills/NullableAttribtues.cs
+++ b/src/Polyfills/NullableAttribtues.cs
@@ -3,7 +3,7 @@
 #pragma warning disable
 #nullable enable
 
-// This was copied from https://github.com/dotnet/runtime/blob/39b9607807f29e48cae4652cd74735182b31182e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+// This was copied from https://github.com/dotnet/runtime/blob/906c53718074c669286fd5b0cd88bc7a56a0cd10/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 // and updated to have the scope of the attributes be internal.
 
 #if !NETCOREAPP
@@ -107,7 +107,7 @@ internal sealed class MemberNotNullAttribute : Attribute
     /// <param name="member">
     /// The field or property member that is promised to be not-null.
     /// </param>
-    public MemberNotNullAttribute(string member) => Members = new[] { member };
+    public MemberNotNullAttribute(string member) => Members = [member];
 
     /// <summary>Initializes the attribute with the list of field and property members.</summary>
     /// <param name="members">
@@ -126,7 +126,7 @@ internal sealed class MemberNotNullWhenAttribute : Attribute
 {
     /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
     /// <param name="returnValue">
-    /// The return value condition. If the method returns this value, the associated parameter will not be null.
+    /// The return value condition. If the method returns this value, the associated field or property member will not be null.
     /// </param>
     /// <param name="member">
     /// The field or property member that is promised to be not-null.
@@ -134,12 +134,12 @@ internal sealed class MemberNotNullWhenAttribute : Attribute
     public MemberNotNullWhenAttribute(bool returnValue, string member)
     {
         ReturnValue = returnValue;
-        Members = new[] { member };
+        Members = [member];
     }
 
     /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
     /// <param name="returnValue">
-    /// The return value condition. If the method returns this value, the associated parameter will not be null.
+    /// The return value condition. If the method returns this value, the associated field and property members will not be null.
     /// </param>
     /// <param name="members">
     /// The list of field and property members that are promised to be not-null.


### PR DESCRIPTION
Fixes #8728, #8729, #8730, #8731, #8732.

## Summary

Reconciliation of the five open `area-vendored-sync` drift reports. Most of the upstream churn turns out to be irrelevant to the regions we vendor, so the bulk of this PR is metadata: bumping `baseline_ref_sha` / `baseline_blob_sha` in `eng/vendored-files.json` to the current heads of `dotnet/runtime` (`906c5371`) and `dotnet/command-line-api` (`fa1991f8`).

## Changes per issue

### #8728 – `src/Polyfills/NullableAttribtues.cs`
Ported the relevant upstream changes:

- Doc-comment fixes in `MemberNotNullWhenAttribute` (s/associated parameter/associated field or property member/).
- Single-element array initializers switched to collection-expression syntax (`new[] { member }` → `[member]`).

Not ported:

- Upstream's new `#if !NETSTANDARD2_1` guard around the first batch of attributes. Our local copy is already wrapped in `#if !NETCOREAPP`, so the guard does not apply.

### #8729 – `src/Analyzers/MSTest.SourceGeneration/Helpers/SystemPolyfills.cs`
No code change. The local copy only mirrors `NotNullWhenAttribute`, which is not affected by any upstream change. Notes/scope in the manifest tightened to reflect that.

### #8730 – `src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/FileUtilities.cs`
No code change. Upstream completely rewrote `PathInternal.GetIsCaseSensitive` into a static OS-based check (`OperatingSystem.IsWindows/MacOS/IOS/TvOS`). The local probe-based implementation is intentionally retained because:

- The platform targets `netstandard2.0` where those `OperatingSystem.IsX` APIs are not first-class.
- The probe better reflects mount-level case sensitivity (e.g. a case-insensitive volume on Linux).

Manifest notes/scope updated to record the intentional divergence so future reviewers do not silently flip behaviour.

### #8731 / #8732 – `src/Platform/Microsoft.Testing.Platform/CommandLine/ResponseFileHelper.cs`
No code change. Upstream:

- Renamed `CliParser.cs` → `CommandLineParser.cs` (handles #8731 missing-path signal).
- Renamed `CliToken` / `CliCommand` / `CliOption` / `CliDirective` → `Token` / `Command` / `Option` / `Directive` throughout `StringExtensions.cs`.

Neither rename touches the helpers we vendor (`ExpandResponseFile`, `SplitLine`, and the `SplitCommandLine` boundary state machine). The manifest source path for entry 0 is updated to `CommandLineParser.cs`, and the URL comment at the top of `ResponseFileHelper.cs` is repointed accordingly.

## Validation

- `python .github/scripts/check_vendored_files.py validate` → `Manifest OK: 9 entries, 10 sources.`
- `.\build.cmd` → `Build succeeded. 0 Warning(s) 0 Error(s)`.