### PR TITLE
Tighten MSTEST0065 to fire on argument types, not only the generic T (#8766)

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -69,12 +69,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             return;
         }
 
-        ITypeSymbol comparedType = targetMethod.TypeArguments[0];
-        if (!ShouldReport(comparedType, genericEnumerableSymbol))
-        {
-            return;
-        }
-
         // When either argument is the null literal, the user is performing a null check rather than
         // a collection equality check, so suggesting CollectionAssert.AreEqual / Assert.AreSequenceEqual
         // would be misleading.
@@ -89,9 +83,34 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             return;
         }
 
+        // Determine the type to report on. Prefer the generic type argument when it itself is a collection
+        // (the historical behavior, which gives the cleanest diagnostic display). Otherwise, fall back to the
+        // un-converted static type of the `expected`/`actual` arguments at the call site so we still catch
+        // patterns where the caller widened to a non-collection type (e.g. `Assert.AreEqual<object>(arr1, arr2)`
+        // or `Assert.AreEqual((object)arr1, (object)arr2)`) which would otherwise silently use reference equality.
+        ITypeSymbol comparedType = targetMethod.TypeArguments[0];
+        ITypeSymbol? reportedType = ShouldReport(comparedType, genericEnumerableSymbol)
+            ? comparedType
+            : GetCollectionArgumentType(invocation, firstParameterName, genericEnumerableSymbol)
+                ?? GetCollectionArgumentType(invocation, "actual", genericEnumerableSymbol);
+
+        if (reportedType is null)
+        {
+            return;
+        }
+
         string methodName = $"Assert.{targetMethod.Name}";
-        string comparedTypeDisplay = comparedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        string comparedTypeDisplay = reportedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule, methodName, comparedTypeDisplay));
+    }
+
+    private static ITypeSymbol? GetCollectionArgumentType(IInvocationOperation invocation, string parameterName, INamedTypeSymbol genericEnumerableSymbol)
+    {
+        IArgumentOperation? argument = invocation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == parameterName);
+        ITypeSymbol? argumentType = argument?.Value.WalkDownConversion().Type;
+        return argumentType is not null && ShouldReport(argumentType, genericEnumerableSymbol)
+            ? argumentType
+            : null;
     }
 
     private static bool ShouldReport(ITypeSymbol comparedType, INamedTypeSymbol genericEnumerableSymbol)

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -107,7 +107,12 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
     private static ITypeSymbol? GetCollectionArgumentType(IInvocationOperation invocation, string parameterName, INamedTypeSymbol genericEnumerableSymbol)
     {
         IArgumentOperation? argument = invocation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == parameterName);
