### PR TITLE
Trigger Expert Code Review when draft PR becomes ready for review

### DIFF
--- a/.github/workflows/review-on-open.agent.lock.yml
+++ b/.github/workflows/review-on-open.agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ad51ec84a6af6440cf76ffe39a1aaed07265af5237c1c2d0d4cc183ff19797de","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3be6296f539f301de627adb55eb5f717751ceef406858115383ae3fce458af3c","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"9f050961da586148d135e113d8bb025185cdf2b8","version":"v0.75.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.18"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Automatically runs the expert-reviewer agent when a non-draft PR is opened.
+# Automatically runs the expert-reviewer agent when a PR becomes ready for review — either opened as non-draft, or transitioned from draft to ready.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -53,7 +53,7 @@
 #   - ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
-name: "Expert Code Review (on open)"
+name: "Expert Code Review (on PR ready)"
 on:
   pull_request:
     types:
@@ -70,7 +70,7 @@ concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}"
   cancel-in-progress: true
 
-run-name: "Expert Code Review (on open)"
+run-name: "Expert Code Review (on PR ready)"
 
 jobs:
   activation:
@@ -108,7 +108,7 @@ jobs:
           trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.pre_activation.outputs.setup-parent-span-id || needs.pre_activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"
@@ -122,7 +122,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AGENT_VERSION: "1.0.52"
           GH_AW_INFO_CLI_VERSION: "v0.75.4"
-          GH_AW_INFO_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_INFO_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -214,21 +214,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
+          cat << 'GH_AW_PROMPT_451a5ee8d784cf5f_EOF'
           <system>
