### PR TITLE
Suppress banner and default stdout/stderr to `failed` in LLM environments

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
@@ -63,20 +63,14 @@ internal sealed class LLMEnvironmentDetector
     /// </summary>
     /// <param name="environment">The environment abstraction to use for reading environment variables.</param>
     public LLMEnvironmentDetector(IEnvironment environment)
-        => _environment = environment;
+        => _environment = environment ?? throw new ArgumentNullException(nameof(environment));
 
     /// <summary>
     /// Detects if the current environment is hosted by a known LLM/AI agent CLI.
     /// </summary>
     /// <returns><c>true</c> if a known LLM agent environment is detected; otherwise, <c>false</c>.</returns>
     public bool IsLLMEnvironment()
-        => GetLLMEnvironment() is not null;
-
-    private string? GetLLMEnvironment()
-    {
-        string?[] results = DetectionRules.Select(r => r.GetResult(_environment)).Where(r => r != null).ToArray();
-        return results.Length > 0 ? string.Join(", ", results) : null;
-    }
+        => DetectionRules.Any(r => r.GetResult(_environment) is not null);
 
     /// <summary>
     /// Base class for environment detection rules that can be evaluated against environment variables.

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
@@ -3,8 +3,14 @@
 
 namespace Microsoft.Testing.Platform.Helpers;
 
-// Copy from https://github.com/dotnet/sdk/tree/eaad2a6f937b2c8d9247c53d71b57204f5d127b2/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
-internal static class LLMEnvironmentDetector
+// Adapted from https://github.com/dotnet/sdk/tree/eaad2a6f937b2c8d9247c53d71b57204f5d127b2/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+// Diverged from the upstream telemetry-only version so detection results can drive
+// user-facing platform defaults (ANSI mode, banner, --show-stdout/--show-stderr).
+// IMPORTANT: keep the environment-variable list below in sync with
+// test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
+// (LLMEnvironmentVariables) so child processes spawned by acceptance tests can be
+// deterministically isolated from an ambient agent shell.
+internal sealed class LLMEnvironmentDetector
 {
     private static readonly EnvironmentDetectionRuleWithResult<string>[] DetectionRules =
     [
@@ -50,15 +56,27 @@ internal static class LLMEnvironmentDetector
         new EnvironmentDetectionRuleWithResult<string>("generic_agent", new BooleanEnvironmentRule("AGENT_CLI")),
     ];
 
-    private static string? LLMEnvironment { get; } = GetLLMEnvironment();
+    private readonly IEnvironment _environment;
 
-    private static string? GetLLMEnvironment()
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LLMEnvironmentDetector"/> class.
+    /// </summary>
+    /// <param name="environment">The environment abstraction to use for reading environment variables.</param>
+    public LLMEnvironmentDetector(IEnvironment environment)
+        => _environment = environment;
+
+    /// <summary>
+    /// Detects if the current environment is hosted by a known LLM/AI agent CLI.
+    /// </summary>
+    /// <returns><c>true</c> if a known LLM agent environment is detected; otherwise, <c>false</c>.</returns>
+    public bool IsLLMEnvironment()
+        => GetLLMEnvironment() is not null;
+
+    private string? GetLLMEnvironment()
     {
-        string?[] results = DetectionRules.Select(r => r.GetResult()).Where(r => r != null).ToArray();
+        string?[] results = DetectionRules.Select(r => r.GetResult(_environment)).Where(r => r != null).ToArray();
         return results.Length > 0 ? string.Join(", ", results) : null;
     }
-
-    public static bool IsLLMEnvironment() => !RoslynString.IsNullOrEmpty(LLMEnvironment);
 
     /// <summary>
     /// Base class for environment detection rules that can be evaluated against environment variables.
@@ -66,10 +84,11 @@ internal static class LLMEnvironmentDetector
     private abstract class EnvironmentDetectionRule
     {
         /// <summary>
-        /// Evaluates the rule against the current environment.
+        /// Evaluates the rule against the provided environment abstraction.
         /// </summary>
+        /// <param name="environment">The environment abstraction to use for reading environment variables.</param>
         /// <returns>True if the rule matches the current environment; otherwise, false.</returns>
-        public abstract bool IsMatch();
+        public abstract bool IsMatch(IEnvironment environment);
     }
 
     /// <summary>
@@ -82,10 +101,8 @@ internal static class LLMEnvironmentDetector
         public BooleanEnvironmentRule(params string[] variables)
             => _variables = variables ?? throw new ArgumentNullException(nameof(variables));
 
-        public override bool IsMatch()
-#pragma warning disable RS0030 // Do not use banned APIs - fine here.
-            => _variables.Any(variable => EnvironmentVariableParser.ParseBool(Environment.GetEnvironmentVariable(variable), defaultValue: false));
-#pragma warning restore RS0030 // Do not use banned APIs
+        public override bool IsMatch(IEnvironment environment)
+            => _variables.Any(variable => EnvironmentVariableParser.ParseBool(environment.GetEnvironmentVariable(variable), defaultValue: false));
     }
 
     private static class EnvironmentVariableParser
