### PR TITLE
Simplify AzDO pipelines by extracting shared templates

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -119,29 +119,7 @@ extends:
               image: windows.vs2026preview.scout.amd64
               os: windows
             steps:
-            - task: PowerShell@2
-              displayName: 'Install Windows SDK'
-              inputs:
-                targetType: filePath
-                filePath: './eng/install-windows-sdk.ps1'
-                failOnStderr: true
-                showWarnings: true
-
-            - task: PowerShell@2
-              displayName: 'Install procdump'
-              inputs:
-                targetType: filePath
-                filePath: ./eng/install-procdump.ps1
-                failOnStderr: true
-                showWarnings: true
-
-            - task: PowerShell@2
-              displayName: 'Install Access Database Engine'
-              inputs:
-                targetType: filePath
-                filePath: ./eng/install-access-database-engine.ps1
-                failOnStderr: true
-                showWarnings: true
+            - template: /eng/pipelines/steps/install-windows-prereqs.yml@self
 
             - script: eng\common\CIBuild.cmd
                 -configuration $(_BuildConfig)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,8 @@ stages:
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
+        variables:
+        - template: /eng/pipelines/variables/test-env-vars.yml
         strategy:
           matrix:
             Release:
@@ -68,21 +70,8 @@ stages:
             Debug:
               _BuildConfig: Debug
         steps:
-        - task: PowerShell@2
-          displayName: 'Install Windows SDK'
-          inputs:
-            targetType: filePath
-            filePath: './eng/install-windows-sdk.ps1'
-            failOnStderr: true
-            showWarnings: true
+        - template: /eng/pipelines/steps/install-windows-prereqs.yml
 
-        - task: PowerShell@2
-          displayName: 'Install procdump'
-          inputs:
-            targetType: filePath
-            filePath: ./eng/install-procdump.ps1
-            failOnStderr: true
-            showWarnings: true
         - task: PowerShell@2
           displayName: 'Enable local dumps'
           inputs:
@@ -92,13 +81,6 @@ stages:
               Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"
               New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "$(Build.SourcesDirectory)\artifacts\CrashDumps" -PropertyType ExpandString -Force
               New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpCount" -Value 10 -PropertyType DWord -Force
-        - task: PowerShell@2
-          displayName: 'Install Access Database Engine'
-          inputs:
-            targetType: filePath
-            filePath: ./eng/install-access-database-engine.ps1
-            failOnStderr: true
-            showWarnings: true
 
         - script: eng\common\CIBuild.cmd
             -configuration $(_BuildConfig)
@@ -118,10 +100,6 @@ stages:
             name: Test
             displayName: Test
             condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
-            env:
-              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              DOTNET_CLI_CONTEXT_VERBOSE: 1
 
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
@@ -147,10 +125,6 @@ stages:
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-            env:
-              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              DOTNET_CLI_CONTEXT_VERBOSE: 1
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Test Results folders'
@@ -195,6 +169,8 @@ stages:
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+        variables:
+        - template: /eng/pipelines/variables/test-env-vars.yml
         strategy:
           matrix:
             Release:
@@ -212,68 +188,9 @@ stages:
           displayName: Build
 
         - ${{ if eq(parameters.SkipTests, False) }}:
-          # Because the build step is using -ci flag, restore is done in a local .packages directory.
-          # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
-          # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-          - script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog --no-progress --output detailed -p:UsingDotNetTest=true
-            name: Test
-            displayName: Test
-            condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
-            env:
-              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              DOTNET_CLI_CONTEXT_VERBOSE: 1
-
-          # Integration tests are redundant in Release—they spawn child processes that already cover
-          # both Debug and Release configurations. Use --test-modules to run only unit tests.
-          #
-          # --test-modules bypasses MSBuild evaluation, so test/Directory.Build.targets cannot inject
-          # any of its TestingPlatformCommandLineArguments. We therefore restore the subset of those
-          # options that makes sense in Release:
-          #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
-          #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
-          #   --report-azdo — surfaces failed tests in the AzDO UI.
-          #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
-          #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
-          #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
-          # We intentionally do NOT pass:
-          #   --crashdump — gated on .NETCoreApp in Directory.Build.targets; the CrashDump extension's
-          #     ValidateTestHostEnvironmentVariablesAsync hard-fails the run on non-NETCoreApp hosts
-          #     (see src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs).
-          #     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
-          #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
-          #     below), so collecting coverage in Release would just write unused .coverage files.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
-            name: TestRelease
-            displayName: Test (unit tests only)
-            condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-            env:
-              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              DOTNET_CLI_CONTEXT_VERBOSE: 1
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Test Results folders'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-              ArtifactName: TestResults_Linux_$(_BuildConfig)_Attempt$(System.JobAttempt)
-            condition: always()
-
-          - task: CopyFiles@2
-            displayName: 'Copy binlogs'
-            inputs:
-              SourceFolder: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite'
-              Contents: |
-                **/*.binlog
-              TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish integration tests binlogs'
-            inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
-              ArtifactName: Integration_Tests_Linux_Binlogs_$(_BuildConfig)
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+          - template: /eng/pipelines/steps/test-non-windows.yml
+            parameters:
+              osName: Linux
 
       - job: MacOS
         timeoutInMinutes: 90
@@ -281,6 +198,8 @@ stages:
           name: Azure Pipelines
           vmImage: macos-latest
           os: macOS
+        variables:
+        - template: /eng/pipelines/variables/test-env-vars.yml
         strategy:
           matrix:
             Release:
@@ -298,68 +217,9 @@ stages:
           displayName: Build
 
         - ${{ if eq(parameters.SkipTests, False) }}:
-          # Because the build step is using -ci flag, restore is done in a local .packages directory.
-          # We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
-          # Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
-          - script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog --no-progress --output detailed -p:UsingDotNetTest=true
-            name: Test
-            displayName: Test
-            condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
-            env:
-              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              DOTNET_CLI_CONTEXT_VERBOSE: 1
-
-          # Integration tests are redundant in Release—they spawn child processes that already cover
-          # both Debug and Release configurations. Use --test-modules to run only unit tests.
-          #
-          # --test-modules bypasses MSBuild evaluation, so test/Directory.Build.targets cannot inject
-          # any of its TestingPlatformCommandLineArguments. We therefore restore the subset of those
-          # options that makes sense in Release:
-          #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
-          #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
-          #   --report-azdo — surfaces failed tests in the AzDO UI.
-          #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
-          #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
-          #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
-          # We intentionally do NOT pass:
-          #   --crashdump — gated on .NETCoreApp in Directory.Build.targets; the CrashDump extension's
-          #     ValidateTestHostEnvironmentVariablesAsync hard-fails the run on non-NETCoreApp hosts
-          #     (see src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs).
-          #     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
-          #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
-          #     below), so collecting coverage in Release would just write unused .coverage files.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
-            name: TestRelease
-            displayName: Test (unit tests only)
-            condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
-            env:
-              DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
-              NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
-              DOTNET_CLI_CONTEXT_VERBOSE: 1
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish Test Results folders'
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-              ArtifactName: TestResults_MacOs_$(_BuildConfig)_Attempt$(System.JobAttempt)
-            condition: always()
-
-          - task: CopyFiles@2
-            displayName: 'Copy binlogs'
-            inputs:
-              SourceFolder: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite'
-              Contents: |
-                **/*.binlog
-              TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
-
-          - task: PublishBuildArtifacts@1
-            displayName: 'Publish integration tests binlogs'
-            inputs:
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
-              ArtifactName: Integration_Tests_MacOS_Binlogs_$(_BuildConfig)
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+          - template: /eng/pipelines/steps/test-non-windows.yml
+            parameters:
+              osName: MacOS
 
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
         variables:
-        - template: /eng/pipelines/variables/test-env-vars.yml
+          - template: /eng/pipelines/variables/test-env-vars.yml
         strategy:
           matrix:
             Release:
@@ -170,7 +170,7 @@ stages:
           name: NetCore-Public
           demands: ImageOverride -equals build.ubuntu.2204.amd64.open
         variables:
-        - template: /eng/pipelines/variables/test-env-vars.yml
+          - template: /eng/pipelines/variables/test-env-vars.yml
         strategy:
           matrix:
             Release:
@@ -199,7 +199,7 @@ stages:
           vmImage: macos-latest
           os: macOS
         variables:
-        - template: /eng/pipelines/variables/test-env-vars.yml
+          - template: /eng/pipelines/variables/test-env-vars.yml
         strategy:
           matrix:
             Release:

--- a/eng/pipelines/steps/install-windows-prereqs.yml
+++ b/eng/pipelines/steps/install-windows-prereqs.yml
@@ -1,0 +1,26 @@
+# Windows-only prerequisites shared by the testfx Windows build/test pipelines.
+# Installs the Windows SDK, procdump, and the Access Database Engine.
+steps:
+- task: PowerShell@2
+  displayName: 'Install Windows SDK'
+  inputs:
+    targetType: filePath
+    filePath: ./eng/install-windows-sdk.ps1
+    failOnStderr: true
+    showWarnings: true
+
+- task: PowerShell@2
+  displayName: 'Install procdump'
+  inputs:
+    targetType: filePath
+    filePath: ./eng/install-procdump.ps1
+    failOnStderr: true
+    showWarnings: true
+
+- task: PowerShell@2
+  displayName: 'Install Access Database Engine'
+  inputs:
+    targetType: filePath
+    filePath: ./eng/install-access-database-engine.ps1
+    failOnStderr: true
+    showWarnings: true

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -1,0 +1,67 @@
+# Test + publish steps shared by the Linux and macOS jobs in azure-pipelines.yml.
+#
+# Assumes the consuming job declares:
+#   - the matrix variable `_BuildConfig` (Debug or Release)
+#   - the job-level environment variables from eng/pipelines/variables/test-env-vars.yml
+parameters:
+- name: osName
+  type: string
+  values:
+  - Linux
+  - MacOS
+
+steps:
+# Because the build step is using -ci flag, restore is done in a local .packages directory.
+# We need to pass NUGET_PACKAGES so that when dotnet test is doing evaluation phase on the projects, it can resolve .props/.targets from packages and import them.
+# Otherwise, props/targets are not imported. It's important that they are imported so that IsTestingPlatformApplication ends up being set.
+- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog --no-progress --output detailed -p:UsingDotNetTest=true
+  name: Test
+  displayName: Test
+  condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
+
+# Integration tests are redundant in Release—they spawn child processes that already cover
+# both Debug and Release configurations. Use --test-modules to run only unit tests.
+#
+# --test-modules bypasses MSBuild evaluation, so test/Directory.Build.targets cannot inject
+# any of its TestingPlatformCommandLineArguments. We therefore restore the subset of those
+# options that makes sense in Release:
+#   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
+#     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
+#   --report-azdo — surfaces failed tests in the AzDO UI.
+#   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
+#   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
+#     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
+# We intentionally do NOT pass:
+#   --crashdump — gated on .NETCoreApp in Directory.Build.targets; the CrashDump extension's
+#     ValidateTestHostEnvironmentVariablesAsync hard-fails the run on non-NETCoreApp hosts
+#     (see src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpEnvironmentVariableProvider.cs).
+#     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
+#   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
+#     in azure-pipelines.yml), so collecting coverage in Release would just write unused .coverage files.
+- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
+  name: TestRelease
+  displayName: Test (unit tests only)
+  condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Test Results folders'
+  inputs:
+    PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+    ArtifactName: TestResults_${{ parameters.osName }}_$(_BuildConfig)_Attempt$(System.JobAttempt)
+  condition: always()
+
+- task: CopyFiles@2
+  displayName: 'Copy binlogs'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite'
+    Contents: |
+      **/*.binlog
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish integration tests binlogs'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
+    ArtifactName: Integration_Tests_${{ parameters.osName }}_Binlogs_$(_BuildConfig)
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'))

--- a/eng/pipelines/variables/test-env-vars.yml
+++ b/eng/pipelines/variables/test-env-vars.yml
@@ -1,0 +1,18 @@
+# Environment variables needed by `dotnet test` invocations in azure-pipelines.yml.
+# Declared as job-level variables so they apply to every step in the consuming job
+# (Azure Pipelines automatically exposes pipeline variables as environment variables
+# to scripts).
+#
+# - DOTNET_ROOT pins the .NET host to the locally restored SDK under .dotnet/, so
+#   `dotnet test` uses the same toolchain as the build steps.
+# - NUGET_PACKAGES mirrors the `-ci` flag's restore destination so `dotnet test`'s
+#   MSBuild evaluation phase can resolve .props/.targets from the same package cache
+#   (ensures IsTestingPlatformApplication is set correctly).
+# - DOTNET_CLI_CONTEXT_VERBOSE surfaces extra diagnostics in `dotnet test` output.
+variables:
+- name: DOTNET_ROOT
+  value: $(Build.SourcesDirectory)/.dotnet
+- name: NUGET_PACKAGES
+  value: $(Build.SourcesDirectory)/.packages
+- name: DOTNET_CLI_CONTEXT_VERBOSE
+  value: 1


### PR DESCRIPTION
Extract duplicated parts of the AzDO pipelines into reusable templates under `eng/pipelines/`:

- `variables/test-env-vars.yml` centralizes `DOTNET_ROOT`, `NUGET_PACKAGES`, and `DOTNET_CLI_CONTEXT_VERBOSE` that were repeated on **6** `dotnet test` invocations.
- `steps/install-windows-prereqs.yml` centralizes the Windows SDK + procdump + Access Database Engine install steps shared by the PR and official Windows jobs.
- `steps/test-non-windows.yml` captures the full Linux/macOS test+publish flow (Debug test, Release `--test-modules` test, publish TestResults, copy + publish binlogs) parameterized by `osName`.

### What changed

- **`azure-pipelines.yml`**
  - Windows job: now consumes `install-windows-prereqs.yml` and hoists the three test env vars to job-level `variables` (drops 2 `env:` blocks).
  - Linux job: ~80 lines of post-build steps collapsed into a single `template:` call.
  - macOS job: ~80 lines of post-build steps collapsed into a single `template:` call.
- **`azure-pipelines-official.yml`**
  - Windows job: reuses `install-windows-prereqs.yml`.
- **`eng/common/`**: untouched (Arcade-mirrored).

### Numbers

|  | Before | After |
|---|---:|---:|
| `azure-pipelines.yml` | 370 | 238 |
| `azure-pipelines-official.yml` | 283 | 240 |
| Shared templates | 0 | 104 |
| **Total** | **653** | **582** |

The long `--test-modules` explanation comment used to appear **3×** verbatim; now it lives once in the template (plus one Windows-specific copy that uses the `.exe` glob).

### Minor behavior note

The macOS artifact name is now consistently `MacOS` — the original code had `TestResults_MacOs_...` (mixed case) but `Integration_Tests_MacOS_Binlogs_...` (upper case); both are now `MacOS` via the template parameter.

### Validation

- All YAML files parse cleanly (`yaml.safe_load` on all 3 root pipelines + 3 templates).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
