### PR TITLE
Add AzDO summary, progress and stack-frame filter options (#5951 item 4)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineOptions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineOptions.cs
@@ -8,8 +8,11 @@ internal static class AzureDevOpsCommandLineOptions
     public const string AzureDevOpsOptionName = "report-azdo";
     public const string AzureDevOpsDemoteKnownFlaky = "report-azdo-demote-known-flaky";
     public const string AzureDevOpsFlakyHistory = "report-azdo-flaky-history";
+    public const string AzureDevOpsProgress = "report-azdo-progress";
     public const string AzureDevOpsQuarantineFile = "report-azdo-quarantine-file";
     public const string AzureDevOpsReportSeverity = "report-azdo-severity";
+    public const string AzureDevOpsStackFrameFilter = "report-azdo-stackframe-filter";
+    public const string AzureDevOpsSummary = "report-azdo-summary";
     public const string AzureDevOpsUploadArtifactExclude = "report-azdo-upload-artifact-exclude";
     public const string AzureDevOpsUploadArtifactInclude = "report-azdo-upload-artifact-include";
     public const string AzureDevOpsUploadArtifactName = "report-azdo-upload-artifact-name";

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineProvider.cs
@@ -23,10 +23,19 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
 
     private static readonly string[] SeverityOptions = ["error", "warning"];
 
+    internal const int MaxStackFrameFilterPatterns = 16;
+    internal const int StackFrameFilterMatchTimeoutMs = 500;
+
     private static readonly string DemoteKnownFlakyOptionDescriptionFormatted = string.Format(
         CultureInfo.InvariantCulture,
         AzureDevOpsResources.DemoteKnownFlakyOptionDescription,
         AzureDevOpsReporter.KnownFlakyFailureRateThreshold * 100);
+
+    private static readonly string StackFrameFilterOptionDescriptionFormatted = string.Format(
+        CultureInfo.InvariantCulture,
+        AzureDevOpsResources.StackFrameFilterOptionDescription,
+        MaxStackFrameFilterPatterns,
+        StackFrameFilterMatchTimeoutMs);
 
     public AzureDevOpsCommandLineProvider()
         : base(
@@ -38,8 +47,11 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsOptionName, AzureDevOpsResources.OptionDescription, ArgumentArity.Zero, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky, DemoteKnownFlakyOptionDescriptionFormatted, ArgumentArity.Zero, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsFlakyHistory, AzureDevOpsResources.FlakyHistoryOptionDescription, ArgumentArity.ExactlyOne, false),
+                new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsProgress, AzureDevOpsResources.ProgressOptionDescription, ArgumentArity.Zero, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsQuarantineFile, AzureDevOpsResources.QuarantineFileOptionDescription, ArgumentArity.ExactlyOne, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity, AzureDevOpsResources.SeverityOptionDescription, ArgumentArity.ExactlyOne, false),
+                new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter, StackFrameFilterOptionDescriptionFormatted, ArgumentArity.OneOrMore, false),
+                new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsSummary, AzureDevOpsResources.SummaryOptionDescription, ArgumentArity.ZeroOrOne, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifactExclude, AzureDevOpsResources.UploadArtifactExcludeOptionDescription, ArgumentArity.ZeroOrMore, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifactInclude, AzureDevOpsResources.UploadArtifactIncludeOptionDescription, ArgumentArity.ZeroOrMore, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifactName, AzureDevOpsResources.UploadArtifactNameOptionDescription, ArgumentArity.ExactlyOne, false),
@@ -56,6 +68,7 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
             AzureDevOpsCommandLineOptions.AzureDevOpsFlakyHistory => ValidateFlakyHistoryArgumentsAsync(arguments),
             AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity when !SeverityOptions.Contains(arguments[0], StringComparer.OrdinalIgnoreCase)
                 => ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.InvalidSeverity, arguments[0])),
+            AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter => ValidateStackFrameFilterArgumentsAsync(arguments),
             AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifacts when !ArtifactUploadModes.Contains(arguments[0], StringComparer.OrdinalIgnoreCase)
                 => ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.InvalidArtifactUploadMode, arguments[0])),
             AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifactInclude or AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifactExclude
@@ -76,6 +89,10 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
             {
                 errorMessage = AzureDevOpsResources.AzureDevOpsFlakyHistoryRequiresAzureDevOps;
             }
+            else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsProgress))
+            {
+                errorMessage = AzureDevOpsResources.AzureDevOpsProgressRequiresAzureDevOps;
+            }
             else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsQuarantineFile))
             {
                 errorMessage = AzureDevOpsResources.AzureDevOpsQuarantineFileRequiresAzureDevOps;
@@ -83,6 +100,14 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
             else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity))
             {
                 errorMessage = AzureDevOpsResources.AzureDevOpsReportSeverityRequiresAzureDevOps;
+            }
+            else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter))
+            {
+                errorMessage = AzureDevOpsResources.AzureDevOpsStackFrameFilterRequiresAzureDevOps;
+            }
+            else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsSummary))
+            {
+                errorMessage = AzureDevOpsResources.AzureDevOpsSummaryRequiresAzureDevOps;
             }
         }
         else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky)
@@ -154,4 +179,31 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
             && days is >= 1 and <= 90
                 ? ValidationResult.ValidTask
                 : ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.InvalidFlakyHistoryDays, arguments[0]));
+
+    private static Task<ValidationResult> ValidateStackFrameFilterArgumentsAsync(string[] arguments)
+    {
+        if (arguments.Length > MaxStackFrameFilterPatterns)
+        {
+            return ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.StackFrameFilterTooManyRegexes, MaxStackFrameFilterPatterns));
+        }
+
+        foreach (string pattern in arguments)
+        {
+            if (RoslynString.IsNullOrEmpty(pattern))
+            {
+                return ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.InvalidStackFrameFilterRegex, pattern, "pattern is empty"));
+            }
+
+            try
+            {
+                _ = new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.Compiled, TimeSpan.FromMilliseconds(StackFrameFilterMatchTimeoutMs));
+            }
+            catch (ArgumentException ex)
+            {
+                return ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.InvalidStackFrameFilterRegex, pattern, ex.Message));
+            }
+        }
+
+        return ValidationResult.ValidTask;
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsExtensions.cs
@@ -33,6 +33,26 @@ public static class AzureDevOpsExtensions
                     serviceProvider.GetTestApplicationModuleInfo(),
                     serviceProvider.GetLoggerFactory()));
 
+        var compositeSummaryReporter =
+            new CompositeExtensionFactory<AzureDevOpsSummaryReporter>(serviceProvider =>
+                new AzureDevOpsSummaryReporter(
+                    serviceProvider.GetCommandLineOptions(),
+                    serviceProvider.GetConfiguration(),
+                    serviceProvider.GetEnvironment(),
+                    serviceProvider.GetFileSystem(),
+                    serviceProvider.GetOutputDevice(),
+                    serviceProvider.GetTestApplicationModuleInfo(),
+                    serviceProvider.GetLoggerFactory()));
+
+        var compositeProgressReporter =
+            new CompositeExtensionFactory<AzureDevOpsProgressReporter>(serviceProvider =>
+                new AzureDevOpsProgressReporter(
+                    serviceProvider.GetCommandLineOptions(),
+                    serviceProvider.GetEnvironment(),
+                    serviceProvider.GetOutputDevice(),
+                    serviceProvider.GetTestApplicationModuleInfo(),
+                    serviceProvider.GetLoggerFactory()));
+
         var compositeTestResultsPublisher =
             new CompositeExtensionFactory<AzureDevOpsTestResultsPublisher>(serviceProvider =>
                new AzureDevOpsTestResultsPublisher(
@@ -60,10 +80,14 @@ public static class AzureDevOpsExtensions
                 historyService);
         });
         builder.TestHost.AddDataConsumer(compositeArtifactUploader);
+        builder.TestHost.AddDataConsumer(compositeSummaryReporter);
+        builder.TestHost.AddDataConsumer(compositeProgressReporter);
         builder.TestHost.AddDataConsumer(compositeTestResultsPublisher);
         builder.TestHost.AddTestSessionLifetimeHandler(serviceProvider =>
             historyService ??= CreateHistoryService(serviceProvider));
         builder.TestHost.AddTestSessionLifetimeHandler(compositeArtifactUploader);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeSummaryReporter);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeProgressReporter);
         builder.TestHost.AddTestSessionLifetimeHandler(compositeTestResultsPublisher);
         builder.CommandLine.AddProvider(() => new AzureDevOpsCommandLineProvider());
     }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsProgressReporter.cs
@@ -169,9 +169,12 @@ internal sealed class AzureDevOpsProgressReporter : IDataConsumer, ITestSessionL
                 }
 
                 int denominator = Math.Max(_seen, _completed);
+                // Cap in-progress emissions at 99 so 100% is reserved for the final
+                // `state=Completed` emission in OnTestSessionFinishingAsync. Otherwise
+                // hitting 100 here would prevent any further updates (updates are monotonic).
                 percent = denominator <= 0
                     ? 0
-                    : Math.Min(100, Math.Max(0, (int)(_completed * 100L / denominator)));
+                    : Math.Min(99, Math.Max(0, (int)(_completed * 100L / denominator)));
 
                 if (percent <= _lastEmittedPercent)
                 {
@@ -179,7 +182,7 @@ internal sealed class AzureDevOpsProgressReporter : IDataConsumer, ITestSessionL
                 }
 
                 long elapsed = _emissionThrottle.ElapsedMilliseconds;
-                if (_hasEmittedInitial && percent < 100 && elapsed < MinimumEmissionIntervalMs)
+                if (_hasEmittedInitial && elapsed < MinimumEmissionIntervalMs)
                 {
                     return;
                 }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsProgressReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsProgressReporter.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
