### PR TITLE
[test-improver] test: add edge case tests for DoNotStoreStaticTestContextAnalyzer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -131,4 +131,111 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenAssigningToInstanceMember_NoDiagnostic()
+    {
+        // Assigning TestContext to an instance field or property should not trigger the diagnostic.
+        // The analyzer only fires when the assignment target has no 'Instance' (i.e. static member).
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private TestContext _testContext;
+                public TestContext TestContext { get; set; }
+
+                [ClassInitialize]
+                public static void ClassInit(TestContext tc)
+                {
+                }
+
+                [TestInitialize]
+                public void TestInit()
+                {
+                    _testContext = TestContext;
+                    TestContext = TestContext;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssigningToLocalVariable_NoDiagnostic()
+    {
+        // Assigning a TestContext parameter to a local variable is fine — not a static member reference.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    TestContext local = tc;
+                    local.WriteLine("");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssigningNonTestContextParameterToStaticField_NoDiagnostic()
+    {
+        // Only assignments where the *value* is a TestContext parameter are flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static string s_name;
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    s_name = "value";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+#if NET
+    [TestMethod]
+    public async Task WhenAssigningTestContextInHelperMethod_Diagnostic()
+    {
+        // The diagnostic fires on any static member assignment of a TestContext parameter,
+        // regardless of whether the containing method is [AssemblyInitialize] or [ClassInitialize].
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext s_testContext;
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    Store(tc);
+                }
+
+                private static void Store(TestContext tc)
+                {
+                    [|s_testContext = tc|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+#endif
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -133,10 +133,11 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenAssigningToInstanceMember_NoDiagnostic()
+    public async Task WhenAssigningTestContextParameterToInstanceMember_NoDiagnostic()
     {
-        // Assigning TestContext to an instance field or property should not trigger the diagnostic.
-        // The analyzer only fires when the assignment target has no 'Instance' (i.e. static member).
+        // Assigning a TestContext *parameter* to an instance field or property should not trigger
+        // the diagnostic. This exercises the analyzer's 'Instance: null' guard while the value still
+        // satisfies the 'Value: IParameterReferenceOperation' check (only the target-side guard fails).
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -144,18 +145,12 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
             public class MyTestClass
             {
                 private TestContext _testContext;
-                public TestContext TestContext { get; set; }
+                public TestContext TestContextProperty { get; set; }
 
-                [ClassInitialize]
-                public static void ClassInit(TestContext tc)
+                public void Store(TestContext tc)
                 {
-                }
-
-                [TestInitialize]
-                public void TestInit()
-                {
-                    _testContext = TestContext;
-                    TestContext = TestContext;
+                    _testContext = tc;
+                    TestContextProperty = tc;
                 }
             }
             """;
@@ -164,9 +159,11 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenAssigningToLocalVariable_NoDiagnostic()
+    public async Task WhenAssigningTestContextParameterToLocalVariable_NoDiagnostic()
     {
-        // Assigning a TestContext parameter to a local variable is fine — not a static member reference.
+        // Assigning a TestContext parameter to a local variable is fine — the assignment target is
+        // not an IMemberReferenceOperation, so the analyzer's pattern doesn't match. An explicit
+        // assignment (not a declaration initializer) is used so OperationKind.SimpleAssignment fires.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -176,7 +173,8 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
                 [AssemblyInitialize]
                 public static void AssemblyInit(TestContext tc)
                 {
-                    TestContext local = tc;
+                    TestContext local;
+                    local = tc;
                     local.WriteLine("");
                 }
             }
@@ -188,7 +186,37 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
     [TestMethod]
     public async Task WhenAssigningNonTestContextParameterToStaticField_NoDiagnostic()
     {
-        // Only assignments where the *value* is a TestContext parameter are flagged.
+        // Covers the IParameterReferenceOperation *type-mismatch* path: the value is a parameter
+        // reference, but its type is not TestContext, so the analyzer must not fire.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static string s_name;
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    Store("value");
+                }
+
+                private static void Store(string name)
+                {
+                    s_name = name;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssigningNonParameterValueToStaticField_NoDiagnostic()
+    {
+        // Covers the 'Value is not IParameterReferenceOperation' path: a literal (or any non-parameter
+        // expression) assigned to a static field must not be flagged, even when the field type is TestContext.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`DoNotStoreStaticTestContextAnalyzer` (MSTEST0024) had only 2 tests: one happy path (diagnostic) and one no-diagnostic case. The analyzer's logic has several distinct conditions (`Instance: null` for static members, `IParameterReferenceOperation` for the value type) that each deserve coverage to prevent regressions.

## Approach

Added four new tests that each probe a specific condition the analyzer checks:

| Test | What it verifies |
|------|-----------------|
| `WhenAssigningToInstanceMember_NoDiagnostic` | Instance field/property assignments are not flagged (the `Instance: null` guard) |
| `WhenAssigningToLocalVariable_NoDiagnostic` | Local variable assignments (not `IMemberReferenceOperation`) are not flagged |
| `WhenAssigningNonTestContextParameterToStaticField_NoDiagnostic` | Only TestContext parameters are flagged — other types assigned to static fields are fine |
| `WhenAssigningTestContextInHelperMethod_Diagnostic` | The diagnostic fires regardless of which method the assignment appears in — any static member assignment of a TestContext parameter is flagged |

## Coverage Impact

These tests cover the four logical branches in `AnalyzeOperation`:
- The `Instance: null` check (both true and false paths)
- The `IParameterReferenceOperation` check (both true and false paths)

## Trade-offs

Minimal maintenance burden — tests are straightforward analyzer verifications with no external dependencies.

## Reproducibility

```bash
./build.sh -test --projects "$(pwd)/test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj"
```

## Test Status

✅ All tests passed (0 errors, 0 warnings)




> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/26919404408) · sonnet46 1.8M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26919404408, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/26919404408 -->

<!-- gh-aw-workflow-id: test-improver -->