### PR TITLE
Add [StackTraceHidden] to MTP and MSTest adapter test execution plumbing

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+[StackTraceHidden]
 internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTestBridgedTestFramework
 {
     private readonly BridgedConfiguration? _configuration;

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 /// Contains the execution logic for this adapter.
 /// </summary>
 [ExtensionUri(EngineConstants.ExecutorUriString)]
+[StackTraceHidden]
 internal sealed class MSTestExecutor : ITestExecutor
 {
     private readonly CancellationToken _cancellationToken;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 /// Class responsible for execution of tests at assembly level and sending tests via framework handle.
 /// </summary>
 #pragma warning disable CA1852 // Seal internal types - This class is inherited in tests.
+[StackTraceHidden]
 internal class TestExecutionManager
 {
     private sealed class RemotingMessageLogger :

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 /// Defines the TestMethod Info object.
 /// </summary>
 #pragma warning disable CA1852 // Seal internal types - This class is inherited in tests.
+[StackTraceHidden]
 internal partial class TestMethodInfo : ITestMethod
 {
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 /// <summary>
 /// This class is responsible to running tests and converting framework TestResults to adapter TestResults.
 /// </summary>
+[StackTraceHidden]
 internal sealed class TestMethodRunner
 {
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 /// <summary>
 /// The runner that runs a single unit test. Also manages the assembly and class cleanup methods at the end of the run.
 /// </summary>
+[StackTraceHidden]
 internal sealed class UnitTestRunner
 #if NETFRAMEWORK
     : MarshalByRefObject

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Testing.Extensions.VSTestBridge;
 /// <summary>
 /// A specialized bridged test framework base class that supports a single test session.
 /// </summary>
+[StackTraceHidden]
 public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTestBridgedTestFrameworkBase, IDisposable
 {
     private readonly IExtension _extension;

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/VSTestBridgedTestFrameworkBase.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/VSTestBridgedTestFrameworkBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Testing.Extensions.VSTestBridge;
 /// <summary>
 /// Represents a base class for bridged test frameworks (support of Microsoft.Testing.Platform while supporting VSTest like APIs).
 /// </summary>
+[StackTraceHidden]
 public abstract class VSTestBridgedTestFrameworkBase : ITestFramework, IDataProducer
 {
     private readonly ITrxReportCapability? _trxReportCapability;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Testing.Platform.Hosts;
 /// This represents either a test host (console or server), or a test host controller.
 /// This doesn't represent an orchestrator host.
 /// </summary>
+[StackTraceHidden]
 internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
 {
     public ServiceProvider ServiceProvider => serviceProvider;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
@@ -15,6 +15,7 @@ using Microsoft.Testing.Platform.TestHost;
 
 namespace Microsoft.Testing.Platform.Hosts;
 
+[StackTraceHidden]
 internal sealed class ConsoleTestHost(
     ServiceProvider serviceProvider,
     Func<TestFrameworkBuilderData, Task<ITestFramework>> buildTestFrameworkAsync,

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ServerTestHost.cs
@@ -21,6 +21,7 @@ using Microsoft.Testing.Platform.TestHost;
 
 namespace Microsoft.Testing.Platform.Hosts;
 
+[StackTraceHidden]
 internal sealed partial class ServerTestHost : CommonHost, IServerTestHost, IDisposable, IOutputDeviceDataProducer
 {
     public const string ProtocolVersion = PlatformVersion.Version;

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControlledHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControlledHost.cs
@@ -8,6 +8,7 @@ using Microsoft.Testing.Platform.IPC.Models;
 namespace Microsoft.Testing.Platform.Hosts;
 
 [UnsupportedOSPlatform("browser")]
+[StackTraceHidden]
 internal sealed class TestHostControlledHost(NamedPipeClient testHostControllerPipeClient, IHost innerHost, CancellationToken cancellationToken) : IHost, IDisposable
 #if NETCOREAPP
 #pragma warning disable SA1001 // Commas should be spaced correctly

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostControllersTestHost.cs
@@ -22,6 +22,7 @@ using Microsoft.Testing.Platform.TestHostControllers;
 namespace Microsoft.Testing.Platform.Hosts;
 
 [UnsupportedOSPlatform("browser")]
+[StackTraceHidden]
 internal sealed class TestHostControllersTestHost : CommonHost, IHost, IDisposable, IOutputDeviceDataProducer
 {
     private readonly TestHostControllerConfiguration _testHostsInformation;


### PR DESCRIPTION
Follow-up to #8853 (assertion internals) and continues addressing @Youssef1313's feedback on #8826:

> Why not use `StackTraceHidden` instead of trying to alter stack trace manually.

This PR annotates the MTP and MSTest adapter test execution plumbing types that always sit between the user test method and the top of a failure stack trace, so the runtime omits their frames from the public `StackTrace` surface.

#### Types annotated with `[StackTraceHidden]`

**Microsoft.Testing.Platform hosts** (`Microsoft.Testing.Platform.Hosts`):
- `CommonHost` (abstract base)
- `ConsoleTestHost`
- `ServerTestHost`
- `TestHostControlledHost`
- `TestHostControllersTestHost`

**VSTest bridge** (`Microsoft.Testing.Extensions.VSTestBridge`):
- `VSTestBridgedTestFrameworkBase`
- `SynchronizedSingleSessionVSTestBridgedTestFramework`

**MSTest adapter** (`Microsoft.VisualStudio.TestPlatform.MSTestAdapter` / `MSTest.TestAdapter`):
- `MSTestBridgedTestFramework`
- `MSTestExecutor`
- `TestExecutionManager`
- `UnitTestRunner`
- `TestMethodRunner`
- `TestMethodInfo` (annotated on one partial; applies to all sibling partials via attribute merging)

#### Scope rationale

Kept narrow to types explicitly mentioned in #8826 plus the immediate execution wrappers between user code and reporter. Broader sweeps (e.g. all internals in `Microsoft.Testing.Platform`) are intentionally avoided to:
- preserve extension authors' ability to debug their own extension code (extension contract types are not annotated),
- avoid hiding frames that may carry genuine diagnostic value.

#### Notes / out of scope

- Compiler-generated `MoveNext` / closure frames inside annotated async/iterator methods may still leak — a known `[StackTraceHidden]` runtime limitation. The rendering-layer filter proposed in #8826 may still be needed to handle those plus frames in types we don't own (e.g. VSTest object model).
- Public exception types and the `TestApplication` public entry point are intentionally not annotated.

#### Validation

- `.\build.cmd -c Debug` succeeds with 0 warnings / 0 errors.
- The attribute is metadata-only; no runtime semantic impact beyond stack trace rendering.
