### PR TITLE
Fix CodeQL pipeline MSB4216 by switching to dotnet MSBuild engine

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -59,9 +59,14 @@ jobs:
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
 
+  # Force the .NET SDK MSBuild (x64) instead of the default VS x86 MSBuild on the
+  # windows.vs2026.amd64 image. Since image version 2026.0529.211646 (deployed 2026-06-05),
+  # the bundled VS MSBuild fails to spin up an x86 .NET task host for Arcade tasks declared
+  # with Runtime="NET", producing MSB4216 on InstallDotNetCore. See dotnet/msbuild#13739.
   - script: eng\common\cibuild.cmd
       -configuration $(_BuildConfig)
       -prepareMachine
+      -msbuildEngine dotnet
       /p:Test=false
     displayName: Windows Build
 


### PR DESCRIPTION
## Problem

The scheduled CodeQL pipeline (`microsoft-testfx-codeql-pr`, definition 1407) has been failing every night since 2026-06-05 with:

```
artifacts\toolset\11.0.0-beta.26305.3\InstallDotNetCore.targets(17,5):
error MSB4216: Could not run the ""InstallDotNetCore"" task because MSBuild could not create or connect to a task host
with runtime ""NET"" and architecture ""x86"". [...] the required executable
""D:\a\_work\1\s\.dotnet\sdk\11.0.100-preview.5.26227.104\MSBuild.exe"" exists and can be run.
```

Latest failure: [build 2994041](https://dnceng.visualstudio.com/internal/_build/results?buildId=2994041).

## Root cause

This is the same class of failure addressed in #8355 ([dotnet/msbuild#13739](https://github.com/dotnet/msbuild/issues/13739)) — when an x86 Full Framework MSBuild host runs an Arcade `UsingTask` with `Runtime=""NET""`, MSBuild tries to spin up an x86 .NET task host, which the .NET SDK does not ship.

What changed: the `windows.vs2026.amd64` agent image was updated from `2026.0522.011033` → `2026.0529.211646` between 2026-06-04 (last green build, #2991767) and 2026-06-05 (first failure, #2992621). The Arcade SDK bump in #8810 (26302.1 → 26303.5) that landed at the same time is a red herring — `BuildTasks.props` is byte-identical between the two Arcade versions, and the `Architecture=""*""` attribute is already declared upstream.

The previous workaround in `eng/Tools.props` still applies `Architecture=""*""` to `InstallDotNetCore`, but the new VS MSBuild on this image apparently ignores it (or has a different task-host launch path that defeats it).

## Fix

Pass `-msbuildEngine dotnet` to `cibuild.cmd` in the CodeQL pipeline only. This makes the build use the .NET SDK MSBuild (which is x64) instead of the default VS x86 MSBuild, side-stepping the x86 task-host code path entirely.

- `azure-pipelines.yml` (PR/CI) and `azure-pipelines-official.yml` run on `windows.vs2026preview.scout.amd64` — a different image — and continue to work, so they stay on the VS MSBuild default.
- `eng/Tools.props` (the prior workaround) is left alone so local dev builds launched from an x86 VS Developer Command Prompt still benefit from it.

## Validation

Cannot reproduce locally (requires the specific 1ES-hosted image). The pipeline will be re-validated after merge by the next scheduled run or by manually queuing build 1407.