### PR TITLE
Expand vendored-files manifest with 12 additional tracked files

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -143,6 +143,186 @@
           "scope": "ExpandResponseFile/SplitLine helpers (around line 316)"
         }
       ]
+    },
+    {
+      "id": "platform-paste-arguments",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs",
+      "notes": "Verbatim port of runtime's PasteArguments. Used by TestHostControllersTestHost on non-net8 TFMs to escape ProcessStartInfo arguments.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs",
+          "baseline_ref_sha": "62dfdbff84a97796938836c60697287fc6161aa1",
+          "baseline_blob_sha": "39008fc101067a42be33b747d3cee5f208a202d5",
+          "scope": "entire file; namespace and accessibility adapted to internal"
+        }
+      ]
+    },
+    {
+      "id": "platform-task-extensions",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/TaskExtensions.cs",
+      "notes": "WaitAsync downlevel polyfill, modeled after the runtime's TaskExtensions shared helper.",
+      "sources": [
+        {
+          "repo": "dotnet/aspnetcore",
+          "ref": "main",
+          "path": "src/Shared/TaskExtensions.cs",
+          "baseline_ref_sha": "b9015295c392a23e0bf1cc74cc06633fe75704a4",
+          "baseline_blob_sha": "b06f6efe402a0844c8a258f5aad361f6a38383d3",
+          "scope": "WaitAsync overloads for non-net5 TFMs"
+        }
+      ]
+    },
+    {
+      "id": "platform-ui-language-override",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/UILanguageOverride.cs",
+      "notes": "Adapted from the dotnet CLI's UILanguageOverride with small tweaks for testability (IEnvironment abstraction).",
+      "sources": [
+        {
+          "repo": "dotnet/sdk",
+          "ref": "main",
+          "path": "src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs",
+          "baseline_ref_sha": "1ab3ae8e0338cdd06b3974959c5802ccc5a85978",
+          "baseline_blob_sha": "ea50251065dc0f5ea142812ef39ecfbe37779b4b",
+          "scope": "entire file; environment variable name renamed to TESTINGPLATFORM_UI_LANGUAGE"
+        }
+      ]
+    },
+    {
+      "id": "platform-ci-environment-detector",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/CIEnvironmentDetector.cs",
+      "notes": "Adapted from dotnet CLI telemetry CI detection. Maintained per https://learn.microsoft.com/dotnet/core/tools/telemetry#continuous-integration-detection.",
+      "sources": [
+        {
+          "repo": "dotnet/sdk",
+          "ref": "main",
+          "path": "src/Cli/Microsoft.DotNet.Cli.Definitions/Telemetry/CIEnvironmentDetectorForTelemetry.cs",
+          "baseline_ref_sha": "1ab3ae8e0338cdd06b3974959c5802ccc5a85978",
+          "baseline_blob_sha": "e10e1fc2cd973c6123fd983b16a8f0c1e9191c31",
+          "scope": "CI detection rules and environment variable lists"
+        }
+      ]
+    },
+    {
+      "id": "platform-llm-environment-detector",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs",
+      "notes": "Adapted from dotnet CLI telemetry LLM/agent environment detection.",
+      "sources": [
+        {
+          "repo": "dotnet/sdk",
+          "ref": "main",
+          "path": "src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs",
+          "baseline_ref_sha": "1ab3ae8e0338cdd06b3974959c5802ccc5a85978",
+          "baseline_blob_sha": "94cd49826baadaa10154f13d71a7e2ede224b663",
+          "scope": "LLM/agent detection rules"
+        }
+      ]
+    },
+    {
+      "id": "platform-roslyn-hashcode",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/Helpers/RoslynHashCode.cs",
+      "notes": "Roslyn-style adaptation of runtime's HashCode (preserves the xxHash32 algorithm published by Yann Collet). Tracks the upstream runtime file for drift on the algorithm itself; see also dotnet/roslyn#50156 commentary.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/System.Private.CoreLib/src/System/HashCode.cs",
+          "baseline_ref_sha": "62dfdbff84a97796938836c60697287fc6161aa1",
+          "baseline_blob_sha": "6a80fa07da246f095ee25407aaf6d5c6e8fa5fc5",
+          "scope": "xxHash32 Combine/Add implementation"
+        }
+      ]
+    },
+    {
+      "id": "platform-terminal-native-methods",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NativeMethods.cs",
+      "notes": "Only QueryIsScreenAndTryEnableAnsiColorCodes and its console-mode P/Invokes are copied from msbuild's Framework NativeMethods.",
+      "sources": [
+        {
+          "repo": "dotnet/msbuild",
+          "ref": "main",
+          "path": "src/Framework/NativeMethods.cs",
+          "baseline_ref_sha": "fd084bd416a21d504b5d9bb19c0a1ca83c33533d",
+          "baseline_blob_sha": "915cf0673e4f49f2e7bc286592c036d23441321e",
+          "scope": "QueryIsScreenAndTryEnableAnsiColorCodes and supporting console-mode P/Invokes"
+        }
+      ]
+    },
+    {
+      "id": "platform-terminal-ansi-detector",
+      "local_path": "src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiDetector.cs",
+      "notes": "Ported from Spectre.Console's AnsiDetector (with additional regexes from supports-ansi).",
+      "sources": [
+        {
+          "repo": "spectreconsole/spectre.console",
+          "ref": "main",
+          "path": "src/Spectre.Console.Ansi/AnsiDetector.cs",
+          "baseline_ref_sha": "bbf51e4c2841dae4d574193a7a5695499d453f60",
+          "baseline_blob_sha": "a31831944cb05dac9b48942fe7cb14dac89444d8",
+          "scope": "terminal regex list and ANSI capability detection logic"
+        }
+      ]
+    },
+    {
+      "id": "trx-xxhash128",
+      "local_path": "src/Platform/Microsoft.Testing.Extensions.TrxReport/Hashing/XxHash128.cs",
+      "notes": "Verbatim port of runtime's System.IO.Hashing XxHash128 (BSD-2-Clause xxHash algorithm by Yann Collet). Lives under TestFx.Hashing namespace and is consumed by TRX report hashing.",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash128.cs",
+          "baseline_ref_sha": "62dfdbff84a97796938836c60697287fc6161aa1",
+          "baseline_blob_sha": "23ff9fce02a671f415a535f0a5d1151cda6ed9ba",
+          "scope": "entire file; namespace adapted to TestFx.Hashing"
+        }
+      ]
+    },
+    {
+      "id": "trx-xxhash-shared",
+      "local_path": "src/Platform/Microsoft.Testing.Extensions.TrxReport/Hashing/XxHashShared.cs",
+      "notes": "Verbatim port of runtime's System.IO.Hashing XxHashShared (shared XXH3 implementation used by XxHash128).",
+      "sources": [
+        {
+          "repo": "dotnet/runtime",
+          "ref": "main",
+          "path": "src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs",
+          "baseline_ref_sha": "62dfdbff84a97796938836c60697287fc6161aa1",
+          "baseline_blob_sha": "00f1f919a93c706cbd41a2a2e9d62f26c74b6f92",
+          "scope": "entire file"
+        }
+      ]
+    },
+    {
+      "id": "testframework-ci-environment-detector",
+      "local_path": "src/TestFramework/TestFramework/Internal/CIEnvironmentDetector.cs",
+      "notes": "Independent in-tree copy of the CI detector (test-framework variant exposing an IEnvironment-backed Instance) sharing the rules with the platform copy.",
+      "sources": [
+        {
+          "repo": "dotnet/sdk",
+          "ref": "main",
+          "path": "src/Cli/Microsoft.DotNet.Cli.Definitions/Telemetry/CIEnvironmentDetectorForTelemetry.cs",
+          "baseline_ref_sha": "1ab3ae8e0338cdd06b3974959c5802ccc5a85978",
+          "baseline_blob_sha": "e10e1fc2cd973c6123fd983b16a8f0c1e9191c31",
+          "scope": "CI detection rules and environment variable lists"
+        }
+      ]
+    },
+    {
+      "id": "source-gen-equatable-array",
+      "local_path": "src/Analyzers/MSTest.SourceGeneration/Helpers/EquatableArray{T}.cs",
+      "notes": "Value-equality wrapper over ImmutableArray<T> for incremental source generator caching, ported from ComputeSharp.",
+      "sources": [
+        {
+          "repo": "Sergio0694/ComputeSharp",
+          "ref": "main",
+          "path": "src/ComputeSharp.SourceGeneration/Helpers/EquatableArray%7BT%7D.cs",
+          "baseline_ref_sha": "c3e9ad4faada0d67a122c0e458cf3978993cf6c5",
+          "baseline_blob_sha": "b63b1c8773635ffc132b728d5711acc40aae97e3",
+          "scope": "entire struct"
+        }
+      ]
     }
   ]
 }

