### PR TITLE
[test-improver] test: add edge case tests for TestMethodShouldNotBeIgnoredAnalyzer (MSTEST0015)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestMethodShouldNotBeIgnoredAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestMethodShouldNotBeIgnoredAnalyzerTests.cs
@@ -99,4 +99,107 @@ public sealed class TestMethodShouldNotBeIgnoredAnalyzerTests
                 .WithLocation(0)
                 .WithArguments("MyTestMethod"));
     }
+
+    [TestMethod]
+    public async Task WhenDataTestMethodIsIgnored_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [Ignore]
+                [DataTestMethod]
+                [DataRow(1)]
+                public void {|#0:MyTestMethod|}(int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(TestMethodShouldNotBeIgnoredAnalyzer.TestMethodShouldNotBeIgnoredRule)
+                .WithLocation(0)
+                .WithArguments("MyTestMethod"));
+    }
+
+    [TestMethod]
+    public async Task WhenMultipleTestMethodsAndOnlyOneIsIgnored_DiagnosticOnlyForIgnoredMethod()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void NotIgnoredMethod()
+                {
+                }
+
+                [Ignore]
+                [TestMethod]
+                public void {|#0:IgnoredMethod|}()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(TestMethodShouldNotBeIgnoredAnalyzer.TestMethodShouldNotBeIgnoredRule)
+                .WithLocation(0)
+                .WithArguments("IgnoredMethod"));
+    }
+
+    [TestMethod]
+    public async Task WhenOnlyClassLevelIgnoreWithNoMethodLevelIgnore_NoDiagnostic()
+    {
+        // MSTEST0015 only checks for [Ignore] on the method itself.
+        // A class-level [Ignore] silences the whole class but is not flagged by this rule.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [Ignore]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenIgnoredTestMethodHasMessage_Diagnostic()
+    {
+        // MSTEST0015 fires even when [Ignore] has a justification message.
+        // The presence of a message satisfies MSTEST0014 (IgnoreShouldHaveJustification),
+        // but the method is still ignored and MSTEST0015 still applies.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [Ignore("Tracked by #12345")]
+                [TestMethod]
+                public void {|#0:MyTestMethod|}()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(TestMethodShouldNotBeIgnoredAnalyzer.TestMethodShouldNotBeIgnoredRule)
+                .WithLocation(0)
+                .WithArguments("MyTestMethod"));
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestMethodShouldNotBeIgnoredAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestMethodShouldNotBeIgnoredAnalyzerTests.cs
@@ -180,7 +180,7 @@ public sealed class TestMethodShouldNotBeIgnoredAnalyzerTests
     public async Task WhenIgnoredTestMethodHasMessage_Diagnostic()
     {
         // MSTEST0015 fires even when [Ignore] has a justification message.
-        // The presence of a message satisfies MSTEST0014 (IgnoreShouldHaveJustification),
+        // The presence of a message satisfies MSTEST0066 (IgnoreShouldHaveJustification),
         // but the method is still ignored and MSTEST0015 still applies.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`TestMethodShouldNotBeIgnoredAnalyzer` (MSTEST0015) had only 4 tests. Three important behavioral boundaries were untested:

1. How the analyzer handles `[DataTestMethod]` (a `TestMethodAttribute` derivative paired with `[Ignore]`)
2. Whether a class with mixed ignored/non-ignored methods produces one diagnostic or two
3. Whether a class-level `[Ignore]` (without method-level) triggers the rule
4. Whether an `[Ignore]` with a justification message still fires MSTEST0015 (vs. MSTEST0014)

These are the scenarios users most commonly ask about when enabling this rule.

## Approach

Added four new tests:

| Test | Condition exercised |
|------|---------------------|
| `WhenDataTestMethodIsIgnored_Diagnostic` | `[DataTestMethod]` is a `TestMethodAttribute` derivative — it should be treated like `[TestMethod]` |
| `WhenMultipleTestMethodsAndOnlyOneIsIgnored_DiagnosticOnlyForIgnoredMethod` | Only the method bearing `[Ignore]` gets a diagnostic; the un-ignored sibling is clean |
| `WhenOnlyClassLevelIgnoreWithNoMethodLevelIgnore_NoDiagnostic` | MSTEST0015 inspects **method-level** attributes only — class-level `[Ignore]` doesn't fire it |
| `WhenIgnoredTestMethodHasMessage_Diagnostic` | A justification message satisfies MSTEST0014 but MSTEST0015 still fires — the test is still ignored |

## Trade-offs

Minimal maintenance burden — straightforward analyzer verifications with no mocking or state.

## Test Status

✅ All 8 tests passed (`MSTest.Analyzers.UnitTests` net8.0, 0 warnings, 0 errors)

```
total: 8 | failed: 0 | succeeded: 8 | skipped: 0 | duration: 7.5s
```

## Reproducibility

```bash
./build.sh --build
dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj -f net8.0 --no-build -c Debug --filter "FullyQualifiedName~TestMethodShouldNotBeIgnoredAnalyzerTests"
```




> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/27045157526) · sonnet46 4.6M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27045157526, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27045157526 -->

<!-- gh-aw-workflow-id: test-improver -->