### PR TITLE
[test-improver] test: add StringComparison overload and null-handling tests for Assert.StartsWith/EndsWith

### DIFF
--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.StartsWithEndsWith.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.StartsWithEndsWith.cs
@@ -118,4 +118,170 @@ public partial class AssertTests
         ex.Data["assert.expected"].Should().Be(ex.ExpectedText);
         ex.Data["assert.actual"].Should().Be(ex.ActualText);
     }
+
+    public void StartsWith_WithOrdinalIgnoreCase_WhenMatchesCaseInsensitively_DoesNotThrow()
+        => Assert.StartsWith("FOO", "foobar", StringComparison.OrdinalIgnoreCase);
+
+    public void StartsWith_WithOrdinalIgnoreCase_WhenMatchesExactly_DoesNotThrow()
+        => Assert.StartsWith("foo", "foobar", StringComparison.OrdinalIgnoreCase);
+
+    public void StartsWith_WithOrdinalIgnoreCase_OnFailure_ShouldIncludeComparisonInMessage()
+    {
+        string value = "bar";
+        Action action = () => Assert.StartsWith("foo", value, StringComparison.OrdinalIgnoreCase, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to start with the specified prefix.
+                User-provided message
+
+                expected prefix: "foo"
+                actual:          "bar"
+                comparison:      OrdinalIgnoreCase
+
+                Assert.StartsWith("foo", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"foo\"");
+        ex.ActualText.Should().Be("\"bar\"");
+    }
+
+    public void StartsWith_WhenValueIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.StartsWith("foo", null!);
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.StartsWith failed. The parameter 'value' is invalid. The value cannot be null.");
+    }
+
+    public void StartsWith_WhenPrefixIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.StartsWith(null!, "foobar");
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.StartsWith failed. The parameter 'expectedPrefix' is invalid. The value cannot be null.");
+    }
+
+    public void DoesNotStartWith_WithOrdinalIgnoreCase_WhenDoesNotMatchCaseInsensitively_DoesNotThrow()
+        => Assert.DoesNotStartWith("baz", "foobar", StringComparison.OrdinalIgnoreCase);
+
+    public void DoesNotStartWith_WithOrdinalIgnoreCase_OnFailure_ShouldIncludeComparisonInMessage()
+    {
+        string value = "foobar";
+        Action action = () => Assert.DoesNotStartWith("FOO", value, StringComparison.OrdinalIgnoreCase, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to not start with the specified prefix.
+                User-provided message
+
+                unexpected prefix: "FOO"
+                actual:            "foobar"
+                comparison:        OrdinalIgnoreCase
+
+                Assert.DoesNotStartWith("FOO", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"FOO\"");
+        ex.ActualText.Should().Be("\"foobar\"");
+    }
+
+    public void DoesNotStartWith_WhenValueIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.DoesNotStartWith("foo", null!);
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.DoesNotStartWith failed. The parameter 'value' is invalid. The value cannot be null.");
+    }
+
+    public void DoesNotStartWith_WhenPrefixIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.DoesNotStartWith(null!, "foobar");
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.DoesNotStartWith failed. The parameter 'notExpectedPrefix' is invalid. The value cannot be null.");
+    }
+
+    public void EndsWith_WithOrdinalIgnoreCase_WhenMatchesCaseInsensitively_DoesNotThrow()
+        => Assert.EndsWith("BAR", "foobar", StringComparison.OrdinalIgnoreCase);
+
+    public void EndsWith_WithOrdinalIgnoreCase_WhenMatchesExactly_DoesNotThrow()
+        => Assert.EndsWith("bar", "foobar", StringComparison.OrdinalIgnoreCase);
+
+    public void EndsWith_WithOrdinalIgnoreCase_OnFailure_ShouldIncludeComparisonInMessage()
+    {
+        string value = "foobar";
+        Action action = () => Assert.EndsWith("baz", value, StringComparison.OrdinalIgnoreCase, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to end with the specified suffix.
+                User-provided message
+
+                expected suffix: "baz"
+                actual:          "foobar"
+                comparison:      OrdinalIgnoreCase
+
+                Assert.EndsWith("baz", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"baz\"");
+        ex.ActualText.Should().Be("\"foobar\"");
+    }
+
+    public void EndsWith_WhenValueIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.EndsWith("bar", null!);
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.EndsWith failed. The parameter 'value' is invalid. The value cannot be null.");
+    }
+
+    public void EndsWith_WhenSuffixIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.EndsWith(null!, "foobar");
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.EndsWith failed. The parameter 'expectedSuffix' is invalid. The value cannot be null.");
+    }
+
+    public void DoesNotEndWith_WithOrdinalIgnoreCase_WhenDoesNotMatchCaseInsensitively_DoesNotThrow()
+        => Assert.DoesNotEndWith("baz", "foobar", StringComparison.OrdinalIgnoreCase);
+
+    public void DoesNotEndWith_WithOrdinalIgnoreCase_OnFailure_ShouldIncludeComparisonInMessage()
+    {
+        string value = "foobar";
+        Action action = () => Assert.DoesNotEndWith("BAR", value, StringComparison.OrdinalIgnoreCase, "User-provided message");
+
+        AssertFailedException ex = action.Should().Throw<AssertFailedException>()
+            .WithMessage(
+                """
+                Assertion failed. Expected string to not end with the specified suffix.
+                User-provided message
+
+                unexpected suffix: "BAR"
+                actual:            "foobar"
+                comparison:        OrdinalIgnoreCase
+
+                Assert.DoesNotEndWith("BAR", value)
+                """)
+            .Which;
+
+        ex.ExpectedText.Should().Be("\"BAR\"");
+        ex.ActualText.Should().Be("\"foobar\"");
+    }
+
+    public void DoesNotEndWith_WhenValueIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.DoesNotEndWith("bar", null!);
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.DoesNotEndWith failed. The parameter 'value' is invalid. The value cannot be null.");
+    }
+
+    public void DoesNotEndWith_WhenSuffixIsNull_ShouldThrow()
+    {
+        Action action = () => Assert.DoesNotEndWith(null!, "foobar");
+        action.Should().Throw<AssertFailedException>()
+            .WithMessage("Assert.DoesNotEndWith failed. The parameter 'notExpectedSuffix' is invalid. The value cannot be null.");
+    }
 }


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant for test improvements.*

