### PR TITLE
[docs] Update glossary - daily scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,11 +20,11 @@ An MTP extension (`Microsoft.Testing.Extensions.AzureDevOpsReport`) that formats
 
 ### CodeCoverage
 
-An MTP extension (`Microsoft.Testing.Extensions.CodeCoverage`) that instruments .NET assemblies and collects code-coverage data during a test run. It is developed and maintained in the `devdiv/DevDiv/vs-code-coverage` repository and consumed by this project as a Maestro-managed dependency. The extension supports the `--coverage` command-line option and, via a [command-line option mapping](#commandlineoptionmapping), also accepts the VSTest-compatible `--collect "XPlat Code Coverage"` and `--collect "Code Coverage"` forms for smoother migration from VSTest.
+An MTP extension (`Microsoft.Testing.Extensions.CodeCoverage`) that instruments .NET assemblies and collects code-coverage data during a test run. It is developed and maintained in the `devdiv/DevDiv/vs-code-coverage` repository and consumed by this project as a Maestro-managed dependency. The extension supports the `--coverage` command-line option; VSTest-compatible `--collect "XPlat Code Coverage"` and `--collect "Code Coverage"` forms are proposed via a [command-line option mapping](#commandlineoptionmapping) (see `docs/RFCs/015-Command-Line-Option-Mappings.md`).
 
 ### CommandLineOptionMapping
 
-A proposed MTP extensibility point (see `docs/RFCs/015-Command-Line-Option-Mappings.md`) that lets an extension declaratively accept a user-facing option (e.g. `--collect "XPlat Code Coverage"`) and rewrite it at parse time into one or more first-class MTP options (e.g. `--coverage`). Implemented by `ICommandLineOptionMappingProvider`. Intended to smooth migration from VSTest by allowing legacy `--logger` and `--collect` argument forms to be forwarded to their MTP equivalents without polluting the canonical MTP option set.
+A proposed MTP extensibility point (see `docs/RFCs/015-Command-Line-Option-Mappings.md`) that would let an extension declaratively accept a user-facing option (e.g. `--collect "XPlat Code Coverage"`) and rewrite it at parse time into one or more first-class MTP options (e.g. `--coverage`). In RFC 015, this is expressed via `ICommandLineOptionMappingProvider`. Intended to smooth migration from VSTest by allowing legacy `--logger` and `--collect` argument forms to be forwarded to their MTP equivalents without polluting the canonical MTP option set.
 
 ### CrashDump
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -18,6 +18,14 @@ An MTP extension (`Microsoft.Testing.Extensions.AzureDevOpsReport`) that formats
 
 ## C
 
+### CodeCoverage
+
+An MTP extension (`Microsoft.Testing.Extensions.CodeCoverage`) that instruments .NET assemblies and collects code-coverage data during a test run. It is developed and maintained in the `devdiv/DevDiv/vs-code-coverage` repository and consumed by this project as a Maestro-managed dependency. The extension supports the `--coverage` command-line option and, via a [command-line option mapping](#commandlineoptionmapping), also accepts the VSTest-compatible `--collect "XPlat Code Coverage"` and `--collect "Code Coverage"` forms for smoother migration from VSTest.
+
+### CommandLineOptionMapping
+
+A proposed MTP extensibility point (see `docs/RFCs/015-Command-Line-Option-Mappings.md`) that lets an extension declaratively accept a user-facing option (e.g. `--collect "XPlat Code Coverage"`) and rewrite it at parse time into one or more first-class MTP options (e.g. `--coverage`). Implemented by `ICommandLineOptionMappingProvider`. Intended to smooth migration from VSTest by allowing legacy `--logger` and `--collect` argument forms to be forwarded to their MTP equivalents without polluting the canonical MTP option set.
+
 ### CrashDump
 
 An MTP extension (`Microsoft.Testing.Extensions.CrashDump`) that automatically captures a process memory dump when the test host crashes. Useful for diagnosing unexpected process termination during test runs.


### PR DESCRIPTION
### Glossary Updates

**Scan Type**: Incremental (daily)

**Terms Added**:
- **CodeCoverage**: MTP extension (`Microsoft.Testing.Extensions.CodeCoverage`) from `devdiv/DevDiv/vs-code-coverage` for collecting code-coverage data. Referenced by `--coverage` CLI option and VSTest-compatible `--collect` forms via CommandLineOptionMapping.
- **CommandLineOptionMapping**: RFC 015 extensibility point (`ICommandLineOptionMappingProvider`) that rewrites legacy VSTest option forms into first-class MTP options at parse time.

**Changes Analyzed**:
- Reviewed 1 commit from last 24 hours
- Commit `8da8044`: dependency update — `Microsoft.Testing.Extensions.CodeCoverage` version bumped to `18.8.0-preview.26302.7` from `devdiv/DevDiv/vs-code-coverage`

**Related Changes**:
- Commit `8da8044`: `[main] Update dependencies from devdiv/DevDiv/vs-code-coverage (#8785)`
- `docs/RFCs/015-Command-Line-Option-Mappings.md`: documents the `CommandLineOptionMapping` extensibility point




> Generated by [Glossary Maintainer](https://github.com/microsoft/testfx/actions/runs/26866888862) · sonnet46 1.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+glossary-maintainer%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/glossary-maintainer.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-05T06:13:53.060Z --> on Jun 5, 2026, 6:13 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26866888862, workflow_id: glossary-maintainer, run: https://github.com/microsoft/testfx/actions/runs/26866888862 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->