### PR TITLE
Publish TRX in Release PR jobs by passing --report-trx to --test-modules

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,7 +126,12 @@ stages:
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
           # Use *.exe to cover both net4x (native exe) and net8+/net9+ (apphost exe) in a single glob.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed
+          # --report-trx must be passed explicitly because --test-modules bypasses MSBuild evaluation,
+          # so test/Directory.Build.targets cannot inject it via TestingPlatformCommandLineArguments.
+          # The {asm}_{tfm} placeholder pattern (see Microsoft.Testing.Platform.Services.ArtifactNamingHelper)
+          # mirrors what Directory.Build.targets uses for Debug runs and guarantees a unique, deterministic
+          # TRX per (assembly x target framework) module so files don't collide when multiple test apps run.
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx"
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
@@ -209,7 +214,12 @@ stages:
 
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed
+          # --report-trx must be passed explicitly because --test-modules bypasses MSBuild evaluation,
+          # so test/Directory.Build.targets cannot inject it via TestingPlatformCommandLineArguments.
+          # The {asm}_{tfm} placeholder pattern (see Microsoft.Testing.Platform.Services.ArtifactNamingHelper)
+          # mirrors what Directory.Build.targets uses for Debug runs and guarantees a unique, deterministic
+          # TRX per (assembly x target framework) module so files don't collide when multiple test apps run.
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx"
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
@@ -278,7 +288,12 @@ stages:
 
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed
+          # --report-trx must be passed explicitly because --test-modules bypasses MSBuild evaluation,
+          # so test/Directory.Build.targets cannot inject it via TestingPlatformCommandLineArguments.
+          # The {asm}_{tfm} placeholder pattern (see Microsoft.Testing.Platform.Services.ArtifactNamingHelper)
+          # mirrors what Directory.Build.targets uses for Debug runs and guarantees a unique, deterministic
+          # TRX per (assembly x target framework) module so files don't collide when multiple test apps run.
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx"
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,12 +126,24 @@ stages:
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
           # Use *.exe to cover both net4x (native exe) and net8+/net9+ (apphost exe) in a single glob.
-          # --report-trx must be passed explicitly because --test-modules bypasses MSBuild evaluation,
-          # so test/Directory.Build.targets cannot inject it via TestingPlatformCommandLineArguments.
-          # The {asm}_{tfm} placeholder pattern (see Microsoft.Testing.Platform.Services.ArtifactNamingHelper)
-          # mirrors what Directory.Build.targets uses for Debug runs and guarantees a unique, deterministic
-          # TRX per (assembly x target framework) module so files don't collide when multiple test apps run.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx"
+          #
+          # --test-modules bypasses MSBuild evaluation, so test/Directory.Build.targets cannot inject
+          # any of its TestingPlatformCommandLineArguments. We therefore restore the subset of those
+          # options that makes sense in Release:
+          #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
+          #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
+          #   --report-azdo — surfaces failed tests in the AzDO UI.
+          #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
+          #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
+          #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
+          # We intentionally do NOT pass:
+          #   --crashdump — gated on .NETCoreApp in Directory.Build.targets; the CrashDump extension's
+          #     ValidateTestHostEnvironmentVariablesAsync hard-fails the run on non-NETCoreApp hosts
+          #     (see src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs),
+          #     and this glob mixes net4x and net8+/net9+ hosts.
+          #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
+          #     below), so collecting coverage in Release would just write unused .coverage files.
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
@@ -214,12 +226,24 @@ stages:
 
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
-          # --report-trx must be passed explicitly because --test-modules bypasses MSBuild evaluation,
-          # so test/Directory.Build.targets cannot inject it via TestingPlatformCommandLineArguments.
-          # The {asm}_{tfm} placeholder pattern (see Microsoft.Testing.Platform.Services.ArtifactNamingHelper)
-          # mirrors what Directory.Build.targets uses for Debug runs and guarantees a unique, deterministic
-          # TRX per (assembly x target framework) module so files don't collide when multiple test apps run.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx"
+          #
+          # --test-modules bypasses MSBuild evaluation, so test/Directory.Build.targets cannot inject
+          # any of its TestingPlatformCommandLineArguments. We therefore restore the subset of those
+          # options that makes sense in Release:
+          #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
+          #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
+          #   --report-azdo — surfaces failed tests in the AzDO UI.
+          #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
+          #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
+          #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
+          # We intentionally do NOT pass:
+          #   --crashdump — gated on .NETCoreApp in Directory.Build.targets; the CrashDump extension's
+          #     ValidateTestHostEnvironmentVariablesAsync hard-fails the run on non-NETCoreApp hosts
+          #     (see src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs).
+          #     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
+          #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
+          #     below), so collecting coverage in Release would just write unused .coverage files.
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
@@ -288,12 +312,24 @@ stages:
 
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
-          # --report-trx must be passed explicitly because --test-modules bypasses MSBuild evaluation,
-          # so test/Directory.Build.targets cannot inject it via TestingPlatformCommandLineArguments.
-          # The {asm}_{tfm} placeholder pattern (see Microsoft.Testing.Platform.Services.ArtifactNamingHelper)
-          # mirrors what Directory.Build.targets uses for Debug runs and guarantees a unique, deterministic
-          # TRX per (assembly x target framework) module so files don't collide when multiple test apps run.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx"
+          #
+          # --test-modules bypasses MSBuild evaluation, so test/Directory.Build.targets cannot inject
+          # any of its TestingPlatformCommandLineArguments. We therefore restore the subset of those
+          # options that makes sense in Release:
+          #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
+          #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
+          #   --report-azdo — surfaces failed tests in the AzDO UI.
+          #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
+          #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
+          #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
+          # We intentionally do NOT pass:
+          #   --crashdump — gated on .NETCoreApp in Directory.Build.targets; the CrashDump extension's
+          #     ValidateTestHostEnvironmentVariablesAsync hard-fails the run on non-NETCoreApp hosts
+          #     (see src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs).
+          #     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
+          #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
+          #     below), so collecting coverage in Release would just write unused .coverage files.
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))