@@ -123,10 +140,8 @@ internal static class LLMEnvironmentDetector
         public AnyPresentEnvironmentRule(params string[] variables)
             => _variables = variables ?? throw new ArgumentNullException(nameof(variables));
 
-        public override bool IsMatch()
-#pragma warning disable RS0030 // Do not use banned APIs - fine here.
-            => _variables.Any(variable => !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable)));
-#pragma warning restore RS0030 // Do not use banned APIs
+        public override bool IsMatch(IEnvironment environment)
+            => _variables.Any(variable => !RoslynString.IsNullOrEmpty(environment.GetEnvironmentVariable(variable)));
     }
 
     /// <summary>
@@ -139,8 +154,8 @@ internal static class LLMEnvironmentDetector
         public AnyMatchEnvironmentRule(params EnvironmentDetectionRule[] rules)
             => _rules = rules ?? throw new ArgumentNullException(nameof(rules));
 
-        public override bool IsMatch()
-            => _rules.Any(rule => rule.IsMatch());
+        public override bool IsMatch(IEnvironment environment)
+            => _rules.Any(rule => rule.IsMatch(environment));
     }
 
     /// <summary>
@@ -157,11 +172,9 @@ internal static class LLMEnvironmentDetector
             _expectedValue = expectedValue ?? throw new ArgumentNullException(nameof(expectedValue));
         }
 
-        public override bool IsMatch()
+        public override bool IsMatch(IEnvironment environment)
         {
-#pragma warning disable RS0030 // Do not use banned APIs - fine here.
-            string? value = Environment.GetEnvironmentVariable(_variable);
-#pragma warning restore RS0030 // Do not use banned APIs
+            string? value = environment.GetEnvironmentVariable(_variable);
             return !RoslynString.IsNullOrEmpty(value) && value.Equals(_expectedValue, StringComparison.OrdinalIgnoreCase);
         }
     }
@@ -184,10 +197,11 @@ internal static class LLMEnvironmentDetector
         }
 
         /// <summary>
-        /// Evaluates the rule and returns the result if matched.
+        /// Evaluates the rule against the provided environment and returns the result if matched.
         /// </summary>
+        /// <param name="environment">The environment abstraction to use for reading environment variables.</param>
         /// <returns>The result value if the rule matches; otherwise, null.</returns>
-        public T? GetResult()
-            => _rule.IsMatch() ? _result : null;
+        public T? GetResult(IEnvironment environment)
+            => _rule.IsMatch(environment) ? _result : null;
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.Utilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.Utilities.cs
@@ -171,7 +171,12 @@ internal sealed partial class TestHostBuilder
         bool isNoBannerSet = loggingState.CommandLineParseResult.IsOptionSet(PlatformCommandLineProvider.NoBannerOptionKey);
         string? noBannerEnvironmentVar = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_NOBANNER);
         string? dotnetNoLogoEnvironmentVar = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.DOTNET_NOLOGO);
