### PR TITLE
MSBuild Condition Fixes

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
@@ -71,11 +71,11 @@
 
     <!-- Support for -p:AotMsCodeCoverageInstrumentation="true" during dotnet publish for native aot -->
     <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Sdk="MSTest"
-                      Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' and $(PublishAot) == 'true' ">
+                      Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' and '$(PublishAot)' == 'true' ">
       <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(MicrosoftTestingExtensionsCodeCoverageVersion)</Version>
     </PackageReference>
     <PackageVersion Include="Microsoft.CodeCoverage.MSBuild" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)"
-                    Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' and $(PublishAot) == 'true' and '$(ManagePackageVersionsCentrally)' == 'true' " />
+                    Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' == 'true' and '$(PublishAot)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -23,7 +23,7 @@
 
   <Target Name="_MTPAddArguments" BeforeTargets="ComputeRunArguments">
     <PropertyGroup>
-      <RunArguments Condition="'(TestingPlatformCommandLineArguments)' != ''">$(RunArguments) $(TestingPlatformCommandLineArguments)</RunArguments>
+      <RunArguments Condition="'$(TestingPlatformCommandLineArguments)' != ''">$(RunArguments) $(TestingPlatformCommandLineArguments)</RunArguments>
     </PropertyGroup>
   </Target>
 

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -23,7 +23,7 @@
 
   <Target Name="_MTPAddArguments" BeforeTargets="ComputeRunArguments">
     <PropertyGroup>
-      <RunArguments Condition="'$(TestingPlatformCommandLineArguments)' != ''">$(RunArguments) $(TestingPlatformCommandLineArguments)</RunArguments>
+      <RunArguments Condition=" '$(TestingPlatformCommandLineArguments)' != '' ">$(RunArguments) $(TestingPlatformCommandLineArguments)</RunArguments>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
This pull request addresses minor issues in MSBuild condition expressions to ensure correct property evaluation in build and publish scenarios.

- **MSBuild Condition Fixes:**
  - Corrected the condition in `Microsoft.Testing.Platform.targets` so that `TestingPlatformCommandLineArguments` is properly checked for non-empty value, ensuring additional arguments are appended only when specified.
  - Updated conditions in `NativeAOT.targets` to consistently compare `PublishAot` as a string, preventing potential logical errors during native AOT publish with code coverage enabled.

Fixes #8813 