### PR TITLE
Exclude azure-pipelines-codeql.yml from official pipeline trigger

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -11,6 +11,7 @@ trigger:
     exclude:
       - .github/**
       - .gitignore
+      - azure-pipelines-codeql.yml
 
 parameters:
 - name: isRTM


### PR DESCRIPTION
Changes to the CodeQL pipeline definition (`azure-pipelines-codeql.yml`) should not trigger the official build pipeline.

The unofficial PR pipeline (`azure-pipelines.yml`) already excludes this path from its `pr.paths.exclude` list, so this PR brings the official pipeline in line with the same exclusion for its CI trigger.