--- a/eng/vendored-files.md
+++ b/eng/vendored-files.md
@@ -110,5 +110,20 @@ automation:
 
 - `src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs` —
   intra-repo copy, no external upstream.
+- `src/Platform/Microsoft.Testing.Extensions.Retry/RandomId.cs` —
+  intra-repo copy from `test/Utilities/Microsoft.Testing.TestInfrastructure`,
+  no external upstream.
+- `src/Analyzers/MSTest.SourceGeneration/ObjectModels/DynamicDataTestMethodArgumentsInfo.cs` —
+  intra-repo `// Based on DynamicDataSourceType in:` reference to an MSTest
+  attribute, no external upstream.
+- `src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumeratorWrapper.cs` —
+  the line-44 helper is annotated `// Copy from https://stackoverflow.com/a/15608028/...`;
+  Stack Overflow snippets don't have a trackable upstream file.
 - `src/TestFramework/TestFramework.Extensions/AppModel.cs` — only mentions
   "WinUI source base" without a concrete upstream URL.
+- `src/Polyfills/HashHelpers.cs` — the upstream reference is to the
+  `dotnet/coreclr#1830` pull request (now merged into `dotnet/runtime`), not a
+  specific file; the local code is a trivial three-line helper.
+- `src/Platform/Microsoft.Testing.Extensions.TrxReport/Hashing/BitOperations.cs`
+  and `EmbeddedAttribute.cs` — trivial compiler shims/polyfills that have not
+  meaningfully changed upstream.

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Hashing/XxHashShared.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Hashing/XxHashShared.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Verbatim port of https://github.com/dotnet/runtime/blob/main/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
 using System.Buffers.Binary;
 using System.Numerics;
 #if NET


