### PR TITLE
Add MSTEST0068 - CollectionAssert to Assert analyzer and code fix

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -183,6 +183,9 @@
   <data name="StringAssertToAssertTitle" xml:space="preserve">
     <value>Use 'Assert.{0}' instead of 'StringAssert'</value>
   </data>
+  <data name="CollectionAssertToAssertTitle" xml:space="preserve">
+    <value>Use 'Assert.{0}' instead of 'CollectionAssert'</value>
+  </data>
   <data name="PassCancellationTokenFix" xml:space="preserve">
     <value>Pass 'TestContext.CancellationToken' argument to method call</value>
   </data>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CollectionAssertToAssertFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CollectionAssertToAssertFixer.cs
@@ -97,7 +97,19 @@ public sealed class CollectionAssertToAssertFixer : CodeFixProvider
 
         SyntaxNode root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-        List<ArgumentSyntax> newArguments = BuildNewArguments(orderedArguments!, fixKind);
+        // FixKindInstanceOfType prefers the generic `Assert.AreAllOfType<T>(coll, ...)` overload
+        // when the `expectedType` argument is a `typeof(T)` literal. When it isn't (e.g. a
+        // runtime `Type` expression like `GetType()` or a local variable), we fall back to the
+        // non-generic overload with swapped arguments.
+        bool useGenericAreAllOfType =
+            fixKind == CollectionAssertToAssertAnalyzer.FixKindInstanceOfType
+            && orderedArguments![1].Expression is TypeOfExpressionSyntax;
+
+        string effectiveFixKind = fixKind == CollectionAssertToAssertAnalyzer.FixKindInstanceOfType && !useGenericAreAllOfType
+            ? CollectionAssertToAssertAnalyzer.FixKindSwapTwoArgs
+            : fixKind;
+
+        List<ArgumentSyntax> newArguments = BuildNewArguments(orderedArguments!, effectiveFixKind, useGenericAreAllOfType);
 
         ArgumentListSyntax newArgumentList = invocationExpr.ArgumentList.WithArguments(SyntaxFactory.SeparatedList(newArguments));
 
@@ -120,9 +132,16 @@ public sealed class CollectionAssertToAssertFixer : CodeFixProvider
             _ => SyntaxFactory.IdentifierName("Assert"),
         };
 
+        SimpleNameSyntax newMethodName = useGenericAreAllOfType
+            ? SyntaxFactory.GenericName(
+                SyntaxFactory.Identifier(properAssertMethodName),
+                SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(
+                    ((TypeOfExpressionSyntax)orderedArguments![1].Expression).Type)))
+            : SyntaxFactory.IdentifierName(properAssertMethodName);
+
         MemberAccessExpressionSyntax newMemberAccess = memberAccessExpr
             .WithExpression(newAssertExpression)
-            .WithName(SyntaxFactory.IdentifierName(properAssertMethodName));
+            .WithName(newMethodName);
 
         InvocationExpressionSyntax newInvocationExpr = invocationExpr
             .WithExpression(newMemberAccess)
@@ -164,7 +183,7 @@ public sealed class CollectionAssertToAssertFixer : CodeFixProvider
         return true;
     }
 