-        if (!isNoBannerSet && !(noBannerEnvironmentVar is "1" or "true") && !(dotnetNoLogoEnvironmentVar is "1" or "true"))
+
+        // Skip the banner under detected LLM/AI agent environments to reduce token noise.
+        // To force the banner back on in an LLM environment, clear the LLM env var (or use a non-LLM shell).
+        bool isLLMEnvironment = new LLMEnvironmentDetector(_environment).IsLLMEnvironment();
+
+        if (!isNoBannerSet && !(noBannerEnvironmentVar is "1" or "true") && !(dotnetNoLogoEnvironmentVar is "1" or "true") && !isLLMEnvironment)
         {
             IBannerMessageOwnerCapability? bannerMessageOwnerCapability = testFrameworkCapabilities.GetCapability<IBannerMessageOwnerCapability>();
             string? bannerMessage = bannerMessageOwnerCapability is not null

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -164,6 +164,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
         bool effectiveNoAnsi = noAnsi && ansiOverride == AnsiOverride.None;
 
         bool inCI = new CIEnvironmentDetector(_environment).IsCIEnvironment();
+        bool isLLMEnvironment = new LLMEnvironmentDetector(_environment).IsLLMEnvironment();
 
         AnsiMode ansiMode = ansiOverride switch
         {
@@ -178,7 +179,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
             // No --ansi argument was provided, or `--ansi auto` was provided.
             // Fall back to environment-based detection.
             // In LLM environments, prefer simple text output so that the LLM can parse it easily.
-            _ when effectiveNoAnsi || LLMEnvironmentDetector.IsLLMEnvironment() => AnsiMode.NoAnsi,
+            _ when effectiveNoAnsi || isLLMEnvironment => AnsiMode.NoAnsi,
             _ when inCI => AnsiMode.SimpleAnsi,
             _ => AnsiMode.AnsiIfPossible,
         };
@@ -197,8 +198,8 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
             showPassed = () => true;
         }
 
-        OutputShowMode showStdout = GetShowOutputMode(_commandLineOptions, TerminalTestReporterCommandLineOptionsProvider.ShowStdoutOption);
-        OutputShowMode showStderr = GetShowOutputMode(_commandLineOptions, TerminalTestReporterCommandLineOptionsProvider.ShowStderrOption);
+        OutputShowMode showStdout = GetShowOutputMode(_commandLineOptions, TerminalTestReporterCommandLineOptionsProvider.ShowStdoutOption, isLLMEnvironment);
+        OutputShowMode showStderr = GetShowOutputMode(_commandLineOptions, TerminalTestReporterCommandLineOptionsProvider.ShowStderrOption, isLLMEnvironment);
 
         Func<bool?> shouldShowProgress = noProgress || ansiMode is AnsiMode.NoAnsi or AnsiMode.SimpleAnsi
             // User preference is to not show progress.
@@ -229,7 +230,10 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
         });
     }
 
-    private static OutputShowMode GetShowOutputMode(ICommandLineOptions commandLineOptions, string optionName)
+    // When the option is absent, default to OutputShowMode.Failed when running under a known
+    // LLM/AI environment (less token noise for agents) and to OutputShowMode.All otherwise.
+    // An explicit --show-stdout/--show-stderr value always wins over the LLM-aware default.
+    private static OutputShowMode GetShowOutputMode(ICommandLineOptions commandLineOptions, string optionName, bool isLLMEnvironment)
         => commandLineOptions.TryGetOptionArgumentList(optionName, out string[]? arguments) && arguments is { Length: > 0 }
             ? arguments[0] switch
             {
@@ -237,7 +241,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
                 string s when TerminalTestReporterCommandLineOptionsProvider.ShowOutputNoneArgument.Equals(s, StringComparison.OrdinalIgnoreCase) => OutputShowMode.None,
                 _ => OutputShowMode.All,
             }
-            : OutputShowMode.All;
+            : isLLMEnvironment ? OutputShowMode.Failed : OutputShowMode.All;
 
     private enum AnsiOverride
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -233,6 +233,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
     // When the option is absent, default to OutputShowMode.Failed when running under a known
     // LLM/AI environment (less token noise for agents) and to OutputShowMode.All otherwise.
     // An explicit --show-stdout/--show-stderr value always wins over the LLM-aware default.