-        ITypeSymbol? argumentType = argument?.Value.WalkDownConversion().Type;
+
+        // Use WalkDownBuiltInConversion so we only peel off built-in conversions (boxing, reference,
+        // implicit numeric widening, etc.). A user-defined conversion can convert a collection-typed
+        // operand to a non-collection type (or vice versa), so the call-site static type — the result
+        // of the user-defined conversion — is what the user wrote and what we should reason about.
+        ITypeSymbol? argumentType = argument?.Value.WalkDownBuiltInConversion().Type;
         return argumentType is not null && ShouldReport(argumentType, genericEnumerableSymbol)
             ? argumentType
             : null;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -689,6 +689,193 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "T"));
     }
 
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithExplicitObjectGenericArgumentAndArrayArguments_ReportDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    int[] arr1 = [1, 2];
+                    int[] arr2 = [1, 2];
+                    {|#0:Assert.AreEqual<object>(arr1, arr2)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "int[]"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreNotEqualWithExplicitObjectGenericArgumentAndArrayArguments_ReportDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    int[] arr1 = [1, 2];
+                    int[] arr2 = [1, 2];
+                    {|#0:Assert.AreNotEqual<object>(arr1, arr2)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreNotEqual", "int[]"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithObjectCastOnCollections_ReportDiagnostic()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    List<int> expected = [1, 2];
+                    List<int> actual = [1, 2];
+                    {|#0:Assert.AreEqual((object)expected, (object)actual)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "List<int>"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithMixedObjectAndCollectionArguments_ReportDiagnostic()
+    {
+        // When T resolves to `object` because only one argument is widened, we should still flag the call
+        // based on the un-converted static type of the other argument.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    List<int> expected = [1, 2];
+                    object actual = new List<int> { 1, 2 };
+                    {|#0:Assert.AreEqual(expected, actual)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "List<int>"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithExplicitObjectGenericArgumentAndStringArguments_DoNotReportDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    string s1 = "a";
+                    string s2 = "b";
+                    Assert.AreEqual<object>(s1, s2);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithObjectArgumentsAndNoCollectionType_DoNotReportDiagnostic()
+    {
+        // The user explicitly typed both arguments as object with no observable collection type at the call site.
+        // Without dataflow analysis we cannot know whether the runtime value is a collection, so we must not fire.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    object expected = new List<int> { 1, 2 };
+                    object actual = new List<int> { 1, 2 };
+                    Assert.AreEqual(expected, actual);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnRecord_DoNotReportDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyRecord r1 = new(1);
+                    MyRecord r2 = new(1);
+                    Assert.AreEqual(r1, r2);
+                }
+
+                private sealed record MyRecord(int Value);
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithExplicitObjectGenericArgumentAndNullExpected_DoNotReportDiagnostic()
+    {
+        // The null-literal short-circuit must keep working regardless of how T is inferred at the call site.
+        string code = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    int[]? actual = [1, 2];
+                    Assert.AreEqual<object?>(null, actual);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
     private static DiagnosticResult ExpectedDiagnostic(string methodName, string typeName)
         => VerifyCS.Diagnostic().WithLocation(0).WithArguments(methodName, typeName);
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -876,6 +876,36 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualWithUserDefinedConversionFromCollectionToNonCollection_DoNotReportDiagnostic()
+    {
+        // The argument's call-site static type is `Wrapper`, which is not a collection. The fact that
+        // a user-defined conversion exists from `int[]` to `Wrapper` must not cause MSTEST0065 to fire —
+        // the comparison the user actually wrote is on the Wrapper type, not the underlying array.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    int[] arr1 = [1, 2];
+                    int[] arr2 = [1, 2];
+                    Assert.AreEqual<Wrapper>(arr1, arr2);
+                }
+
+                public sealed class Wrapper
+                {
+                    public static implicit operator Wrapper(int[] values) => new();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
     private static DiagnosticResult ExpectedDiagnostic(string methodName, string typeName)
         => VerifyCS.Diagnostic().WithLocation(0).WithArguments(methodName, typeName);
 


### PR DESCRIPTION
Fixes #8766.

## Summary

Tighten MSTEST0065 (AvoidAssertAreEqualOnCollectionsAnalyzer) so it fires based on the *argument / parameter type at the call site*, not only on the generic type argument `T`. The analyzer previously inspected only `targetMethod.TypeArguments[0]` and so silently missed real-world pit-of-failure patterns where the caller forces `T` to a non-collection type.

Now flagged (in addition to today's cases):

`csharp
int[] arr1 = [1, 2];
int[] arr2 = [1, 2];
Assert.AreEqual<object>(arr1, arr2);            // T = object, but arguments are int[]
Assert.AreEqual((object)arr1, (object)arr2);    // explicit object cast
`

The analyzer now walks back through implicit conversions on the `expected`/`notExpected` and `actual` arguments via `IArgumentOperation.Value.WalkDownConversion()` and fires the diagnostic if either argument's un-converted static type implements `IEnumerable<T>` (and is not `string`).

## Behavior preserved

- Null-literal short-circuit on either `expected`/`notExpected` or `actual`.
- `string` exclusion.
- The display type in the diagnostic message is the historical generic `T` when it is itself a collection; otherwise it is the un-converted argument type that triggered the report.
- MSTEST0017 (argument-order analyzer) is untouched.

## What is *not* covered

The acceptance criteria included `object x = ...; Assert.AreEqual(x, y)` where `x` is declared as `object` but assigned a collection. Without dataflow analysis the analyzer cannot see beyond the local's compile-time type `object`, so that case is intentionally not flagged (an explicit negative test documents this). The mixed case `Assert.AreEqual(list, (object)list2)` is flagged because at least one argument has a collection static type at the call site.

## Risk / migration

This is a tightening of a `Warning`-severity analyzer and will produce **new warnings** on existing codebases that hit the newly-covered patterns. That is the desired effect (more pit-of-failure cases caught). Per the issue, this should ship separately from any severity escalation of MSTEST0065.

## Tests

Added 7 new tests covering both positive and negative cases:

- `Assert.AreEqual<object>(arr1, arr2)` — flagged
- `Assert.AreNotEqual<object>(arr1, arr2)` — flagged
- `Assert.AreEqual((object)expected, (object)actual)` — flagged
- `Assert.AreEqual(list, objectThatIsList)` — flagged (one side has collection static type)
- `Assert.AreEqual<object>(s1, s2)` with `string` arguments — not flagged
- `Assert.AreEqual(objectX, objectY)` with both sides declared as `object` — not flagged (documents dataflow limitation)
- `Assert.AreEqual(record1, record2)` for value-equal record — not flagged
- `Assert.AreEqual<object?>(null, actual)` — null-literal short-circuit preserved across the new path

All 31 `AvoidAssertAreEqualOnCollectionsAnalyzerTests` pass, as do the 123 tests across the related `UseProperAssertMethodsAnalyzer` / `AvoidAssertAreSameWithValueTypesAnalyzer` / `CollectionAssertToAssertMigrationAnalyzer` suites.
