### PR TITLE
Docs: more small consistency fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository is the home for Microsoft.Testing.Platform and extensions, as we
 
 Microsoft.Testing.Platform is a lightweight alternative to VSTest. For more information, see [Microsoft.Testing.Platform overview](https://aka.ms/mtp-overview).
 
-MSTest, Microsoft Testing Framework, is a testing framework for .NET applications. It allows you to write tests, use Test Explorer, create test suites, and apply the red, green, and refactor patterns to write code.
+MSTest, Microsoft Test Framework, is a testing framework for .NET applications. It allows you to write tests, use Test Explorer, create test suites, and apply the red, green, and refactor patterns to write code.
 
 This is a fully supported, open source, and cross-platform test framework with which to write tests targeting .NET Framework, .NET Core, .NET, UWP, and WinUI on Windows, Linux, and Mac.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ You can find the main differences with MSTest v1 in [Deltas w.r.t MSTest V1](del
 
 You can find detailed examples and explanations of MSTest features at
 
+- [Writing your first test with MSTest](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-mstest)
 - [MSTest element via runsettings](https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#mstest-element)
 - [Use the MSTest framework in unit tests](https://learn.microsoft.com/visualstudio/test/using-microsoft-visualstudio-testtools-unittesting-members-in-unit-tests)
 - [Create a data-driven unit test](https://learn.microsoft.com/visualstudio/test/how-to-create-a-data-driven-unit-test)
@@ -27,7 +28,6 @@ You can find detailed examples and explanations of MSTest features at
 
 For technical reasoning and implementation details, you can refer to the list of RFCs:
 
-- [Writing your first test with mstest](https://learn.microsoft.com/dotnet/core/testing/unit-testing-with-mstest)
 - [Framework Extensibility Trait Attributes](RFCs/001-Framework-Extensibility-Trait-Attributes.md)
 - [Framework Extensibility for Custom Assertions](RFCs/002-Framework-Extensibility-Custom-Assertions.md)
 - [Customize Running tests](RFCs/003-Customize-Running-Tests.md)

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -8,7 +8,7 @@ To build and test all functionalities of MSTest, we recommend installing [Visual
 
 - `.NET desktop development`
 - `Universal Windows Platform development`
-- `.Net Core cross-platform development`
+- `.NET Core cross-platform development`
 
 ## Recommended workflow
 
@@ -125,6 +125,7 @@ with
 | bin               | Build output of each project.                          |
 | obj               | Intermediate directory for each project.               |
 | packages          | NuGet packages produced by all projects in the repo.   |
+| TestResults       | Test results produced by test runs.                    |
 | SymStore          | Storage for converted Windows PDBs                     |
 | log               | Build binary log and other logs.                       |
 | tmp               | Temp files generated during build.                     |


### PR DESCRIPTION
Follow-up to #8862 with a few more small docs consistency fixes spotted in the same files.

## `README.md` — name consistency

`MSTest, Microsoft Testing Framework, is a testing framework...` — the same file's H1 is `Microsoft Test Framework (MSTest)`. Replaced `Testing` -> `Test` so the acronym expands the same way in both places.

## `docs/dev-guide.md`

### `.Net` -> `.NET`

The VS workloads list has `.Net Core cross-platform development`; the two bullets above it already use `.NET`.

### Build layout table missing `TestResults`

The `artifacts/` directory tree lists `TestResults` but the legend table below doesn't describe it. Added a row.

## `docs/README.md`

`Writing your first test with mstest` was the first bullet under "you can refer to the list of RFCs" — it's a learn.microsoft.com tutorial, not an RFC. Moved it into the "detailed examples" list above (where similar tutorial links live) and capitalized `mstest` -> `MSTest`.

## Verification

No behavioral or build impact — Markdown-only doc changes.