### PR TITLE
Document that AddOpenTelemetryProvider does not register default instrumentation or exporters

### DIFF
--- a/samples/public/MTPOTel/Program.cs
+++ b/samples/public/MTPOTel/Program.cs
@@ -28,7 +28,9 @@ public class Program
             _ => new TestFrameworkCapabilities(),
             (capabilities, serviceProvider) => new SimpleTestFramework(serviceProvider));
 
-        // Enable OpenTelemetry with console exporter
+        // Enable OpenTelemetry with console exporter. AddOpenTelemetryProvider does not register any instrumentation
+        // or exporter by default, so the delegates must call AddTestingPlatformInstrumentation() to subscribe to the
+        // Microsoft Testing Platform source/meter and wire whatever exporter(s) you want.
         testApplicationBuilder.AddOpenTelemetryProvider(
             tracing =>
             {

--- a/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/OpenTelemetryProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/OpenTelemetryProviderExtensions.cs
@@ -17,15 +17,24 @@ namespace Microsoft.Testing.Extensions;
 public static class OpenTelemetryProviderExtensions
 {
     /// <summary>
-    /// Adds OpenTelemetry tracing and metrics providers to the application builder, allowing customization of tracing
-    /// and metrics configuration.
+    /// Registers OpenTelemetry tracing and metrics providers whose lifetime is managed by the Microsoft Testing Platform.
     /// </summary>
-    /// <remarks>This method enables distributed tracing and metrics collection for the application. To
-    /// customize telemetry behavior, provide configuration delegates for tracing and/or metrics. If no delegates are
-    /// supplied, default OpenTelemetry settings are used.</remarks>
+    /// <remarks>The providers are created with empty configuration. Callers are responsible for wiring everything
+    /// the providers should observe and export, including:
+    /// <list type="bullet">
+    /// <item><description>The Microsoft Testing Platform instrumentation, via
+    /// <see cref="AddTestingPlatformInstrumentation(TracerProviderBuilder)"/> and
+    /// <see cref="AddTestingPlatformInstrumentation(MeterProviderBuilder)"/>. Without these, no MTP activities or
+    /// metrics are collected even if exporters are registered.</description></item>
+    /// <item><description>Any additional activity sources, meters, or instrumentation libraries the caller wants.</description></item>
+    /// <item><description>At least one exporter (for example, <c>AddOtlpExporter</c> or <c>AddConsoleExporter</c>);
+    /// without an exporter, collected telemetry is not emitted anywhere.</description></item>
+    /// </list>
+    /// No defaults are applied — this method does not pick instrumentation or exporters on the caller's behalf because
+    /// the right choice depends on the target observability backend.</remarks>
     /// <param name="builder">The application builder to which the OpenTelemetry providers will be added. Cannot be null.</param>
-    /// <param name="withTracing">An optional delegate to configure the tracing provider. If null, default tracing configuration is applied.</param>
-    /// <param name="withMetrics">An optional delegate to configure the metrics provider. If null, default metrics configuration is applied.</param>
+    /// <param name="withTracing">An optional delegate to configure the tracing provider (sources, instrumentation, exporters).</param>
+    /// <param name="withMetrics">An optional delegate to configure the metrics provider (meters, instrumentation, exporters).</param>
     public static void AddOpenTelemetryProvider(this ITestApplicationBuilder builder, Action<TracerProviderBuilder>? withTracing = null, Action<MeterProviderBuilder>? withMetrics = null)
         => ((TestApplicationBuilder)builder).Telemetry.AddOpenTelemetryProvider(serviceProvider =>
         {
@@ -37,9 +46,10 @@ public static class OpenTelemetryProviderExtensions
     /// Enables instrumentation for the Microsoft Testing Platform by adding its activity source to the specified tracer
     /// provider builder.
     /// </summary>
-    /// <remarks>Use this method to collect telemetry from components that emit activities under the
-    /// "Microsoft.Testing.Platform" source. This is typically required to enable distributed tracing for operations
-    /// performed by the Microsoft Testing Platform.</remarks>
+    /// <remarks>Call this method from the <c>withTracing</c> delegate of
+    /// <see cref="AddOpenTelemetryProvider(ITestApplicationBuilder, Action{TracerProviderBuilder}?, Action{MeterProviderBuilder}?)"/>,
+    /// or on any <see cref="TracerProviderBuilder"/> configured outside that helper, to collect activities emitted under
+    /// the <c>Microsoft.Testing.Platform</c> source.</remarks>
     /// <param name="builder">The tracer provider builder to which the Microsoft Testing Platform activity source will be added.</param>
     /// <returns>The tracer provider builder with the Microsoft Testing Platform activity source configured for instrumentation.</returns>
     public static TracerProviderBuilder AddTestingPlatformInstrumentation(this TracerProviderBuilder builder)
@@ -49,9 +59,10 @@ public static class OpenTelemetryProviderExtensions
     /// Adds instrumentation for the Microsoft Testing Platform to the specified <see cref="MeterProviderBuilder"/>
     /// instance.
     /// </summary>
-    /// <remarks>Use this method to enable collection of metrics emitted by the Microsoft Testing Platform.
-    /// This is typically required when monitoring or analyzing test execution within applications that utilize the
-    /// platform.</remarks>
+    /// <remarks>Call this method from the <c>withMetrics</c> delegate of
+    /// <see cref="AddOpenTelemetryProvider(ITestApplicationBuilder, Action{TracerProviderBuilder}?, Action{MeterProviderBuilder}?)"/>,
+    /// or on any <see cref="MeterProviderBuilder"/> configured outside that helper, to collect metrics emitted under
+    /// the <c>Microsoft.Testing.Platform</c> meter.</remarks>
     /// <param name="builder">The <see cref="MeterProviderBuilder"/> to which the Microsoft Testing Platform instrumentation will be added.</param>
     /// <returns>The same <see cref="MeterProviderBuilder"/> instance, configured to include metrics from the Microsoft Testing
     /// Platform.</returns>

--- a/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/PACKAGE.md
@@ -14,9 +14,17 @@ dotnet add package Microsoft.Testing.Extensions.OpenTelemetry
 
 This package extends Microsoft.Testing.Platform with:
 
-- **OpenTelemetry integration**: instruments test execution and produces OpenTelemetry-compatible traces and metrics that can be exported by user-configured exporters (for example, OTLP exporters)
-- **Observability**: enables you to route test execution data, via your own OpenTelemetry exporter configuration, into observability backends (e.g. Jaeger, Prometheus, Grafana)
-- **Standards-based**: leverages the OpenTelemetry .NET SDK so that data is sent only to the telemetry exporters and endpoints that you configure
+- **OpenTelemetry integration**: exposes the Microsoft Testing Platform activity source and meter (both named `Microsoft.Testing.Platform`) so test execution can be observed via the OpenTelemetry .NET SDK.
+- **Lifecycle management**: ties the lifetime of a `TracerProvider` and `MeterProvider` to the test application, so they are disposed alongside the test host.
+- **Observability**: lets you route test execution data, via your own OpenTelemetry exporter configuration, into observability backends (e.g. Jaeger, Prometheus, Grafana).
+- **Standards-based**: leverages the OpenTelemetry .NET SDK so that data is sent only to the telemetry exporters and endpoints that you configure.
+
+> Note: `AddOpenTelemetryProvider` does **not** register any instrumentation or exporter by default. To actually collect MTP telemetry you must, from the `withTracing` / `withMetrics` delegates:
+>
+> - call `AddTestingPlatformInstrumentation()` on both the `TracerProviderBuilder` and the `MeterProviderBuilder` to subscribe to the Microsoft Testing Platform source/meter, and
+> - register at least one exporter (for example `AddOtlpExporter`, `AddConsoleExporter`, or a vendor-specific exporter).
+>
+> Without instrumentation, no MTP activities or metrics are collected; without an exporter, collected telemetry is not emitted anywhere.
 
 ## Documentation
 


### PR DESCRIPTION
Fixes #8409.

## Problem

`AddOpenTelemetryProvider` documented that omitting `withTracing` / `withMetrics` would use "default OpenTelemetry settings", but it actually built empty `TracerProvider` / `MeterProvider` instances. The PACKAGE.md claim that the extension "instruments test execution with OpenTelemetry-compatible traces and metrics" was therefore not true for the zero-configuration path — `builder.AddOpenTelemetryProvider();` produced no MTP telemetry.

## Approach

Per the issue, option #2: keep runtime behavior under the caller's control and make the API contract honest. Auto-registering MTP instrumentation inside the provider was considered but rejected to preserve the (real, if niche) scenario of using this extension purely to manage the lifecycle of an OTel pipeline for application-only telemetry; the caller still needs a `Program.cs` to wire exporters either way, so the convenience gain was small.

- `OpenTelemetryProviderExtensions.cs`: XML docs on `AddOpenTelemetryProvider` now state explicitly that no instrumentation or exporter is registered by default and that the caller must wire both via the delegates, including `AddTestingPlatformInstrumentation()` to subscribe to MTP. `AddTestingPlatformInstrumentation` docs describe both use sites (inside the delegates and on a `TracerProviderBuilder` / `MeterProviderBuilder` configured outside the helper).
- `PACKAGE.md`: drops the misleading "instruments test execution" framing and spells out the wiring required to actually collect MTP telemetry.
- `samples/public/MTPOTel/Program.cs`: adds a short comment summarising the contract.

No public API surface change, no runtime behavior change — docs and sample only.

## Verification

Built the extension cleanly (Debug, all TFMs) — 0 warnings, 0 errors.