### PR TITLE
Restore internal TestRequestExecutionTimeInfo for binary compat with older MSBuild extension

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Testing.Platform.Extensions.Messages;
 //
 // This type is intentionally marked [Obsolete] so we remember to drop it in the next major
 // release (where breaking binary compatibility with the 2.2.x extension line is acceptable).
-[Obsolete("Kept only for binary compatibility with Microsoft.Testing.Platform.MSBuild <= 2.2.x. Do not use; remove in the next major release.")]
+// Tracked by https://github.com/microsoft/testfx/issues/8925.
+[Obsolete("Kept only for binary compatibility with Microsoft.Testing.Platform.MSBuild <= 2.2.x. Do not use; remove in the next major release. See https://github.com/microsoft/testfx/issues/8925.")]
 internal readonly struct TestRequestExecutionTimeInfo(TimingInfo timingInfo) : IData
 {
     public string DisplayName => nameof(TestRequestExecutionTimeInfo);

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
@@ -19,6 +19,10 @@ namespace Microsoft.Testing.Platform.Extensions.Messages;
 // Microsoft.Testing.Extensions.MSBuild) can still resolve the type at load time. The type
 // is never published by the current platform, so the consumer's switch arm that handles it
 // simply never fires.
+//
+// This type is intentionally marked [Obsolete] so we remember to drop it in the next major
+// release (where breaking binary compatibility with the 2.2.x extension line is acceptable).
+[Obsolete("Kept only for binary compatibility with Microsoft.Testing.Platform.MSBuild <= 2.2.x. Do not use; remove in the next major release.")]
 internal readonly struct TestRequestExecutionTimeInfo(TimingInfo timingInfo) : IData
 {
     public string DisplayName => nameof(TestRequestExecutionTimeInfo);

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestRequestExecutionTimeInfo.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Extensions.Messages;
+
+// This internal type was removed in https://github.com/microsoft/testfx/pull/8514 but
+// is referenced by older shipped versions of Microsoft.Testing.Extensions.MSBuild
+// (packaged as Microsoft.Testing.Platform.MSBuild <= 2.2.x). When such an older extension
+// is loaded against this newer Microsoft.Testing.Platform assembly — a common scenario
+// when another package (e.g. xunit.v3.core.mtp-v2) pins an older Microsoft.Testing.Platform.MSBuild
+// version while a newer package (e.g. Microsoft.Testing.Extensions.TrxReport) brings in this
+// newer Microsoft.Testing.Platform — the old MSBuildConsumer's static initializer fails with:
+//   System.TypeLoadException: Could not load type
+//   'Microsoft.Testing.Platform.Extensions.Messages.TestRequestExecutionTimeInfo'
+//   from assembly 'Microsoft.Testing.Platform, Version=2.3.0.0, ...'
+// To preserve binary compatibility with previously shipped extensions, the type definition
+// must continue to exist in this assembly even though no code in this version publishes it.
+// The internal extension projects which still need the InternalsVisibleTo grant (e.g.
+// Microsoft.Testing.Extensions.MSBuild) can still resolve the type at load time. The type
+// is never published by the current platform, so the consumer's switch arm that handles it
+// simply never fires.
+internal readonly struct TestRequestExecutionTimeInfo(TimingInfo timingInfo) : IData
+{
+    public string DisplayName => nameof(TestRequestExecutionTimeInfo);
+
+    public string? Description => "Information about the test execution times.";
+
+    public TimingInfo TimingInfo { get; } = timingInfo;
+
+    public override string ToString()
+    {
+        StringBuilder builder = new StringBuilder("TestRequestExecutionTimeInfo { DisplayName = ")
+            .Append(DisplayName)
+            .Append(", Description = ")
+            .Append(Description)
+            .Append(", TimingInfo = ")
+            .Append(TimingInfo.ToString())
+            .Append(" }");
+
+        return builder.ToString();
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestHostTestFrameworkInvoker.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestHostTestFrameworkInvoker.cs
@@ -40,7 +40,8 @@ internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : 
     // simply dropped by AsynchronousMessageBus, but the old shipped consumer still
     // needs it published in order to emit the run summary to MSBuild.
     // See: https://github.com/microsoft/testfx/pull/8514 (removal),
-    //      https://github.com/microsoft/testfx/pull/8921 (binary-compat restore).
+    //      https://github.com/microsoft/testfx/pull/8921 (binary-compat restore),
+    //      https://github.com/microsoft/testfx/issues/8925 (remove in next major).
     public Type[] DataTypesProduced => [typeof(TestRequestExecutionTimeInfo)];
 #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestHostTestFrameworkInvoker.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestHostTestFrameworkInvoker.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Testing.Platform.Capabilities;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Helpers;
@@ -17,7 +18,7 @@ using Microsoft.Testing.Platform.TestHost;
 namespace Microsoft.Testing.Platform.Requests;
 
 [SuppressMessage("Performance", "CA1852: Seal internal types", Justification = "HotReload needs to inherit and override ExecuteRequestAsync")]
-internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : ITestFrameworkInvoker, IOutputDeviceDataProducer
+internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : ITestFrameworkInvoker, IOutputDeviceDataProducer, IDataProducer
 {
     protected IServiceProvider ServiceProvider { get; } = serviceProvider;
 
@@ -28,6 +29,20 @@ internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : 
     public string DisplayName => string.Empty;
 
     public string Description => string.Empty;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    // TestRequestExecutionTimeInfo is kept only for binary compatibility with the
+    // Microsoft.Testing.Platform.MSBuild <= 2.2.x extension, whose MSBuildConsumer
+    // depends on receiving this message to trigger its end-of-session summary
+    // (HandleSummaryAsync sends the TestRunSummaryRequest over the IPC pipe to
+    // MSBuild). The current in-tree consumer no longer lists this type in its
+    // DataTypesConsumed, so when paired with this newer platform the message is
+    // simply dropped by AsynchronousMessageBus, but the old shipped consumer still
+    // needs it published in order to emit the run summary to MSBuild.
+    // See: https://github.com/microsoft/testfx/pull/8514 (removal),
+    //      https://github.com/microsoft/testfx/pull/8921 (binary-compat restore).
+    public Type[] DataTypesProduced => [typeof(TestRequestExecutionTimeInfo)];
+#pragma warning restore CS0618 // Type or member is obsolete
 
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
@@ -44,6 +59,8 @@ internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : 
             }
         }
 
+        DateTimeOffset startTime = DateTimeOffset.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
         SessionUid sessionId = ServiceProvider.GetTestSessionContext().SessionUid;
         await logger.LogDebugAsync($"Test session UID: '{sessionId.Value}'").ConfigureAwait(false);
 
@@ -74,6 +91,14 @@ internal class TestHostTestFrameworkInvoker(IServiceProvider serviceProvider) : 
             CloseTestSessionResult closeTestSessionResult = await testFramework.CloseTestSessionAsync(new(sessionId, cancellationToken)).ConfigureAwait(false);
             await HandleTestSessionResultAsync(logger, "CloseTestSession", sessionId, closeTestSessionResult.IsSuccess, closeTestSessionResult.WarningMessage, closeTestSessionResult.ErrorMessage, cancellationToken).ConfigureAwait(false);
         }
+
+        DateTimeOffset endTime = DateTimeOffset.UtcNow;
+#pragma warning disable CS0618 // Type or member is obsolete
+        // Republished for binary compatibility with the older Microsoft.Testing.Platform.MSBuild
+        // extension (<= 2.2.x). Current in-tree consumers do not listen for this message, so it
+        // is silently dropped by AsynchronousMessageBus when only the new extension is loaded.
+        await messageBus.PublishAsync(this, new TestRequestExecutionTimeInfo(new TimingInfo(startTime, endTime, stopwatch.Elapsed))).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     public virtual async Task ExecuteRequestAsync(ITestFramework testFramework, TestExecutionRequest request, IMessageBus messageBus, CancellationToken cancellationToken)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ForwardCompatibilityTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ForwardCompatibilityTests.cs
@@ -37,6 +37,8 @@ public class ForwardCompatibilityTests : AcceptanceTestBase<ForwardCompatibility
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
         <LangVersion>preview</LangVersion>
+        <!-- We provide our own Main, so disable the SDK-generated entry point. -->
+        <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
     </PropertyGroup>
 
     <ItemGroup>
@@ -50,6 +52,13 @@ public class ForwardCompatibilityTests : AcceptanceTestBase<ForwardCompatibility
         <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$PreviousExtensionVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.Telemetry" Version="$PreviousExtensionVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$PreviousExtensionVersion$" />
+        <!--
+            Microsoft.Testing.Platform.MSBuild ships the auto-loaded MSBuildConsumer extension.
+            Pinning it to an older version exercises the scenario where a newer
+            Microsoft.Testing.Platform must still load the older MSBuildConsumer binary without
+            crashing on removed-but-still-referenced internal types (e.g. TestRequestExecutionTimeInfo).
+        -->
+        <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="$PreviousExtensionVersion$" />
     </ItemGroup>
 </Project>
 
@@ -60,6 +69,7 @@ using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.MSBuild;
 using Microsoft.Testing.Platform.Services;
 
 public class Program
@@ -78,6 +88,12 @@ public class Program
         builder.AddRetryProvider();
         builder.AddAppInsightsTelemetryProvider();
         builder.AddTrxReportProvider();
+        // The MSBuildConsumer is constructed unconditionally when its extension is registered,
+        // even when the MSBuild integration is not active. Registering it here ensures we
+        // exercise the type-load path that previously broke when the platform removed the
+        // internal TestRequestExecutionTimeInfo type that older MSBuildConsumer binaries
+        // reference in their DataTypesConsumed array.
+        builder.AddMSBuild();
 
         using ITestApplication app = await builder.BuildAsync();
         return await app.RunAsync();


### PR DESCRIPTION
## Summary

PR #8514 deleted the internal `TestRequestExecutionTimeInfo` struct from `Microsoft.Testing.Platform`. Older shipped versions of `Microsoft.Testing.Extensions.MSBuild` (packaged as `Microsoft.Testing.Platform.MSBuild` <= 2.2.x) still reference the type from their `DataTypesConsumed` static array, so any test app that ends up with the **new** `Microsoft.Testing.Platform.dll` and the **old** `Microsoft.Testing.Extensions.MSBuild.dll` side-by-side crashes immediately on startup with:

```
System.TypeLoadException: Could not load type 'Microsoft.Testing.Platform.Extensions.Messages.TestRequestExecutionTimeInfo'
    from assembly 'Microsoft.Testing.Platform, Version=2.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
   at Microsoft.Testing.Extensions.MSBuild.MSBuildConsumer..ctor(IServiceProvider, ICommandLineOptions)
```

### Repro from issue #10202

The user-supplied repro pairs `xunit.v3.core.mtp-v2` 4.0.0-pre.108 (transitively pins `Microsoft.Testing.Platform.MSBuild` 2.2.2) with `Microsoft.Testing.Extensions.TrxReport` 2.3.0-preview (brings in the new `Microsoft.Testing.Platform` 2.3.0). NuGet keeps the older `Microsoft.Testing.Extensions.MSBuild.dll` while upgrading the platform, triggering the crash.

## Fix

Restore the internal `TestRequestExecutionTimeInfo` struct as a binary-compat shim. The current platform never publishes it, so the consumer's switch arm that would handle it is now dead code in old extension binaries — but the type *exists*, so the static field initializer no longer trips the type loader. A doc comment on the type explains why it's kept around.

## Regression test

Extends the existing `ForwardCompatibilityTests` test asset to also pin `Microsoft.Testing.Platform.MSBuild` to the previous version (2.2.1), set `GenerateTestingPlatformEntryPoint=false` (preserving the asset's custom `Main`), and call `builder.AddMSBuild()`. I verified the test:

- **fails** with the exact `TypeLoadException` above when the fix file is removed
- **passes** with the fix restored
- doesn't regress the rest of `Microsoft.Testing.Platform.UnitTests` (1104/1104 pass)