### PR DESCRIPTION
## What

Audits all source files under `src/` (MTP + MSTest) for `// Copied from`, `// Adapted from`, `// Based on`, `// Verbatim port of`, and bare `github.com/...` style annotations pointing at concrete upstream files, and registers each one in `eng/vendored-files.json` so the weekly drift check can flag updates.

This brings the manifest from **9** to **21** tracked entries.

## New entries

| Id | Upstream |
| -- | -------- |
| `platform-paste-arguments` | dotnet/runtime `System.Private.CoreLib/.../PasteArguments.cs` |
| `platform-task-extensions` | dotnet/aspnetcore `src/Shared/TaskExtensions.cs` |
| `platform-ui-language-override` | dotnet/sdk `src/Cli/Microsoft.DotNet.Cli.Utils/UILanguageOverride.cs` |
| `platform-ci-environment-detector` | dotnet/sdk `CIEnvironmentDetectorForTelemetry.cs` |
| `platform-llm-environment-detector` | dotnet/sdk `LLMEnvironmentDetectorForTelemetry.cs` |
| `platform-roslyn-hashcode` | dotnet/runtime `System.Private.CoreLib/.../HashCode.cs` |
| `platform-terminal-native-methods` | dotnet/msbuild `src/Framework/NativeMethods.cs` |
| `platform-terminal-ansi-detector` | spectreconsole/spectre.console `src/Spectre.Console.Ansi/AnsiDetector.cs` |
| `trx-xxhash128` | dotnet/runtime `System.IO.Hashing/.../XxHash128.cs` |
| `trx-xxhash-shared` | dotnet/runtime `System.IO.Hashing/.../XxHashShared.cs` (was unannotated locally) |
| `testframework-ci-environment-detector` | dotnet/sdk (second copy in TestFramework) |
| `source-gen-equatable-array` | Sergio0694/ComputeSharp `EquatableArray%7BT%7D.cs` |

## Also

- Adds a missing `// Verbatim port of …` header on `src/Platform/Microsoft.Testing.Extensions.TrxReport/Hashing/XxHashShared.cs` (verbatim copy of the runtime file, was previously unannotated).
- Extends the **Excluded files** section of `eng/vendored-files.md` to document the intra-repo copies, Stack Overflow snippets, and trivial polyfill shims that intentionally remain outside the manifest:
  - `RandomId.cs` (intra-repo)
  - `DynamicDataTestMethodArgumentsInfo.cs` (intra-repo)
  - `AssemblyEnumeratorWrapper.cs` (Stack Overflow snippet)
  - `HashHelpers.cs` (PR-only reference)
  - `BitOperations.cs` / `EmbeddedAttribute.cs` (trivial polyfill shims)

## Validation

`python .github/scripts/check_vendored_files.py validate` → `Manifest OK: 21 entries, 22 sources.`
