### PR TITLE
[efficiency-improver] perf: use SingleOrDefault instead of OfType().Select() for stdout/stderr in OpenTelemetryResultHandler

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/TestApplicationResult.cs
@@ -37,7 +37,7 @@ internal sealed class TestApplicationResult : ITestApplicationProcessExitCode, I
         _policiesService = policiesService;
         if (otelService is not null)
         {
-            _openTelemetryResultHandler = new OpenTelemetryResultHandler(otelService, environment);
+            _openTelemetryResultHandler = new OpenTelemetryResultHandler(otelService);
         }
 
         _isDiscovery = _commandLineOptions.IsOptionSet(PlatformCommandLineProvider.DiscoverTestsOptionKey);

--- a/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.Telemetry;
 
 internal sealed class OpenTelemetryResultHandler : IDisposable
 {
     private readonly IPlatformOpenTelemetryService _otelService;
-    private readonly IEnvironment _environment;
     private readonly ICounter<int> _totalDiscoveredTests;
     private readonly ICounter<int> _totalStartedTests;
     private readonly ICounter<int> _totalCompletedTests;
@@ -25,10 +23,9 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
     private readonly Dictionary<TestNodeUid, Queue<IPlatformActivity>> _testActivities = [];
     private bool _disposed;
 
-    public OpenTelemetryResultHandler(IPlatformOpenTelemetryService otelService, IEnvironment environment)
+    public OpenTelemetryResultHandler(IPlatformOpenTelemetryService otelService)
     {
         _otelService = otelService;
-        _environment = environment;
         _totalDiscoveredTests = otelService.CreateCounter<int>("tests.discovered");
         _totalStartedTests = otelService.CreateCounter<int>("tests.started");
         _totalCompletedTests = otelService.CreateCounter<int>("tests.completed");
@@ -191,8 +188,8 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
             activity.SetTag($"test.metadataProperty.{metadataProperty.Key}", metadataProperty.Value);
         }
 
-        activity.SetTag("test.stdout", string.Join(_environment.NewLine, testNode.Properties.OfType<StandardOutputProperty>().Select(x => x.StandardOutput)));
-        activity.SetTag("test.stderr", string.Join(_environment.NewLine, testNode.Properties.OfType<StandardErrorProperty>().Select(x => x.StandardError)));
+        activity.SetTag("test.stdout", testNode.Properties.SingleOrDefault<StandardOutputProperty>()?.StandardOutput ?? string.Empty);
+        activity.SetTag("test.stderr", testNode.Properties.SingleOrDefault<StandardErrorProperty>()?.StandardError ?? string.Empty);
 
         int index = 0;
         foreach (FileArtifactProperty fileArtifactProperty in testNode.Properties.OfType<FileArtifactProperty>())

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Telemetry;
 
 using Moq;
@@ -13,7 +12,6 @@ namespace Microsoft.Testing.Platform.UnitTests;
 public sealed class OpenTelemetryResultHandlerTests : IDisposable
 {
     private readonly Mock<IPlatformOpenTelemetryService> _otelService = new();
-    private readonly Mock<IEnvironment> _environment = new();
     private readonly FakeCounter<int> _discoveredCounter = new();
     private readonly FakeCounter<int> _startedCounter = new();
     private readonly FakeCounter<int> _completedCounter = new();
@@ -34,9 +32,8 @@ public sealed class OpenTelemetryResultHandlerTests : IDisposable
         _otelService.Setup(s => s.CreateCounter<int>("tests.skipped", null, null, null)).Returns(_skippedCounter);
         _otelService.Setup(s => s.CreateCounter<int>("tests.unknown", null, null, null)).Returns(_unknownCounter);
         _otelService.Setup(s => s.CreateHistogram<double>("tests.duration", null, null, null)).Returns(_durationHistogram);
-        _environment.SetupGet(e => e.NewLine).Returns("\n");
 
-        _handler = new OpenTelemetryResultHandler(_otelService.Object, _environment.Object);
+        _handler = new OpenTelemetryResultHandler(_otelService.Object);
     }
 
     [TestMethod]


### PR DESCRIPTION
🤖 *This is a draft PR from [Efficiency Improver](https://github.com/microsoft/testfx/actions), an automated AI assistant focused on reducing energy consumption and computational footprint.*

---

## Goal & Rationale

`HandleTestResult` in `OpenTelemetryResultHandler` called `Properties.OfType<StandardOutputProperty>().Select(x => x.StandardOutput)` and `Properties.OfType<StandardErrorProperty>().Select(x => x.StandardError)` inside `string.Join` to emit stdout/stderr as OTel activity tags.

`PropertyBag.OfType<T>()` walks the linked list and **allocates a new `TProperty[]` array** for the result — even when the goal is to extract the value from a single property. The `string.Join` then processes the projected `IEnumerable<string>`. `SingleOrDefault<T>()` returns the match directly with no intermediate allocation.

As a result, `_environment` (previously used only to supply `Environment.NewLine` as the join separator) is no longer needed in this class. The field and constructor parameter are removed, simplifying the constructor.

## Focus Area

**Code-Level Efficiency** — unnecessary heap allocation per test result in OpenTelemetry-enabled runs.

## Approach

```csharp
// Before — 2 array allocs + 2 Select() enumerators per test result
activity.SetTag("test.stdout", string.Join(_environment.NewLine,
    testNode.Properties.OfType<StandardOutputProperty>().Select(x => x.StandardOutput)));
activity.SetTag("test.stderr", string.Join(_environment.NewLine,
    testNode.Properties.OfType<StandardErrorProperty>().Select(x => x.StandardError)));

// After — zero intermediate arrays, same linked-list walk
activity.SetTag("test.stdout", testNode.Properties.SingleOrDefault<StandardOutputProperty>()?.StandardOutput ?? string.Empty);
activity.SetTag("test.stderr", testNode.Properties.SingleOrDefault<StandardErrorProperty>()?.StandardError ?? string.Empty);
```

## Energy Efficiency Evidence

**Proxy metric used:** heap allocation count
*(Direct energy measurement unavailable; allocation reduction is a standard Green Software proxy for lower GC energy.)*

| Metric | Before | After |
|--------|--------|-------|
| `StandardOutputProperty[]` allocations / test result | 1 | 0 |
| `StandardErrorProperty[]` allocations / test result | 1 | 0 |
| `Select()` LINQ enumerator allocations / test result | 2 | 0 |
| Linked-list walks for stdout | 1 | 1 (unchanged) |
| Linked-list walks for stderr | 1 | 1 (unchanged) |

For a CI run with 1 000 completed tests using OTel reporting:
- **4 000 fewer** short-lived heap objects per run (2 arrays + 2 enumerators per test × 1 000 tests)

## Green Software Foundation Context

**Hardware Efficiency** — fewer short-lived allocations per test result means less GC work per test result published to OTel, allowing the hardware to do more reporting per joule.

## Trade-offs

- **Semantic difference**: `OfType().Select()` in `string.Join` would concatenate multiple `StandardOutputProperty` values with a newline separator; `SingleOrDefault` returns only one match (or throws if multiple exist). In practice these properties are single-valued — the same pattern is already used in the AzureDevOps publisher for identical property types (PR #8884).
- Constructor signature change: `environment` parameter removed. The class is `internal sealed`, so there are no external callers.
- No readability impact.

## Test Status

✅ Full solution build: `./build.sh -build` — **Build succeeded. 0 Warning(s). 0 Error(s).**
✅ Unit tests: `OpenTelemetryResultHandlerTests` — **22 passed, 0 failed.**

## Reproducibility

```bash
./build.sh -build
dotnet test test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj \
    -f net8.0 --no-build -c Debug \
    --filter "FullyQualifiedName~OpenTelemetryResultHandler"
```




> Generated by [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27106062959) · sonnet46 5M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27106062959, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27106062959 -->

<!-- gh-aw-workflow-id: efficiency-improver -->