### PR TITLE
[code-simplifier] Simplify Assert code-fix helpers: defer async root fetch, inline adapter lambda

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AssertToAssertFixerHelpers.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AssertToAssertFixerHelpers.cs
@@ -31,8 +31,6 @@ internal static class AssertToAssertFixerHelpers
         string? fixKindPropertyKey,
         Func<Document, InvocationExpressionSyntax, string, string?, CancellationToken, Task<Document>> fixAssertAsync)
     {
-        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
         Diagnostic diagnostic = context.Diagnostics[0];
         if (!diagnostic.Properties.TryGetValue(properAssertMethodNamePropertyKey, out string? properAssertMethodName)
             || properAssertMethodName is null)
@@ -46,6 +44,8 @@ internal static class AssertToAssertFixerHelpers
         {
             return;
         }
+
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
         if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is not InvocationExpressionSyntax invocationExpr)
         {

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/StringAssertToAssertFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/StringAssertToAssertFixer.cs
@@ -36,15 +36,7 @@ public sealed class StringAssertToAssertFixer : CodeFixProvider
             AssertToAssertAnalyzerHelpers.ProperAssertMethodNameKey,
             CodeFixResources.StringAssertToAssertTitle,
             fixKindPropertyKey: null,
-            FixAssertAsync);
-
-    private static Task<Document> FixAssertAsync(
-        Document document,
-        InvocationExpressionSyntax invocationExpr,
-        string properAssertMethodName,
-        string? fixKind,
-        CancellationToken cancellationToken)
-        => FixStringAssertAsync(document, invocationExpr, properAssertMethodName, cancellationToken);
+            (doc, expr, methodName, _, ct) => FixStringAssertAsync(doc, expr, methodName, ct));
 
     private static async Task<Document> FixStringAssertAsync(
         Document document,
@@ -52,7 +44,6 @@ public sealed class StringAssertToAssertFixer : CodeFixProvider
         string properAssertMethodName,
         CancellationToken cancellationToken)
     {
-        // Check if the invocation expression has a member access expression
         if (invocationExpr.Expression is not MemberAccessExpressionSyntax memberAccessExpr)
         {
             return document;
@@ -73,8 +64,6 @@ public sealed class StringAssertToAssertFixer : CodeFixProvider
         ArgumentListSyntax newArgumentList = invocationExpr.ArgumentList.WithArguments(SyntaxFactory.SeparatedList<ArgumentSyntax>(newArguments));
         InvocationExpressionSyntax newInvocationExpr = invocationExpr.WithArgumentList(newArgumentList);
 
-        // Replace StringAssert with Assert in the member access expression
-        // Change StringAssert.MethodName to Assert.ProperMethodName
         MemberAccessExpressionSyntax newMemberAccess = memberAccessExpr.WithExpression(SyntaxFactory.IdentifierName("Assert"))
             .WithName(SyntaxFactory.IdentifierName(properAssertMethodName));
         newInvocationExpr = newInvocationExpr.WithExpression(newMemberAccess);


### PR DESCRIPTION
## Code Simplification — 2026-06-05

This PR simplifies code introduced in #8848 (the String/Collection Assert code-fix scaffolding refactor) to improve clarity and code flow while preserving all functionality.

### Files Simplified

- `src/Analyzers/MSTest.Analyzers.CodeFixes/AssertToAssertFixerHelpers.cs` — defer async root acquisition until after cheap synchronous checks
- `src/Analyzers/MSTest.Analyzers.CodeFixes/StringAssertToAssertFixer.cs` — inline adapter lambda, remove obvious comments

### Improvements Made

1. **Deferred async work in `AssertToAssertFixerHelpers.RegisterCodeFixAsync`**
   - `SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(...)` was fetched unconditionally at the top of the method, before two cheap `Dictionary.TryGetValue` checks that can cause early returns.
   - Moving the await after those guards skips the async round-trip when the diagnostic properties are missing, which is consistent with the "synchronous guards first, async work second" pattern.

2. **Removed `FixAssertAsync` adapter method from `StringAssertToAssertFixer`**
   - The method was a pure bridge: it accepted the shared callback signature (including `string? fixKind`) but immediately ignored `fixKind` and forwarded to `FixStringAssertAsync`.
   - Replaced with an inline lambda `(doc, expr, methodName, _, ct) => FixStringAssertAsync(doc, expr, methodName, ct)` where the `_` discard explicitly signals that `fixKind` is not used for this fixer. This removes 9 lines without any loss of clarity.

3. **Removed two obvious comments from `FixStringAssertAsync`**
   - `// Check if the invocation expression has a member access expression` — the pattern match immediately below is self-explanatory.
   - `// Replace StringAssert with Assert in the member access expression` / `// Change StringAssert.MethodName to Assert.ProperMethodName` — two lines saying the same thing about obvious code.

### Changes Based On

- #8848 — Refactor String/Collection Assert code-fix scaffolding into shared base

### Testing

- ✅ No behavioral changes — all modifications are purely structural
- ✅ Lambda matches `Func<Document, InvocationExpressionSyntax, string, string?, CancellationToken, Task<Document>>` exactly
- ✅ Root reordering does not affect any code path that passes the guards

### Review Focus

Please verify:
- The `_` discard in the lambda is idiomatic in this codebase
- The early-return order in `RegisterCodeFixAsync` still makes logical sense

---

*Automated by Code Simplifier Agent*


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27019418694) · sonnet46 2.7M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-06T14:15:14.790Z --> on Jun 6, 2026, 2:15 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27019418694, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27019418694 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->