### PR TITLE
Skip Copilot code review for OneLocBuild and Maestro PRs

### DIFF
--- a/.github/workflows/skip-copilot-review-bot-prs.yml
+++ b/.github/workflows/skip-copilot-review-bot-prs.yml
@@ -1,0 +1,28 @@
+name: Skip Copilot code review for bot PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-copilot-reviewer:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'microsoft/testfx' && (github.event.pull_request.user.login == 'dotnet-bot' || github.event.pull_request.user.login == 'dotnet-maestro[bot]') && (startsWith(github.event.pull_request.title, 'Localized file check-in') || startsWith(github.event.pull_request.title, '[main] Update dependencies from dotnet/') || startsWith(github.event.pull_request.title, '[main] Update dependencies from microsoft/') || startsWith(github.event.pull_request.title, '[main] Update dependencies from devdiv/')) }}
+    steps:
+    - name: Remove Copilot as a requested reviewer
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        # The CopilotAutoReview ruleset automatically requests a review from
+        # copilot-pull-request-reviewer on every PR. For mechanical bot PRs
+        # (OneLocBuild, Maestro dependency flow), that review is pure noise,
+        # so we drop the request as soon as it's added.
+        # Returns 422 if the reviewer wasn't requested (already removed or never added) - ignore.
+        gh api -X DELETE \
+          "repos/$REPO/pulls/$PR/requested_reviewers" \
+          -f 'reviewers[]=copilot-pull-request-reviewer' || true

--- a/.github/workflows/skip-copilot-review-bot-prs.yml
+++ b/.github/workflows/skip-copilot-review-bot-prs.yml
@@ -22,7 +22,16 @@ jobs:
         # copilot-pull-request-reviewer on every PR. For mechanical bot PRs
         # (OneLocBuild, Maestro dependency flow), that review is pure noise,
         # so we drop the request as soon as it's added.
-        # Returns 422 if the reviewer wasn't requested (already removed or never added) - ignore.
-        gh api -X DELETE \
-          "repos/$REPO/pulls/$PR/requested_reviewers" \
-          -f 'reviewers[]=copilot-pull-request-reviewer' || true
+        #
+        # We check first instead of unconditionally deleting so that real
+        # errors (auth, transient outages, etc.) still surface as workflow
+        # failures rather than being masked by `|| true`.
+        if gh api "repos/$REPO/pulls/$PR/requested_reviewers" \
+             --jq '.users[].login' | grep -qxF 'copilot-pull-request-reviewer'; then
+          echo "Removing copilot-pull-request-reviewer from PR #$PR."
+          gh api -X DELETE \
+            "repos/$REPO/pulls/$PR/requested_reviewers" \
+            -f 'reviewers[]=copilot-pull-request-reviewer'
+        else
+          echo "copilot-pull-request-reviewer is not currently requested on PR #$PR; nothing to do."
+        fi


### PR DESCRIPTION
The `CopilotAutoReview` ruleset on `main` enables `copilot_code_review` with `review_on_push: true`, so every PR (including mechanical ones) automatically gets a review request for `copilot-pull-request-reviewer`.

Adding `dotnet-bot` to the ruleset's bypass list does **not** suppress this — `bypass_actors` only exempts an actor from rules that *restrict* an action (deletion, push, etc.), and is a no-op for trigger-style rules like `copilot_code_review`. See e.g. #8762, which got reviewed despite the bypass entry.

This workflow drops the Copilot review request immediately after the PR opens or is updated, for the same set of bot PRs that `enable-auto-merge.yml` already auto-merges:

- author `dotnet-bot` or `dotnet-maestro[bot]`
- title starts with `Localized file check-in` or `[main] Update dependencies from {dotnet,microsoft,devdiv}/`

So the policy stays coherent: anything we auto-merge as mechanical, we also skip Copilot review on.

`synchronize` is included because the rule has `review_on_push: true`, which re-requests Copilot on every push.