### PR TITLE
[code-simplifier] Simplify fully-qualified names in TFM moniker helper and its call sites

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Configuration.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Configuration.cs
@@ -43,7 +43,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         string currentTestApplicationPath = _testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
         string assemblyName = _testApplicationModuleInfo.TryGetAssemblyName() ?? Path.GetFileNameWithoutExtension(currentTestApplicationPath);
         string automatedTestStorage = Path.GetFileNameWithoutExtension(currentTestApplicationPath);
-        string targetFrameworkMoniker = Microsoft.Testing.Extensions.TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
+        string targetFrameworkMoniker = TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
         string agentName = _environment.GetEnvironmentVariable("AGENT_NAME") ?? _environment.MachineName;
         string? stageName = _environment.GetEnvironmentVariable("SYSTEM_STAGENAME");
         string? jobName = _environment.GetEnvironmentVariable("SYSTEM_JOBNAME");

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -162,7 +162,7 @@ internal sealed class HtmlReportEngine
             ?? _environment.GetEnvironmentVariable("USER")
             ?? "user";
         string moduleName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string targetFrameworkMoniker = Microsoft.Testing.Extensions.TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
+        string targetFrameworkMoniker = TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
         string raw = $"{user}_{_environment.MachineName}_{moduleName}_{targetFrameworkMoniker}_{finishTime:yyyy-MM-dd_HH_mm_ss}.html";
         return ReplaceInvalidFileNameChars(raw);
     }

--- a/src/Platform/SharedExtensionHelpers/TargetFrameworkMonikerHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/TargetFrameworkMonikerHelper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Testing.Extensions;
 internal static class TargetFrameworkMonikerHelper
 {
     public static string GetTargetFrameworkMoniker()
-        => TargetFrameworkParser.GetShortTargetFramework(Assembly.GetEntryAssembly()?.GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>()?.FrameworkDisplayName)
-            ?? TargetFrameworkParser.GetShortTargetFramework(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
+        => TargetFrameworkParser.GetShortTargetFramework(Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
+            ?? TargetFrameworkParser.GetShortTargetFramework(RuntimeInformation.FrameworkDescription)
             ?? "unknown";
 }


### PR DESCRIPTION
This PR simplifies code introduced by #8893 to improve clarity and follow established project conventions.

### Files Simplified

- `src/Platform/SharedExtensionHelpers/TargetFrameworkMonikerHelper.cs` — removed unnecessary fully-qualified type names
- `src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Configuration.cs` — removed redundant namespace prefix on call site
- `src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs` — removed redundant namespace prefix on call site

### Improvements Made

1. **Removed redundant fully-qualified names in `TargetFrameworkMonikerHelper.cs`**
   - `System.Runtime.Versioning.TargetFrameworkAttribute` → `TargetFrameworkAttribute`
   - `System.Runtime.InteropServices.RuntimeInformation` → `RuntimeInformation`
   - Both `System.Runtime.Versioning` and `System.Runtime.InteropServices` are globally imported via the repo-wide `<Using>` items in `Directory.Build.props`, making the long names redundant.

2. **Removed redundant namespace prefix at call sites**
   - `Microsoft.Testing.Extensions.TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker()` → `TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker()`
   - Both `AzureDevOpsReport` and `HtmlReport` are sub-namespaces of `Microsoft.Testing.Extensions`, so C# parent-namespace resolution makes the helper accessible without a `using` directive or full qualification. This is consistent with how `ReportFileNameSanitizer` (also in `Microsoft.Testing.Extensions`) is already used without qualification in `HtmlReportEngine.cs`.

### Changes Based On

Recent changes from:
- #8893 — Deduplicate target framework moniker resolution across Azure DevOps and HTML report extensions

### Testing

- ✅ No functional changes — behavior is identical
- ✅ All changes are pure readability improvements aligned with existing code patterns in the file

### Review Focus

Please verify:
- Functionality is preserved (these are purely cosmetic name changes)
- Simplifications are consistent with the conventions used elsewhere in the same files

---

*Automated by Code Simplifier Agent*


<!-- gh-aw-tracker-id: code-simplifier -->




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item was blocked because it doesn't meet the GitHub integrity level.
>
> - [#8887](https://github.com/microsoft/testfx/pull/8887) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27094193844) · sonnet46 3.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-08T13:48:42.284Z --> on Jun 8, 2026, 1:48 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27094193844, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27094193844 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->