### PR TITLE
Tighten MSTEST0065 fixer to drop out-of-scope InAnyOrder action (#8765)

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidAssertAreEqualOnCollectionsFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidAssertAreEqualOnCollectionsFixer.cs
@@ -53,20 +53,18 @@ public sealed class AvoidAssertAreEqualOnCollectionsFixer : CodeFixProvider
             return;
         }
 
+        // Intentionally only two code actions are offered: ordered element-wise comparison
+        // ('Assert.AreSequenceEqual') and deep structural comparison ('Assert.AreEquivalent').
+        // An 'Assert.AreSequenceEqual(..., SequenceOrder.InAnyOrder)' action is NOT offered because
+        // order-insensitive comparison is a behavior change rather than a fidelity-preserving fix;
+        // users who want that semantic should opt in to it explicitly. See issue #8765.
         if (replacementContext.CanOfferSequenceFixes)
         {
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title: string.Format(CultureInfo.InvariantCulture, CodeFixResources.AvoidAssertAreEqualOnCollectionsOrderedFix, replacementContext.SequenceMethodName),
-                    ct => ApplyFixAsync(context.Document, invocation, replacementContext, preserveGenericTypeArguments: false, addInAnyOrderArgument: false, useEquivalentMethod: false, ct),
+                    ct => ApplyFixAsync(context.Document, invocation, replacementContext, preserveGenericTypeArguments: false, useEquivalentMethod: false, ct),
                     equivalenceKey: $"{nameof(AvoidAssertAreEqualOnCollectionsFixer)}.Ordered"),
-                diagnostic);
-
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    title: string.Format(CultureInfo.InvariantCulture, CodeFixResources.AvoidAssertAreEqualOnCollectionsInAnyOrderFix, replacementContext.SequenceMethodName),
-                    ct => ApplyFixAsync(context.Document, invocation, replacementContext, preserveGenericTypeArguments: false, addInAnyOrderArgument: true, useEquivalentMethod: false, ct),
-                    equivalenceKey: $"{nameof(AvoidAssertAreEqualOnCollectionsFixer)}.InAnyOrder"),
                 diagnostic);
         }
 
@@ -75,7 +73,7 @@ public sealed class AvoidAssertAreEqualOnCollectionsFixer : CodeFixProvider
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title: string.Format(CultureInfo.InvariantCulture, CodeFixResources.AvoidAssertAreEqualOnCollectionsEquivalentFix, replacementContext.EquivalentMethodName),
-                    ct => ApplyFixAsync(context.Document, invocation, replacementContext, preserveGenericTypeArguments: true, addInAnyOrderArgument: false, useEquivalentMethod: true, ct),
+                    ct => ApplyFixAsync(context.Document, invocation, replacementContext, preserveGenericTypeArguments: true, useEquivalentMethod: true, ct),
                     equivalenceKey: $"{nameof(AvoidAssertAreEqualOnCollectionsFixer)}.Equivalent"),
                 diagnostic);
         }
@@ -118,7 +116,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsFixer : CodeFixProvider
         InvocationExpressionSyntax invocation,
         ReplacementContext replacementContext,
         bool preserveGenericTypeArguments,
