### PR TITLE
Dogfood --report-azdo-summary and --report-azdo-progress in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,6 +111,10 @@ stages:
           #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
           #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
           #   --report-azdo — surfaces failed tests in the AzDO UI.
+          #   --report-azdo-progress — emits ##vso[task.progress] records so long-running test sessions
+          #     show a live progress bar on the AzDO timeline. No-op outside AzDO (gated on TF_BUILD).
+          #   --report-azdo-summary — writes a Markdown job summary and uploads it via ##vso[task.uploadsummary]
+          #     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD).
           #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
           #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
           #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
@@ -121,7 +125,7 @@ stages:
           #     and this glob mixes net4x and net8+/net9+ hosts.
           #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
           #     below), so collecting coverage in Release would just write unused .coverage files.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --report-azdo-progress --report-azdo-summary --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,10 +111,12 @@ stages:
           #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
           #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
           #   --report-azdo — surfaces failed tests in the AzDO UI.
-          #   --report-azdo-progress — emits ##vso[task.progress] records so long-running test sessions
-          #     show a live progress bar on the AzDO timeline. No-op outside AzDO (gated on TF_BUILD).
+          #   --report-azdo-progress — emits ##vso[task.logdetail ...;progress=...] timeline records so
+          #     long-running test sessions show live progress on the AzDO timeline. No-op outside AzDO
+          #     (gated on TF_BUILD; emits a warning if the option is set but TF_BUILD is not 'true').
           #   --report-azdo-summary — writes a Markdown job summary and uploads it via ##vso[task.uploadsummary]
-          #     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD).
+          #     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD;
+          #     emits a warning if the option is set but TF_BUILD is not 'true').
           #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
           #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
           #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -28,10 +28,12 @@ steps:
 #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
 #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
 #   --report-azdo — surfaces failed tests in the AzDO UI.
-#   --report-azdo-progress — emits ##vso[task.progress] records so long-running test sessions
-#     show a live progress bar on the AzDO timeline. No-op outside AzDO (gated on TF_BUILD).
+#   --report-azdo-progress — emits ##vso[task.logdetail ...;progress=...] timeline records so
+#     long-running test sessions show live progress on the AzDO timeline. No-op outside AzDO
+#     (gated on TF_BUILD; emits a warning if the option is set but TF_BUILD is not 'true').
 #   --report-azdo-summary — writes a Markdown job summary and uploads it via ##vso[task.uploadsummary]
-#     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD).
+#     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD;
+#     emits a warning if the option is set but TF_BUILD is not 'true').
 #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
 #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
 #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -28,6 +28,10 @@ steps:
 #   --report-trx + --report-trx-filename "{asm}_{tfm}.trx" — TRX per (assembly x TFM),
 #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
 #   --report-azdo — surfaces failed tests in the AzDO UI.
+#   --report-azdo-progress — emits ##vso[task.progress] records so long-running test sessions
+#     show a live progress bar on the AzDO timeline. No-op outside AzDO (gated on TF_BUILD).
+#   --report-azdo-summary — writes a Markdown job summary and uploads it via ##vso[task.uploadsummary]
+#     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD).
 #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
 #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
 #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
@@ -38,7 +42,7 @@ steps:
 #     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
 #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
 #     in azure-pipelines.yml), so collecting coverage in Release would just write unused .coverage files.
-- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
+- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --report-azdo-progress --report-azdo-summary --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
   name: TestRelease
   displayName: Test (unit tests only)
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -15,7 +15,7 @@
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --diagnostic --diagnostic-output-directory $(RepoRoot)artifacts/log/$(Configuration) --diagnostic-file-prefix $(ModuleName) --diagnostic-verbosity trace</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo --report-azdo-progress --report-azdo-summary</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>
 
   </PropertyGroup>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -16,8 +16,8 @@
     <TestingPlatformCommandLineArguments Condition=" $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo</TestingPlatformCommandLineArguments>
-    <!-- --report-azdo-progress and --report-azdo-summary implement ITestSessionLifetimeHandler and emit a
-         warning on the output device when TF_BUILD is not 'true', unlike the silent --report-azdo. Gate them
+    <!-- The report-azdo-progress and report-azdo-summary options implement ITestSessionLifetimeHandler and emit a
+         warning on the output device when TF_BUILD is not 'true', unlike the silent report-azdo. Gate them
          on $(TF_BUILD) so local 'dotnet test' runs stay quiet and only CI pipelines opt into the AzDO output. -->
     <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-progress --report-azdo-summary</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -15,7 +15,11 @@
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --diagnostic --diagnostic-output-directory $(RepoRoot)artifacts/log/$(Configuration) --diagnostic-file-prefix $(ModuleName) --diagnostic-verbosity trace</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo --report-azdo-progress --report-azdo-summary</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo</TestingPlatformCommandLineArguments>
+    <!-- --report-azdo-progress and --report-azdo-summary implement ITestSessionLifetimeHandler and emit a
+         warning on the output device when TF_BUILD is not 'true', unlike the silent --report-azdo. Gate them
+         on $(TF_BUILD) so local 'dotnet test' runs stay quiet and only CI pipelines opt into the AzDO output. -->
+    <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-progress --report-azdo-summary</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>
 
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Wires the recently-merged `--report-azdo-summary` and `--report-azdo-progress` AzureDevOpsReport options into both testfx CI test paths so we dogfood them on every run.

Both options are gated on `TF_BUILD=true` ([`AzureDevOpsSummaryReporter.cs#L99`](https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs#L99), [`AzureDevOpsProgressReporter.cs#L97`](https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsProgressReporter.cs#L97)) so they are a no-op for local `dotnet test` runs and only emit `##vso[...]` commands inside an AzDO pipeline. Smoke-tested locally with `Microsoft.Testing.Platform.UnitTests` to confirm the options are accepted and produce the expected `…skipping…` notice outside AzDO.

## Changes

- `test/Directory.Build.targets` — extends the always-on `--report-azdo` injection (Debug `-p:UsingDotNetTest=true` path).
- `azure-pipelines.yml` — extends the Release `--test-modules` script (Windows).
- `eng/pipelines/steps/test-non-windows.yml` — same extension for the Linux/macOS template.

## Deferred to follow-up PRs

Considered (and rejected for now) — happy to do these as separate PRs if there is interest:

| Option | Why deferred |
| --- | --- |
| `--report-html` | API is `[Experimental(""TPEXP"")]` and the test apps disable `GenerateTestingPlatformEntryPoint`, so each of ~15 `Program.cs` would need an explicit `AddHtmlReportProvider()` call plus a `TPEXP` suppression. Worth doing, but a different change. |
| `--report-azdo-upload-artifacts files` | All modules share one `--results-directory`, so the uploader's `GetFiles(..., AllDirectories)` would emit N² uploads. Needs per-module `--results-directory` isolation or precise include patterns first. |
| `--minimum-expected-tests` | Redundant — MTP already returns `ExitCode.ZeroTests` when zero tests run. |
| `--retry-failed-tests` | Changes test semantics; should be rolled out deliberately. |
| `--publish-azdo-*` / `--report-azdo-flaky-history` / `--report-azdo-quarantine-file` | Larger Arcade-integration work. |