### PR DESCRIPTION
Fixes #8882

## Problem

In the PR pipeline (`azure-pipelines.yml`), the Release jobs (Windows/Linux/macOS) invoke:

```
dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/Release/**/*UnitTests.{exe|dll}" \
  --results-directory <dir> --no-progress --output detailed
```

Because `--test-modules` runs the test apps directly and **bypasses MSBuild project evaluation**, the `TestingPlatformCommandLineArguments` injected by `test/Directory.Build.targets` under the `UsingDotNetTest=true` branch — including `--report-trx` and `--report-trx-filename` — never reach the test hosts. The `artifacts/TestResults/Release` directory therefore stays empty, and the "Publish TRX Test Results" / "Publish Test Results folders" steps warn:

> ##[warning]No test result files matching ''[ ''*.trx'' ]'' were found.
> ##[warning]Directory ''/mnt/vss/_work/1/s/artifacts/TestResults/Release'' is empty.

This regressed when the Release jobs switched from `.slnf`-based runs to `--test-modules`.

## Fix

Pass `--report-trx --report-trx-filename "{asm}_{tfm}.trx"` explicitly on the three Release `TestRelease` scripts (Windows, Linux, macOS).

- `--report-trx` re-enables TRX generation (the TrxReport extension is already referenced by every unit-test project via `test/Directory.Build.targets`).
- `{asm}` and `{tfm}` are resolved by `Microsoft.Testing.Platform.Services.ArtifactNamingHelper` to the entry assembly name and short target framework, mirroring what `test/Directory.Build.targets` already uses for Debug runs (`$(MSBuildProjectName)_$(TargetFramework)`). This produces a unique, deterministic TRX per `(assembly × TFM)` test module so files don''t collide when multiple test apps run in parallel, and it''s easier to triage than the default `<user>_<machine>_<timestamp>.trx`.

Verified locally:

```
dotnet test --no-build --test-modules "artifacts/bin/Microsoft.Testing.Platform.UnitTests/Release/**/*UnitTests.exe" \
  --results-directory <dir> --no-progress --output detailed \
  --report-trx --report-trx-filename "{asm}_{tfm}.trx"
```

Produced:

```
Microsoft.Testing.Platform.UnitTests_net462.trx
Microsoft.Testing.Platform.UnitTests_net8.0.trx
Microsoft.Testing.Platform.UnitTests_net9.0.trx
```

The Debug jobs are unaffected because they invoke `dotnet test -c Debug --no-build ... -p:UsingDotNetTest=true` and go through project evaluation, which still applies the `Directory.Build.targets` argument injection.
