### PR TITLE
[perf-improver] perf: eliminate string allocations in ANSI render hot path

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiCodes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiCodes.cs
@@ -90,12 +90,24 @@ internal static class AnsiCodes
     public const string EraseInDisplay = "J";
 
     /// <summary>
+    /// Shortcut for <see cref="CSI"/> + <see cref="EraseInDisplay"/> — clears from cursor to end of screen.
+    /// Prefer this constant over inline string interpolation to avoid per-call heap allocation.
+    /// </summary>
+    public const string CsiEraseInDisplay = CSI + EraseInDisplay;
+
+    /// <summary>
     /// Clears everything from cursor to the end of the current line.
     /// </summary>
     /// <remarks>
     /// Print <see cref="CSI"/><see cref="EraseInLine"/> to clear.
     /// </remarks>
     public const string EraseInLine = "K";
+
+    /// <summary>
+    /// Shortcut for <see cref="CSI"/> + <see cref="EraseInLine"/> — clears from cursor to end of current line.
+    /// Prefer this constant over inline string interpolation to avoid per-call heap allocation.
+    /// </summary>
+    public const string CsiEraseInLine = CSI + EraseInLine;
 
     /// <summary>
     /// Hides the cursor.

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -229,14 +229,13 @@ internal sealed class AnsiTerminal : ITerminal
 
     public void MoveCursorUp(int lineCount)
     {
-        string moveCursor = $"{AnsiCodes.CSI}{lineCount}{AnsiCodes.MoveUpToLineStart}";
         if (_isBatching)
         {
-            _stringBuilder.AppendLine(moveCursor);
+            _stringBuilder.Append(AnsiCodes.CSI).Append(lineCount).Append(AnsiCodes.MoveUpToLineStart).AppendLine();
         }
         else
         {
-            _console.WriteLine(moveCursor);
+            _console.WriteLine($"{AnsiCodes.CSI}{lineCount}{AnsiCodes.MoveUpToLineStart}");
         }
     }
 
@@ -264,7 +263,7 @@ internal sealed class AnsiTerminal : ITerminal
         }
 
         AppendLine($"{AnsiCodes.CSI}{_currentFrame.RenderedLines.Count + 2}{AnsiCodes.MoveUpToLineStart}");
-        Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInDisplay}");
+        Append(AnsiCodes.CsiEraseInDisplay);
         _currentFrame.Clear();
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -243,14 +243,14 @@ internal sealed class AnsiTerminalTestProgressFrame
                         {
                             // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
                             // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
-                            terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                            terminal.Append(AnsiCodes.CsiEraseInLine);
                             AppendTestWorkerProgress(progressItem, currentLine, terminal);
                         }
                     }
                     else
                     {
                         // These lines are different or the line was updated. Render the whole line.
-                        terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                        terminal.Append(AnsiCodes.CsiEraseInLine);
                         AppendTestWorkerProgress(progressItem, currentLine, terminal);
                     }
                 }
@@ -278,14 +278,14 @@ internal sealed class AnsiTerminalTestProgressFrame
                         {
                             // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
                             // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
-                            terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                            terminal.Append(AnsiCodes.CsiEraseInLine);
                             AppendTestWorkerDetail(detailItem, currentLine, terminal);
                         }
                     }
                     else
                     {
                         // These lines are different or the line was updated. Render the whole line.
-                        terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}");
+                        terminal.Append(AnsiCodes.CsiEraseInLine);
                         AppendTestWorkerDetail(detailItem, currentLine, terminal);
                     }
                 }
@@ -317,7 +317,7 @@ internal sealed class AnsiTerminalTestProgressFrame
         // We rendered more lines in previous frame. Clear them.
         if (previousFrame.RenderedLines != null && i < previousFrame.RenderedLines.Count)
         {
-            terminal.Append($"{AnsiCodes.CSI}{AnsiCodes.EraseInDisplay}");
+            terminal.Append(AnsiCodes.CsiEraseInDisplay);
         }
     }
 


### PR DESCRIPTION
🤖 *This is an automated contribution from [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26827520829).*

## Goal and Rationale

The live-progress render loop runs every 500 ms while tests are executing. Three allocation sites in this path were building temporary strings from compile-time-known constants:

1. **`$"{AnsiCodes.CSI}{AnsiCodes.EraseInLine}"`** — used 4× in `AnsiTerminalTestProgressFrame.Render` (once per changed progress or detail line). The result is always the literal `"\x1b[K"`.
2. **`$"{AnsiCodes.CSI}{AnsiCodes.EraseInDisplay}"`** — used in `AnsiTerminalTestProgressFrame.Render` and `AnsiTerminal.EraseProgress`. Always `"\x1b[J"`.
3. **`MoveCursorUp` string allocation** — `AnsiTerminal.MoveCursorUp` built a temporary string even when batching mode was active and the result went straight into a `StringBuilder`.

## Approach

1. Added `AnsiCodes.CsiEraseInLine` (`= CSI + EraseInLine`) and `AnsiCodes.CsiEraseInDisplay` (`= CSI + EraseInDisplay`) as `const string` fields. The C# compiler evaluates these at compile time; no runtime allocation.
2. Replaced all five `$"{AnsiCodes.CSI}{AnsiCodes.EraseIn*}"` interpolations with the new constants.
3. In `AnsiTerminal.MoveCursorUp`, for the hot batching path, replaced string interpolation with direct `StringBuilder.Append` chaining (`Append(CSI).Append(lineCount).Append(MoveUpToLineStart).AppendLine()`). The non-batching path retains the interpolation since it only runs on the very first call after progress is erased.

## Performance Evidence

| Site | Before | After |
|------|--------|-------|
| `CsiEraseInLine` (per changed line) | 1× `string` allocation ~5 bytes | 0 — compile-time constant |
| `CsiEraseInDisplay` (erase / render) | 1× `string` allocation ~4 bytes | 0 — compile-time constant |
| `MoveCursorUp` in batching path | 1× `string` allocation ~8 bytes | 0 — direct `StringBuilder` append |
| Total per 500 ms frame (worst case: all lines changed + erase) | ≥6 short-lived string allocations | 0 for these sites |

**Methodology**: code inspection + diff review. The new constants are `const string` fields initialised from other `const string` fields; the C# compiler folds them at compile time.

## Trade-offs

- `AnsiCodes` gains two constants (+12 lines). Naming follows the existing `SetDefaultColor` pattern (a shortcut that combines prefix + suffix into one constant).
- The non-batching branch of `MoveCursorUp` still builds a string — it's invoked only once per erase cycle (not per frame), so the impact is negligible.

## Test Status

- `Microsoft.Testing.Platform.UnitTests` (net8.0): **1003 passed, 0 failed, 3 skipped** ✅
- Build: **0 warnings, 0 errors** ✅

## Reproducibility

```bash
./build.sh
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
```



> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26827520829)




> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/26827520829) · sonnet46 3.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26827520829, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/26827520829 -->

<!-- gh-aw-workflow-id: perf-improver -->