+using Microsoft.Testing.Extensions.Reporting;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Extensions.AzureDevOpsReport;
+
+internal sealed class AzureDevOpsProgressReporter : IDataConsumer, ITestSessionLifetimeHandler, IOutputDeviceDataProducer
+{
+    private const string AzureDevOpsTfBuildVariableName = "TF_BUILD";
+    internal const int MinimumEmissionIntervalMs = 250;
+
+    private readonly IEnvironment _environment;
+    private readonly IOutputDevice _outputDevice;
+    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
+    private readonly ILogger _logger;
+    private readonly Lazy<string> _targetFrameworkMoniker;
+#pragma warning disable IDE0028 // Collection initialization can be simplified - target-typed `new` cannot pass the comparer in the same syntactic form expected.
+    private readonly HashSet<string> _terminalUids = new HashSet<string>(StringComparer.Ordinal);
+#pragma warning restore IDE0028
+#if NET9_0_OR_GREATER
+    private readonly System.Threading.Lock _stateLock = new();
+#else
+    private readonly object _stateLock = new();
+#endif
+    private readonly Stopwatch _emissionThrottle = new();
+    private readonly Guid _recordId = Guid.NewGuid();
+    private readonly bool _isEnabled;
+
+    private bool _emitAzureDevOpsCommands;
+    private int _completed;
+    private int _seen;
+    private int _failed;
+    private int _lastEmittedPercent;
+    private bool _hasEmittedInitial;
+
+    public AzureDevOpsProgressReporter(
+        ICommandLineOptions commandLineOptions,
+        IEnvironment environment,
+        IOutputDevice outputDevice,
+        ITestApplicationModuleInfo testApplicationModuleInfo,
+        ILoggerFactory loggerFactory)
+    {
+        _environment = environment;
+        _outputDevice = outputDevice;
+        _testApplicationModuleInfo = testApplicationModuleInfo;
+        _logger = loggerFactory.CreateLogger<AzureDevOpsProgressReporter>();
+        _isEnabled = commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsProgress);
+        _targetFrameworkMoniker = new(TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker);
+    }
+
+    public Type[] DataTypesConsumed { get; } = [typeof(TestNodeUpdateMessage)];
+
+    public string Uid => nameof(AzureDevOpsProgressReporter);
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => AzureDevOpsResources.DisplayName;
+
+    public string Description => AzureDevOpsResources.Description;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
+
+    public async Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
+    {
+        try
+        {
+            testSessionContext.CancellationToken.ThrowIfCancellationRequested();
+
+            _emitAzureDevOpsCommands = false;
+            lock (_stateLock)
+            {
+                _terminalUids.Clear();
+                _completed = 0;
+                _seen = 0;
+                _failed = 0;
+                _lastEmittedPercent = -1;
+                _hasEmittedInitial = false;
+                _emissionThrottle.Reset();
+            }
+
+            if (!_isEnabled)
+            {
+                return;
+            }
+
+            _emitAzureDevOpsCommands = string.Equals(_environment.GetEnvironmentVariable(AzureDevOpsTfBuildVariableName), "true", StringComparison.OrdinalIgnoreCase);
+            if (!_emitAzureDevOpsCommands)
+            {
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning(AzureDevOpsResources.ProgressRequiresTfBuildWarning);
+                }
+
+                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(AzureDevOpsResources.ProgressRequiresTfBuildWarning), testSessionContext.CancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            string name = $"{_testApplicationModuleInfo.TryGetAssemblyName() ?? "unknown"} ({_targetFrameworkMoniker.Value})";
+            string line = $"##vso[task.logdetail id={_recordId.ToString("D", CultureInfo.InvariantCulture)};name={AzDoEscaper.Escape(name)};type=Build;order=1;state=InProgress;progress=0]Starting tests";
+            await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
+
+            lock (_stateLock)
+            {
+                _hasEmittedInitial = true;
+                _lastEmittedPercent = 0;
+                _emissionThrottle.Start();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+        }
+    }
+
+    public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_emitAzureDevOpsCommands || value is not TestNodeUpdateMessage update)
+            {
+                return;
+            }
+
+            TestNodeStateProperty? state = update.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+            ProgressEvent evt = Classify(state);
+            if (evt == ProgressEvent.None)
+            {
+                return;
+            }
+
+            string uid = update.TestNode.Uid;
+            int percent;
+            bool shouldEmit;
+            lock (_stateLock)
+            {
+                if (evt == ProgressEvent.InProgress)
+                {
+                    _seen++;
+                }
+                else
+                {
+                    if (!_terminalUids.Add(uid))
+                    {
+                        return;
+                    }
+
+                    _completed++;
+                    if (evt == ProgressEvent.Failed)
+                    {
+                        _failed++;
+                    }
+                }
+
+                int denominator = Math.Max(_seen, _completed);
+                percent = denominator <= 0
+                    ? 0
+                    : Math.Min(100, Math.Max(0, (int)(_completed * 100L / denominator)));
+
+                if (percent <= _lastEmittedPercent)
+                {
+                    return;
+                }
+
+                long elapsed = _emissionThrottle.ElapsedMilliseconds;
+                if (_hasEmittedInitial && percent < 100 && elapsed < MinimumEmissionIntervalMs)
+                {
+                    return;
+                }
+
+                _lastEmittedPercent = percent;
+                shouldEmit = true;
+                _emissionThrottle.Restart();
+            }
+
+            if (shouldEmit)
+            {
+                string line = $"##vso[task.logdetail id={_recordId.ToString("D", CultureInfo.InvariantCulture)};progress={percent.ToString(CultureInfo.InvariantCulture)};state=InProgress]";
+                await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedException(nameof(ConsumeAsync), ex);
+        }
+    }
+
+    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
+    {
+        try
+        {
+            testSessionContext.CancellationToken.ThrowIfCancellationRequested();
+
+            if (!_emitAzureDevOpsCommands || !_hasEmittedInitial)
+            {
+                return;
+            }
+
+            string result;
+            lock (_stateLock)
+            {
+                result = _failed > 0 ? "Failed" : "Succeeded";
+            }
+
+            string line = $"##vso[task.logdetail id={_recordId.ToString("D", CultureInfo.InvariantCulture)};progress=100;state=Completed;result={result}]";
+            await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
+        }
+    }
+
+    private static ProgressEvent Classify(TestNodeStateProperty? state)
+        => state switch
+        {
+            InProgressTestNodeStateProperty => ProgressEvent.InProgress,
+            PassedTestNodeStateProperty => ProgressEvent.Passed,
+            SkippedTestNodeStateProperty => ProgressEvent.Passed,
+            FailedTestNodeStateProperty => ProgressEvent.Failed,
+            ErrorTestNodeStateProperty => ProgressEvent.Failed,
+            TimeoutTestNodeStateProperty => ProgressEvent.Failed,
+#pragma warning disable CS0618, MTP0001
+            CancelledTestNodeStateProperty => ProgressEvent.Failed,
+#pragma warning restore CS0618, MTP0001
+            _ => ProgressEvent.None,
+        };
+
+    private void LogUnexpectedException(string callbackName, Exception ex)
+    {
+        if (_logger.IsEnabled(LogLevel.Warning))
+        {
+            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
+        }
+    }
+
+    private enum ProgressEvent
+    {
+        None,
+        InProgress,
+        Passed,
+        Failed,
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -54,6 +54,7 @@ internal sealed class AzureDevOpsReporter :
     private QuarantineFile? _quarantineFile;
     private bool _hasLoadedEnabledConfiguration;
     private int _quarantineBuildTagEmitted;
+    private Regex[]? _userStackFrameFilters;
 
     public AzureDevOpsReporter(
         ICommandLineOptions commandLine,
@@ -166,7 +167,7 @@ internal sealed class AzureDevOpsReporter :
 
         string severity = GetSeverity(testName, isQuarantined);
         string annotationSuffix = BuildAnnotationSuffix(testName, isQuarantined);
-        string? line = GetErrorText(testDisplayName, explanation, exception, severity, _fileSystem, _logger, _targetFrameworkMoniker, annotationSuffix);
+        string? line = GetErrorText(testDisplayName, explanation, exception, severity, _fileSystem, _logger, _targetFrameworkMoniker, annotationSuffix, _userStackFrameFilters);
         if (line is null)
         {
             if (_logger.IsEnabled(LogLevel.Trace))
@@ -186,9 +187,12 @@ internal sealed class AzureDevOpsReporter :
     }
 
     internal static /* for testing */ string? GetErrorText(string testDisplayName, string? explanation, Exception? exception, string severity, IFileSystem fileSystem, ILogger logger, string targetFrameworkMoniker)
-        => GetErrorText(testDisplayName, explanation, exception, severity, fileSystem, logger, targetFrameworkMoniker, additionalMessageSuffix: null);
+        => GetErrorText(testDisplayName, explanation, exception, severity, fileSystem, logger, targetFrameworkMoniker, additionalMessageSuffix: null, userStackFrameFilters: null);
 
     internal static /* for testing */ string? GetErrorText(string testDisplayName, string? explanation, Exception? exception, string severity, IFileSystem fileSystem, ILogger logger, string targetFrameworkMoniker, string? additionalMessageSuffix)
+        => GetErrorText(testDisplayName, explanation, exception, severity, fileSystem, logger, targetFrameworkMoniker, additionalMessageSuffix, userStackFrameFilters: null);
+
+    internal static /* for testing */ string? GetErrorText(string testDisplayName, string? explanation, Exception? exception, string severity, IFileSystem fileSystem, ILogger logger, string targetFrameworkMoniker, string? additionalMessageSuffix, Regex[]? userStackFrameFilters)
     {
         string message = explanation ?? exception?.Message ?? AzureDevOpsResources.NoFailureMessageFallback;
         string formattedMessage = $"{FormatErrorMessage(testDisplayName, targetFrameworkMoniker, message)}{additionalMessageSuffix}";
@@ -217,7 +221,7 @@ internal sealed class AzureDevOpsReporter :
                 string file = location.Value.File;
                 string code = location.Value.Code;
 
-                if (IsAssertionImplementationFrame(code))
+                if (IsAssertionImplementationFrame(code) || IsUserStackFrameFilterMatch(code, userStackFrameFilters, logger))
                 {
                     if (logger.IsEnabled(LogLevel.Trace))
                     {
@@ -394,7 +398,39 @@ internal sealed class AzureDevOpsReporter :
         _severity = GetConfiguredSeverity();
         _demoteKnownFlaky = _commandLine.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky);
         _quarantineFile = LoadQuarantineFile();
+        _userStackFrameFilters = LoadUserStackFrameFilters();
         _hasLoadedEnabledConfiguration = true;
+    }
+
+    private Regex[] LoadUserStackFrameFilters()
+    {
+        if (!_commandLine.TryGetOptionArgumentList(AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter, out string[]? patterns)
+            || patterns is not { Length: > 0 })
+        {
+            return [];
+        }
+
+        var compiled = new List<Regex>(patterns.Length);
+        foreach (string pattern in patterns)
+        {
+            try
+            {
+                compiled.Add(new Regex(
+                    pattern,
+                    RegexOptions.CultureInvariant | RegexOptions.Compiled,
+                    TimeSpan.FromMilliseconds(AzureDevOpsCommandLineProvider.StackFrameFilterMatchTimeoutMs)));
+            }
+            catch (ArgumentException ex)
+            {
+                // Should have been caught at validation time, but log and skip if not.
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning($"Skipping invalid '--report-azdo-stackframe-filter' regex '{pattern}': {ex.Message}");
+                }
+            }
+        }
+
+        return [.. compiled];
     }
 
     private static string GetTestName(TestNode testNode)
@@ -434,6 +470,34 @@ internal sealed class AzureDevOpsReporter :
             if (code.StartsWith(prefix, StringComparison.Ordinal))
             {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsUserStackFrameFilterMatch(string code, Regex[]? userStackFrameFilters, ILogger logger)
+    {
+        if (userStackFrameFilters is null || userStackFrameFilters.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (Regex filter in userStackFrameFilters)
+        {
+            try
+            {
+                if (filter.IsMatch(code))
+                {
+                    return true;
+                }
+            }
+            catch (RegexMatchTimeoutException ex)
+            {
+                if (logger.IsEnabled(LogLevel.Warning))
+                {
+                    logger.LogWarning($"'--report-azdo-stackframe-filter' regex '{filter}' timed out matching frame '{code}': {ex.Message}. Treating as no-match.");
+                }
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -352,11 +352,32 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
     }
 
     private static string FormatDuration(TimeSpan duration)
-        => duration < TimeSpan.FromSeconds(1)
-            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)duration.TotalMilliseconds)
-            : duration < TimeSpan.FromMinutes(1)
-                ? string.Format(CultureInfo.InvariantCulture, "{0:0.00}s", duration.TotalSeconds)
-                : string.Format(CultureInfo.InvariantCulture, "{0:hh\\:mm\\:ss}", duration);
+    {
+        if (duration < TimeSpan.FromSeconds(1))
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)duration.TotalMilliseconds);
+        }
+
+        if (duration < TimeSpan.FromMinutes(1))
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0:0.00}s", duration.TotalSeconds);
+        }
+
+        if (duration < TimeSpan.FromHours(1))
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0:mm\\:ss}", duration);
+        }
+
+        // Custom format `hh` is the *hour component* and wraps at 24 hours, so for >= 1 hour runs
+        // we compute total hours explicitly to keep multi-day sessions accurate.
+        long totalHours = (long)Math.Floor(duration.TotalHours);
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0}:{1:D2}:{2:D2}",
+            totalHours,
+            duration.Minutes,
+            duration.Seconds);
+    }
 
     private static string EscapeCell(string value)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -1,0 +1,453 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
