### PR TITLE
Condition System.Text.Json PackageReference to netstandard2.0 in AzDO extension and bump to 10.0.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup Label="Test dependencies">

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
@@ -50,6 +50,11 @@ This package extends Microsoft Testing Platform to provide a Azure DevOps report
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+  </ItemGroup>
+
+  <!-- System.Text.Json ships in the .NET shared framework (since .NET Core 3.0).
+       Only netstandard2.0 needs an explicit PackageReference. -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Two related changes to the `System.Text.Json` dependency of the AzDO MTP extension (`Microsoft.Testing.Extensions.AzureDevOpsReport`).

### 1. Condition the `PackageReference` to `netstandard2.0` only

`System.Text.Json` ships in the `Microsoft.NETCore.App` shared framework on `net8.0`/`net9.0`, so an explicit `PackageReference` only adds value for the `netstandard2.0` target consumed by .NET Framework.

This was also the **only** csproj in the repo with an explicit `System.Text.Json` `PackageReference`; core MTP already uses STJ on net8/net9 without one and only references it via the implicit `FrameworkReference`.

### 2. Bump `System.Text.Json` from 8.0.5 → 10.0.8

With the previous commit restricting the pin to `netstandard2.0`, this version only affects the .NET Framework consumer path of the AzDO extension. Moving to the latest LTS line:

| Version | Lifecycle | EOL |
| --- | --- | --- |
| 8.0.x | LTS | Nov 2026 |
| 9.0.x | STS | May 2026 |
| **10.0.x** | **LTS** | **Nov 2028** |

STJ 10 still ships `lib/netstandard2.0` and supports .NET Framework 4.6.2+, so there is no breakage for .NET Framework consumers.

## Validation

- Built the AzDO extension across all 4 TFMs (net8.0, net9.0, netstandard2.0, net462/net472 via consumer): ✅
- Ran `Microsoft.Testing.Extensions.UnitTests` on net8.0, net9.0, net462, net472: ✅ all pass.