-    private static List<ArgumentSyntax> BuildNewArguments(ArgumentSyntax[] orderedArguments, string fixKind)
+    private static List<ArgumentSyntax> BuildNewArguments(ArgumentSyntax[] orderedArguments, string fixKind, bool useGenericAreAllOfType)
     {
         var newArguments = new List<ArgumentSyntax>(orderedArguments.Length + 1);
         switch (fixKind)
@@ -183,6 +202,17 @@ public sealed class CollectionAssertToAssertFixer : CodeFixProvider
                 newArguments.Add(orderedArguments[0]);
                 newArguments.Add(orderedArguments[1]);
                 newArguments.Add(SyntaxFactory.Argument(CreateInAnyOrderExpression()));
+                for (int i = 2; i < orderedArguments.Length; i++)
+                {
+                    newArguments.Add(orderedArguments[i]);
+                }
+
+                break;
+
+            case CollectionAssertToAssertAnalyzer.FixKindInstanceOfType when useGenericAreAllOfType:
+                // Generic `Assert.AreAllOfType<T>(coll, ...)`: drop the `typeof(T)` (ordinal 1)
+                // and keep the collection plus any remaining trailing arguments (e.g. message).
+                newArguments.Add(orderedArguments[0]);
                 for (int i = 2; i < orderedArguments.Length; i++)
                 {
                     newArguments.Add(orderedArguments[i]);

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CollectionAssertToAssertFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CollectionAssertToAssertFixer.cs
@@ -101,9 +101,27 @@ public sealed class CollectionAssertToAssertFixer : CodeFixProvider
 
         ArgumentListSyntax newArgumentList = invocationExpr.ArgumentList.WithArguments(SyntaxFactory.SeparatedList(newArguments));
 
-        // Replace `<anything>.CollectionAssert.<Method>` with `Assert.<ProperMethod>`.
+        // Replace `<qualifier>.CollectionAssert.<Method>` with `<qualifier>.Assert.<ProperMethod>`,
+        // preserving any namespace/alias qualifier so we don't accidentally bind to a different
+        // `Assert` type (or fail to bind at all) when the source file lacks
+        // `using Microsoft.VisualStudio.TestTools.UnitTesting;`.
+        ExpressionSyntax newAssertExpression = memberAccessExpr.Expression switch
+        {
+            // `CollectionAssert.X(...)` (with using directive) → `Assert.X(...)`.
+            IdentifierNameSyntax => SyntaxFactory.IdentifierName("Assert"),
+
+            // `Foo.Bar.CollectionAssert.X(...)` or `global::Foo.Bar.CollectionAssert.X(...)` →
+            // swap only the trailing `CollectionAssert` identifier for `Assert`.
+            MemberAccessExpressionSyntax qualified => qualified.WithName(SyntaxFactory.IdentifierName("Assert")),
+
+            // `SomeAlias::CollectionAssert.X(...)` → `SomeAlias::Assert.X(...)`.
+            AliasQualifiedNameSyntax aliasQualified => aliasQualified.WithName(SyntaxFactory.IdentifierName("Assert")),
+
+            _ => SyntaxFactory.IdentifierName("Assert"),
+        };
+
         MemberAccessExpressionSyntax newMemberAccess = memberAccessExpr
-            .WithExpression(SyntaxFactory.IdentifierName("Assert"))
+            .WithExpression(newAssertExpression)
             .WithName(SyntaxFactory.IdentifierName(properAssertMethodName));
 
         InvocationExpressionSyntax newInvocationExpr = invocationExpr

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CollectionAssertToAssertFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CollectionAssertToAssertFixer.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+
+using Analyzer.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers.CodeFixes;
+
+/// <summary>
+/// Code fixer for <see cref="CollectionAssertToAssertAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CollectionAssertToAssertFixer))]
+[Shared]
+public sealed class CollectionAssertToAssertFixer : CodeFixProvider
+{
+    /// <inheritdoc />
+    public override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(DiagnosticIds.CollectionAssertToAssertRuleId);
+
+    /// <inheritdoc />
+    public sealed override FixAllProvider GetFixAllProvider()
+        // See https://github.com/dotnet/roslyn/blob/main/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        Diagnostic diagnostic = context.Diagnostics[0];
+        if (!diagnostic.Properties.TryGetValue(CollectionAssertToAssertAnalyzer.ProperAssertMethodNameKey, out string? properAssertMethodName)
+            || properAssertMethodName is null
+            || !diagnostic.Properties.TryGetValue(CollectionAssertToAssertAnalyzer.FixKindKey, out string? fixKind)
+            || fixKind is null)
+        {
+            return;
+        }
+
+        if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is not InvocationExpressionSyntax invocationExpr)
+        {
+            return;
+        }
+
+        // We only know how to rewrite `<expr>.<member>(...)`-shaped invocations. `using static` and similar
+        // shapes fall through without a fix; the diagnostic still surfaces so the user can migrate manually.
+        if (invocationExpr.Expression is not MemberAccessExpressionSyntax)
+        {
+            return;
+        }
+
+        string title = string.Format(CultureInfo.InvariantCulture, CodeFixResources.CollectionAssertToAssertTitle, properAssertMethodName);
+        var action = CodeAction.Create(
+            title: title,
+            createChangedDocument: ct => FixCollectionAssertAsync(context.Document, invocationExpr, properAssertMethodName, fixKind, ct),
+            equivalenceKey: title);
+
+        context.RegisterCodeFix(action, diagnostic);
+    }
+
+    private static async Task<Document> FixCollectionAssertAsync(
+        Document document,
+        InvocationExpressionSyntax invocationExpr,
+        string properAssertMethodName,
+        string fixKind,
+        CancellationToken cancellationToken)
+    {
+        if (invocationExpr.Expression is not MemberAccessExpressionSyntax memberAccessExpr)
+        {
+            return document;
+        }
+
+        SemanticModel semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel.GetOperation(invocationExpr, cancellationToken) is not IInvocationOperation invocationOperation)
+        {
+            return document;
+        }
+
+        // Re-order the original arguments according to the source signature's parameter ordinals
+        // (handles named arguments) and strip the name colons because the target Assert method's
+        // parameter names may differ from CollectionAssert's.
+        if (!TryGetArgumentsByOrdinal(invocationOperation, out ArgumentSyntax[]? orderedArguments))
+        {
+            return document;
+        }
+
+        SyntaxNode root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        List<ArgumentSyntax> newArguments = BuildNewArguments(orderedArguments!, fixKind);
+
+        ArgumentListSyntax newArgumentList = invocationExpr.ArgumentList.WithArguments(SyntaxFactory.SeparatedList(newArguments));
+
+        // Replace `<anything>.CollectionAssert.<Method>` with `Assert.<ProperMethod>`.
+        MemberAccessExpressionSyntax newMemberAccess = memberAccessExpr
+            .WithExpression(SyntaxFactory.IdentifierName("Assert"))
+            .WithName(SyntaxFactory.IdentifierName(properAssertMethodName));
+
+        InvocationExpressionSyntax newInvocationExpr = invocationExpr
+            .WithExpression(newMemberAccess)
+            .WithArgumentList(newArgumentList)
+            .WithLeadingTrivia(invocationExpr.GetLeadingTrivia())
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(invocationExpr, newInvocationExpr));
+    }
+
+    private static bool TryGetArgumentsByOrdinal(IInvocationOperation invocationOperation, out ArgumentSyntax[]? orderedArguments)
+    {
+        int parameterCount = invocationOperation.TargetMethod.Parameters.Length;
+        var ordered = new ArgumentSyntax[parameterCount];
+        int filled = 0;
+        foreach (IArgumentOperation argument in invocationOperation.Arguments)
+        {
+            if (argument.Parameter is null
+                || argument.Parameter.Ordinal < 0
+                || argument.Parameter.Ordinal >= parameterCount
+                || argument.Syntax is not ArgumentSyntax argumentSyntax)
+            {
+                orderedArguments = null;
+                return false;
+            }
+
+            // Strip the name colon because the target Assert overload may have differently-named parameters.
+            ordered[argument.Parameter.Ordinal] = argumentSyntax.WithNameColon(null);
+            filled++;
+        }
+
+        if (filled != parameterCount)
+        {
+            orderedArguments = null;
+            return false;
+        }
+
+        orderedArguments = ordered;
+        return true;
+    }
+
+    private static List<ArgumentSyntax> BuildNewArguments(ArgumentSyntax[] orderedArguments, string fixKind)
+    {
+        var newArguments = new List<ArgumentSyntax>(orderedArguments.Length + 1);
+        switch (fixKind)
+        {
+            case CollectionAssertToAssertAnalyzer.FixKindSwapTwoArgs:
+                newArguments.Add(orderedArguments[1]);
+                newArguments.Add(orderedArguments[0]);
+                for (int i = 2; i < orderedArguments.Length; i++)
+                {
+                    newArguments.Add(orderedArguments[i]);
+                }
+
+                break;
+
+            case CollectionAssertToAssertAnalyzer.FixKindAddInAnyOrder:
+                newArguments.Add(orderedArguments[0]);
+                newArguments.Add(orderedArguments[1]);
+                newArguments.Add(SyntaxFactory.Argument(CreateInAnyOrderExpression()));
+                for (int i = 2; i < orderedArguments.Length; i++)
+                {
+                    newArguments.Add(orderedArguments[i]);
+                }
+
+                break;
+
+            default:
+                // FixKindSimple: keep the arguments in their original positional order.
+                newArguments.AddRange(orderedArguments);
+                break;
+        }
+
+        return newArguments;
+    }
+
+    // Emit a fully-qualified reference to avoid breaking when the file lacks a using directive
+    // for `Microsoft.VisualStudio.TestTools.UnitTesting` (e.g. fully-qualified CollectionAssert calls).
+    private static ExpressionSyntax CreateInAnyOrderExpression()
+        => SyntaxFactory.ParseExpression("Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder");
+}

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Změňte na class a přidejte [TestClass]</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Opravit pořadí skutečných/očekávaných argumentů</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Wechseln Sie zu „Klasse“, und fügen Sie „[Testklasse]“ hinzu</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Reihenfolge der tatsächlichen/erwarteten Argumente korrigieren</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Cambiar a "class" y agregar "[TestClass]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Corregir el orden de los argumentos reales o esperados</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Remplacez par « classe » et ajoutez « [TestClass] »</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Corriger l’ordre des arguments réels/attendus</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Cambia in 'class' e aggiungi '[TestClass]'</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Correggi l'ordine degli argomenti effettivi/previsti</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">'class' に変更し、'[TestClass]' を追加します</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">実際の引数と予想される引数の順序を修正する</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">'class'로 변경하고 '[TestClass]'를 추가합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">실제/예상 인수 순서 수정</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Zmień na wartość „class” i dodaj element „[TestClass]”</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Napraw rzeczywistą/oczekiwaną kolejność argumentów</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Alterar para 'classe' e adicionar '[TestClass]'</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Corrigir ordem de argumentos real/esperada</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Изменить на "class" и добавить "[TestClass]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Исправить порядок фактических и ожидаемых аргументов</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">‘class’ olarak değiştirin ve ‘[TestClass]’ ekleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">Fiili/beklenen bağımsız değişken sırasını düzelt</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">更改为 "class" 并添加 "[TestClass]"</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">修复实际/预期参数顺序</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">變更為 'class'，並新增 '[TestClass]'</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FixAssertionArgsOrder">
         <source>Fix actual/expected arguments order</source>
         <target state="translated">修正實際/預期的引數順序</target>

