### PR TITLE
Add [StackTraceHidden] to assertion API internals

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
@@ -222,8 +222,8 @@ public sealed partial class Assert
 
     #endregion // AreAllDistinct
 
-    // TODO: Deduplicate with the same adapter in Assert.CollectionEquivalence.cs (introduced by PR #8234)
-    // once both PRs have landed.
+    // Note: This duplicates the adapter in Assert.CollectionEquivalence.cs (introduced by PR #8234).
+    // Consider deduplicating once both PRs have landed.
     [StackTraceHidden]
     private sealed class NonGenericEqualityComparerAdapter : IEqualityComparer<object?>
     {

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
@@ -222,8 +222,7 @@ public sealed partial class Assert
 
     #endregion // AreAllDistinct
 
-    // Note: This duplicates the adapter in Assert.CollectionEquivalence.cs (introduced by PR #8234).
-    // Consider deduplicating once both PRs have landed.
+    // Adapts a non-generic IEqualityComparer to IEqualityComparer<object?> for assertion helpers.
     [StackTraceHidden]
     private sealed class NonGenericEqualityComparerAdapter : IEqualityComparer<object?>
     {

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllDistinct.cs
@@ -224,6 +224,7 @@ public sealed partial class Assert
 
     // TODO: Deduplicate with the same adapter in Assert.CollectionEquivalence.cs (introduced by PR #8234)
     // once both PRs have landed.
+    [StackTraceHidden]
     private sealed class NonGenericEqualityComparerAdapter : IEqualityComparer<object?>
     {
         private readonly IEqualityComparer _comparer;

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreAllOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreAllOfType.cs
@@ -159,6 +159,7 @@ public sealed partial class Assert
         ReportAssertFailed(structured);
     }
 
+    [StackTraceHidden]
     private readonly struct TypeMismatch
     {
         public TypeMismatch(int index, Type? actualType)

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Comparer.cs
@@ -8,6 +8,7 @@ public sealed partial class Assert
     /// <summary>
     /// Walks two object graphs and reports the first structural difference, if any.
     /// </summary>
+    [StackTraceHidden]
     private sealed partial class EquivalenceComparer
     {
         // Member info caches keyed by runtime type.

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.DictionaryView.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.DictionaryView.cs
@@ -11,6 +11,7 @@ public sealed partial class Assert
     /// Routes lookups back to the source dictionary so the source's own
     /// <see cref="IEqualityComparer{T}"/> for keys is preserved.
     /// </summary>
+    [StackTraceHidden]
     private abstract class DictionaryView
     {
         internal abstract IEnumerable<KeyValuePair<object, object?>> Entries { get; }
@@ -30,6 +31,7 @@ public sealed partial class Assert
         }
     }
 
+    [StackTraceHidden]
     private readonly struct DictionaryLookup
     {
         internal DictionaryLookup(bool found, object? value)
@@ -43,6 +45,7 @@ public sealed partial class Assert
         internal object? Value { get; }
     }
 
+    [StackTraceHidden]
     private sealed class NonGenericDictionaryView : DictionaryView
     {
         private readonly IDictionary _source;
@@ -84,6 +87,7 @@ public sealed partial class Assert
         }
     }
 
+    [StackTraceHidden]
     private sealed class GenericDictionaryView : DictionaryView
     {
         private static readonly ConcurrentDictionary<Type, GenericDictionaryAccessors> AccessorCache = new();
@@ -123,6 +127,7 @@ public sealed partial class Assert
     /// source's native methods (<c>TryGetValue</c>, <c>ContainsKey</c>) so the source's
     /// <see cref="IEqualityComparer{TKey}"/> is honored.
     /// </summary>
+    [StackTraceHidden]
     private sealed class GenericDictionaryAccessors
     {
         private readonly MethodInfo _tryGetValueMethod;

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.MemberAccessor.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.MemberAccessor.cs
@@ -8,6 +8,7 @@ public sealed partial class Assert
     /// <summary>
     /// Reference-equality comparer used for keys in the topology maps of <see cref="EquivalenceComparer"/>.
     /// </summary>
+    [StackTraceHidden]
     private sealed class ReferenceObjectComparer : IEqualityComparer<object>
     {
         internal static readonly ReferenceObjectComparer Instance = new();
@@ -25,6 +26,7 @@ public sealed partial class Assert
     /// Cached set of public instance properties and fields for a type, with both an alphabetically-sorted
     /// array (for deterministic traversal) and a name-keyed dictionary (for O(1) lookup).
     /// </summary>
+    [StackTraceHidden]
     private sealed class MemberLookup
     {
         internal MemberLookup(MemberAccessor[] sorted, IReadOnlyDictionary<string, MemberAccessor> byName)
@@ -41,6 +43,7 @@ public sealed partial class Assert
     /// <summary>
     /// Describes how to read a single member (property or field) from an instance.
     /// </summary>
+    [StackTraceHidden]
     private sealed class MemberAccessor
     {
         private readonly PropertyInfo? _property;

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Mismatch.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEquivalent.Mismatch.cs
@@ -9,6 +9,7 @@ public sealed partial class Assert
     /// A single structural mismatch found by <see cref="EquivalenceComparer"/>, carrying the dotted
     /// member path, a localized reason summary, and any expected/actual snippets to render.
     /// </summary>
+    [StackTraceHidden]
     private sealed class EquivalenceMismatch
     {
         private EquivalenceMismatch(string path, string reason, string? expectedText, string? actualText, bool isComparisonFailure)

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
@@ -674,6 +674,7 @@ public sealed partial class Assert
         WrongExceptionType,
     }
 
+    [StackTraceHidden]
     private readonly struct ThrowsExceptionState
     {
         public Exception? ExceptionThrown { get; }

--- a/src/TestFramework/TestFramework/Assertions/CollectionAssert.Helpers.cs
+++ b/src/TestFramework/TestFramework/Assertions/CollectionAssert.Helpers.cs
@@ -277,6 +277,7 @@ public sealed partial class CollectionAssert
     /// <summary>
     /// compares the objects using object.Equals.
     /// </summary>
+    [StackTraceHidden]
     private sealed class ObjectComparer : IComparer
     {
         int IComparer.Compare(object? x, object? y) => Equals(x, y) ? 0 : -1;


### PR DESCRIPTION
Addresses feedback from @Youssef1313 on #8826 (https://github.com/microsoft/testfx/issues/8826#issuecomment-3565710594):

> Why not use `StackTraceHidden` instead of trying to alter stack trace manually.

This PR adds `[StackTraceHidden]` to nested helper types inside the assertion API that previously could leak into user-facing failure stack traces:

- `NonGenericEqualityComparerAdapter` (`Assert.AreAllDistinct`)
- `TypeMismatch` (`Assert.AreAllOfType`)
- `EquivalenceComparer` partial (`Assert.AreEquivalent.Comparer` and sibling partials)
- `DictionaryView`, `DictionaryLookup`, `NonGenericDictionaryView`, `GenericDictionaryView`, `GenericDictionaryAccessors` (`Assert.AreEquivalent.DictionaryView`)
- `ReferenceObjectComparer`, `MemberLookup`, `MemberAccessor` (`Assert.AreEquivalent.MemberAccessor`)
- `EquivalenceMismatch` (`Assert.AreEquivalent.Mismatch`)
- `ThrowsExceptionState` (`Assert.ThrowsException`)
- `ObjectComparer` (`CollectionAssert.Helpers`)

Top-level assertion types (`Assert`, `CollectionAssert`, `StringAssert`, `AssertExtensions`, `AssertScope`, etc.) and all `InterpolatedStringHandler` structs were already annotated, so this PR fills in the remaining nested helpers within `src/TestFramework/TestFramework/Assertions/`.

Enum-typed helpers (`IEquatableOutcome`, `ThrowsFailureKind`) are skipped because `[StackTraceHidden]` does not target enums.

#### Notes / out of scope

- MTP / adapter plumbing frames that may also appear in user failure traces are out of scope for this PR.
- Compiler-generated iterator/lambda state-machine frames inside annotated types may still appear in some cases — that is a known runtime limitation of `[StackTraceHidden]` and not addressed here.