## Goal and Rationale

`Assert.StartsWith`, `Assert.DoesNotStartWith`, `Assert.EndsWith`, and `Assert.DoesNotEndWith` each have two overloads: one defaulting to `StringComparison.Ordinal` and one accepting an explicit `StringComparison`. The existing tests in `AssertTests.StartsWithEndsWith.cs` only exercised the default `Ordinal` path — the `StringComparison` overloads and null parameter handling were completely untested.

These are real logic paths worth testing:
- The `StringComparison` overload is the core of case-insensitive string assertion, commonly used in multi-culture test suites.
- Null handling follows `CheckParameterNotNull` which throws a specific `AssertFailedException` message — a contract worth verifying.

## Approach

Added 18 new tests to `AssertTests.StartsWithEndsWith.cs` covering:

| Category | Count | Methods |
|---|---|---|
| `OrdinalIgnoreCase` success (case mismatch / exact match passes) | 6 | `StartsWith` × 2, `DoesNotStartWith` × 1, `EndsWith` × 2, `DoesNotEndWith` × 1 |
| `OrdinalIgnoreCase` failure message includes `comparison:` | 4 | all four methods |
| Null `value` → `AssertFailedException` | 4 | all four methods |
| Null prefix/suffix → `AssertFailedException` | 4 | all four methods |

## Coverage Impact

| File | Before | After |
|---|---|---|
| `AssertTests.StartsWithEndsWith.cs` | 8 tests | 26 tests (+18) |
| `Assert.StartsWith.cs` / `Assert.EndsWith.cs` | `StringComparison` overloads untested | now covered |

## Trade-offs

- Tests are straightforward string comparisons — low maintenance burden.
- Null-handling tests depend on the exact exception message format; if the format changes, these tests will catch the regression intentionally.

## Reproducibility

```bash
./build.sh --projects "$(pwd)/test/UnitTests/TestFramework.UnitTests/TestFramework.UnitTests.csproj" -test
```

## Test Status

✅ All `TestFramework.UnitTests` tests pass (net8.0 and net9.0)




> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/26853985393) · sonnet46 4.5M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26853985393, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/26853985393 -->

<!-- gh-aw-workflow-id: test-improver -->