### PR TITLE
Auto-promote scalar JSON values for arg-bearing CLI options (fixes #8830)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
@@ -168,6 +169,28 @@ internal sealed class AggregatedConfiguration(
             .FirstOrDefault();
 
         return jsonProvider?.EnumerateCommandLineOptions() ?? [];
+    }
+
+    /// <summary>
+    /// Normalizes JSON-sourced scalar command-line option entries to the indexed shape for any
+    /// option in <paramref name="optionByName"/> with <see cref="ArgumentArity.Min"/> &gt;= 1,
+    /// so that subsequent <see cref="TryGetCommandLineOptionFromProviders"/> and validator passes
+    /// see a uniform representation. See
+    /// <see cref="JsonConfigurationSource.JsonConfigurationProvider.NormalizeCommandLineOptionScalars"/>
+    /// for the full rationale.
+    /// </summary>
+    /// <remarks>
+    /// A no-op when no JSON configuration source is registered. Safe to call at most once after
+    /// the option registry is fully assembled and before any consumer reads command-line option
+    /// values from <see cref="IConfiguration"/>.
+    /// </remarks>
+    internal void NormalizeJsonCommandLineOptionScalars(IReadOnlyDictionary<string, CommandLineOption> optionByName)
+    {
+        JsonConfigurationSource.JsonConfigurationProvider? jsonProvider = _configurationProviders
+            .OfType<JsonConfigurationSource.JsonConfigurationProvider>()
+            .FirstOrDefault();
+
+        jsonProvider?.NormalizeCommandLineOptionScalars(optionByName);
     }
 
     public async Task CheckTestResultsDirectoryOverrideAndCreateItAsync(IFileLoggerProvider? fileLoggerProvider)

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Resources;
@@ -408,6 +409,108 @@ internal sealed partial class JsonConfigurationSource
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Rewrites scalar <c>commandLineOptions:&lt;name&gt;</c> entries to the indexed shape
+        /// (<c>commandLineOptions:&lt;name&gt;:0</c>) for options registered with
+        /// <see cref="ArgumentArity.Min"/> &gt;= 1, using <paramref name="optionByName"/> as the
+        /// option registry.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The CLI-backed configuration provider stores zero-arity flags at the bare option key and
+        /// arg-bearing options under indexed keys (one per argument). The JSON provider cannot
+        /// distinguish these shapes at parse time because the user freely writes either
+        /// <c>"foo": "value"</c> (scalar) or <c>"foo": ["value"]</c> (array). For arg-bearing
+        /// options that always require at least one argument, a scalar value is always the first
+        /// argument — never a presence marker. Storing it under the indexed key normalizes the
+        /// shape so both <see cref="EnumerateCommandLineOptions"/> and
+        /// <see cref="AggregatedConfiguration.TryGetCommandLineOptionFromProviders"/> see one
+        /// consistent representation.
+        /// </para>
+        /// <para>
+        /// In particular, this fixes the JSON scalar/bool ambiguity from #6349/#8830: a value like
+        /// <c>"my-option": "true"</c> for an arg-bearing option used to be misinterpreted as a
+        /// presence marker (zero arguments) instead of being passed as the first argument value.
+        /// </para>
+        /// <para>
+        /// Optional-arg options (<c>Min == 0 &amp;&amp; Max &gt;= 1</c>) are left untouched because
+        /// either interpretation (presence vs. scalar argument) is semantically valid; users who
+        /// need to disambiguate should use the explicit array form.
+        /// </para>
+        /// </remarks>
+        internal void NormalizeCommandLineOptionScalars(IReadOnlyDictionary<string, CommandLineOption> optionByName)
+        {
+            if (_singleValueData is null || _singleValueData.Count == 0)
+            {
+                return;
+            }
+
+            const string sectionName = PlatformConfigurationConstants.CommandLineOptionsSectionName;
+            string sectionPrefix = sectionName + PlatformConfigurationConstants.KeyDelimiter;
+
+            List<(string OldKey, string NewKey, string Value)>? rewrites = null;
+
+            foreach (KeyValuePair<string, string?> kvp in _singleValueData)
+            {
+                if (!kvp.Key.StartsWith(sectionPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Bare key only: "commandLineOptions:<name>" with no further colon. Indexed entries
+                // already use the canonical shape and are not subject to the scalar/bool ambiguity.
+                string remainder = kvp.Key.Substring(sectionPrefix.Length);
+                if (remainder.Length == 0
+                    || remainder.IndexOf(PlatformConfigurationConstants.KeyDelimiter, StringComparison.Ordinal) >= 0)
+                {
+                    continue;
+                }
+
+                // A null value at the bare key represents an empty object/array; the schema
+                // validator in EnumerateCommandLineOptions will reject it later. Skip here so we
+                // never promote a placeholder to an indexed slot.
+                if (kvp.Value is null)
+                {
+                    continue;
+                }
+
+                if (!optionByName.TryGetValue(remainder, out CommandLineOption? option))
+                {
+                    // Unknown option name. Leave alone so the unknown-option validator pass can
+                    // surface a clear error referencing testconfig.json.
+                    continue;
+                }
+
+                if (option.Arity.Min < 1)
+                {
+                    continue;
+                }
+
+                string newKey = kvp.Key + PlatformConfigurationConstants.KeyDelimiter + "0";
+
+                // Defensive: if the indexed slot already exists, the JSON contained both a scalar
+                // and an array entry for the same option, which the schema validator will flag as
+                // malformed. Don't clobber.
+                if (_singleValueData.ContainsKey(newKey))
+                {
+                    continue;
+                }
+
+                (rewrites ??= []).Add((kvp.Key, newKey, kvp.Value));
+            }
+
+            if (rewrites is null)
+            {
+                return;
+            }
+
+            foreach ((string oldKey, string newKey, string value) in rewrites)
+            {
+                _singleValueData.Remove(oldKey);
+                _singleValueData[newKey] = value;
+            }
         }
 
         private static bool StartsWithChar(string text, char c)

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
@@ -214,8 +214,8 @@ internal sealed partial class TestHostBuilder
             // "timeout": "true" was misinterpreted as a presence marker. See #6349/#8830.
             //
             // Defensive: option providers may register duplicate names; CommandLineOptionsValidator
-            // catches that later (ValidateOptionsAreNotDuplicated) and reports a clear error. Use
-            // TryAdd here so the normalization step itself doesn't crash for that malformed setup.
+            // catches that later (ValidateOptionsAreNotDuplicated) and reports a clear error. Skip
+            // duplicates here so the normalization step itself doesn't crash for that malformed setup.
             var optionByName = new Dictionary<string, CommandLineOption>(StringComparer.OrdinalIgnoreCase);
             foreach (ICommandLineOptionsProvider optionsProvider in context.CommandLineHandler.SystemCommandLineOptionsProviders
                 .Concat(context.CommandLineHandler.ExtensionsCommandLineOptionsProviders))

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
@@ -5,6 +5,7 @@ using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.OutputDevice;
@@ -207,6 +208,29 @@ internal sealed partial class TestHostBuilder
         IReadOnlyList<JsonCommandLineOptionEntry> jsonCommandLineOptions;
         try
         {
+            // Normalize JSON-sourced scalar option entries to the indexed shape for arg-bearing
+            // options before any consumer reads them. This makes "foo": "value" in testconfig.json
+            // behave identically to "foo": ["value"], removing the foot-gun where a scalar like
+            // "timeout": "true" was misinterpreted as a presence marker. See #6349/#8830.
+            //
+            // Defensive: option providers may register duplicate names; CommandLineOptionsValidator
+            // catches that later (ValidateOptionsAreNotDuplicated) and reports a clear error. Use
+            // TryAdd here so the normalization step itself doesn't crash for that malformed setup.
+            var optionByName = new Dictionary<string, CommandLineOption>(StringComparer.OrdinalIgnoreCase);
+            foreach (ICommandLineOptionsProvider optionsProvider in context.CommandLineHandler.SystemCommandLineOptionsProviders
+                .Concat(context.CommandLineHandler.ExtensionsCommandLineOptionsProviders))
+            {
+                foreach (CommandLineOption option in optionsProvider.GetCommandLineOptions())
+                {
+                    if (!optionByName.ContainsKey(option.Name))
+                    {
+                        optionByName.Add(option.Name, option);
+                    }
+                }
+            }
+
+            context.Configuration.NormalizeJsonCommandLineOptionScalars(optionByName);
+
             jsonCommandLineOptions = context.Configuration.EnumerateJsonCommandLineOptions();
         }
         catch (FormatException ex) when (!loggingState.CommandLineParseResult.HasTool)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Services;
@@ -479,9 +478,196 @@ public sealed class JsonCommandLineOptionsTests
     }
 
     // ---------------------------------------------------------------------
+    // NormalizeJsonCommandLineOptionScalars (issue #8830 — scalar/bool ambiguity)
+    // ---------------------------------------------------------------------
+    [TestMethod]
+    public async Task NormalizeScalars_ArgBearingOption_BooleanStringTrue_BecomesArgumentValue()
+    {
+        // The pre-#8830 behavior treated "timeout": "true" as a presence marker because the
+        // scalar value parsed as a bool. After normalization the value must be surfaced as the
+        // first argument, both through EnumerateJsonCommandLineOptions and through the unified
+        // ICommandLineOptions lookup.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"timeout\": \"true\"}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreEqual("timeout", entry.OptionName);
+        Assert.IsFalse(entry.IsDisabled);
+        Assert.AreSequenceEqual(new[] { "true" }, entry.Arguments.ToArray());
+
+        Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("timeout", out bool isSet, out string[] arguments));
+        Assert.IsTrue(isSet);
+        Assert.AreSequenceEqual(new[] { "true" }, arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_ArgBearingOption_BooleanStringFalse_BecomesArgumentValue()
+    {
+        // Symmetric to the "true" case: "false" must not be interpreted as an explicit disable for
+        // an arg-bearing option. Without normalization the unified lookup would report isSet=false
+        // and the option would silently appear unset to the rest of the platform.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"timeout\": \"false\"}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreEqual("timeout", entry.OptionName);
+        Assert.IsFalse(entry.IsDisabled);
+        Assert.AreSequenceEqual(new[] { "false" }, entry.Arguments.ToArray());
+
+        Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("timeout", out bool isSet, out string[] arguments));
+        Assert.IsTrue(isSet);
+        Assert.AreSequenceEqual(new[] { "false" }, arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_ArgBearingOption_NonBoolScalar_RemainsAsArgument()
+    {
+        // Non-bool scalars already worked before #8830 thanks to the second branch in
+        // TryGetCommandLineOptionFromProviders; normalization must preserve this behavior while
+        // moving the storage into the canonical indexed shape.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"timeout\": \"30s\"}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreEqual("timeout", entry.OptionName);
+        Assert.AreSequenceEqual(new[] { "30s" }, entry.Arguments.ToArray());
+
+        Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("timeout", out bool isSet, out string[] arguments));
+        Assert.IsTrue(isSet);
+        Assert.AreSequenceEqual(new[] { "30s" }, arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_ZeroArityOption_BooleanScalar_RemainsPresenceMarker()
+    {
+        // Zero-arity flags must keep their bool→presence-marker semantics. Normalization is a
+        // no-op for them because their arity (Min == 0) signals that the bare key is meaningful
+        // as-is.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"no-banner\": true}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("no-banner", "desc", ArgumentArity.Zero, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreEqual("no-banner", entry.OptionName);
+        Assert.IsFalse(entry.IsDisabled);
+        Assert.IsEmpty(entry.Arguments);
+
+        Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("no-banner", out bool isSet, out string[] arguments));
+        Assert.IsTrue(isSet);
+        Assert.IsEmpty(arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_OptionalArgOption_BooleanScalar_LeftUntouched()
+    {
+        // Min=0, Max>=1 (optional-arg) is genuinely ambiguous between a presence marker and a
+        // scalar argument. We preserve the historical presence-marker interpretation; users that
+        // really mean to pass "true"/"false" as a value must use the explicit array form.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"opt-arg\": \"true\"}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("opt-arg", "desc", ArgumentArity.ZeroOrOne, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreEqual("opt-arg", entry.OptionName);
+        Assert.IsFalse(entry.IsDisabled);
+        Assert.IsEmpty(entry.Arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_UnknownOption_LeftUntouched()
+    {
+        // Unknown options must not be rewritten — the validator's unknown-option pass needs to see
+        // the original entry to emit a clear error referencing testconfig.json.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"unknown\": \"true\"}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("other", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreEqual("unknown", entry.OptionName);
+        Assert.IsFalse(entry.IsDisabled);
+        Assert.IsEmpty(entry.Arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_IndexedEntries_LeftUntouched()
+    {
+        // Array form is already in the canonical shape and must not be touched, including when an
+        // option that takes multiple args is involved.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"filter-uid\": [\"a\",\"b\"]}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("filter-uid", "desc", ArgumentArity.OneOrMore, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreSequenceEqual(new[] { "a", "b" }, entry.Arguments.ToArray());
+
+        Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("filter-uid", out bool isSet, out string[] arguments));
+        Assert.IsTrue(isSet);
+        Assert.AreSequenceEqual(new[] { "a", "b" }, arguments);
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_CaseInsensitive_RewritesByOptionName()
+    {
+        // testconfig.json keys are case-insensitive throughout the platform. A JSON entry "Timeout"
+        // must be matched against the registry's "timeout" and normalized accordingly.
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(
+            "{\"commandLineOptions\": {\"Timeout\": \"true\"}}");
+
+        aggregated.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
+
+        JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
+        Assert.AreSequenceEqual(new[] { "true" }, entry.Arguments.ToArray());
+    }
+
+    [TestMethod]
+    public async Task NormalizeScalars_NoJsonSource_IsNoOp()
+    {
+        // The platform may build an AggregatedConfiguration without a JSON source registered;
+        // normalization must degrade to a no-op rather than throw.
+        AggregatedConfiguration configuration = new(
+            [],
+            new CurrentTestApplicationModuleInfo(new SystemEnvironment(), new SystemProcessHandler()),
+            new Mock<IFileSystem>().Object,
+            new SystemEnvironment(),
+            CommandLineParseResult.Empty);
+
+        configuration.NormalizeJsonCommandLineOptionScalars(OptionsByName(
+            new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
+
+        Assert.IsEmpty(configuration.EnumerateJsonCommandLineOptions());
+
+        // The await keeps the test method asynchronous to match the surrounding suite style.
+        await Task.CompletedTask;
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
     private static async Task<IReadOnlyList<JsonCommandLineOptionEntry>> EnumerateAsync(string json)
+    {
+        AggregatedConfiguration aggregated = await BuildAggregatedAsync(json);
+        return aggregated.EnumerateJsonCommandLineOptions();
+    }
+
+    private static async Task<AggregatedConfiguration> BuildAggregatedAsync(string json)
     {
         Mock<IFileSystem> fileSystem = new();
         fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(true);
@@ -492,8 +678,18 @@ public sealed class JsonCommandLineOptionsTests
         configurationManager.AddConfigurationSource(() => new JsonConfigurationSource(testApplicationModuleInfo, fileSystem.Object, null));
 
         IConfiguration configuration = await configurationManager.BuildAsync(null, CommandLineParseResult.Empty);
-        var aggregated = (AggregatedConfiguration)configuration;
-        return aggregated.EnumerateJsonCommandLineOptions();
+        return (AggregatedConfiguration)configuration;
+    }
+
+    private static IReadOnlyDictionary<string, CommandLineOption> OptionsByName(params CommandLineOption[] options)
+    {
+        var dict = new Dictionary<string, CommandLineOption>(StringComparer.OrdinalIgnoreCase);
+        foreach (CommandLineOption option in options)
+        {
+            dict[option.Name] = option;
+        }
+
+        return dict;
     }
 
     private sealed class TestProvider : ICommandLineOptionsProvider


### PR DESCRIPTION
Resolves #8830.

## Problem

In `testconfig.json`, a bare scalar like
```json
{ "platformOptions": { "commandLineOptions": { "results-directory": "TestResults" } } }
```
was read by `JsonConfigurationProvider` as a *presence marker* via `bool.TryParse` for any option whose schema requires an argument. For an arg-bearing option, `"timeout": "true"` therefore enabled the option with zero args instead of passing `"true"` as the first argument value — a quiet foot-gun.

## Fix

Normalize `_singleValueData` once at startup using the registered option registry: when an option has `Arity.Min >= 1`, rewrite the bare scalar key
```
commandLineOptions:<name>
```
into the indexed form
```
commandLineOptions:<name>:0
```
so the value is consistently surfaced as the first argument by both `EnumerateCommandLineOptions` and `TryGetCommandLineOptionFromProviders`.

Optional-arg options (`Min=0, Max>=1`) remain ambiguous by design and are left untouched (workaround: use the array form `["true"]`). Zero-arity and unknown options are also left as-is — the existing validator catches unknown options.

## Wire-up

`TestHostBuilder.CommonServices.cs` builds an `OrdinalIgnoreCase` option lookup from the system + extension command-line providers and calls the new `AggregatedConfiguration.NormalizeJsonCommandLineOptionScalars` *before* `EnumerateJsonCommandLineOptions`, so the validator and any other consumer sees the rewritten form.

## Tests

Added 9 new `[TestMethod]`s in `JsonCommandLineOptionsTests.cs` covering:
- arg-bearing scalar promoted
- `"true"` / `"false"` strings on arg-bearing options promoted (regression for the original ambiguity)
- non-bool scalar promoted
- zero-arity option left as presence marker
- optional-arg option left untouched (still ambiguous, documented workaround)
- unknown option untouched
- already-indexed JSON untouched
- case-insensitive option lookup
- no-op when no JSON source is registered

All 380 existing Configuration / CommandLine tests pass; full `net9.0` build clean with `-warnaserror`.