### PR TITLE
[efficiency-improver] perf: single-pass TRX message partitioning in TrxReportEngine

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Results.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Results.cs
@@ -110,22 +110,44 @@ internal sealed partial class TrxReportEngine
             IReadOnlyList<TrxStreamMessage>? trxMessages = testResult.Messages;
             if (trxMessages is not null)
             {
-                IEnumerable<string?> nonErrorMessages = trxMessages.Where(x => x.Kind == TrxStreamMessageKind.StandardOutput).Select(x => x.Message);
-                if (nonErrorMessages.Any())
+                // Single pass: partition messages by kind into separate StringBuilders,
+                // avoiding the double-enumeration that .Any() + string.Join() would cause.
+                StringBuilder? stdOut = null;
+                StringBuilder? stdErr = null;
+                StringBuilder? debugTrace = null;
+
+                foreach (TrxStreamMessage msg in trxMessages)
                 {
-                    output.Add(new XElement("StdOut", RemoveInvalidXmlChar(string.Join(Environment.NewLine, nonErrorMessages))));
+                    switch (msg.Kind)
+                    {
+                        case TrxStreamMessageKind.StandardOutput:
+                            stdOut?.Append(Environment.NewLine);
+                            (stdOut ??= new StringBuilder()).Append(msg.Message);
+                            break;
+                        case TrxStreamMessageKind.StandardError:
+                            stdErr?.Append(Environment.NewLine);
+                            (stdErr ??= new StringBuilder()).Append(msg.Message);
+                            break;
+                        case TrxStreamMessageKind.DebugOrTrace:
+                            debugTrace?.Append(Environment.NewLine);
+                            (debugTrace ??= new StringBuilder()).Append(msg.Message);
+                            break;
+                    }
                 }
 
-                IEnumerable<string?> errorMessages = trxMessages.Where(x => x.Kind == TrxStreamMessageKind.StandardError).Select(x => x.Message);
-                if (errorMessages.Any())
+                if (stdOut is not null)
                 {
-                    output.Add(new XElement("StdErr", RemoveInvalidXmlChar(string.Join(Environment.NewLine, errorMessages))));
+                    output.Add(new XElement("StdOut", RemoveInvalidXmlChar(stdOut.ToString())));
                 }
 
-                IEnumerable<string?> debugOrTraceMessages = trxMessages.Where(x => x.Kind == TrxStreamMessageKind.DebugOrTrace).Select(x => x.Message);
-                if (debugOrTraceMessages.Any())
+                if (stdErr is not null)
                 {
-                    output.Add(new XElement("DebugTrace", RemoveInvalidXmlChar(string.Join(Environment.NewLine, debugOrTraceMessages))));
+                    output.Add(new XElement("StdErr", RemoveInvalidXmlChar(stdErr.ToString())));
+                }
+
+                if (debugTrace is not null)
+                {
+                    output.Add(new XElement("DebugTrace", RemoveInvalidXmlChar(debugTrace.ToString())));
                 }
             }
 


### PR DESCRIPTION
🤖 *This PR was created by Efficiency Improver, an automated AI assistant focused on reducing energy consumption and computational footprint.*

## Goal and Rationale

In `TrxReportEngine.Results.cs`, message output for each test result was processed with three separate deferred LINQ chains, each enumerated **twice**:

```csharp
// Before: 6 total enumerations of trxMessages per test result
IEnumerable<string?> nonErrorMessages = trxMessages.Where(x => x.Kind == TrxStreamMessageKind.StandardOutput).Select(x => x.Message);
if (nonErrorMessages.Any())                                     // enumeration 1
    output.Add(...string.Join(Environment.NewLine, nonErrorMessages));  // enumeration 2
// ...same pattern repeated for StandardError and DebugOrTrace
```

## Focus Area

**Code-Level Efficiency** — redundant enumeration and unnecessary LINQ state-machine allocations in TRX report generation.

## Approach

Replace the three Where/Select/Any/Join passes with a **single `foreach`** that partitions messages into three nullable `StringBuilder`s:

```csharp
// After: 1 enumeration of trxMessages per test result
StringBuilder? stdOut = null;
StringBuilder? stdErr = null;
StringBuilder? debugTrace = null;

foreach (TrxStreamMessage msg in trxMessages)
{
    switch (msg.Kind)
    {
        case TrxStreamMessageKind.StandardOutput:
            stdOut?.Append(Environment.NewLine);
            (stdOut ??= new StringBuilder()).Append(msg.Message);
            break;
        // ...
    }
}
```

## Energy Efficiency Evidence

**Proxy metrics**: heap allocation + CPU instruction count.

| | Before | After |
|---|---|---|
| `trxMessages` enumerations | up to 6 | 1 |
| LINQ enumerator allocations | 6 per test result | 0 |
| `string.Join` intermediate arrays | up to 3 per test result | 0 |

**Call frequency**: `AddResults` is called once per test run, but the inner loop executes once per test result. For a suite of 10,000 tests that produce output, the before path creates ~60,000 LINQ state machine instances and up to 30,000 intermediate string arrays. The after path creates zero.

**Green Software Foundation — Hardware Efficiency**: fewer CPU cycles and GC-induced pauses per functional unit (one test result written to TRX).

## Trade-offs

Slightly more verbose than the LINQ version, but the logic is straightforward and well-commented. Wire format is identical — the same newline-joined strings are written to the XML elements.

## Test Status

✅ Build succeeded (`./build.sh`)  
✅ All unit tests passed (`./build.sh -test`)




> Generated by [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/26785997649) · sonnet46 7.1M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26785997649, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/26785997649 -->

<!-- gh-aw-workflow-id: efficiency-improver -->