--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ MSTEST0064 | Usage | Info | PreferAsyncAssertionAnalyzer, [Documentation](https:
 MSTEST0065 | Usage | Warning | AvoidAssertAreEqualOnCollectionsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0065)
 MSTEST0066 | Design | Info | IgnoreShouldHaveJustificationAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0066)
 MSTEST0067 | Usage | Disabled | AvoidThreadSleepAndTaskWaitInTestsAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0067)
+MSTEST0068 | Usage | Info | CollectionAssertToAssertAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0068)

--- a/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// MSTEST0068: Use 'Assert' instead of 'CollectionAssert'.
+/// </summary>
+/// <remarks>
+/// The analyzer captures <c>CollectionAssert</c> method calls and suggests using equivalent
+/// <c>Assert</c> methods. The mapping is:
+/// <list type="bullet">
+/// <item><description><c>CollectionAssert.AreEqual(a, b)</c> → <c>Assert.AreSequenceEqual(a, b)</c></description></item>
+/// <item><description><c>CollectionAssert.AreNotEqual(a, b)</c> → <c>Assert.AreNotSequenceEqual(a, b)</c></description></item>
+/// <item><description><c>CollectionAssert.AreEquivalent(a, b)</c> → <c>Assert.AreSequenceEqual(a, b, SequenceOrder.InAnyOrder)</c></description></item>
+/// <item><description><c>CollectionAssert.AreNotEquivalent(a, b)</c> → <c>Assert.AreNotSequenceEqual(a, b, SequenceOrder.InAnyOrder)</c></description></item>
+/// <item><description><c>CollectionAssert.AllItemsAreNotNull(a)</c> → <c>Assert.AreAllNotNull(a)</c></description></item>
+/// <item><description><c>CollectionAssert.AllItemsAreUnique(a)</c> → <c>Assert.AreAllDistinct(a)</c></description></item>
+/// <item><description><c>CollectionAssert.AllItemsAreInstancesOfType(coll, t)</c> → <c>Assert.AreAllOfType(t, coll)</c> (argument order swap)</description></item>
+/// <item><description><c>CollectionAssert.Contains(coll, x)</c> → <c>Assert.Contains(x, coll)</c> (argument order swap)</description></item>
+/// <item><description><c>CollectionAssert.DoesNotContain(coll, x)</c> → <c>Assert.DoesNotContain(x, coll)</c> (argument order swap)</description></item>
+/// </list>
+/// Overloads of <c>AreEqual</c>/<c>AreNotEqual</c> that take an <c>IComparer</c> are skipped because
+/// <c>Assert.AreSequenceEqual</c> expects an <c>IEqualityComparer&lt;T&gt;</c> (different semantics).
+/// Overloads of <c>AreEquivalent</c>/<c>AreNotEquivalent</c> that take an <c>IEqualityComparer&lt;T&gt;</c>
+/// are also skipped (out of scope for this analyzer). <c>IsSubsetOf</c>/<c>IsNotSubsetOf</c> have no
+/// direct <c>Assert</c> equivalent today and are not handled.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class CollectionAssertToAssertAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// Key used by the code-fix to recover the target <c>Assert</c> method name from the diagnostic properties.
+    /// </summary>
+    internal const string ProperAssertMethodNameKey = nameof(ProperAssertMethodNameKey);
+
+    /// <summary>
+    /// Key used by the code-fix to recover the rewrite strategy from the diagnostic properties.
+    /// Values are <see cref="FixKindSimple"/>, <see cref="FixKindSwapTwoArgs"/>, or <see cref="FixKindAddInAnyOrder"/>.
+    /// </summary>
+    internal const string FixKindKey = nameof(FixKindKey);
+
+    internal const string FixKindSimple = "Simple";
+    internal const string FixKindSwapTwoArgs = "SwapTwoArgs";
+    internal const string FixKindAddInAnyOrder = "AddInAnyOrder";
+
+    private static readonly LocalizableResourceString Title = new(nameof(Resources.CollectionAssertToAssertTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.CollectionAssertToAssertMessageFormat), Resources.ResourceManager, typeof(Resources));
+
+    internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        DiagnosticIds.CollectionAssertToAssertRuleId,
+        Title,
+        MessageFormat,
+        null,
+        Category.Usage,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+        = ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingCollectionAssert, out INamedTypeSymbol? collectionAssertTypeSymbol))
+            {
+                return;
+            }
+
+            context.RegisterOperationAction(context => AnalyzeInvocationOperation(context, collectionAssertTypeSymbol), OperationKind.Invocation);
+        });
+    }
+
+    private static void AnalyzeInvocationOperation(OperationAnalysisContext context, INamedTypeSymbol collectionAssertTypeSymbol)
+    {
+        var operation = (IInvocationOperation)context.Operation;
+        IMethodSymbol targetMethod = operation.TargetMethod;
+
+        if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, collectionAssertTypeSymbol))
+        {
+            return;
+        }
+
+        (string AssertMethodName, string FixKind)? mapping = targetMethod.Name switch
+        {
+            "AreEqual" when !HasIComparerParameter(targetMethod) => ("AreSequenceEqual", FixKindSimple),
+            "AreNotEqual" when !HasIComparerParameter(targetMethod) => ("AreNotSequenceEqual", FixKindSimple),
+            "AreEquivalent" when !targetMethod.IsGenericMethod && !HasIComparerParameter(targetMethod) => ("AreSequenceEqual", FixKindAddInAnyOrder),
+            "AreNotEquivalent" when !targetMethod.IsGenericMethod && !HasIComparerParameter(targetMethod) => ("AreNotSequenceEqual", FixKindAddInAnyOrder),
+            "AllItemsAreNotNull" => ("AreAllNotNull", FixKindSimple),
+            "AllItemsAreUnique" => ("AreAllDistinct", FixKindSimple),
+            "AllItemsAreInstancesOfType" => ("AreAllOfType", FixKindSwapTwoArgs),
+            "Contains" => ("Contains", FixKindSwapTwoArgs),
+            "DoesNotContain" => ("DoesNotContain", FixKindSwapTwoArgs),
+            _ => null,
+        };
+
+        if (mapping is not { } map)
+        {
+            return;
+        }
+
+        // Sanity-check the operand count for the rewrite strategies that require it.
+        if ((map.FixKind == FixKindSwapTwoArgs || map.FixKind == FixKindAddInAnyOrder)
+            && operation.Arguments.Length < 2)
+        {
+            return;
+        }
+
+        ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+            .Add(ProperAssertMethodNameKey, map.AssertMethodName)
+            .Add(FixKindKey, map.FixKind);
+
+        context.ReportDiagnostic(context.Operation.CreateDiagnostic(
+            Rule,
+            properties: properties,
+            map.AssertMethodName,
+            targetMethod.Name));
+    }
+
+    private static bool HasIComparerParameter(IMethodSymbol method)
+    {
+        foreach (IParameterSymbol parameter in method.Parameters)
+        {
+            ITypeSymbol type = parameter.Type;
+            if (type is INamedTypeSymbol named
+                && (named.Name == "IComparer" || named.Name == "IEqualityComparer")
+                && named.ContainingNamespace?.ToDisplayString() is "System.Collections" or "System.Collections.Generic")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
@@ -26,7 +26,7 @@ namespace MSTest.Analyzers;
 /// <item><description><c>CollectionAssert.AreNotEquivalent(a, b)</c> → <c>Assert.AreNotSequenceEqual(a, b, SequenceOrder.InAnyOrder)</c></description></item>
 /// <item><description><c>CollectionAssert.AllItemsAreNotNull(a)</c> → <c>Assert.AreAllNotNull(a)</c></description></item>
 /// <item><description><c>CollectionAssert.AllItemsAreUnique(a)</c> → <c>Assert.AreAllDistinct(a)</c></description></item>
-/// <item><description><c>CollectionAssert.AllItemsAreInstancesOfType(coll, t)</c> → <c>Assert.AreAllOfType(t, coll)</c> (argument order swap)</description></item>
+/// <item><description><c>CollectionAssert.AllItemsAreInstancesOfType(coll, typeof(T))</c> → <c>Assert.AreAllOfType&lt;T&gt;(coll)</c> (uses the generic <c>Assert</c> overload when the type expression is a <c>typeof</c>; otherwise falls back to <c>Assert.AreAllOfType(t, coll)</c> with an argument-order swap)</description></item>
 /// <item><description><c>CollectionAssert.Contains(coll, x)</c> → <c>Assert.Contains(x, coll)</c> (argument order swap)</description></item>
 /// <item><description><c>CollectionAssert.DoesNotContain(coll, x)</c> → <c>Assert.DoesNotContain(x, coll)</c> (argument order swap)</description></item>
 /// </list>
@@ -53,6 +53,7 @@ public sealed class CollectionAssertToAssertAnalyzer : DiagnosticAnalyzer
     internal const string FixKindSimple = "Simple";
     internal const string FixKindSwapTwoArgs = "SwapTwoArgs";
     internal const string FixKindAddInAnyOrder = "AddInAnyOrder";
+    internal const string FixKindInstanceOfType = "InstanceOfType";
 
     private static readonly LocalizableResourceString Title = new(nameof(Resources.CollectionAssertToAssertTitle), Resources.ResourceManager, typeof(Resources));
     private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.CollectionAssertToAssertMessageFormat), Resources.ResourceManager, typeof(Resources));
