### PR TITLE
Use GitHub Issue Type field instead of type/* labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,8 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve Microsoft.Testing.Platform and MSTest
-labels: [type/bug, needs/triage]
+labels: [needs/triage]
+type: Bug
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,8 @@
 ---
 name: Feature request
 about: Suggest a new feature/idea for Microsoft.Testing.Platform or MSTest
-labels: [type/feature, needs/triage]
+labels: [needs/triage]
+type: Feature
 ---
 
 ## Summary


### PR DESCRIPTION
Switches the bug report and feature request issue templates to use the native GitHub **Issue Type** field instead of the `type/bug` and `type/feature` labels.

## Changes

- `.github/ISSUE_TEMPLATE/bug-report.md`: remove `type/bug` from `labels:`, add `type: Bug` to the frontmatter.
- `.github/ISSUE_TEMPLATE/feature-request.md`: remove `type/feature` from `labels:`, add `type: Feature` (same migration pattern).

The `microsoft` org exposes three native issue types — **Task**, **Bug**, **Feature** — so these two templates map cleanly onto the built-in feature.

## Not in scope

- `rfc.md` keeps `type/rfc` since there is no corresponding GH issue type.
- `LabelManagement.IssueUpdated.yml` keeps its `type/` label-sync rule for the remaining `type/*` labels (`type/regression`, `type/breaking-change`, `type/tech-debt`, `type/flaky-test`, `type/rfc`, ...) that don't have a GH Type equivalent.
- `eng/migrate-labels.ps1` is a one-time label-taxonomy migration tool, not a triage workflow, so it is left untouched.

## Follow-up (optional)

Existing open issues that already carry `type/bug` or `type/feature` won't be automatically migrated by this change — only newly opened issues created from these templates will use the GH Type field. A one-shot back-fill could be scripted separately if desired.
