### PR TITLE
[test-improver] test: add edge case tests for PreferTestMethodOverDataTestMethodAnalyzer (MSTEST0044)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestMethodOverDataTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestMethodOverDataTestMethodAnalyzerTests.cs
@@ -183,4 +183,93 @@ public sealed class PreferTestMethodOverDataTestMethodAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenDataTestMethodUsedWithDataRowAttribute_FixerPreservesDataRow()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [[|DataTestMethod|]]
+                [DataRow(1)]
+                [DataRow(2)]
+                public void MyTestMethod(int value)
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DataRow(1)]
+                [DataRow(2)]
+                public void MyTestMethod(int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenDataTestMethodUsedOutsideTestClass_Diagnostic()
+    {
+        // The analyzer fires on DataTestMethod regardless of whether the containing
+        // class has [TestClass]. DataTestMethod should always be replaced with TestMethod.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class NonTestClass
+            {
+                [[|DataTestMethod|]]
+                public void MyMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class NonTestClass
+            {
+                [TestMethod]
+                public void MyMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenClassInheritsTwoLevelsFromDataTestMethod_OnlyDirectInheritanceIsFlagged()
+    {
+        // The analyzer only flags *direct* inheritance from DataTestMethodAttribute.
+        // A class that inherits from a class that already extends DataTestMethodAttribute
+        // is NOT flagged — only the direct child is.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            internal class [|MyDataTestMethodAttribute|] : DataTestMethodAttribute
+            {
+            }
+
+            internal sealed class MyOtherDataTestMethodAttribute : MyDataTestMethodAttribute
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`PreferTestMethodOverDataTestMethodAnalyzer` (MSTEST0044) had 6 tests. Three behavioral boundaries were untested:

1. **Fixer + `[DataRow]` coexistence** — developers often use `[DataTestMethod]` *because* they think it's required for `[DataRow]` to work; the fixer should replace it with `[TestMethod]` while leaving all `[DataRow]` attributes untouched.
2. **Method outside `[TestClass]`** — the analyzer does not gate on test-class context; the diagnostic fires regardless of whether the containing class is a test class.
3. **Two-level inheritance** — the `AnalyzeNamedType` path uses `Equals(namedTypeSymbol.BaseType, ...)` (not `.Inherits(...)`), so only **direct** children of `DataTestMethodAttribute` are flagged; a grandchild class is not.

## Approach

Added three new tests to `PreferTestMethodOverDataTestMethodAnalyzerTests.cs`:

| Test | What it exercises |
|---|---|
| `WhenDataTestMethodUsedWithDataRowAttribute_FixerPreservesDataRow` | Code-fix preserves `[DataRow]` siblings |
| `WhenDataTestMethodUsedOutsideTestClass_Diagnostic` | Diagnostic fires on non-`[TestClass]` methods |
| `WhenClassInheritsTwoLevelsFromDataTestMethod_OnlyDirectInheritanceIsFlagged` | Only direct `DataTestMethodAttribute` inheritance is flagged |

## Test Status

```
Test run summary: Passed! (net8.0|x64)
  total: 9
  failed: 0
  succeeded: 9
  skipped: 0
```

## Trade-offs

- No production code changes — tests only.
- The two-level inheritance test uses a non-`sealed` intermediate class (required so it can be subclassed), matching the real-world scenario.




> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/27076593925) · sonnet46 5.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27076593925, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27076593925 -->

<!-- gh-aw-workflow-id: test-improver -->