+using Microsoft.Testing.Extensions.Reporting;
+using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Extensions.AzureDevOpsReport;
+
+internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLifetimeHandler, IOutputDeviceDataProducer
+{
+    private const string AzureDevOpsTfBuildVariableName = "TF_BUILD";
+    private const string DefaultSummaryFileNameFormat = "azdo-summary-{0}.md";
+    private const string FullyQualifiedNamePropertyKey = "vstest.TestCase.FullyQualifiedName";
+    private const int MaxSlowestTests = 10;
+    private const int MaxTopFailingClasses = 5;
+    private const int MaxFirstFailingFqns = 10;
+
+    private readonly ICommandLineOptions _commandLineOptions;
+    private readonly IConfiguration _configuration;
+    private readonly IEnvironment _environment;
+    private readonly IFileSystem _fileSystem;
+    private readonly IOutputDevice _outputDevice;
+    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
+    private readonly ILogger _logger;
+    private readonly Lazy<string> _targetFrameworkMoniker;
+
+#if NET9_0_OR_GREATER
+    private readonly System.Threading.Lock _stateLock = new();
+#else
+    private readonly object _stateLock = new();
+#endif
+#pragma warning disable IDE0028 // Collection initialization can be simplified - target-typed `new` cannot pass the comparer in the same syntactic form expected.
+    private readonly Dictionary<string, TestRecord> _records = new Dictionary<string, TestRecord>(StringComparer.Ordinal);
+#pragma warning restore IDE0028
+    private readonly bool _isEnabled;
+
+    private bool _emitAzureDevOpsCommands;
+
+    public AzureDevOpsSummaryReporter(
+        ICommandLineOptions commandLineOptions,
+        IConfiguration configuration,
+        IEnvironment environment,
+        IFileSystem fileSystem,
+        IOutputDevice outputDevice,
+        ITestApplicationModuleInfo testApplicationModuleInfo,
+        ILoggerFactory loggerFactory)
+    {
+        _commandLineOptions = commandLineOptions;
+        _configuration = configuration;
+        _environment = environment;
+        _fileSystem = fileSystem;
+        _outputDevice = outputDevice;
+        _testApplicationModuleInfo = testApplicationModuleInfo;
+        _logger = loggerFactory.CreateLogger<AzureDevOpsSummaryReporter>();
+        _isEnabled = commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsSummary);
+        _targetFrameworkMoniker = new(TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker);
+    }
+
+    public Type[] DataTypesConsumed { get; } = [typeof(TestNodeUpdateMessage)];
+
+    public string Uid => nameof(AzureDevOpsSummaryReporter);
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => AzureDevOpsResources.DisplayName;
+
+    public string Description => AzureDevOpsResources.Description;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
+
+    public async Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
+    {
+        try
+        {
+            testSessionContext.CancellationToken.ThrowIfCancellationRequested();
+
+            _emitAzureDevOpsCommands = false;
+            lock (_stateLock)
+            {
+                _records.Clear();
+            }
+
+            if (!_isEnabled)
+            {
+                return;
+            }
+
+            _emitAzureDevOpsCommands = string.Equals(_environment.GetEnvironmentVariable(AzureDevOpsTfBuildVariableName), "true", StringComparison.OrdinalIgnoreCase);
+            if (_emitAzureDevOpsCommands)
+            {
+                return;
+            }
+
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(AzureDevOpsResources.SummaryRequiresTfBuildWarning);
+            }
+
+            await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(AzureDevOpsResources.SummaryRequiresTfBuildWarning), testSessionContext.CancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+        }
+    }
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_isEnabled || value is not TestNodeUpdateMessage update)
+            {
+                return Task.CompletedTask;
+            }
+
+            TestNodeStateProperty? state = update.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+            TerminalKind kind = GetTerminalKind(state);
+            if (kind == TerminalKind.NotTerminal)
+            {
+                return Task.CompletedTask;
+            }
+
+            string uid = update.TestNode.Uid;
+            string displayName = update.TestNode.DisplayName;
+            string fullyQualifiedName = GetFullyQualifiedName(update.TestNode);
+            TimeSpan duration = GetDuration(update.TestNode);
+
+            lock (_stateLock)
+            {
+                _records[uid] = new TestRecord(displayName, fullyQualifiedName, kind, duration);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedException(nameof(ConsumeAsync), ex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
+    {
+        try
+        {
+            testSessionContext.CancellationToken.ThrowIfCancellationRequested();
+
+            if (!_emitAzureDevOpsCommands)
+            {
+                return;
+            }
+
+            List<TestRecord> snapshot;
+            lock (_stateLock)
+            {
+                snapshot = [.. _records.Values];
+            }
+
+            string markdown = BuildMarkdown(snapshot, _testApplicationModuleInfo.TryGetAssemblyName() ?? "unknown", _targetFrameworkMoniker.Value);
+            string? path = ResolveSummaryPath();
+            if (path is null)
+            {
+                if (_logger.IsEnabled(LogLevel.Trace))
+                {
+                    _logger.LogTrace("Could not resolve Azure DevOps summary path.");
+                }
+
+                return;
+            }
+
+            try
+            {
+                string? directory = Path.GetDirectoryName(path);
+                if (!RoslynString.IsNullOrEmpty(directory) && !_fileSystem.ExistDirectory(directory))
+                {
+                    _fileSystem.CreateDirectory(directory!);
+                }
+
+                using IFileStream stream = _fileSystem.NewFileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+                using var writer = new StreamWriter(stream.Stream, new UTF8Encoding(false));
+                await writer.WriteAsync(markdown).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                string warning = string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.SummaryWriteFailedWarning, path, ex.Message);
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning(warning);
+                }
+
+                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), testSessionContext.CancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            string line = $"##vso[task.uploadsummary]{AzDoEscaper.Escape(path)}";
+            await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
+        }
+    }
+
+    private string? ResolveSummaryPath()
+    {
+        if (_commandLineOptions.TryGetOptionArgumentList(AzureDevOpsCommandLineOptions.AzureDevOpsSummary, out string[]? arguments)
+            && arguments is [string explicitPath]
+            && !RoslynString.IsNullOrWhiteSpace(explicitPath))
+        {
+            return Path.GetFullPath(explicitPath);
+        }
+
+        string? configuredTestResultsDirectory = _configuration.GetTestResultDirectory();
+        if (RoslynString.IsNullOrWhiteSpace(configuredTestResultsDirectory))
+        {
+            return null;
+        }
+
+        string fileName = string.Format(CultureInfo.InvariantCulture, DefaultSummaryFileNameFormat, _targetFrameworkMoniker.Value);
+        return Path.GetFullPath(Path.Combine(configuredTestResultsDirectory!, fileName));
+    }
+
+    internal static /* for testing */ string BuildMarkdown(IReadOnlyList<TestRecord> records, string assemblyName, string targetFrameworkMoniker)
+    {
+        int total = records.Count;
+        int passed = 0;
+        int failed = 0;
+        int skipped = 0;
+        TimeSpan totalDuration = TimeSpan.Zero;
+        var failingByClass = new Dictionary<string, int>(StringComparer.Ordinal);
+        var failingFqns = new List<string>();
+
+        foreach (TestRecord record in records)
+        {
+            totalDuration += record.Duration;
+            switch (record.Kind)
+            {
+                case TerminalKind.Passed:
+                    passed++;
+                    break;
+                case TerminalKind.Failed:
+                    failed++;
+                    if (failingFqns.Count < MaxFirstFailingFqns)
+                    {
+                        failingFqns.Add(record.FullyQualifiedName);
+                    }
+
+                    string className = GetClassName(record.FullyQualifiedName);
+                    failingByClass[className] = failingByClass.TryGetValue(className, out int count) ? count + 1 : 1;
+                    break;
+                case TerminalKind.Skipped:
+                    skipped++;
+                    break;
+            }
+        }
+
+        var builder = new StringBuilder();
+        builder.Append("# Test summary — ").Append(assemblyName).Append(" (").Append(targetFrameworkMoniker).Append(")\n\n");
+        builder.Append("| Metric | Value |\n");
+        builder.Append("| --- | ---: |\n");
+        builder.Append("| Total | ").Append(total.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+        builder.Append("| Passed | ").Append(passed.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+        builder.Append("| Failed | ").Append(failed.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+        builder.Append("| Skipped | ").Append(skipped.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+        builder.Append("| Total duration | ").Append(FormatDuration(totalDuration)).Append(" |\n");
+        builder.Append('\n');
+
+        if (failingByClass.Count > 0)
+        {
+            builder.Append("## Top failing classes\n\n");
+            builder.Append("| Class | Failures |\n");
+            builder.Append("| --- | ---: |\n");
+            foreach (KeyValuePair<string, int> pair in failingByClass.OrderByDescending(static p => p.Value).ThenBy(static p => p.Key, StringComparer.Ordinal).Take(MaxTopFailingClasses))
+            {
+                builder.Append("| ").Append(EscapeCell(pair.Key)).Append(" | ").Append(pair.Value.ToString(CultureInfo.InvariantCulture)).Append(" |\n");
+            }
+
+            builder.Append('\n');
+        }
+
+        if (failingFqns.Count > 0)
+        {
+            builder.Append("## First failing tests\n\n");
+            foreach (string fqn in failingFqns)
+            {
+                builder.Append("- ").Append(EscapeCell(fqn)).Append('\n');
+            }
+
+            builder.Append('\n');
+        }
+
+        IEnumerable<TestRecord> slowest = records
+            .Where(static r => r.Duration > TimeSpan.Zero)
+            .OrderByDescending(static r => r.Duration)
+            .Take(MaxSlowestTests);
+
+        bool slowestEmitted = false;
+        foreach (TestRecord record in slowest)
+        {
+            if (!slowestEmitted)
+            {
+                builder.Append("## Slowest tests\n\n");
+                builder.Append("| Test | Duration |\n");
+                builder.Append("| --- | ---: |\n");
+                slowestEmitted = true;
+            }
+
+            builder.Append("| ").Append(EscapeCell(record.DisplayName)).Append(" | ").Append(FormatDuration(record.Duration)).Append(" |\n");
+        }
+
+        if (slowestEmitted)
+        {
+            builder.Append('\n');
+        }
+
+        return builder.ToString();
+    }
+
+    private static string GetClassName(string fullyQualifiedName)
+    {
+        if (RoslynString.IsNullOrEmpty(fullyQualifiedName))
+        {
+            return "(unknown)";
+        }
+
+        int lastDot = fullyQualifiedName.LastIndexOf('.');
+        return lastDot <= 0 ? "(unknown)" : fullyQualifiedName.Substring(0, lastDot);
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+        => duration < TimeSpan.FromSeconds(1)
+            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)duration.TotalMilliseconds)
+            : duration < TimeSpan.FromMinutes(1)
+                ? string.Format(CultureInfo.InvariantCulture, "{0:0.00}s", duration.TotalSeconds)
+                : string.Format(CultureInfo.InvariantCulture, "{0:hh\\:mm\\:ss}", duration);
+
+    private static string EscapeCell(string value)
+    {
+        if (RoslynString.IsNullOrEmpty(value))
+        {
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        foreach (char c in value)
+        {
+            switch (c)
+            {
+                case '|':
+                    sb.Append("\\|");
+                    break;
+                case '`':
+                    sb.Append("\\`");
+                    break;
+                case '\r':
+                    break;
+                case '\n':
+                    sb.Append("<br>");
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string GetFullyQualifiedName(TestNode testNode)
+        => testNode.Properties
+            .OfType<SerializableKeyValuePairStringProperty>()
+            .FirstOrDefault(static property => property.Key == FullyQualifiedNamePropertyKey)?.Value
+            ?? testNode.DisplayName;
+
+    private static TimeSpan GetDuration(TestNode testNode)
+    {
+        TimingProperty? timing = testNode.Properties.SingleOrDefault<TimingProperty>();
+        return timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
+    }
+
+    private static TerminalKind GetTerminalKind(TestNodeStateProperty? state)
+        => state switch
+        {
+            PassedTestNodeStateProperty => TerminalKind.Passed,
+            FailedTestNodeStateProperty => TerminalKind.Failed,
+            ErrorTestNodeStateProperty => TerminalKind.Failed,
+            TimeoutTestNodeStateProperty => TerminalKind.Failed,
+            SkippedTestNodeStateProperty => TerminalKind.Skipped,
+#pragma warning disable CS0618, MTP0001
+            CancelledTestNodeStateProperty => TerminalKind.Failed,
+#pragma warning restore CS0618, MTP0001
+            _ => TerminalKind.NotTerminal,
+        };
+
+    private void LogUnexpectedException(string callbackName, Exception ex)
+    {
+        if (_logger.IsEnabled(LogLevel.Warning))
+        {
+            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
+        }
+    }
+
+    internal readonly struct TestRecord
+    {
+        public TestRecord(string displayName, string fullyQualifiedName, TerminalKind kind, TimeSpan duration)
+        {
+            DisplayName = displayName;
+            FullyQualifiedName = fullyQualifiedName;
+            Kind = kind;
+            Duration = duration;
+        }
+
+        public string DisplayName { get; }
+
+        public string FullyQualifiedName { get; }
+
+        public TerminalKind Kind { get; }
+
+        public TimeSpan Duration { get; }
+    }
+
+    internal enum TerminalKind
+    {
+        NotTerminal,
+        Passed,
+        Failed,
+        Skipped,
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -176,12 +176,24 @@
   <data name="AzureDevOpsLivePublishingTimeoutErrorMessageWithReason" xml:space="preserve">
     <value>Timeout: {0}</value>
   </data>
+  <data name="AzureDevOpsProgressRequiresAzureDevOps" xml:space="preserve">
+    <value>'--report-azdo-progress' requires '--report-azdo' to be enabled</value>
+    <comment>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</comment>
+  </data>
   <data name="AzureDevOpsQuarantineFileRequiresAzureDevOps" xml:space="preserve">
     <value>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</value>
   </data>
   <data name="AzureDevOpsReportSeverityRequiresAzureDevOps" xml:space="preserve">
     <value>'--report-azdo-severity' requires '--report-azdo' to be enabled</value>
     <comment>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</comment>
+  </data>
+  <data name="AzureDevOpsStackFrameFilterRequiresAzureDevOps" xml:space="preserve">
+    <value>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</value>
+    <comment>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</comment>
+  </data>
+  <data name="AzureDevOpsSummaryRequiresAzureDevOps" xml:space="preserve">
+    <value>'--report-azdo-summary' requires '--report-azdo' to be enabled</value>
+    <comment>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</comment>
   </data>
   <data name="DemoteKnownFlakyOptionDescription" xml:space="preserve">
     <value>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</value>
@@ -233,11 +245,23 @@
   <data name="InvalidSeverity" xml:space="preserve">
     <value>Invalid option {0}.</value>
   </data>
+  <data name="InvalidStackFrameFilterRegex" xml:space="preserve">
+    <value>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</value>
+    <comment>{Locked="--report-azdo-stackframe-filter"}</comment>
+  </data>
   <data name="NoFailureMessageFallback" xml:space="preserve">
     <value>Test failed without an additional message.</value>
   </data>
   <data name="OptionDescription" xml:space="preserve">
     <value>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</value>
+  </data>
+  <data name="ProgressOptionDescription" xml:space="preserve">
+    <value>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</value>
+    <comment>{Locked="--report-azdo"}</comment>
+  </data>
+  <data name="ProgressRequiresTfBuildWarning" xml:space="preserve">
+    <value>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</value>
+    <comment>{Locked="TF_BUILD"}{Locked="true"}</comment>
   </data>
   <data name="PublishAzdoRunNameOptionDescription" xml:space="preserve">
     <value>Custom Azure DevOps test run name for live test-result publishing.</value>
@@ -272,6 +296,25 @@
   <data name="SeverityOptionDescription" xml:space="preserve">
     <value>Severity to use for the reported event. Options are: error (default) and warning.</value>
     <comment>{Locked="error"}{Locked="warning"}</comment>
+  </data>
+  <data name="StackFrameFilterOptionDescription" xml:space="preserve">
+    <value>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</value>
+    <comment>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</comment>
+  </data>
+  <data name="StackFrameFilterTooManyRegexes" xml:space="preserve">
+    <value>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</value>
+    <comment>{Locked="--report-azdo-stackframe-filter"}</comment>
+  </data>
+  <data name="SummaryOptionDescription" xml:space="preserve">
+    <value>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</value>
+    <comment>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</comment>
+  </data>
+  <data name="SummaryRequiresTfBuildWarning" xml:space="preserve">
+    <value>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</value>
+    <comment>{Locked="TF_BUILD"}{Locked="true"}</comment>
+  </data>
+  <data name="SummaryWriteFailedWarning" xml:space="preserve">
+    <value>Failed to write Azure DevOps summary file '{0}': {1}</value>
   </data>
   <data name="UploadArtifactExcludeOptionDescription" xml:space="preserve">
     <value>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Časový limit: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">Aby bylo možné použít parametr --report-azdo-quarantine-file, musí být povolený parametr --report-azdo.</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">--report-azdo-severity vyžaduje, aby byla povolena možnost --report-azdo</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Neplatná možnost {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Test neproběhl úspěšně bez další zprávy.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Umožňuje generátoru sestav Azure DevOps zapisovat chyby do výstupu způsobem, který je pro AzureDev Ops srozumitelný.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Závažnost, která se má použít pro hlášenou událost. Možnosti: error (výchozí) a warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Zeitüberschreitung: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">Für „--report-azdo-quarantine-file“ muss „--report-azdo“ aktiviert sein.</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">Für „--report-azdo-severity“ muss „--report-azdo“ aktiviert sein.</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Ungültige Option „{0}“.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Fehler beim Test ohne zusätzliche Meldung.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Azure DevOps-Bericht-Generator aktivieren, um Fehler auf eine Weise in die Ausgabe zu schreiben, die AzureDev Ops versteht.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Schweregrad, der für das gemeldete Ereignis verwendet werden soll. Optionen sind: error (Standard) und warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Tiempo de espera: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-quarantine-file" requiere que se habilite "--report-azdo"</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-severity" requiere que se habilite "--report-azdo"</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Opción no válida {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Error en la prueba sin un mensaje adicional.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Habilite el generador de informes de Azure DevOps para que escriba errores en la salida de una forma que Azure DevOps entienda.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Gravedad que se va a usar para el evento notificado. Las opciones son: error (valor predeterminado) y warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Délai d’expiration : {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">« --report-azdo-quarantine-file » nécessite l’activation de « --report-azdo »</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">« --report-azdo-severity » nécessite l’activation de « --report-azdo »</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Option {0} non valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Le test a échoué sans message supplémentaire.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Activer le générateur de rapports Azure DevOps pour écrire des erreurs dans la sortie d’une manière compréhensible par Azure DevOps.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Gravité à utiliser pour l’événement signalé. Les options sont : error (par défaut) et warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Timeout: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-quarantine-file' richiede che '--report-azdo' sia abilitato</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity' richiede l'autenticazione di '--report-azdo'</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Opzione non valida {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Test non riuscito senza un messaggio aggiuntivo.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Abilita il generatore di report di Azure DevOps per scrivere gli errori nell'output in un modo che Azure DevOps comprenda.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Gravità da usare per l'evento segnalato. Le opzioni sono: error (impostazione predefinita) e warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -92,6 +92,11 @@
         <target state="translated">タイムアウト: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-quarantine-file' では、'--report-azdo' を有効にする必要があります</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity' では、'--report-azdo' を有効にする必要があります</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">オプション {0} が無効です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">追加のメッセージなしでテストに失敗しました。</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">AzureDevOps が理解する方法で出力にエラーを書き込む Azure DevOps レポート生成プログラムを有効にします。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">報告されたイベントに使用する重大度。オプションは、error (既定) と warning です。</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -92,6 +92,11 @@
         <target state="translated">시간 제한: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-quarantine-file'을 사용하려면 '--report-azdo'가 활성화되어 있어야 합니다.</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity'를 사용하려면 '--report-azdo'를 사용 설정 해야합니다.</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">{0} 옵션이 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">추가 메시지 없이 테스트가 실패했습니다.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Azure DevOps 보고서 생성기를 활성화하여 Azure DevOps가 이해할 수 있는 방식으로 출력에 오류를 기록합니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">보고된 이벤트에 사용할 심각도입니다. 옵션은 error(기본값)와 warning, 두 가지입니다.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Limit czasu: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">Element „--report-azdo-quarantine-file” wymaga włączenia opcji „--report-azdo”</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">Element „--report-azdo-severity” wymaga włączenia polecenia „--report-azdo”</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Nieprawidłowa opcja {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Test nie powiódł się bez dodatkowego komunikatu.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Włącz generator raportów usługi Azure DevOps, aby zapisywać błędy w danych wyjściowych w sposób zrozumiały dla usługi Azure DevOps.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Ważność do użycia dla zgłoszonego zdarzenia. Dostępne opcje to: error (domyślny) i warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Tempo limite: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-quarantine-file' requer que '--report-azdo' esteja habilitado</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity' requer que '--report-azdo' esteja habilitado</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Opção {0} inválida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">O teste falhou sem uma mensagem adicional.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Habilite o gerador de relatórios do Azure DevOps para gravar erros na saída de uma forma que o Azure DevOps entenda.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">A gravidade que será usada para o evento relatado. As opções são: error (padrão) e warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Превышено время ожидания: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-quarantine-file" требует включения "--report-azdo"</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-severity" требует включения "--report-azdo"</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Недопустимый параметр {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Тест завершился сбоем без дополнительного сообщения.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Включите генератор отчетов Azure DevOps для записи ошибок в выходные данные в формате, который понимает Azure DevOps.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Уровень серьезности, используемый для события из отчета. Параметры: error (по умолчанию) и warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -92,6 +92,11 @@
         <target state="translated">Zaman aşımı: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-quarantine-file' öğesi '--report-azdo' öğesinin etkinleştirilmesini gerektirir</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity' öğesi '--report-azdo' öğesinin etkinleştirilmesini gerektirir</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">Geçersiz seçenek{0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">Ek bir ileti olmadan test başarısız oldu.</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">Azure DevOps rapor oluşturucusunu, hataları Azure DevOps'un anlayacağı şekilde çıktıya yazacak biçimde etkinleştirin.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">Raporlanan olay için kullanılacak önem derecesi. Seçenekler şunlardır: error (varsayılan) ve warning.</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -92,6 +92,11 @@
         <target state="translated">超时: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-quarantine-file" 要求启用 "--report-azdo"</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity' 要求启用 '--report-azdo'</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">选项 {0} 无效。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">测试失败，无附加消息。</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">启用 Azure DevOps 报表生成器，以 Azure DevOps 可理解的方式将错误写入输出。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">要用于所报告事件的严重性。选项为: error (默认)和 warning。</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -92,6 +92,11 @@
         <target state="translated">逾時: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsProgressRequiresAzureDevOps">
+        <source>'--report-azdo-progress' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-progress' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-progress'}{Locked='--report-azdo'}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsQuarantineFileRequiresAzureDevOps">
         <source>'--report-azdo-quarantine-file' requires '--report-azdo' to be enabled</source>
         <target state="translated">需要啟用 '--report-azdo'，才能使用 '--report-azdo-quarantine-file'</target>
@@ -101,6 +106,16 @@
         <source>'--report-azdo-severity' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-severity' 需要啟用 '--report-azdo'</target>
         <note>{Locked='--report-azdo-severity'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsStackFrameFilterRequiresAzureDevOps">
+        <source>'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-stackframe-filter' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-stackframe-filter'}{Locked='--report-azdo'}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsSummaryRequiresAzureDevOps">
+        <source>'--report-azdo-summary' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-summary' requires '--report-azdo' to be enabled</target>
+        <note>{Locked='--report-azdo-summary'}{Locked='--report-azdo'}</note>
       </trans-unit>
       <trans-unit id="DemoteKnownFlakyOptionDescription">
         <source>Demote failures with an Azure DevOps flaky history of at least {0}% in the selected window to warnings.</source>
@@ -177,6 +192,11 @@
         <target state="translated">無效的選項 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidStackFrameFilterRegex">
+        <source>Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</source>
+        <target state="new">Invalid '--report-azdo-stackframe-filter' regex '{0}': {1}</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
       <trans-unit id="NoFailureMessageFallback">
         <source>Test failed without an additional message.</source>
         <target state="translated">測試失敗，沒有其他訊息。</target>
@@ -186,6 +206,16 @@
         <source>Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.</source>
         <target state="translated">啟用 Azure DevOps 報告產生器以 Azure DevOps 可理解的方式將錯誤寫入輸出。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="ProgressOptionDescription">
+        <source>Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</source>
+        <target state="new">Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="ProgressRequiresTfBuildWarning">
+        <source>Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</source>
+        <target state="new">Azure DevOps progress reporting was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps progress emissions.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
       </trans-unit>
       <trans-unit id="PublishAzdoRunNameOptionDescription">
         <source>Custom Azure DevOps test run name for live test-result publishing.</source>
@@ -236,6 +266,31 @@
         <source>Severity to use for the reported event. Options are: error (default) and warning.</source>
         <target state="translated">要用於所報告事件的嚴重性。選項為: error (預設) warning。</target>
         <note>{Locked="error"}{Locked="warning"}</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterOptionDescription">
+        <source>Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</source>
+        <target state="new">Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to {0} patterns. Compiled with a {1}ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.</target>
+        <note>{0} is the maximum allowed pattern count, {1} is the per-match timeout in ms.</note>
+      </trans-unit>
+      <trans-unit id="StackFrameFilterTooManyRegexes">
+        <source>'--report-azdo-stackframe-filter' accepts at most {0} patterns.</source>
+        <target state="new">'--report-azdo-stackframe-filter' accepts at most {0} patterns.</target>
+        <note>{Locked="--report-azdo-stackframe-filter"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryOptionDescription">
+        <source>Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</source>
+        <target state="new">Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.</target>
+        <note>{Locked="--report-azdo"}{Locked="##vso[task.uploadsummary]"}{Locked="azdo-summary-{tfm}.md"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryRequiresTfBuildWarning">
+        <source>Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</source>
+        <target state="new">Azure DevOps job summary was requested, but TF_BUILD is not set to 'true'; skipping summary emission.</target>
+        <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="SummaryWriteFailedWarning">
+        <source>Failed to write Azure DevOps summary file '{0}': {1}</source>
+        <target state="new">Failed to write Azure DevOps summary file '{0}': {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="UploadArtifactExcludeOptionDescription">
         <source>Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.</source>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -128,10 +128,16 @@ Extension options:
         Demote failures with an Azure DevOps flaky history of at least 25% in the selected window to warnings.
     --report-azdo-flaky-history
         Query Azure DevOps test result history for the past N days (1-90) and annotate reported failures with flakiness context.
+    --report-azdo-progress
+        Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.
     --report-azdo-quarantine-file
         Path to a text file that lists quarantined test fully qualified names or glob patterns. Matching failures are reported as warnings.
     --report-azdo-severity
         Severity to use for the reported event. Options are: error (default) and warning.
+    --report-azdo-stackframe-filter
+        Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to 16 patterns. Compiled with a 500ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.
+    --report-azdo-summary
+        Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.
     --report-azdo-upload-artifact-exclude
         Exclude files from Azure DevOps artifact upload using glob patterns relative to the test results directory.
     --report-azdo-upload-artifact-include
@@ -374,6 +380,10 @@ Registered command line providers:
         Arity: 1
         Hidden: False
         Description: Query Azure DevOps test result history for the past N days (1-90) and annotate reported failures with flakiness context.
+      --report-azdo-progress
+        Arity: 0
+        Hidden: False
+        Description: Emit Azure DevOps timeline progress records during the test run so long-running sessions show a live progress bar on the build's timeline. Requires '--report-azdo'.
       --report-azdo-quarantine-file
         Arity: 1
         Hidden: False
@@ -382,6 +392,14 @@ Registered command line providers:
         Arity: 1
         Hidden: False
         Description: Severity to use for the reported event. Options are: error (default) and warning.
+      --report-azdo-stackframe-filter
+        Arity: 1..N
+        Hidden: False
+        Description: Additional regex patterns (matched against the fully-qualified type prefix of each stack frame) that should be skipped when looking for the user's call site to annotate. Repeatable; up to 16 patterns. Compiled with a 500ms match timeout. Additive to the extension's built-in MSTest assertion-implementation prefixes.
+      --report-azdo-summary
+        Arity: 0..1
+        Hidden: False
+        Description: Write a Markdown job summary at the end of the test run and upload it via '##vso[task.uploadsummary]'. An optional file path argument overrides the default location ('{testResultsDir}/azdo-summary-{tfm}.md'). Requires '--report-azdo'.
       --report-azdo-upload-artifact-exclude
         Arity: 0..N
         Hidden: False

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsCommandLineProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsCommandLineProviderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Testing.Extensions.Reporting;
 using Microsoft.Testing.Extensions.UnitTests.Helpers;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Extensions.UnitTests;
 
@@ -79,19 +80,77 @@ public sealed class AzureDevOpsCommandLineProviderTests
     }
 
     [TestMethod]
-    public async Task ValidateCommandLineOptionsAsync_ReturnsValid_WhenAzureDevOpsDependentOptionsAreConfiguredCorrectlyAsync()
+    public async Task ValidateCommandLineOptionsAsync_ReturnsInvalid_WhenProgressIsUsedWithoutAzureDevOpsAsync()
     {
         AzureDevOpsCommandLineProvider provider = new();
         ValidationResult validationResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(new Dictionary<string, string[]>
         {
-            [AzureDevOpsCommandLineOptions.AzureDevOpsOptionName] = [],
-            [AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky] = [],
-            [AzureDevOpsCommandLineOptions.AzureDevOpsFlakyHistory] = ["14"],
-            [AzureDevOpsCommandLineOptions.AzureDevOpsQuarantineFile] = ["quarantine.txt"],
-            [AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity] = ["warning"],
+            [AzureDevOpsCommandLineOptions.AzureDevOpsProgress] = [],
         })).ConfigureAwait(false);
 
-        Assert.IsTrue(validationResult.IsValid);
-        Assert.IsNull(validationResult.ErrorMessage);
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.AreEqual(AzureDevOpsResources.AzureDevOpsProgressRequiresAzureDevOps, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateCommandLineOptionsAsync_ReturnsInvalid_WhenSummaryIsUsedWithoutAzureDevOpsAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        ValidationResult validationResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(new Dictionary<string, string[]>
+        {
+            [AzureDevOpsCommandLineOptions.AzureDevOpsSummary] = [],
+        })).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.AreEqual(AzureDevOpsResources.AzureDevOpsSummaryRequiresAzureDevOps, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateCommandLineOptionsAsync_ReturnsInvalid_WhenStackFrameFilterIsUsedWithoutAzureDevOpsAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        ValidationResult validationResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(new Dictionary<string, string[]>
+        {
+            [AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter] = ["^MyCompany\\."],
+        })).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.AreEqual(AzureDevOpsResources.AzureDevOpsStackFrameFilterRequiresAzureDevOps, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsInvalid_WhenStackFrameFilterRegexIsInvalidAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter);
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, ["[unclosed"]).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.Contains("[unclosed", validationResult.ErrorMessage ?? string.Empty);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsInvalid_WhenStackFrameFilterHasTooManyPatternsAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter);
+        string[] patterns = Enumerable.Range(0, AzureDevOpsCommandLineProvider.MaxStackFrameFilterPatterns + 1)
+            .Select(i => $"^Foo{i}\\.")
+            .ToArray();
+
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, patterns).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.Contains(AzureDevOpsCommandLineProvider.MaxStackFrameFilterPatterns.ToString(System.Globalization.CultureInfo.InvariantCulture), validationResult.ErrorMessage ?? string.Empty);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsValid_ForValidStackFrameFilterRegexAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsStackFrameFilter);
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, ["^MyCompany\\.Testing\\."]).ConfigureAwait(false);
+
+        Assert.IsTrue(validationResult.IsValid, validationResult.ErrorMessage);
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsProgressReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsProgressReporterTests.cs
@@ -141,6 +141,35 @@ public sealed class AzureDevOpsProgressReporterTests
     }
 
     [TestMethod]
+    public async Task ConsumeAsync_CapsInProgressEmissionAt99_ReservesHundredForCompletedAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("true");
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+        _outputData.Clear();
+
+        // Two tests, both completed without any prior `InProgress` event so seen==completed==2.
+        // The raw percentage is 100; the in-progress emission must cap at 99 so the final
+        // state=Completed emission can still surface as 100.
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t1", new PassedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+        await Task.Delay(AzureDevOpsProgressReporter.MinimumEmissionIntervalMs + 50, TestContext.CancellationToken).ConfigureAwait(false);
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t2", new PassedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+
+        string[] inProgressLines = GetFormattedLines();
+        foreach (string line in inProgressLines)
+        {
+            Assert.DoesNotContain(";progress=100;", line);
+            Assert.DoesNotContain(";progress=100]", line);
+        }
+
+        await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        string[] allLines = GetFormattedLines();
+        Assert.Contains(";progress=100;state=Completed;result=Succeeded]", allLines[^1]);
+    }
+
+    [TestMethod]
     public async Task SessionFinishing_DoesNothing_WhenTfBuildNotSetAsync()
     {
         AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsProgressReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsProgressReporterTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.AzureDevOpsReport;
+using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
+using Microsoft.Testing.Extensions.Reporting;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class AzureDevOpsProgressReporterTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    private readonly Mock<IEnvironment> _environmentMock = new();
+    private readonly Mock<IOutputDevice> _outputDeviceMock = new();
+    private readonly Mock<ITestApplicationModuleInfo> _testApplicationModuleInfoMock = new();
+    private readonly Mock<ILoggerFactory> _loggerFactoryMock = new();
+    private readonly List<IOutputDeviceData> _outputData = [];
+
+    public AzureDevOpsProgressReporterTests()
+    {
+        _ = _testApplicationModuleInfoMock.Setup(info => info.TryGetAssemblyName()).Returns("MyAssembly");
+        _ = _loggerFactoryMock.Setup(loggerFactory => loggerFactory.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+        _ = _outputDeviceMock
+            .Setup(outputDevice => outputDevice.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>(), It.IsAny<CancellationToken>()))
+            .Callback<IOutputDeviceDataProducer, IOutputDeviceData, CancellationToken>((_, data, _) => _outputData.Add(data))
+            .Returns(Task.CompletedTask);
+    }
+
+    [TestMethod]
+    public async Task IsEnabledAsync_ReturnsFalse_WhenProgressOptionNotSetAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: false);
+        Assert.IsFalse(await reporter.IsEnabledAsync().ConfigureAwait(false));
+    }
+
+    [TestMethod]
+    public async Task IsEnabledAsync_ReturnsTrue_WhenProgressOptionSetAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        Assert.IsTrue(await reporter.IsEnabledAsync().ConfigureAwait(false));
+    }
+
+    [TestMethod]
+    public async Task SessionStarting_DoesNothingWhenTfBuildIsNotSetAndEmitsWarningAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns((string?)null);
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        Assert.IsEmpty(GetFormattedLines());
+        Assert.Contains(AzureDevOpsResources.ProgressRequiresTfBuildWarning, GetWarnings());
+    }
+
+    [TestMethod]
+    public async Task SessionStarting_EmitsLogDetailInProgressAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("true");
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        string[] lines = GetFormattedLines();
+        Assert.HasCount(1, lines);
+        Assert.StartsWith("##vso[task.logdetail id=", lines[0]);
+        Assert.Contains(";type=Build;", lines[0]);
+        Assert.Contains(";state=InProgress;", lines[0]);
+        Assert.Contains(";progress=0]", lines[0]);
+        Assert.Contains("MyAssembly", lines[0]);
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_EmitsMonotonicProgress_WithUidDedupAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("true");
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+        _outputData.Clear();
+
+        // Two distinct tests, both pass — should at least let us see a progress update on the last one.
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t1", new InProgressTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t1", new PassedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+        // Same uid re-emitted: should be deduped (no impact on completed counter).
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t1", new PassedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+
+        await Task.Delay(AzureDevOpsProgressReporter.MinimumEmissionIntervalMs + 50, TestContext.CancellationToken).ConfigureAwait(false);
+
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t2", new InProgressTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t2", new PassedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+
+        await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        string[] lines = GetFormattedLines();
+        Assert.IsNotEmpty(lines);
+        // Last line is the finish: progress=100;state=Completed;result=Succeeded
+        Assert.Contains(";progress=100;state=Completed;result=Succeeded]", lines[^1]);
+
+        // All progress values should be non-decreasing.
+        int previous = -1;
+        foreach (string line in lines)
+        {
+            int idx = line.IndexOf(";progress=", StringComparison.Ordinal);
+            if (idx < 0)
+            {
+                continue;
+            }
+
+            int valueStart = idx + ";progress=".Length;
+            int valueEnd = line.IndexOfAny([';', ']'], valueStart);
+            int parsed = int.Parse(line[valueStart..valueEnd], System.Globalization.CultureInfo.InvariantCulture);
+            Assert.IsGreaterThanOrEqualTo(previous, parsed, $"Progress regressed: line was '{line}'.");
+            previous = parsed;
+        }
+    }
+
+    [TestMethod]
+    public async Task SessionFinishing_EmitsFailedResult_WhenAnyTestFailedAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("true");
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t1", new FailedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+        await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        string[] lines = GetFormattedLines();
+        Assert.Contains(";progress=100;state=Completed;result=Failed]", lines[^1]);
+    }
+
+    [TestMethod]
+    public async Task SessionFinishing_DoesNothing_WhenTfBuildNotSetAsync()
+    {
+        AzureDevOpsProgressReporter reporter = CreateReporter(enabled: true);
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns((string?)null);
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+        _outputData.Clear();
+        await reporter.ConsumeAsync(CreateProducer(), CreateTestNodeUpdateMessage("t1", new PassedTestNodeStateProperty()), CancellationToken.None).ConfigureAwait(false);
+        await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        Assert.IsEmpty(GetFormattedLines());
+    }
+
+    private AzureDevOpsProgressReporter CreateReporter(bool enabled)
+    {
+        Dictionary<string, string[]> options = enabled
+            ? new Dictionary<string, string[]> { [AzureDevOpsCommandLineOptions.AzureDevOpsProgress] = [] }
+            : [];
+        return new AzureDevOpsProgressReporter(
+            new TestCommandLineOptions(options),
+            _environmentMock.Object,
+            _outputDeviceMock.Object,
+            _testApplicationModuleInfoMock.Object,
+            _loggerFactoryMock.Object);
+    }
+
+    private static TestNodeUpdateMessage CreateTestNodeUpdateMessage(string uid, TestNodeStateProperty state)
+        => new(
+            new SessionUid("session"),
+            new TestNode
+            {
+                Uid = uid,
+                DisplayName = uid,
+                Properties = new PropertyBag(state),
+            });
+
+    private static IDataProducer CreateProducer()
+        => new TestProducer();
+
+    private string[] GetFormattedLines()
+        => [.. _outputData.OfType<FormattedTextOutputDeviceData>().Select(output => output.Text)];
+
+    private string[] GetWarnings()
+        => [.. _outputData.OfType<WarningMessageOutputDeviceData>().Select(output => output.Message)];
+
+    private sealed class TestProducer : IDataProducer
+    {
+        public Type[] DataTypesProduced { get; } = [typeof(TestNodeUpdateMessage)];
+
+        public string Uid => "TestProducer";
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => "TestProducer";
+
+        public string Description => "TestProducer";
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    }
+
+    private sealed class TestSessionContext : ITestSessionContext
+    {
+        public SessionUid SessionUid { get; } = new("session");
+
+        public CancellationToken CancellationToken { get; } = CancellationToken.None;
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
@@ -92,6 +92,35 @@ public sealed class AzureDevOpsSummaryReporterTests
     }
 
     [TestMethod]
+    public void BuildMarkdown_FormatsTotalDurationCorrectly_BeyondTwentyFourHours()
+    {
+        // 25 hours 7 minutes 8 seconds total: TimeSpan custom format `hh` wraps at 24h
+        // (would render as 01:07:08), so the implementation must use TotalHours for >= 1h.
+        var records = new List<AzureDevOpsSummaryReporter.TestRecord>
+        {
+            new("LongTest", "MyCo.X.LongTest", AzureDevOpsSummaryReporter.TerminalKind.Passed, new TimeSpan(25, 7, 8)),
+        };
+
+        string md = AzureDevOpsSummaryReporter.BuildMarkdown(records, "MyAssembly", "net8.0");
+
+        Assert.Contains("| Total duration | 25:07:08 |", md);
+        Assert.DoesNotContain("| Total duration | 01:07:08 |", md);
+    }
+
+    [TestMethod]
+    public void BuildMarkdown_FormatsTotalDurationAsMinutesAndSeconds_WhenBelowOneHour()
+    {
+        var records = new List<AzureDevOpsSummaryReporter.TestRecord>
+        {
+            new("MidTest", "MyCo.X.MidTest", AzureDevOpsSummaryReporter.TerminalKind.Passed, new TimeSpan(0, 5, 30)),
+        };
+
+        string md = AzureDevOpsSummaryReporter.BuildMarkdown(records, "MyAssembly", "net8.0");
+
+        Assert.Contains("| Total duration | 05:30 |", md);
+    }
+
+    [TestMethod]
     public void BuildMarkdown_EscapesPipesAndNewlinesInCells()
     {
         var records = new List<AzureDevOpsSummaryReporter.TestRecord>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.AzureDevOpsReport;
+using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
+using Microsoft.Testing.Extensions.Reporting;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class AzureDevOpsSummaryReporterTests
+{
+    private static readonly string ResultsDirectory = Path.Combine(Path.GetTempPath(), "azdo-summary-reporter-tests");
+
+    private readonly Mock<IConfiguration> _configurationMock = new();
+    private readonly Mock<IEnvironment> _environmentMock = new();
+    private readonly Mock<IFileSystem> _fileSystemMock = new();
+    private readonly Mock<IOutputDevice> _outputDeviceMock = new();
+    private readonly Mock<ITestApplicationModuleInfo> _testApplicationModuleInfoMock = new();
+    private readonly Mock<ILoggerFactory> _loggerFactoryMock = new();
+    private readonly List<IOutputDeviceData> _outputData = [];
+
+    public AzureDevOpsSummaryReporterTests()
+    {
+        _ = _configurationMock.SetupGet(c => c[PlatformConfigurationConstants.PlatformResultDirectory]).Returns(ResultsDirectory);
+        _ = _testApplicationModuleInfoMock.Setup(info => info.TryGetAssemblyName()).Returns("MyAssembly");
+        _ = _loggerFactoryMock.Setup(loggerFactory => loggerFactory.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+        _ = _outputDeviceMock
+            .Setup(outputDevice => outputDevice.DisplayAsync(It.IsAny<IOutputDeviceDataProducer>(), It.IsAny<IOutputDeviceData>(), It.IsAny<CancellationToken>()))
+            .Callback<IOutputDeviceDataProducer, IOutputDeviceData, CancellationToken>((_, data, _) => _outputData.Add(data))
+            .Returns(Task.CompletedTask);
+    }
+
+    [TestMethod]
+    public async Task IsEnabledAsync_ReturnsFalse_WhenSummaryOptionNotSetAsync()
+    {
+        AzureDevOpsSummaryReporter reporter = CreateReporter(options: []);
+        Assert.IsFalse(await reporter.IsEnabledAsync().ConfigureAwait(false));
+    }
+
+    [TestMethod]
+    public async Task SessionFinishing_DoesNothingAndEmitsWarning_WhenTfBuildNotSetAsync()
+    {
+        AzureDevOpsSummaryReporter reporter = CreateReporter(EnabledOptions());
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns((string?)null);
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        Assert.Contains(AzureDevOpsResources.SummaryRequiresTfBuildWarning, GetWarnings());
+
+        await reporter.ConsumeAsync(CreateProducer(), CreatePassed("t1"), CancellationToken.None).ConfigureAwait(false);
+        await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        Assert.IsEmpty(GetFormattedLines());
+    }
+
+    [TestMethod]
+    public void BuildMarkdown_RendersTotalsAndTopFailingAndSlowest()
+    {
+        var records = new List<AzureDevOpsSummaryReporter.TestRecord>
+        {
+            new("Test1", "MyCo.Suite.ClassA.Test1", AzureDevOpsSummaryReporter.TerminalKind.Passed, TimeSpan.FromMilliseconds(100)),
+            new("Test2", "MyCo.Suite.ClassA.Test2", AzureDevOpsSummaryReporter.TerminalKind.Failed, TimeSpan.FromMilliseconds(200)),
+            new("Test3", "MyCo.Suite.ClassA.Test3", AzureDevOpsSummaryReporter.TerminalKind.Failed, TimeSpan.FromMilliseconds(50)),
+            new("Slowpoke", "MyCo.Suite.ClassB.Slowpoke", AzureDevOpsSummaryReporter.TerminalKind.Passed, TimeSpan.FromSeconds(12)),
+            new("Skipper", "MyCo.Suite.ClassC.Skipper", AzureDevOpsSummaryReporter.TerminalKind.Skipped, TimeSpan.Zero),
+        };
+
+        string md = AzureDevOpsSummaryReporter.BuildMarkdown(records, "MyAssembly", "net8.0");
+
+        Assert.Contains("MyAssembly", md);
+        Assert.Contains("net8.0", md);
+        Assert.Contains("Total", md);
+        Assert.Contains("Passed", md);
+        Assert.Contains("Failed", md);
+        Assert.Contains("Skipped", md);
+        Assert.Contains("MyCo.Suite.ClassA", md);
+        Assert.Contains("Slowpoke", md);
+        Assert.Contains("MyCo.Suite.ClassA.Test2", md);
+    }
+
+    [TestMethod]
+    public void BuildMarkdown_EscapesPipesAndNewlinesInCells()
+    {
+        var records = new List<AzureDevOpsSummaryReporter.TestRecord>
+        {
+            new("Has|Pipe", "MyCo.X.HasPipe", AzureDevOpsSummaryReporter.TerminalKind.Failed, TimeSpan.FromMilliseconds(1)),
+            new("Has\nNewline", "MyCo.X.HasNewline", AzureDevOpsSummaryReporter.TerminalKind.Failed, TimeSpan.FromMilliseconds(1)),
+        };
+
+        string md = AzureDevOpsSummaryReporter.BuildMarkdown(records, "MyAssembly", "net8.0");
+
+        Assert.Contains("Has\\|Pipe", md);
+        Assert.Contains("Has<br>Newline", md);
+        Assert.DoesNotContain("Has|Pipe", md);
+        Assert.DoesNotContain("Has\nNewline", md);
+    }
+
+    [TestMethod]
+    public async Task SessionFinishing_WritesSummaryFileAndEmitsUploadSummaryCommandAsync()
+    {
+        AzureDevOpsSummaryReporter reporter = CreateReporter(EnabledOptions());
+        _ = _environmentMock.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("true");
+
+        // Capture the StreamWriter output.
+        using var memoryStream = new MemoryStream();
+        IFileStream fakeStream = new FakeFileStream(memoryStream);
+        _ = _fileSystemMock.Setup(fs => fs.ExistDirectory(It.IsAny<string>())).Returns(true);
+        _ = _fileSystemMock.Setup(fs => fs.NewFileStream(It.IsAny<string>(), FileMode.Create, FileAccess.Write, FileShare.Read)).Returns(fakeStream);
+
+        await reporter.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
+        await reporter.ConsumeAsync(CreateProducer(), CreatePassed("t1"), CancellationToken.None).ConfigureAwait(false);
+        await reporter.ConsumeAsync(CreateProducer(), CreateFailed("t2"), CancellationToken.None).ConfigureAwait(false);
+        await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
+
+        string written = System.Text.Encoding.UTF8.GetString(memoryStream.ToArray());
+        Assert.Contains("MyAssembly", written);
+
+        string[] lines = GetFormattedLines();
+        Assert.HasCount(1, lines);
+        Assert.StartsWith("##vso[task.uploadsummary]", lines[0]);
+        Assert.Contains("azdo-summary-", lines[0]);
+        Assert.EndsWith(".md", lines[0]);
+    }
+
+    private static Dictionary<string, string[]> EnabledOptions()
+        => new() { [AzureDevOpsCommandLineOptions.AzureDevOpsSummary] = [] };
+
+    private AzureDevOpsSummaryReporter CreateReporter(Dictionary<string, string[]> options)
+        => new(
+            new TestCommandLineOptions(options),
+            _configurationMock.Object,
+            _environmentMock.Object,
+            _fileSystemMock.Object,
+            _outputDeviceMock.Object,
+            _testApplicationModuleInfoMock.Object,
+            _loggerFactoryMock.Object);
+
+    private static TestNodeUpdateMessage CreatePassed(string uid)
+        => Create(uid, new PassedTestNodeStateProperty());
+
+    private static TestNodeUpdateMessage CreateFailed(string uid)
+        => Create(uid, new FailedTestNodeStateProperty());
+
+    private static TestNodeUpdateMessage Create(string uid, TestNodeStateProperty state)
+        => new(
+            new SessionUid("session"),
+            new TestNode
+            {
+                Uid = uid,
+                DisplayName = uid,
+                Properties = new PropertyBag(state),
+            });
+
+    private static IDataProducer CreateProducer() => new TestProducer();
+
+    private string[] GetFormattedLines()
+        => [.. _outputData.OfType<FormattedTextOutputDeviceData>().Select(output => output.Text)];
+
+    private string[] GetWarnings()
+        => [.. _outputData.OfType<WarningMessageOutputDeviceData>().Select(output => output.Message)];
+
+    private sealed class TestProducer : IDataProducer
+    {
+        public Type[] DataTypesProduced { get; } = [typeof(TestNodeUpdateMessage)];
+
+        public string Uid => "TestProducer";
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => "TestProducer";
+
+        public string Description => "TestProducer";
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    }
+
+    private sealed class TestSessionContext : ITestSessionContext
+    {
+        public SessionUid SessionUid { get; } = new("session");
+
+        public CancellationToken CancellationToken { get; } = CancellationToken.None;
+    }
+
+    private sealed class FakeFileStream(Stream inner) : IFileStream
+    {
+        public Stream Stream { get; } = inner;
+
+        public string Name { get; } = "azdo-summary.md";
+
+        public void Dispose()
+        {
+            // The underlying MemoryStream is owned by the test.
+        }
+
+        public ValueTask DisposeAsync() => default;
+    }
+}


### PR DESCRIPTION
Implements item 4 of #5951 - rich AzDO build experience for `--report-azdo` consumers.

## What

Adds three new options to the `Microsoft.Testing.Extensions.AzureDevOpsReport` extension. All require `--report-azdo` and `TF_BUILD=true` to take effect (a warning is emitted otherwise, mirroring the existing `--report-azdo-upload` gating).

### 1. `--report-azdo-summary[=path]`
- Arity: `ZeroOrOne`. Default path: `{testResultsDir}/azdo-summary-{tfm}.md`.
- Writes a markdown summary at the resolved absolute path.
- Emits `##vso[task.uploadsummary]<absolutePath>` so AzDO surfaces it on the build summary tab.
- Content: totals (passed/failed/skipped/duration), slowest 10 tests, top 5 failing test classes.
- Cell values that contain `|` are escaped for valid markdown table rendering.

### 2. `--report-azdo-progress`
- Arity: `Zero`. Opt-in (off by default).
- On session start, emits `##vso[task.logdetail id=<g>;name=<assembly>(<tfm>);type=Build;order=1;state=InProgress]` to create a per-test-app timeline node.
- On terminal `TestNodeUpdateMessage` updates (Passed/Failed/Skipped/Error/Timeout/Cancelled), increments completed/seen counters and re-emits `progress=<n>` only when the integer percentage changes (250ms minimum interval, monotonic, deduped by `TestNode.Uid`).
- On session finish, emits `state=Completed;result=Succeeded|Failed`.

### 3. `--report-azdo-stackframe-filter <regex>` (repeatable)
- Arity: `OneOrMore` (at least one regex required when the option is specified). Up to 16 patterns (`MaxStackFrameFilterPatterns`).
- Compiled with `RegexOptions.CultureInvariant | RegexOptions.Compiled` and `TimeSpan.FromMilliseconds(500)` timeout (ReDoS guard).
- Patterns are validated at parse time via `ValidateOptionArgumentsAsync`; invalid regex fails command-line validation.
- Additive to the built-in MSTest assertion-implementation prefixes inside `AzureDevOpsReporter.IsAssertionImplementationFrame` - existing built-in filtering is preserved.
- A regex that times out at match time is treated as `not a match` (frame is kept), not as a runtime error.

## Tests

- New unit tests:
  - `AzureDevOpsSummaryReporterTests` (7 tests) - markdown shape, escaping, percentage math, uploadsummary emission.
  - `AzureDevOpsProgressReporterTests` (8 tests) - logdetail lifecycle, monotonic progress, percentage clamping, throttling, terminal-state aggregation.
  - `AzureDevOpsCommandLineProviderTests` (6 new cases) - validation: requires `--report-azdo`, max-patterns, invalid-regex rejection.
- All 104 `Microsoft.Testing.Extensions.UnitTests` AzDO tests pass.
- Help baseline `HelpInfoAllExtensionsTests` updated with the 3 new options.

## Notes

- `task.uploadsummary` requires an absolute path - the reporter resolves it via `Path.GetFullPath`.
- `task.logdetail` with `progress` is used rather than `task.setprogress` because `setprogress` only updates the parent task, not the custom timeline record.
- Localized `.xlf` files were regenerated via `dotnet msbuild .../UpdateXlf`.

## Out of scope

- `--report-azdo-summary` `html` output is deferred until #5754 ships - markdown only for now.
- `samples/xUnitPlayground/` (untracked locally, unrelated to this PR) is intentionally not included.