@@ -105,7 +106,7 @@ public sealed class CollectionAssertToAssertAnalyzer : DiagnosticAnalyzer
             "AreNotEquivalent" when !targetMethod.IsGenericMethod && !HasIComparerParameter(targetMethod) => ("AreNotSequenceEqual", FixKindAddInAnyOrder),
             "AllItemsAreNotNull" => ("AreAllNotNull", FixKindSimple),
             "AllItemsAreUnique" => ("AreAllDistinct", FixKindSimple),
-            "AllItemsAreInstancesOfType" => ("AreAllOfType", FixKindSwapTwoArgs),
+            "AllItemsAreInstancesOfType" => ("AreAllOfType", FixKindInstanceOfType),
             "Contains" => ("Contains", FixKindSwapTwoArgs),
             "DoesNotContain" => ("DoesNotContain", FixKindSwapTwoArgs),
             _ => null,
@@ -117,7 +118,7 @@ public sealed class CollectionAssertToAssertAnalyzer : DiagnosticAnalyzer
         }
 
         // Sanity-check the operand count for the rewrite strategies that require it.
-        if ((map.FixKind == FixKindSwapTwoArgs || map.FixKind == FixKindAddInAnyOrder)
+        if ((map.FixKind is FixKindSwapTwoArgs or FixKindAddInAnyOrder or FixKindInstanceOfType)
             && operation.Arguments.Length < 2)
         {
             return;

--- a/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
@@ -46,7 +46,7 @@ public sealed class CollectionAssertToAssertAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// Key used by the code-fix to recover the rewrite strategy from the diagnostic properties.
-    /// Values are <see cref="FixKindSimple"/>, <see cref="FixKindSwapTwoArgs"/>, or <see cref="FixKindAddInAnyOrder"/>.
+    /// Values are <see cref="FixKindSimple"/>, <see cref="FixKindSwapTwoArgs"/>, <see cref="FixKindAddInAnyOrder"/>, or <see cref="FixKindInstanceOfType"/>.
     /// </summary>
     internal const string FixKindKey = nameof(FixKindKey);
 

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -72,4 +72,5 @@ internal static class DiagnosticIds
     public const string AvoidAssertAreEqualOnCollectionsRuleId = "MSTEST0065";
     public const string IgnoreShouldHaveJustificationRuleId = "MSTEST0066";
     public const string AvoidThreadSleepAndTaskWaitInTestsRuleId = "MSTEST0067";
+    public const string CollectionAssertToAssertRuleId = "MSTEST0068";
 }

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -531,6 +531,12 @@ The type declaring these methods should also respect the following rules:
   <data name="StringAssertToAssertMessageFormat" xml:space="preserve">
     <value>Use 'Assert.{0}' instead of 'StringAssert.{1}'</value>
   </data>
+  <data name="CollectionAssertToAssertTitle" xml:space="preserve">
+    <value>Use 'Assert' instead of 'CollectionAssert'</value>
+  </data>
+  <data name="CollectionAssertToAssertMessageFormat" xml:space="preserve">
+    <value>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</value>
+  </data>
   <data name="DataRowShouldBeValidMessageFormat_GenericTypeArgumentNotResolved" xml:space="preserve">
     <value>The type of the generic parameter '{0}' could not be inferred.</value>
   </data>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -285,6 +285,16 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="translated">Metody ClassInitialize musí mít platné rozložení</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -286,6 +286,16 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="translated">ClassInitialize-Methoden müssen über ein gültiges Layout verfügen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -285,6 +285,16 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="translated">Los métodos ClassInitialize deben tener un diseño válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -285,6 +285,16 @@ Le type doit être une classe
         <target state="translated">La méthode ClassInitialize doit avoir une disposition valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -285,6 +285,16 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="translated">Il metodo ClassInitialize deve avere un layout valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -285,6 +285,16 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">ClassInitialize メソッドには有効なレイアウトが必要です</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -285,6 +285,16 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">ClassInitialize 메서드에는 유효한 레이아웃이 있어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -285,6 +285,16 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="translated">Metody ClassInitialize powinny mieć prawidłowy układ</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -285,6 +285,16 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <target state="translated">Os métodos ClassInitialize devem ter um layout válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -291,6 +291,16 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">Методы ClassInitialize должны использовать допустимый макет</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -285,6 +285,16 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="translated">ClassInitialize yöntemleri geçerli bir düzene sahip olmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -285,6 +285,16 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">ClassInitialize 方法应具有有效的布局</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -285,6 +285,16 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">ClassInitialize 方法應該具有有效的配置</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollectionAssertToAssertMessageFormat">
+        <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
+        <target state="new">Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CollectionAssertToAssertTitle">
+        <source>Use 'Assert' instead of 'CollectionAssert'</source>
+        <target state="new">Use 'Assert' instead of 'CollectionAssert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataRowShouldBeValidDescription">
         <source>DataRow entry should have the following layout to be valid:
 - should only be set on a test method;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/CollectionAssertToAssertAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/CollectionAssertToAssertAnalyzerTests.cs
@@ -350,7 +350,7 @@ public sealed class CollectionAssertToAssertAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenCollectionAssertAllItemsAreInstancesOfType_FixesToAreAllOfTypeWithSwappedArgs()
+    public async Task WhenCollectionAssertAllItemsAreInstancesOfType_WithTypeof_FixesToGenericAreAllOfType()
     {
         string code = """
             using System;
@@ -382,8 +382,58 @@ public sealed class CollectionAssertToAssertAnalyzerTests
                 public void MyTestMethod()
                 {
                     var a = new List<object> { 1, 2, 3 };
-                    Assert.AreAllOfType(typeof(int), a);
-                    Assert.AreAllOfType(typeof(int), a, "message");
+                    Assert.AreAllOfType<int>(a);
+                    Assert.AreAllOfType<int>(a, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreAllOfType", "AllItemsAreInstancesOfType"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreAllOfType", "AllItemsAreInstancesOfType"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAllItemsAreInstancesOfType_WithRuntimeType_FixesToNonGenericAreAllOfTypeWithSwappedArgs()
+    {
+        string code = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<object> { 1, 2, 3 };
+                    Type t = typeof(int);
+                    {|#0:CollectionAssert.AllItemsAreInstancesOfType(a, t)|};
+                    {|#1:CollectionAssert.AllItemsAreInstancesOfType(a, t, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<object> { 1, 2, 3 };
+                    Type t = typeof(int);
+                    Assert.AreAllOfType(t, a);
+                    Assert.AreAllOfType(t, a, "message");
                 }
             }
             """;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/CollectionAssertToAssertAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/CollectionAssertToAssertAnalyzerTests.cs
@@ -1,0 +1,629 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
+    MSTest.Analyzers.CollectionAssertToAssertAnalyzer,
+    MSTest.Analyzers.CodeFixes.CollectionAssertToAssertFixer>;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public sealed class CollectionAssertToAssertAnalyzerTests
+{
+    [TestMethod]
+    public async Task WhenCollectionAssertAreEqual_FixesToAreSequenceEqual()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 1, 2, 3 };
+                    {|#0:CollectionAssert.AreEqual(a, b)|};
+                    {|#1:CollectionAssert.AreEqual(a, b, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 1, 2, 3 };
+                    Assert.AreSequenceEqual(a, b);
+                    Assert.AreSequenceEqual(a, b, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreSequenceEqual", "AreEqual"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreSequenceEqual", "AreEqual"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAreNotEqual_FixesToAreNotSequenceEqual()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 3, 2, 1 };
+                    {|#0:CollectionAssert.AreNotEqual(a, b)|};
+                    {|#1:CollectionAssert.AreNotEqual(a, b, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 3, 2, 1 };
+                    Assert.AreNotSequenceEqual(a, b);
+                    Assert.AreNotSequenceEqual(a, b, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreNotSequenceEqual", "AreNotEqual"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreNotSequenceEqual", "AreNotEqual"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAreEqualWithIComparer_NoDiagnostic()
+    {
+        string code = """
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 1, 2, 3 };
+                    IComparer comparer = Comparer<int>.Default;
+                    CollectionAssert.AreEqual(a, b, comparer);
+                    CollectionAssert.AreEqual(a, b, comparer, "message");
+                    CollectionAssert.AreNotEqual(a, b, comparer);
+                    CollectionAssert.AreNotEqual(a, b, comparer, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAreEquivalent_FixesToAreSequenceEqualWithInAnyOrder()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 3, 2, 1 };
+                    {|#0:CollectionAssert.AreEquivalent(a, b)|};
+                    {|#1:CollectionAssert.AreEquivalent(a, b, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 3, 2, 1 };
+                    Assert.AreSequenceEqual(a, b, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+                    Assert.AreSequenceEqual(a, b, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreSequenceEqual", "AreEquivalent"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreSequenceEqual", "AreEquivalent"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAreNotEquivalent_FixesToAreNotSequenceEqualWithInAnyOrder()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 4, 5, 6 };
+                    {|#0:CollectionAssert.AreNotEquivalent(a, b)|};
+                    {|#1:CollectionAssert.AreNotEquivalent(a, b, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 4, 5, 6 };
+                    Assert.AreNotSequenceEqual(a, b, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
+                    Assert.AreNotSequenceEqual(a, b, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreNotSequenceEqual", "AreNotEquivalent"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreNotSequenceEqual", "AreNotEquivalent"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAreEquivalentWithIEqualityComparer_NoDiagnostic()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    IEnumerable<int> a = new List<int> { 1, 2, 3 };
+                    IEnumerable<int> b = new List<int> { 3, 2, 1 };
+                    var comparer = EqualityComparer<int>.Default;
+                    CollectionAssert.AreEquivalent(a, b, comparer);
+                    CollectionAssert.AreEquivalent(a, b, comparer, "message");
+                    CollectionAssert.AreNotEquivalent(a, b, comparer);
+                    CollectionAssert.AreNotEquivalent(a, b, comparer, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAllItemsAreNotNull_FixesToAreAllNotNull()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<object> { new(), new() };
+                    {|#0:CollectionAssert.AllItemsAreNotNull(a)|};
+                    {|#1:CollectionAssert.AllItemsAreNotNull(a, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<object> { new(), new() };
+                    Assert.AreAllNotNull(a);
+                    Assert.AreAllNotNull(a, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreAllNotNull", "AllItemsAreNotNull"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreAllNotNull", "AllItemsAreNotNull"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAllItemsAreUnique_FixesToAreAllDistinct()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    {|#0:CollectionAssert.AllItemsAreUnique(a)|};
+                    {|#1:CollectionAssert.AllItemsAreUnique(a, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    Assert.AreAllDistinct(a);
+                    Assert.AreAllDistinct(a, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreAllDistinct", "AllItemsAreUnique"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreAllDistinct", "AllItemsAreUnique"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertAllItemsAreInstancesOfType_FixesToAreAllOfTypeWithSwappedArgs()
+    {
+        string code = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<object> { 1, 2, 3 };
+                    {|#0:CollectionAssert.AllItemsAreInstancesOfType(a, typeof(int))|};
+                    {|#1:CollectionAssert.AllItemsAreInstancesOfType(a, typeof(int), "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<object> { 1, 2, 3 };
+                    Assert.AreAllOfType(typeof(int), a);
+                    Assert.AreAllOfType(typeof(int), a, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("AreAllOfType", "AllItemsAreInstancesOfType"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("AreAllOfType", "AllItemsAreInstancesOfType"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertContains_FixesToContainsWithSwappedArgs()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    {|#0:CollectionAssert.Contains(a, 2)|};
+                    {|#1:CollectionAssert.Contains(a, 2, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    Assert.Contains(2, a);
+                    Assert.Contains(2, a, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("Contains", "Contains"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("Contains", "Contains"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertDoesNotContain_FixesToDoesNotContainWithSwappedArgs()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    {|#0:CollectionAssert.DoesNotContain(a, 4)|};
+                    {|#1:CollectionAssert.DoesNotContain(a, 4, "message")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    Assert.DoesNotContain(4, a);
+                    Assert.DoesNotContain(4, a, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("DoesNotContain", "DoesNotContain"),
+                VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(1).WithArguments("DoesNotContain", "DoesNotContain"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertIsSubsetOf_NoDiagnostic()
+    {
+        // IsSubsetOf / IsNotSubsetOf have no direct Assert equivalent today; they are out of scope.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2 };
+                    var b = new List<int> { 1, 2, 3 };
+                    CollectionAssert.IsSubsetOf(a, b);
+                    CollectionAssert.IsNotSubsetOf(b, a);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenNotCollectionAssertMethod_NoDiagnostic()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    Assert.AreSequenceEqual(a, a);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertContains_PreservesEmptyLines()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void ShouldNotRemoveEmptyLine()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+
+                    {|#0:CollectionAssert.Contains(a, 1)|};
+
+                    {|#1:CollectionAssert.Contains(a, 2)|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void ShouldNotRemoveEmptyLine()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+
+                    Assert.Contains(1, a);
+
+                    Assert.Contains(2, a);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            [
+                VerifyCS.Diagnostic().WithLocation(0).WithArguments("Contains", "Contains"),
+                VerifyCS.Diagnostic().WithLocation(1).WithArguments("Contains", "Contains"),
+            ],
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertContains_HandlesNamedAndOutOfOrderArguments()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    {|#0:CollectionAssert.Contains(element: 2, collection: a)|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    Assert.Contains(2, a);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("Contains", "Contains"),
+            fixedCode);
+    }
+}

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/CollectionAssertToAssertAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/CollectionAssertToAssertAnalyzerTests.cs
@@ -626,4 +626,88 @@ public sealed class CollectionAssertToAssertAnalyzerTests
             VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("Contains", "Contains"),
             fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertIsFullyQualified_FixPreservesQualifier()
+    {
+        // Regression: the fixer must preserve a fully-qualified CollectionAssert qualifier so the
+        // rewritten call binds to MSTest's Assert even when the file has no
+        // `using Microsoft.VisualStudio.TestTools.UnitTesting;` directive.
+        string code = """
+            using System.Collections.Generic;
+
+            [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
+            public class MyTestClass
+            {
+                [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    {|#0:Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.Contains(a, 1)|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+
+            [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
+            public class MyTestClass
+            {
+                [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    Microsoft.VisualStudio.TestTools.UnitTesting.Assert.Contains(1, a);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("Contains", "Contains"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCollectionAssertIsGlobalQualified_FixPreservesGlobalQualifier()
+    {
+        // Regression: `global::` qualifier must be preserved so the rewrite continues to bind unambiguously.
+        string code = """
+            using System.Collections.Generic;
+
+            [global::Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
+            public class MyTestClass
+            {
+                [global::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 1, 2, 3 };
+                    {|#0:global::Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert.AreEqual(a, b)|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+
+            [global::Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
+            public class MyTestClass
+            {
+                [global::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
+                public void MyTestMethod()
+                {
+                    var a = new List<int> { 1, 2, 3 };
+                    var b = new List<int> { 1, 2, 3 };
+                    global::Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreSequenceEqual(a, b);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("AreSequenceEqual", "AreEqual"),
+            fixedCode);
+    }
 }


### PR DESCRIPTION
Fixes #8764.

Adds the **MSTEST0068** analyzer + code fix to migrate legacy `CollectionAssert.*` calls to their modern `Assert.*` equivalents.

## Mappings

| `CollectionAssert` | `Assert` |
| --- | --- |
| `AreEqual` / `AreNotEqual` | `AreSequenceEqual` / `AreNotSequenceEqual` |
| `AreEquivalent` / `AreNotEquivalent` | `AreSequenceEqual` / `AreNotSequenceEqual` with `SequenceOrder.InAnyOrder` |
| `AllItemsAreNotNull` | `AreAllNotNull` |
| `AllItemsAreUnique` | `AreAllDistinct` |
| `AllItemsAreInstancesOfType(coll, type)` | `AreAllOfType(type, coll)` |
| `Contains(coll, x)` | `Contains(x, coll)` |
| `DoesNotContain(coll, x)` | `DoesNotContain(x, coll)` |

## Skipped overloads

- `AreEqual` / `AreNotEqual` overloads taking an `IComparer` are not migrated (no equivalent on `Assert`).
- `AreEquivalent` / `AreNotEquivalent` overloads taking an `IEqualityComparer<T>` are not migrated.
- `IsSubsetOf` / `IsNotSubsetOf` have no `Assert` equivalent and are not migrated.

## Notes

- Diagnostic `MSTEST0068`, category `Usage`, severity `Info`.
- Argument-swap and `SequenceOrder` insertion are operation-based, so named/out-of-order arguments are normalized correctly.
- `SequenceOrder.InAnyOrder` is emitted fully-qualified to avoid breaking files that lack the `Microsoft.VisualStudio.TestTools.UnitTesting` using directive.
- `AllItemsAreInstancesOfType` -> `AreAllOfType` changes null-element semantics: `CollectionAssert.AllItemsAreInstancesOfType` allowed nulls, while `Assert.AreAllOfType` treats them as failures. The new behavior is arguably more correct and matches the issue mandate.