-        bool addInAnyOrderArgument,
         bool useEquivalentMethod,
         CancellationToken cancellationToken)
     {
@@ -136,11 +133,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsFixer : CodeFixProvider
         if (!useEquivalentMethod && replacementContext.ComparerArgument is not null)
         {
             arguments.Add(StripArgumentName(replacementContext.ComparerArgument));
-        }
-
-        if (addInAnyOrderArgument)
-        {
-            arguments.Add(SyntaxFactory.Argument(CreateInAnyOrderExpression()));
         }
 
         if (replacementContext.MessageArgument is not null)
@@ -172,9 +164,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsFixer : CodeFixProvider
 
     private static ArgumentSyntax StripArgumentName(ArgumentSyntax argument)
         => argument.WithNameColon(null);
-
-    private static ExpressionSyntax CreateInAnyOrderExpression()
-        => SyntaxFactory.ParseExpression("Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder");
 
     private readonly record struct ReplacementContext(
         ArgumentSyntax ExpectedArgument,

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -229,13 +229,10 @@
     <value>Use async assertion</value>
   </data>
   <data name="AvoidAssertAreEqualOnCollectionsOrderedFix" xml:space="preserve">
-    <value>Replace with `Assert.{0}` (ordered)</value>
-  </data>
-  <data name="AvoidAssertAreEqualOnCollectionsInAnyOrderFix" xml:space="preserve">
-    <value>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</value>
+    <value>Use ordered, element-wise comparison ('Assert.{0}')</value>
   </data>
   <data name="AvoidAssertAreEqualOnCollectionsEquivalentFix" xml:space="preserve">
-    <value>Replace with `Assert.{0}`</value>
+    <value>Use deep structural comparison ('Assert.{0}')</value>
   </data>
   <data name="AddIgnoreJustificationFix" xml:space="preserve">
     <value>Add a placeholder justification to '[Ignore]'</value>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Nahraďte výrazem `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Nahraďte výrazem `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Nahraďte výrazem `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Nahraďte výrazem `Assert.{0}` (seřazeno)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Nahraďte výrazem `Assert.{0}` (seřazeno)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Ersetzen Sie dies durch `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Ersetzen Sie dies durch `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Ersetzen Sie dies durch `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Ersetzen Sie dies durch `Assert.{0}` (sortiert)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Ersetzen Sie dies durch `Assert.{0}` (sortiert)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Reemplazar por `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Reemplazar por `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Reemplazar por `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Reemplazar por `Assert.{0}` (ordenado)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Reemplazar por `Assert.{0}` (ordenado)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Remplacer par `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Remplacer par `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Remplacer par `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Remplacer par `Assert.{0}` (ordonné)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Remplacer par `Assert.{0}` (ordonné)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Sostituire con `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Sostituire con `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Sostituire con `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Sostituire con `Assert.{0}` (ordinato)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Sostituire con `Assert.{0}` (ordinato)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">`Assert.{0}` で置き換える</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">`Assert.{0}(..., SequenceOrder.InAnyOrder)` で置き換える</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">`Assert.{0}` で置き換える</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">`Assert.{0}` で置き換える (順序指定)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">`Assert.{0}` で置き換える (順序指定)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">`Assert.{0}`(으)로 바꾸기</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">`Assert.{0}(..., SequenceOrder.InAnyOrder)`(으)로 바꾸기</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">`Assert.{0}`(으)로 바꾸기</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">`Assert.{0}`(으)로 바꾸기(정렬됨)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">`Assert.{0}`(으)로 바꾸기(정렬됨)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Zamień na `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Zamień na `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Zamień na `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Zamień na `Assert.{0}` (uporządkowane)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Zamień na `Assert.{0}` (uporządkowane)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Substituir por `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Substituir por `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Substituir por `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Substituir por `Assert.{0}` (ordenado)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Substituir por `Assert.{0}` (ordenado)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">Заменить на `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">Заменить на `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Заменить на `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">Заменить на `Assert.{0}` (по порядку)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">Заменить на `Assert.{0}` (по порядку)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">`Assert.{0}` ile değiştirin</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">`Assert.{0}(..., SequenceOrder.InAnyOrder)` ile değiştirin</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">`Assert.{0}` ile değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">`Assert.{0}` ile değiştirin (sıralı)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">`Assert.{0}` ile değiştirin (sıralı)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">替换为 `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">替换为 `Assert.{0}(..., SequenceOrder.InAnyOrder)`</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">替换为 `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">替换为 `Assert.{0}` (有序)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">替换为 `Assert.{0}` (有序)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -28,18 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsEquivalentFix">
-        <source>Replace with `Assert.{0}`</source>
-        <target state="translated">取代為 `Assert.{0}`</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="AvoidAssertAreEqualOnCollectionsInAnyOrderFix">
-        <source>Replace with `Assert.{0}(..., SequenceOrder.InAnyOrder)`</source>
-        <target state="translated">以 `Assert.{0}(..., SequenceOrder.InAnyOrder)` 取代</target>
+        <source>Use deep structural comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">取代為 `Assert.{0}`</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreEqualOnCollectionsOrderedFix">
-        <source>Replace with `Assert.{0}` (ordered)</source>
-        <target state="translated">取代為 `Assert.{0}` (按順序)</target>
+        <source>Use ordered, element-wise comparison ('Assert.{0}')</source>
+        <target state="needs-review-translation">取代為 `Assert.{0}` (按順序)</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAssertAreSameWithValueTypesFix">

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -387,46 +387,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
-    public async Task CodeFix_InAnyOrder_ForAreEqual()
-    {
-        string code = """
-            using System.Collections.Generic;
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod]
-                public void MyTestMethod()
-                {
-                    List<int> expected = [1, 2];
-                    List<int> actual = [1, 2];
-                    {|#0:Assert.AreEqual(expected, actual)|};
-                }
-            }
-            """;
-
-        string fixedCode = """
-            using System.Collections.Generic;
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod]
-                public void MyTestMethod()
-                {
-                    List<int> expected = [1, 2];
-                    List<int> actual = [1, 2];
-                    Assert.AreSequenceEqual(expected, actual, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
-                }
-            }
-            """;
-
-        await VerifyCodeFixAsync(code, fixedCode, codeActionIndex: 1, "Assert.AreEqual", "List<int>");
-    }
-
-    [TestMethod]
     public async Task CodeFix_Equivalent_ForAreEqual()
     {
         string code = """
@@ -463,7 +423,7 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
             }
             """;
 
-        await VerifyCodeFixAsync(code, fixedCode, codeActionIndex: 2, "Assert.AreEqual", "List<int>");
+        await VerifyCodeFixAsync(code, fixedCode, codeActionIndex: 1, "Assert.AreEqual", "List<int>");
     }
 
     [TestMethod]
@@ -507,46 +467,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
-    public async Task CodeFix_InAnyOrder_ForAreNotEqual()
-    {
-        string code = """
-            using System.Collections.Generic;
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod]
-                public void MyTestMethod()
-                {
-                    List<int> expected = [1, 2];
-                    List<int> actual = [1, 2];
-                    {|#0:Assert.AreNotEqual(expected, actual)|};
-                }
-            }
-            """;
-
-        string fixedCode = """
-            using System.Collections.Generic;
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod]
-                public void MyTestMethod()
-                {
-                    List<int> expected = [1, 2];
-                    List<int> actual = [1, 2];
-                    Assert.AreNotSequenceEqual(expected, actual, Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder);
-                }
-            }
-            """;
-
-        await VerifyCodeFixAsync(code, fixedCode, codeActionIndex: 1, "Assert.AreNotEqual", "List<int>");
-    }
-
-    [TestMethod]
     public async Task CodeFix_Equivalent_ForAreNotEqual()
     {
         string code = """
@@ -583,7 +503,7 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
             }
             """;
 
-        await VerifyCodeFixAsync(code, fixedCode, codeActionIndex: 2, "Assert.AreNotEqual", "List<int>");
+        await VerifyCodeFixAsync(code, fixedCode, codeActionIndex: 1, "Assert.AreNotEqual", "List<int>");
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes #8765.

Per the issue, the MSTEST0065 (AvoidAssertAreEqualOnCollections) code fixer should offer exactly **two** code actions per diagnostic:

- `Use ordered, element-wise comparison ('Assert.AreSequenceEqual')` — for ordered/strict comparison.
- `Use deep structural comparison ('Assert.AreEquivalent')` — for structural comparison.

The previously-offered third action that produced `Assert.AreSequenceEqual(..., SequenceOrder.InAnyOrder)` has been removed because it represents a *behavior change* rather than a fidelity-preserving fix; users who want order-insensitive comparison semantics should opt in to it explicitly.

## Changes

- `AvoidAssertAreEqualOnCollectionsFixer.cs`: removed the InAnyOrder `RegisterCodeFix` block, `addInAnyOrderArgument` parameter on `ApplyFixAsync`, and `CreateInAnyOrderExpression()` helper. Added an explanatory comment block citing #8765.
- `CodeFixResources.resx`: removed the `AvoidAssertAreEqualOnCollectionsInAnyOrderFix` string and updated the two surviving titles to match the wording prescribed in the issue.
- Regenerated 13 XLF localization files via the `UpdateXlf` target.
- `AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs`: removed the two `CodeFix_InAnyOrder_*` tests and shifted `codeActionIndex` from `2` → `1` on the surviving `CodeFix_Equivalent_*` tests.

## Validation

Built `MSTest.Analyzers.CodeFixes.csproj` and `MSTest.Analyzers.UnitTests.csproj` cleanly. All 21 `AvoidAssertAreEqualOnCollections`-prefixed tests pass.
