### PR TITLE
[test-improver] test: add edge case tests for PublicTypeShouldBeTestClassAnalyzer (MSTEST0004)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PublicTypeShouldBeTestClassAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PublicTypeShouldBeTestClassAnalyzerTests.cs
@@ -173,4 +173,135 @@ public sealed class PublicTypeShouldBeTestClassAnalyzerTests
            code,
            code);
     }
+
+    [TestMethod]
+    public async Task WhenPublicRecordClass_Diagnostic()
+    {
+        // A `record` (record class) has TypeKind.Class and is subject to the same rule as a plain class.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public record [|MyRecord|]
+            {
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public record MyRecord
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenPublicRecordStruct_NoDiagnostic()
+    {
+        // A `record struct` has TypeKind.Struct, not Class, so the analyzer does not flag it.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public record struct MyRecord
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenPublicClassNestedInsideInternalClass_NoDiagnostic()
+    {
+        // The resultant visibility of a public nested class inside an internal outer class is internal,
+        // so the analyzer does not flag it.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            internal class OuterClass
+            {
+                public class InnerClass
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenPublicClassNestedInsidePublicNonTestClass_Diagnostic()
+    {
+        // Both the outer and nested class are publicly visible and lack [TestClass].
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class [|OuterClass|]
+            {
+                public class [|InnerClass|]
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class OuterClass
+            {
+                [TestClass]
+                public class InnerClass
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenPublicClassNestedInsideTestClass_Diagnostic()
+    {
+        // The outer class has [TestClass] so it is fine; the nested public class does not.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class OuterTestClass
+            {
+                public class [|InnerHelper|]
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class OuterTestClass
+            {
+                [TestClass]
+                public class InnerHelper
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            fixedCode);
+    }
 }


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`PublicTypeShouldBeTestClassAnalyzer` (MSTEST0004) had 8 tests covering the basic "public class without `[TestClass]`" path and several well-known no-diagnostic cases (abstract, static, non-public, etc.), but missed four real-world scenarios:

1. **`public record` (record class)** — records have `TypeKind.Class` in Roslyn; the analyzer should flag them just like plain classes, but there was no test confirming this.
2. **`public record struct`** — value-type records have `TypeKind.Struct`; the analyzer explicitly skips non-Class types, so these should never be flagged.
3. **Nested public class inside an `internal` outer class** — `GetResultantVisibility()` returns `Internal` here, so the rule does not apply. Without a test, a future change to the visibility check could silently start flagging these.
4. **Nested public class inside a public outer class** — both the outer and inner classes lack `[TestClass]` and have resultant-public visibility, so the analyzer should flag both. Verifies that the rule walks all named types, not just top-level ones.
5. **Nested public class inside a `[TestClass]`** — the outer class is fine; the inner class has no `[TestClass]` and should be flagged. The fix correctly adds `[TestClass]` only to the inner class.

## Approach

- Added 5 new `[TestMethod]` test cases to `PublicTypeShouldBeTestClassAnalyzerTests`.
- Each test uses `VerifyCS.VerifyCodeFixAsync` (following the existing pattern) to assert both the diagnostic location and the code-fix output.
- No production code changes.

## Test Status

```
Test run summary: Passed!
  total: 13
  failed: 0
  succeeded: 13
  skipped: 0
  duration: 6s 633ms
```

✅ All 13 tests pass (`MSTest.Analyzers.UnitTests`, net8.0, Debug — 8 original + 5 new).

## Reproducibility

```bash
./build.sh --restore   # first run only
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "ClassName=MSTest.Analyzers.UnitTests.PublicTypeShouldBeTestClassAnalyzerTests"
```

## Trade-offs

- Tests only exercise existing code paths in the analyzer — no production changes, no maintenance burden beyond the tests themselves.
- The nested-class scenarios document subtleties of `GetResultantVisibility()` that would otherwise be implicit and easy to break in a refactor.




> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/27173160092) · sonnet46 6.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests)
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27173160092, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27173160092 -->

<!-- gh-aw-workflow-id: test-improver -->