### PR TITLE
[perf-improver] perf: eliminate per-call string allocation in AnsiTerminal.SetColor and use HashSet for KnownFileExtensions

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiCodes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiCodes.cs
@@ -127,6 +127,32 @@ internal static class AnsiCodes
     /// </remarks>
     public const string RemoveBusySpinner = $"{Esc}]9;4;0;{Esc}\\";
 
+    /// <summary>
+    /// Returns the pre-computed ANSI escape sequence that switches the foreground to <paramref name="color"/>.
+    /// Callers should prefer this over building the string inline to avoid per-call heap allocation.
+    /// </summary>
+    public static string GetSetColorEscapeCode(TerminalColor color) => color switch
+    {
+        TerminalColor.Black => "\x1b[30m",
+        TerminalColor.DarkRed => "\x1b[31m",
+        TerminalColor.DarkGreen => "\x1b[32m",
+        TerminalColor.DarkYellow => "\x1b[33m",
+        TerminalColor.DarkBlue => "\x1b[34m",
+        TerminalColor.DarkMagenta => "\x1b[35m",
+        TerminalColor.DarkCyan => "\x1b[36m",
+        TerminalColor.Gray => "\x1b[37m",
+        TerminalColor.Default => "\x1b[39m",
+        TerminalColor.DarkGray => "\x1b[90m",
+        TerminalColor.Red => "\x1b[91m",
+        TerminalColor.Green => "\x1b[92m",
+        TerminalColor.Yellow => "\x1b[93m",
+        TerminalColor.Blue => "\x1b[94m",
+        TerminalColor.Magenta => "\x1b[95m",
+        TerminalColor.Cyan => "\x1b[96m",
+        TerminalColor.White => "\x1b[97m",
+        _ => $"{CSI}{(int)color}{SetColor}",
+    };
+
     public static string Colorize(string? s, TerminalColor color)
         => RoslynString.IsNullOrWhiteSpace(s) ? s ?? string.Empty : $"{CSI}{(int)color}{SetColor}{s}{SetDefaultColor}";
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -16,25 +16,9 @@ internal sealed class AnsiTerminal : ITerminal
     /// File extensions that we will link to directly, all other files
     /// are linked to their directory, to avoid opening dlls, or executables.
     /// </summary>
-    private static readonly string[] KnownFileExtensions =
-    [
-        // code files
-        ".cs",
-        ".vb",
-        ".fs",
-        // logs
-        ".log",
-        ".txt",
-        // reports
-        ".coverage",
-        ".ctrf",
-        ".html",
-        ".junit",
-        ".nunit",
-        ".trx",
-        ".xml",
-        ".xunit"
-    ];
+    private static readonly HashSet<string> KnownFileExtensions = new HashSet<string>(
+        [".cs", ".vb", ".fs", ".log", ".txt", ".coverage", ".ctrf", ".html", ".junit", ".nunit", ".trx", ".xml", ".xunit"],
+        StringComparer.Ordinal);
 
     private readonly IConsole _console;
     private readonly string? _baseDirectory;
@@ -113,7 +97,7 @@ internal sealed class AnsiTerminal : ITerminal
 
     public void SetColor(TerminalColor color)
     {
-        string setColor = $"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}";
+        string setColor = AnsiCodes.GetSetColorEscapeCode(color);
         if (_isBatching)
         {
             _stringBuilder.Append(setColor);


### PR DESCRIPTION
🤖 *This is an automated contribution from [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26764951982).*

## Goal and Rationale

Two allocation hotspots in the terminal output path:

1. **`AnsiTerminal.SetColor`** — Every call to `SetColor(TerminalColor)` built a new `string` via `$"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}"`. This happens during every live-progress render frame (once per assembly × 3 color changes per row × every 500 ms). There are only 17 possible `TerminalColor` values, so the strings can be pre-computed.

2. **`KnownFileExtensions`** — The 13-element `string[]` was scanned linearly by `Array.Contains` on every `AppendLink` call (triggered for each failed-test file link in the run summary). A `HashSet<string>` gives O(1) lookup.

## Approach

1. Added `AnsiCodes.GetSetColorEscapeCode(TerminalColor)` — a switch expression that returns interned compile-time string literals (e.g. `"\x1b[32m"`) for every known color. No heap allocation for common cases. Falls back to string interpolation for any unexpected future value.

2. `AnsiTerminal.SetColor` now calls `AnsiCodes.GetSetColorEscapeCode(color)` instead of building the string inline.

3. Changed `KnownFileExtensions` from `private static readonly string[]` to `private static readonly HashSet<string>` initialized with `StringComparer.Ordinal` (preserving the existing case-sensitive behaviour).

## Performance Evidence

| Site | Before | After |
|------|--------|-------|
| `AnsiTerminal.SetColor` (per call) | 1 × `string` allocation (~6–8 bytes, formatting) | 0 — returns interned literal |
| `KnownFileExtensions.Contains` | O(n) — up to 13 comparisons | O(1) HashSet lookup |
| Frame-level colour allocations (10 assemblies, 500 ms cadence) | ~30 strings/sec | 0 |

**Methodology**: code inspection + diff review. The switch expression returns literal strings which the runtime interns; no heap allocation occurs.

## Trade-offs

- `AnsiCodes` gains one method (~20 lines). The switch explicitly enumerates all 17 `TerminalColor` values; adding a new value without updating the switch falls back to the interpolated string (no regression).
- `KnownFileExtensions` is now a `HashSet` (one allocation at class init) instead of an array. The comparer is `Ordinal` to preserve existing case-sensitivity.

## Test Status

- `Microsoft.Testing.Platform.UnitTests` (net8.0): **995 passed, 0 failed, 3 skipped** ✅

## Reproducibility

```bash
./build.sh
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
```




> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26764951982) · sonnet46 7.6M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26764951982, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/26764951982 -->

<!-- gh-aw-workflow-id: perf-improver -->