### PR TITLE
Fix CodeQL UAP build by skipping uap10.0.16299 on the CodeQL pipeline

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,16 @@
   <!-- The TFMs to build and test against. -->
   <PropertyGroup>
     <!-- The windows SDK version of UWP, Modern UWP and WinUI could be aligned -->
-    <UwpMinimum>uap10.0.16299</UwpMinimum>
+    <!--
+      $(UwpMinimum) (uap10.0.16299) requires desktop msbuild.exe because
+      MSBuild.Sdk.Extras Workarounds.targets refuses to build full-MSBuild targets
+      under 'dotnet msbuild'. The CodeQL pipeline runs with -msbuildEngine dotnet
+      to work around https://github.com/dotnet/msbuild/issues/13739, so it sets
+      $(SkipUapTargetFramework)=true to opt out of the UAP target. UAP-specific
+      code paths are still source-scanned via the other TFMs that the affected
+      projects multi-target (net462, net8.0, net9.0).
+    -->
+    <UwpMinimum Condition=" '$(SkipUapTargetFramework)' != 'true' ">uap10.0.16299</UwpMinimum>
     <ModernUwpMinimum>net9.0-windows10.0.17763.0</ModernUwpMinimum>
     <WinUiMinimum>net8.0-windows10.0.18362.0</WinUiMinimum>
 

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -63,11 +63,17 @@ jobs:
   # windows.vs2026.amd64 image. Since image version 2026.0529.211646 (deployed 2026-06-05),
   # the bundled VS MSBuild fails to spin up an x86 .NET task host for Arcade tasks declared
   # with Runtime="NET", producing MSB4216 on InstallDotNetCore. See dotnet/msbuild#13739.
+  #
+  # Skip the uap10.0.16299 target framework on this pipeline because MSBuild.Sdk.Extras'
+  # Workarounds.targets refuses to build full-MSBuild targets under 'dotnet msbuild'.
+  # UAP-specific code paths are still scanned via the other TFMs the affected projects
+  # multi-target (net462, net8.0, net9.0).
   - script: eng\common\cibuild.cmd
       -configuration $(_BuildConfig)
       -prepareMachine
       -msbuildEngine dotnet
       /p:Test=false
+      /p:SkipUapTargetFramework=true
     displayName: Windows Build
 
   - task: CodeQL3000Finalize@0


### PR DESCRIPTION
## Problem

PR #8897 added `-msbuildEngine dotnet` to the CodeQL pipeline as a second workaround for MSB4216 (the first being [`eng/Tools.props`](https://github.com/microsoft/testfx/blob/main/eng/Tools.props) from #8355). That fixed MSB4216 but **broke every project that multi-targets `uap10.0.16299`** because `MSBuild.Sdk.Extras\Workarounds.targets` refuses to build full-MSBuild targets under `dotnet build` / `dotnet msbuild`:

```
.packages\msbuild.sdk.extras\3.0.44\Build\Workarounds.targets(27,5): error :
  If you are building projects that require targets from full MSBuild or
  MSBuildFrameworkToolsPath, you need to use desktop msbuild ('msbuild.exe')
  instead of 'dotnet build' or 'dotnet msbuild'
  [...\MSTest.TestAdapter.csproj::TargetFramework=uap10.0.16299]
```

## Why not just revert #8897?

Simply reverting #8897 brings us back to the original MSB4216 failure that PR was created to fix:
```
artifacts\toolset\11.0.0-beta.26305.3\InstallDotNetCore.targets(17,5):
error MSB4216: Could not run the "InstallDotNetCore" task because MSBuild could not
create or connect to a task host with runtime "NET" and architecture "x86".
```
The `eng/Tools.props` `UsingTask` override from #8355 doesn't reliably suppress this on the new `windows.vs2026.amd64` image. We can't update the bundled MSBuild from our side.

## Fix

Opt the CodeQL pipeline out of the `uap10.0.16299` target framework so `-msbuildEngine dotnet` (which sidesteps MSB4216) can build everything else:

- **`Directory.Build.props`**: gate `<UwpMinimum>` on a new `$(SkipUapTargetFramework)` property. `$(UwpMinimum)` is the single source of truth for `uap10.0.16299` across the repo — it feeds every multi-targeting project's `TargetFrameworks` and every UAP-specific conditional. Blanking it out makes MSBuild silently drop the resulting empty `;;` segment from `$(TargetFrameworks)`.
- **`azure-pipelines-codeql.yml`**: pass `/p:SkipUapTargetFramework=true` (CodeQL pipeline only).

UAP-specific code paths are still source-scanned via the other TFMs the affected projects multi-target (`net462`, `net8.0`, `net9.0`), so CodeQL coverage is essentially unchanged. The two other Windows-flavored TFMs (`net9.0-windows10.0.17763.0`, `net8.0-windows10.0.18362.0`) and all non-Windows TFMs are unaffected.

The `eng/Tools.props` workaround from #8355 is left in place so local dev builds (which use desktop MSBuild) still benefit from it.

## Verification

Built locally with the exact CodeQL pipeline arguments:

```
build.cmd -c Debug -msbuildEngine dotnet -projects src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj /p:SkipUapTargetFramework=true
```
Result: `Build succeeded. 0 Warning(s) 0 Error(s)` — no `uap10.0.16299` output produced, all other TFMs built (`net462`, `net8.0`, `net9.0`, `net9.0-windows10.0.17763.0`, `net8.0-windows10.0.18362.0`) and the dependency graph (`MSTestAdapter.PlatformServices`, `TestFramework`, `TestFramework.Extensions`, `Microsoft.Testing.*`, …) built cleanly.

The next scheduled CodeQL run (or manual queue of pipeline 1407) will confirm MSB4216 stays fixed and UAP10 no longer blocks the build.