### PR TITLE
Stop test-improver from adding VB.NET tests for analyzers

### DIFF
--- a/.github/workflows/test-improver.md
+++ b/.github/workflows/test-improver.md
@@ -343,6 +343,12 @@ Maintain a single open issue titled `[test-improver] Monthly Activity {YYYY}-{MM
    - Use `* [ ]` checkboxes in "Suggested Actions". Never use plain bullets there.
 4. Do not update the activity issue if nothing was done in the current run.
 
+## Repository-specific constraints
+
+The following constraints are **hard rules** for this repository. They override any opportunities surfaced from backlog, memory, or coverage gaps:
+
+- **Do NOT add VB.NET tests for analyzers.** The maintainers are not interested in VB.NET coverage for `MSTest.Analyzers` (or any analyzer project). Skip any backlog item that proposes adding VB-specific test cases for an analyzer (e.g. "Add VB.NET tests for `<Name>Analyzer`"). If memory still references such items, prune them from the backlog and do not surface them in the Monthly Activity Summary. C# tests for analyzers remain in scope.
+
 ## Guidelines
 
 - **No breaking changes** without maintainer approval via a tracked issue.

--- a/.github/workflows/test-improver.md
+++ b/.github/workflows/test-improver.md
@@ -347,7 +347,7 @@ Maintain a single open issue titled `[test-improver] Monthly Activity {YYYY}-{MM
 
 The following constraints are **hard rules** for this repository. They override any opportunities surfaced from backlog, memory, or coverage gaps:
 
-- **Do NOT add VB.NET tests for analyzers.** The maintainers are not interested in VB.NET coverage for `MSTest.Analyzers` (or any analyzer project). Skip any backlog item that proposes adding VB-specific test cases for an analyzer (e.g. "Add VB.NET tests for `<Name>Analyzer`"). If memory still references such items, prune them from the backlog and do not surface them in the Monthly Activity Summary. C# tests for analyzers remain in scope.
+- **Do NOT add VB.NET tests for analyzers.** The maintainers are not interested in VB.NET coverage for `MSTest.Analyzers` (or any analyzer project). Skip any backlog item that proposes adding VB-specific test cases for an analyzer (e.g. "Add VB.NET tests for `<Name>Analyzer`"). If memory still references such items, **remove those entries from memory** and prune them from the backlog; do not surface them in the Monthly Activity Summary. C# tests for analyzers remain in scope.
 
 ## Guidelines
 


### PR DESCRIPTION
Related to #8747.

The `test-improver` agentic workflow has been repeatedly opening PRs that add VB.NET test cases for analyzers (e.g. the recent `test-assist/vb-asserts-in-catch-blocks` PR for `AvoidAssertsInCatchBlocksAnalyzer`). We are not interested in expanding VB.NET coverage for the analyzer projects.

This change adds a new **Repository-specific constraints** section to `.github/workflows/test-improver.md` (right before *Guidelines*) with a hard rule that:

- Instructs the workflow to **not** add VB.NET tests for analyzers (`MSTest.Analyzers` or any analyzer project).
- Tells it to skip backlog items of the form `Add VB.NET tests for <Name>Analyzer`.
- Tells it to prune such items from repo memory and from the Monthly Activity Summary.
- Explicitly keeps C# tests for analyzers in scope.

The constraint is placed in its own section above *Guidelines* and is described as a hard rule that overrides backlog/memory/coverage-gap suggestions, so it is hard to miss.

### Lock file

I re-ran `gh aw compile test-improver --strict` to validate. The lock file is unchanged content-wise (the `.md` body is pulled in at runtime via `{{#runtime-import .github/workflows/test-improver.md}}`), so no `.lock.yml` update is needed in this PR.

### Follow-up (manual)

After this merges, the currently open `[test-improver]` VB analyzer PR should be closed manually so the workflow does not try to maintain it; the next scheduled run will drop the "VB.NET coverage gaps" backlog item from issue #8747.