+    // TODO(#8772): Update the --show-stdout/--show-stderr help text to reflect the LLM-aware default.
     private static OutputShowMode GetShowOutputMode(ICommandLineOptions commandLineOptions, string optionName, bool isLLMEnvironment)
         => commandLineOptions.TryGetOptionArgumentList(optionName, out string[]? arguments) && arguments is { Length: > 0 }
             ? arguments[0] switch

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ShowOutputOptionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ShowOutputOptionTests.cs
@@ -65,6 +65,40 @@ public sealed class ShowOutputOptionTests : AcceptanceTestBase<ShowOutputOptionT
 
     [TestMethod]
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ShowStdout_DefaultInLLMEnvironment_ShowsStandardOutputOnlyForFailedTests(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--output detailed --no-progress --no-ansi",
+            new Dictionary<string, string?>
+            {
+                { "CLAUDECODE", "1" },
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("stdout from failing test");
+        testHostResult.AssertOutputDoesNotContain("stdout from passing test");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ShowStdout_All_InLLMEnvironment_StillShowsAllStandardOutput(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--show-stdout all --output detailed --no-progress --no-ansi",
+            new Dictionary<string, string?>
+            {
+                { "CLAUDECODE", "1" },
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("stdout from failing test");
+        testHostResult.AssertOutputContains("stdout from passing test");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     public async Task ShowStdout_InvalidArgument_ReturnsError(string tfm)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
@@ -123,6 +157,40 @@ public sealed class ShowOutputOptionTests : AcceptanceTestBase<ShowOutputOptionT
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
             "--output detailed --no-progress --no-ansi",
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("stderr from failing test");
+        testHostResult.AssertOutputContains("stderr from passing test");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ShowStderr_DefaultInLLMEnvironment_ShowsErrorOutputOnlyForFailedTests(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--output detailed --no-progress --no-ansi",
+            new Dictionary<string, string?>
+            {
+                { "CLAUDECODE", "1" },
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertOutputContains("stderr from failing test");
+        testHostResult.AssertOutputDoesNotContain("stderr from passing test");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ShowStderr_All_InLLMEnvironment_StillShowsAllErrorOutput(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--show-stderr all --output detailed --no-progress --no-ansi",
+            new Dictionary<string, string?>
+            {
+                { "CLAUDECODE", "1" },
+            },
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertOutputContains("stderr from failing test");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/NoBannerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/NoBannerTests.cs
@@ -56,6 +56,24 @@ public class NoBannerTests : AcceptanceTestBase<NoBannerTests.TestAssetFixture>
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
+    public async Task UsingLLMEnvironmentVar_TheBannerDoesNotAppear(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            null,
+            new Dictionary<string, string?>
+            {
+                // CLAUDECODE matches LLMEnvironmentDetector's claude rule (BooleanEnvironmentRule).
+                { "CLAUDECODE", "1" },
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.ZeroTests);
+        testHostResult.AssertOutputDoesNotMatchRegex(_bannerRegexMatchPattern);
+    }
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
     public async Task WithoutUsingNoBanner_TheBannerAppears(string tfm)
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/NoBannerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/NoBannerTests.cs
@@ -63,7 +63,7 @@ public class NoBannerTests : AcceptanceTestBase<NoBannerTests.TestAssetFixture>
             null,
             new Dictionary<string, string?>
             {
-                // CLAUDECODE matches LLMEnvironmentDetector's claude rule (BooleanEnvironmentRule).
+                // CLAUDECODE matches LLMEnvironmentDetector's claude rule (AnyPresentEnvironmentRule).
                 { "CLAUDECODE", "1" },
             },
             cancellationToken: TestContext.CancellationToken);

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
@@ -5,6 +5,37 @@ namespace Microsoft.Testing.TestInfrastructure;
 
 public static class WellKnownEnvironmentVariables
 {
+    /// <summary>
+    /// Environment variables that the Microsoft.Testing.Platform LLM detector inspects.
+    /// Keep in sync with <c>LLMEnvironmentDetector</c>.
+    /// </summary>
+    public static readonly string[] LLMEnvironmentVariables =
+    [
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CURSOR_EDITOR",
+        "CURSOR_AI",
+        "GEMINI_CLI",
+        "GITHUB_COPILOT_CLI_MODE",
+        "GH_COPILOT_WORKING_DIRECTORY",
+        "COPILOT_CLI",
+        "CODEX_CLI",
+        "CODEX_SANDBOX",
+        "OR_APP_NAME",
+        "AMP_HOME",
+        "QWEN_CODE",
+        "DROID_CLI",
+        "OPENCODE_AI",
+        "ZED_ENVIRONMENT",
+        "ZED_TERM",
+        "KIMI_CLI",
+        "GOOSE_TERMINAL",
+        "CLINE_TASK_ID",
+        "ROO_CODE_TASK_ID",
+        "WINDSURF_SESSION",
+        "AGENT_CLI",
+    ];
+
     public static readonly string[] ToSkipEnvironmentVariables =
     [
         // Skip dotnet root, we redefine it below.
@@ -49,6 +80,13 @@ public static class WellKnownEnvironmentVariables
         "DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY",
 
         // Isolate from the skip banner in case of parent, children tests
-        "TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER"
+        "TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER",
+
+        // LLM / AI agent CLI environment variables - keep in sync with
+        // src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs.
+        // We filter these out so acceptance tests are not affected by the ambient
+        // shell the developer (or CI) happens to be running them from. Tests that
+        // need to exercise LLM-aware behavior must set the relevant variable explicitly.
+        .. LLMEnvironmentVariables,
     ];
 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
@@ -9,7 +9,7 @@ public static class WellKnownEnvironmentVariables
     /// Environment variables that the Microsoft.Testing.Platform LLM detector inspects.
     /// Keep in sync with <c>LLMEnvironmentDetector</c>.
     /// </summary>
-    public static readonly string[] LLMEnvironmentVariables =
+    public static readonly IReadOnlyList<string> LLMEnvironmentVariables =
     [
         "CLAUDECODE",
         "CLAUDE_CODE_ENTRYPOINT",


### PR DESCRIPTION
## Summary

Extends `LLMEnvironmentDetector` so that AI agent CLIs (Claude Code, Gemini CLI, GitHub Copilot CLI, Aider, Cursor, etc.) also get quieter output defaults out of the box. This reduces token consumption on every test run an agent triggers, without changing anything for humans or CI.

When an LLM environment is detected (existing detection — see `LLMEnvironmentDetector.DetectionRules`), the following defaults flip:

| Option | Default (human) | Default (LLM) |
| --- | --- | --- |
| Banner (`--no-banner`) | shown | suppressed (both platform + framework banner) |
| `--show-stdout` | `All` | `Failed` |
| `--show-stderr` | `All` | `Failed` |

ANSI mode is already disabled in LLM environments today; this PR extends the same opt-in mechanism to the two largest contributors of run-time noise.

Any explicit user-provided value still wins (e.g. `--show-stdout all` overrides the new default).

## Why opt-in (instead of #7664's universal change)

Issue #7664 proposes changing `--show-stdout` / `--show-stderr` defaults to `Failed` for **everyone**, which is a breaking change for human and CI workflows. This PR takes the LLM-opt-in subset:

- No behavior change for humans or CI.
- Agents win immediately, without waiting for a major version.
- Easy escape hatch: unset the LLM env var (or pass an explicit value).
- Compatible with #7664 if/when it ships — the LLM defaults would simply become a no-op.

## Implementation notes

- `LLMEnvironmentDetector` refactored from `static` to instance with an injected `IEnvironment`. Detection rules remain `static`. This makes the new behaviors testable via env-var injection.
- `TerminalOutputDevice` hoists `isLLMEnvironment` once next to the existing `inCI` lookup and threads it into `GetShowOutputMode`.
- `DisplayBannerIfEnabledAsync` short-circuits when LLM is detected (mirrors existing `--no-banner` / `DOTNET_NOLOGO` behavior; suppresses both platform and framework banners).
- Test infrastructure (`WellKnownEnvironmentVariables.ToSkipEnvironmentVariables`) broadly filters the 23 LLM env vars when spawning child processes, so existing tests are not affected by the parent agent host.
- Help-text wording for `--show-stdout` / `--show-stderr` was intentionally **not** changed (still says `Default is 'All'.`) to keep this PR tight and avoid 13-XLF churn. Defer to a wording-only follow-up.

## Tests

New acceptance tests (all green locally on `net8.0` / `net10.0` / `net462`):

- `NoBannerTests.UsingLLMEnvironmentVar_TheBannerDoesNotAppear` — sets `CLAUDECODE=1`, asserts banner is suppressed.
- `ShowOutputOptionTests.ShowStdout_DefaultInLLMEnvironment_ShowsStandardOutputOnlyForFailedTests`
- `ShowOutputOptionTests.ShowStderr_DefaultInLLMEnvironment_ShowsErrorOutputOnlyForFailedTests`
- `ShowOutputOptionTests.ShowStdout_All_InLLMEnvironment_StillShowsAllStandardOutput` (explicit override still wins; stderr is symmetric and covered by impl)

Existing `NoBannerTests`, `AnsiOptionTests`, `HelpInfoTests`, `HelpInfoAllExtensionsTests`, and the full `ShowOutputOptionTests` suite still pass.

Related: #7664