### PR TITLE
[efficiency-improver] perf: cache newline+color string in SimpleAnsiTerminal

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleAnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SimpleAnsiTerminal.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 internal sealed class SimpleAnsiTerminal : SimpleTerminal
 {
     private string? _foregroundColor;
+    // Cached concatenation of "\n" + _foregroundColor, computed once in SetColor to avoid
+    // re-allocating the same string on every Append/AppendLine call when a color is active.
+    private string? _newlineAndColor;
     private bool _prependColor;
 
     public SimpleAnsiTerminal(IConsole console)
@@ -49,6 +52,7 @@ internal sealed class SimpleAnsiTerminal : SimpleTerminal
     {
         string setColor = $"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}";
         _foregroundColor = setColor;
+        _newlineAndColor = "\n" + setColor;
         Console.Write(setColor);
         // This call set the color for current line, no need to prepend on next write.
         _prependColor = false;
@@ -57,10 +61,11 @@ internal sealed class SimpleAnsiTerminal : SimpleTerminal
     public override void ResetColor()
     {
         _foregroundColor = null;
+        _newlineAndColor = null;
         _prependColor = false;
         Console.Write(AnsiCodes.SetDefaultColor);
     }
 
     private string? SetColorPerLine(string value)
-        => _foregroundColor == null ? value : value.Replace("\n", $"\n{_foregroundColor}");
+        => _newlineAndColor == null ? value : value.Replace("\n", _newlineAndColor);
 }


### PR DESCRIPTION
🤖 *Efficiency Improver — automated AI assistant focused on reducing the energy consumption and computational footprint of this repository.*

## Goal and Rationale

Eliminate a per-call heap allocation in `SimpleAnsiTerminal.SetColorPerLine`. This method is called on every `Append` and `AppendLine` invocation while a foreground color is active — which is the common case during any colored test run in a CI environment (Azure DevOps, GitHub Actions, etc.).

## Focus Area

**Code-Level Efficiency** — unnecessary object allocation per terminal write.

## Approach

Previously, `SetColorPerLine` constructed the replacement string `$"\n{_foregroundColor}"` on **every call**:

```csharp
// Before: allocates "\n" + _foregroundColor on every Append/AppendLine
private string? SetColorPerLine(string value)
    => _foregroundColor == null ? value : value.Replace("\n", $"\n{_foregroundColor}");
```

Since `_foregroundColor` only changes when `SetColor` or `ResetColor` is called, the `"\n" + _foregroundColor` string can be cached at color-change time and reused for all subsequent writes:

```csharp
// After: compute once in SetColor, reuse on every Append/AppendLine
private string? _newlineAndColor; // cached "\n" + _foregroundColor

public override void SetColor(TerminalColor color)
{
    string setColor = $"{AnsiCodes.CSI}{(int)color}{AnsiCodes.SetColor}";
    _foregroundColor = setColor;
    _newlineAndColor = "\n" + setColor; // computed once per color change
    ...
}

public override void ResetColor()
{
    _foregroundColor = null;
    _newlineAndColor = null; // cleared on reset
    ...
}

private string? SetColorPerLine(string value)
    => _newlineAndColor == null ? value : value.Replace("\n", _newlineAndColor); // no allocation
```

## Energy Efficiency Evidence

**Proxy metric**: heap allocation count.

- **Before**: 1 short-lived string object allocated per `Append`/`AppendLine` call when a color is active
- **After**: 0 allocations per call — the replacement string is computed once per `SetColor` invocation

`SimpleAnsiTerminal` is used in CI environments that support ANSI but not full cursor control (Azure DevOps, GitHub Actions, etc.). A test run producing 1 000 colored output lines would previously allocate ~1 000 unnecessary small strings (~10–15 bytes each). These all become GC garbage immediately, adding pressure on the GC and wasting CPU cycles reclaiming them.

**GSF — Hardware Efficiency**: fewer short-lived heap objects → less GC work → better utilization of CPU and DRAM already in use.

## Trade-offs

- An additional `string?` field (`_newlineAndColor`) is added to `SimpleAnsiTerminal`. This is negligible — one pointer-sized field on a per-session singleton.
- No behaviour change: `_newlineAndColor` is always `"\n" + _foregroundColor` when non-null, matching the previous inline computation exactly.

## Reproducibility

```bash
./build.sh          # verify build succeeds
```

Unit test coverage: `TerminalTestReporterTests.SimpleAnsiTerminal_OutputFormattingIsCorrect` exercises colored output through `SimpleAnsiTerminal`.

## Test Status

✅ Build succeeded (0 errors, 0 warnings)  
✅ `Microsoft.Testing.Platform.UnitTests` — all tests passed




> Generated by [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/26982600474) · sonnet46 7.7M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 26982600474, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/26982600474 -->

<!-- gh-aw-workflow-id: efficiency-improver -->