-          GH_AW_PROMPT_016ed230f1b9b90d_EOF
+          GH_AW_PROMPT_451a5ee8d784cf5f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt_multi.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
+          cat << 'GH_AW_PROMPT_451a5ee8d784cf5f_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:30), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_016ed230f1b9b90d_EOF
+          GH_AW_PROMPT_451a5ee8d784cf5f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
+          cat << 'GH_AW_PROMPT_451a5ee8d784cf5f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -257,13 +257,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_016ed230f1b9b90d_EOF
+          GH_AW_PROMPT_451a5ee8d784cf5f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
+          cat << 'GH_AW_PROMPT_451a5ee8d784cf5f_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/review-shared.md}}
           {{#runtime-import .github/workflows/review-on-open.agent.md}}
-          GH_AW_PROMPT_016ed230f1b9b90d_EOF
+          GH_AW_PROMPT_451a5ee8d784cf5f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -384,7 +384,7 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"
@@ -489,9 +489,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ae95ca95506a5ae7_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9b3db657b4e0fb2c_EOF'
           {"add_comment":{"max":5},"create_pull_request_review_comment":{"max":30,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ae95ca95506a5ae7_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9b3db657b4e0fb2c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -742,7 +742,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_03fb2c8025b94867_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_29ac96e90c23b06d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -783,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_03fb2c8025b94867_EOF
+          GH_AW_MCP_CONFIG_29ac96e90c23b06d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1057,7 +1057,7 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"
@@ -1082,7 +1082,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/review-on-open.agent.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
@@ -1099,7 +1099,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/review-on-open.agent.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
@@ -1117,7 +1117,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/review-on-open.agent.md"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1132,7 +1132,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/review-on-open.agent.md"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1147,7 +1147,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/review-on-open.agent.md"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
@@ -1203,7 +1203,7 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"
@@ -1272,8 +1272,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          WORKFLOW_NAME: "Expert Code Review (on open)"
-          WORKFLOW_DESCRIPTION: "Automatically runs the expert-reviewer agent when a non-draft PR is opened."
+          WORKFLOW_NAME: "Expert Code Review (on PR ready)"
+          WORKFLOW_DESCRIPTION: "Automatically runs the expert-reviewer agent when a PR becomes ready for review — either opened as non-draft, or transitioned from draft to ready."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1403,7 +1403,7 @@ jobs:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"
@@ -1443,7 +1443,7 @@ jobs:
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
       GH_AW_ENGINE_VERSION: "1.0.52"
       GH_AW_WORKFLOW_ID: "review-on-open.agent"
-      GH_AW_WORKFLOW_NAME: "Expert Code Review (on open)"
+      GH_AW_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
       GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/review-on-open.agent.md"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
@@ -1464,7 +1464,7 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"
@@ -1539,7 +1539,7 @@ jobs:
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.activation.outputs.setup-parent-span-id || needs.activation.outputs.setup-span-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on open)"
+          GH_AW_SETUP_WORKFLOW_NAME: "Expert Code Review (on PR ready)"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/review-on-open.agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.52"
           GH_AW_INFO_AWF_VERSION: "v0.25.53"

--- a/.github/workflows/review-on-open.agent.lock.yml
+++ b/.github/workflows/review-on-open.agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6b9954e9bf8983971c619ec0eaff1f25e880bc5e398b1a4a632c06cdb6d2f03b","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ad51ec84a6af6440cf76ffe39a1aaed07265af5237c1c2d0d4cc183ff19797de","compiler_version":"v0.75.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"9f050961da586148d135e113d8bb025185cdf2b8","version":"v0.75.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.53"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.53"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.18"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -58,6 +58,7 @@ on:
   pull_request:
     types:
     - opened
+    - ready_for_review
   # roles: # Roles processed as role check in pre-activation job
   # - admin # Roles processed as role check in pre-activation job
   # - maintainer # Roles processed as role check in pre-activation job
@@ -213,21 +214,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
+          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
           <system>
-          GH_AW_PROMPT_35834297cdfc6352_EOF
+          GH_AW_PROMPT_016ed230f1b9b90d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt_multi.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
+          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
           <safe-output-tools>
           Tools: add_comment(max:5), create_pull_request_review_comment(max:30), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_35834297cdfc6352_EOF
+          GH_AW_PROMPT_016ed230f1b9b90d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
+          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -256,13 +257,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_35834297cdfc6352_EOF
+          GH_AW_PROMPT_016ed230f1b9b90d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_35834297cdfc6352_EOF'
+          cat << 'GH_AW_PROMPT_016ed230f1b9b90d_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/review-shared.md}}
           {{#runtime-import .github/workflows/review-on-open.agent.md}}
-          GH_AW_PROMPT_35834297cdfc6352_EOF
+          GH_AW_PROMPT_016ed230f1b9b90d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -488,9 +489,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_824a51814315adc6_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_ae95ca95506a5ae7_EOF'
           {"add_comment":{"max":5},"create_pull_request_review_comment":{"max":30,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"submit_pull_request_review":{"allowed_events":["COMMENT","REQUEST_CHANGES"],"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_824a51814315adc6_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ae95ca95506a5ae7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -741,7 +742,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_216c1064395b6fad_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_03fb2c8025b94867_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -782,7 +783,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_216c1064395b6fad_EOF
+          GH_AW_MCP_CONFIG_03fb2c8025b94867_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/review-on-open.agent.md
+++ b/.github/workflows/review-on-open.agent.md
@@ -1,6 +1,6 @@
 ---
-name: "Expert Code Review (on open)"
-description: "Automatically runs the expert-reviewer agent when a non-draft PR is opened."
+name: "Expert Code Review (on PR ready)"
+description: "Automatically runs the expert-reviewer agent when a PR becomes ready for review — either opened as non-draft, or transitioned from draft to ready."
 
 # Non-draft PRs trigger this workflow.
 # The `roles` setting restricts execution to users with admin, maintainer, or

--- a/.github/workflows/review-on-open.agent.md
+++ b/.github/workflows/review-on-open.agent.md
@@ -6,11 +6,12 @@ description: "Automatically runs the expert-reviewer agent when a non-draft PR i
 # The `roles` setting restricts execution to users with admin, maintainer, or
 # write permissions, and fork PRs are blocked by the compiled repository_id guard.
 #
-# NOTE: Only `opened` is used here; for PRs transitioned from draft to ready,
-# use the `/review` slash command.
+# Triggers on both `opened` (PR opened as non-draft) and `ready_for_review`
+# (PR transitioned from draft to ready). The `if:` condition below filters out
+# draft PRs so the `opened` event is a no-op for drafts.
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
   roles: [admin, maintainer, write]
 
 # Skip draft PRs and OneLocBuild localization check-in PRs (authored by dotnet-bot)


### PR DESCRIPTION
The `Expert Code Review (on open)` workflow only listened to `pull_request: opened`, so it never ran when a PR was transitioned from draft to ready for review (GitHub fires a separate `ready_for_review` event in that case). Users had to fall back to the `/review` slash command.

This adds `ready_for_review` to the trigger `types`. The existing `if:` condition (`github.event.pull_request.draft == false`) already filters out drafts, so the `opened` event remains a no-op for drafts and there is no behavior change for normal non-draft opens.

Recompiled the lock file with `gh aw compile review-on-open.agent --strict`.

### Context

This was noticed alongside a transient failure on https://github.com/microsoft/testfx/actions/runs/27191975267, where the agent step failed because the gh-aw firewall `awf-squid` container reported unhealthy (`dependency failed to start: container awf-squid is unhealthy`). That failure is an infrastructure issue inside the gh-aw runtime stack — not something this workflow can fix — and the right mitigation there is a re-run. This PR addresses the second, actionable issue: the missing `ready_for_review` trigger.