### PR TITLE
Bump Nerdbank.MessagePack from 1.1.62 to 1.2.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,7 @@
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <!-- This comes transitively via StreamJsonRpc, but we want to upgrade it to fix a security vulnerability -->
-    <PackageVersion Include="Nerdbank.MessagePack" Version="1.1.62" />
+    <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Management" Version="9.0.4" />


### PR DESCRIPTION
Upgrades the centrally-managed `Nerdbank.MessagePack` package from `1.1.62` to `1.2.4` to fix a known security vulnerability.`Nerdbank.MessagePack` comes transitively via `StreamJsonRpc` but is pinned in `Directory.Packages.props` specifically to take the vulnerability fix. The three consumers (`FSharpPlayground`, `Microsoft.Testing.Platform.Acceptance.IntegrationTests`, `MSTest.Acceptance.IntegrationTests`) pick up the new version automatically via CPM.Restore validated locally.