### PR TITLE
Fix MSTEST0068 build errors: replace CollectionAssert with Assert.AreSequenceEqual

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
@@ -81,14 +81,15 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer(), CreateFailedTestNodeUpdateMessage(), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEquivalent(
+        Assert.AreSequenceEqual(
             new[]
             {
                 "##vso[build.addbuildtag]has-crashdump",
                 "##vso[build.addbuildtag]has-hangdump",
                 "##vso[build.addbuildtag]has-test-failures",
             },
-            GetFormattedLines());
+            GetFormattedLines(),
+            SequenceOrder.InAnyOrder);
         Assert.DoesNotContain(line => line.Contains("artifact.upload", StringComparison.Ordinal), GetFormattedLines());
         Assert.IsEmpty(GetWarnings());
     }
@@ -134,7 +135,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("inside.trx")}" },
             GetFormattedLines());
     }
@@ -158,7 +159,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer(), CreateFailedTestNodeUpdateMessage(), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[]
             {
                 "##vso[build.addbuildtag]has-crashdump",
@@ -187,7 +188,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("keep.trx")}" },
             GetFormattedLines());
     }
@@ -207,13 +208,14 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer("HangDumpProcessLifetimeHandler", "Hang dump"), CreateFileArtifact(InResults("hang", "dump.log")), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEquivalent(
+        Assert.AreSequenceEqual(
             new[]
             {
                 "##vso[build.addbuildtag]has-crashdump",
                 "##vso[build.addbuildtag]has-hangdump",
             },
-            GetFormattedLines());
+            GetFormattedLines(),
+            SequenceOrder.InAnyOrder);
     }
 
     [TestMethod]
@@ -268,7 +270,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer(), CreateFailedTestNodeUpdateMessage(), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[] { "Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags." },
             GetWarnings());
         Assert.IsEmpty(GetFormattedLines());
@@ -329,7 +331,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        CollectionAssert.AreEqual(
+        Assert.AreSequenceEqual(
             new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{escapedSpecialPath}" },
             GetFormattedLines());
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -304,7 +304,7 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.AreEqual(7, runId);
         Assert.HasCount(1, task.DelayCalls);
         Assert.AreEqual(TimeSpan.FromSeconds(3), task.DelayCalls[0]);
-        CollectionAssert.AreEqual(new[] { "send:1", "delay:3", "send:2" }, events);
+        Assert.AreSequenceEqual(new[] { "send:1", "delay:3", "send:2" }, events);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
@@ -449,7 +449,7 @@ public sealed class CrashDumpTests
                 .OrderBy(static p => p, StringComparer.Ordinal)
                 .ToArray();
             string[] expected = new[] { fresh1, fresh2 }.OrderBy(static p => p, StringComparer.Ordinal).ToArray();
-            CollectionAssert.AreEqual(expected, publishedDumps);
+            Assert.AreSequenceEqual(expected, publishedDumps);
         }
         finally
         {
@@ -499,7 +499,7 @@ public sealed class CrashDumpTests
                 .OfType<FileArtifact>()
                 .Select(static a => a.FileInfo.FullName)
                 .ToArray();
-            CollectionAssert.AreEqual(new[] { testhostDump }, publishedDumps);
+            Assert.AreSequenceEqual(new[] { testhostDump }, publishedDumps);
 
             // The "expected dump not found" warning must NOT be emitted: the testhost dump was
             // recognized via the regex even though `expectedDumpFile` (literal `%p` substitution)
@@ -550,7 +550,7 @@ public sealed class CrashDumpTests
                 .OfType<FileArtifact>()
                 .Select(static a => a.FileInfo.FullName)
                 .ToArray();
-            CollectionAssert.AreEqual(new[] { testhostDump }, publishedDumps);
+            Assert.AreSequenceEqual(new[] { testhostDump }, publishedDumps);
             string captured = string.Join(" | ", outputDevice.Displayed);
             Assert.DoesNotContain("dump_555_backup_555.dmp", captured, "CannotFindExpectedCrashDumpFile must not be displayed when the testhost dump was recognized via the regex.");
         }
@@ -602,7 +602,7 @@ public sealed class CrashDumpTests
                 .OrderBy(static p => p, StringComparer.Ordinal)
                 .ToArray();
             string[] expected = new[] { testhostDump, childDump }.OrderBy(static p => p, StringComparer.Ordinal).ToArray();
-            CollectionAssert.AreEqual(expected, publishedDumps);
+            Assert.AreSequenceEqual(expected, publishedDumps);
             string captured = string.Join(" | ", outputDevice.Displayed);
             Assert.DoesNotContain("Dump_%e_123.dmp", captured, "CannotFindExpectedCrashDumpFile must not be displayed when the testhost dump was recognized via the regex.");
         }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs
@@ -58,7 +58,7 @@ public class TrxStreamingSerializerTests
         Assert.AreEqual(TrxStreamMessageKind.DebugOrTrace, round.Messages[2].Kind);
         Assert.IsNull(round.Messages[2].Message);
         Assert.IsNotNull(round.Categories);
-        CollectionAssert.AreEqual(new[] { "cat-a", "cat-b" }, round.Categories.ToArray());
+        Assert.AreSequenceEqual(new[] { "cat-a", "cat-b" }, round.Categories.ToArray());
         Assert.IsNotNull(round.Metadata);
         Assert.AreEqual("k", round.Metadata[0].Key);
         Assert.AreEqual("v", round.Metadata[0].Value);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationExtensionsTests.cs
@@ -110,7 +110,7 @@ public sealed class CommandLineConfigurationExtensionsTests
 
         Assert.IsTrue(configuration.TryGetCommandLineOptionArguments("hangdump-timeout", out string[]? arguments));
         Assert.IsNotNull(arguments);
