### PR TITLE
[test-improver] test: add edge case tests for UseRetryWithTestMethodAnalyzer (MSTEST0035)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseRetryWithTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseRetryWithTestMethodAnalyzerTests.cs
@@ -196,4 +196,73 @@ public sealed class UseRetryWithTestMethodAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenDataTestMethodHasRetryAttribute_NoDiagnostic()
+    {
+        // DataTestMethodAttribute derives from TestMethodAttribute, so [Retry] on a [DataTestMethod] is valid.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DataTestMethod]
+                [Retry(maxRetryAttempts: 3)]
+                [DataRow(1)]
+                public void M(int x)
+                {
+                }
+
+                [Retry(maxRetryAttempts: 3)]
+                [DataTestMethod]
+                [DataRow(2)]
+                public void M2(int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestInitializeHasRetryAttribute_Diagnostic()
+    {
+        // [TestInitialize] is a fixture method, not a test method. Placing [Retry] on it is invalid.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                [Retry(maxRetryAttempts: 3)]
+                public void [|Setup|]()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodInNonTestClassHasRetryAttribute_Diagnostic()
+    {
+        // A method with [Retry] inside a class that is not decorated with [TestClass] should be flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyHelper
+            {
+                [Retry(maxRetryAttempts: 3)]
+                public void [|M|]()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`UseRetryWithTestMethodAnalyzer` (MSTEST0035) had only 7 tests covering the basic "retry on test method" and "retry on test class" paths, but missed several real-world scenarios:

1. **`[DataTestMethod]` with `[Retry]`** — `DataTestMethodAttribute` inherits from `TestMethodAttribute`. Without a test for this, a refactor of the inheritance check could silently start reporting `[DataTestMethod]` methods as false positives.
2. **`[TestInitialize]` with `[Retry]`** — Fixture methods are not test methods. A developer might accidentally put `[Retry]` on a `[TestInitialize]` method expecting it to retry; the analyzer should flag this.
3. **Method in a non-test class with `[Retry]`** — The existing diagnostic test only covered methods *inside* a `[TestClass]`. A method in a helper class with no `[TestClass]` decorator should also be flagged.

## Approach

- Added `WhenDataTestMethodHasRetryAttribute_NoDiagnostic`: confirms the `Inherits(testMethodAttributeSymbol)` check correctly covers the `DataTestMethod → TestMethod` inheritance chain.
- Added `WhenTestInitializeHasRetryAttribute_Diagnostic`: confirms fixture attributes do not satisfy the "test method" guard.
- Added `WhenMethodInNonTestClassHasRetryAttribute_Diagnostic`: confirms the method-level check fires regardless of whether the containing class is a `[TestClass]`.

## Coverage Impact

Not measured separately; these tests exercise existing analyzer code paths with no production changes.

## Test Status

✅ All **10 tests** passed (`MSTest.Analyzers.UnitTests` net8.0):

```
Test run summary: Passed!
  total: 10
  failed: 0
  succeeded: 10
  skipped: 0
  duration: 6s 128ms
```

## Reproducibility

```bash
./build.sh --restore   # first run only, installs .NET SDK
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "ClassName=MSTest.Analyzers.Test.UseRetryWithTestMethodAnalyzerTests"
```




> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/27107808842) · sonnet46 7.6M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27107808842, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27107808842 -->

<!-- gh-aw-workflow-id: test-improver -->