-        CollectionAssert.AreEqual(new[] { "5m" }, arguments);
+        Assert.AreSequenceEqual(new[] { "5m" }, arguments);
     }
 
     [TestMethod]
@@ -124,7 +124,7 @@ public sealed class CommandLineConfigurationExtensionsTests
 
         Assert.IsTrue(configuration.TryGetCommandLineOptionArguments("filter-uid", out string[]? arguments));
         Assert.IsNotNull(arguments);
-        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, arguments);
+        Assert.AreSequenceEqual(new[] { "a", "b", "c" }, arguments);
     }
 
     [TestMethod]
@@ -140,7 +140,7 @@ public sealed class CommandLineConfigurationExtensionsTests
 
         Assert.IsTrue(configuration.TryGetCommandLineOptionArguments("foo", out string[]? arguments));
         Assert.IsNotNull(arguments);
-        CollectionAssert.AreEqual(new[] { "indexed" }, arguments);
+        Assert.AreSequenceEqual(new[] { "indexed" }, arguments);
     }
 
     [TestMethod]
@@ -175,14 +175,14 @@ public sealed class CommandLineConfigurationExtensionsTests
         Assert.IsTrue(options.IsOptionSet("filter-uid"));
 
         Assert.IsTrue(options.TryGetOptionArgumentList("hangdump-timeout", out string[]? timeoutArgs));
-        CollectionAssert.AreEqual(new[] { "10m" }, timeoutArgs);
+        Assert.AreSequenceEqual(new[] { "10m" }, timeoutArgs);
 
         Assert.IsTrue(options.TryGetOptionArgumentList("hangdump", out string[]? hangdumpArgs));
         Assert.IsNotNull(hangdumpArgs);
         Assert.IsEmpty(hangdumpArgs);
 
         Assert.IsTrue(options.TryGetOptionArgumentList("filter-uid", out string[]? filterArgs));
-        CollectionAssert.AreEqual(new[] { "a", "b" }, filterArgs);
+        Assert.AreSequenceEqual(new[] { "a", "b" }, filterArgs);
     }
 
     private static IConfiguration BuildConfiguration(IReadOnlyList<KeyValuePair<string, string?>> entries)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
@@ -52,7 +52,7 @@ public sealed class JsonCommandLineOptionsTests
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(entries);
         Assert.AreEqual("timeout", entry.OptionName);
         Assert.IsFalse(entry.IsDisabled);
-        CollectionAssert.AreEqual(new[] { "30s" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "30s" }, entry.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -88,7 +88,7 @@ public sealed class JsonCommandLineOptionsTests
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(entries);
         Assert.AreEqual("filter-uid", entry.OptionName);
         Assert.IsFalse(entry.IsDisabled);
-        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "a", "b", "c" }, entry.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -164,7 +164,7 @@ public sealed class JsonCommandLineOptionsTests
         Assert.HasCount(4, entries);
 
         JsonCommandLineOptionEntry timeout = entries.Single(e => e.OptionName == "timeout");
-        CollectionAssert.AreEqual(new[] { "30s" }, timeout.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "30s" }, timeout.Arguments.ToArray());
         Assert.IsFalse(timeout.IsDisabled);
 
         JsonCommandLineOptionEntry noBanner = entries.Single(e => e.OptionName == "no-banner");
@@ -175,7 +175,7 @@ public sealed class JsonCommandLineOptionsTests
         Assert.IsTrue(hangdump.IsDisabled);
 
         JsonCommandLineOptionEntry filterUid = entries.Single(e => e.OptionName == "filter-uid");
-        CollectionAssert.AreEqual(new[] { "a", "b" }, filterUid.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "a", "b" }, filterUid.Arguments.ToArray());
     }
 
     // ---------------------------------------------------------------------

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
@@ -21,7 +21,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "--filter", "MyTest" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "--filter", "MyTest" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -35,7 +35,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -60,7 +60,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "exec", "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "exec", "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -74,7 +74,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "exec", "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "exec", "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -86,7 +86,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "exec", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "exec", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -112,7 +112,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -124,7 +124,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -142,7 +142,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        CollectionAssert.AreEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
     }
 
     private static Mock<IEnvironment> CreateDotnetMuxerEnvironment(string[] commandLineArgs)


### PR DESCRIPTION
Builds were failing with 99 `MSTEST0068` errors (e.g. on #8811) after the new `CollectionAssertToAssertAnalyzer` started reporting against existing call sites in our own unit tests.

This PR applies the analyzer's suggested fix at every flagged location:

- `CollectionAssert.AreEqual(a, b)` → `Assert.AreSequenceEqual(a, b)`
- `CollectionAssert.AreEquivalent(a, b)` → `Assert.AreSequenceEqual(a, b, SequenceOrder.InAnyOrder)`

I reviewed each of the 31 distinct call sites individually — all of them operate on simple `string[]` collections where the suggested mapping is semantically equivalent (default equality, ordered vs. multiset semantics preserved), so no analyzer suggestion needed to be opted out and no follow-up issue is required.

Files touched:

- `test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs`
- `test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationExtensionsTests.cs`
- `test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs`
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs`
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs`
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs`
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs`

Verified locally with:

```
build.cmd -c Debug -projects test\UnitTests\Microsoft.Testing.Platform.UnitTests\Microsoft.Testing.Platform.UnitTests.csproj
build.cmd -c Debug -projects test\UnitTests\Microsoft.Testing.Extensions.UnitTests\Microsoft.Testing.Extensions.UnitTests.csproj /warnaserror /p:TreatWarningsAsErrors=true
```

Both succeed with 0 errors / 0 warnings.