### PR TITLE
[MSTest.Sdk] Wire Microsoft.Testing.Extensions.JUnitReport into MSTest.Sdk (opt-in)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,6 +65,13 @@
       This is a early preview package, keep 2.0.0-alpha or similar suffix even in official builds.
     -->
     <MSTestSourceGenerationVersionPrefix>2.0.0</MSTestSourceGenerationVersionPrefix>
+
+    <MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel>alpha</MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel>
+
+    <!--
+      This is an early preview package, keep 1.0.0-alpha or similar suffix even in official builds.
+    -->
+    <MicrosoftTestingExtensionsJUnitReportVersionPrefix>1.0.0</MicrosoftTestingExtensionsJUnitReportVersionPrefix>
   </PropertyGroup>
 
   <!-- Pack config -->

--- a/src/Package/MSTest.Sdk/MSTest.Sdk.csproj
+++ b/src/Package/MSTest.Sdk/MSTest.Sdk.csproj
@@ -42,7 +42,15 @@
       <_MSTestSourceGenerationVersionSuffix>$(_MSTestSourceGenerationPreReleaseVersionLabel)$(_BuildNumberLabels)</_MSTestSourceGenerationVersionSuffix>
       <_MSTestSourceGenerationVersion>$(MSTestSourceGenerationVersionPrefix)</_MSTestSourceGenerationVersion>
       <_MSTestSourceGenerationVersion Condition="'$(_MSTestSourceGenerationVersionSuffix)' != ''">$(_MSTestSourceGenerationVersion)-$(_MSTestSourceGenerationVersionSuffix)</_MSTestSourceGenerationVersion>
-      <_TemplateProperties>MSTestSourceGenerationVersion=$(_MSTestSourceGenerationVersion);MSTestVersion=$(Version);MicrosoftTestingPlatformVersion=$(Version.Replace('$(VersionPrefix)', '$(TestingPlatformVersionPrefix)'));MicrosoftNETTestSdkVersion=$(MicrosoftNETTestSdkVersion);MicrosoftTestingExtensionsCodeCoverageVersion=$(MicrosoftTestingExtensionsCodeCoverageVersion);MicrosoftPlaywrightVersion=$(MicrosoftPlaywrightVersion);AspireHostingTestingVersion=$(AspireHostingTestingVersion);MicrosoftTestingExtensionsFakesVersion=$(MicrosoftTestingExtensionsFakesVersion)</_TemplateProperties>
+
+      <_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel>$(MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel)</_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel>
+      <_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuild)' != 'true'">ci</_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel>
+      <_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuild)' != 'true'">dev</_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel>
+      <_MicrosoftTestingExtensionsJUnitReportVersionSuffix>$(_MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel)$(_BuildNumberLabels)</_MicrosoftTestingExtensionsJUnitReportVersionSuffix>
+      <_MicrosoftTestingExtensionsJUnitReportVersion>$(MicrosoftTestingExtensionsJUnitReportVersionPrefix)</_MicrosoftTestingExtensionsJUnitReportVersion>
+      <_MicrosoftTestingExtensionsJUnitReportVersion Condition="'$(_MicrosoftTestingExtensionsJUnitReportVersionSuffix)' != ''">$(_MicrosoftTestingExtensionsJUnitReportVersion)-$(_MicrosoftTestingExtensionsJUnitReportVersionSuffix)</_MicrosoftTestingExtensionsJUnitReportVersion>
+
+      <_TemplateProperties>MSTestSourceGenerationVersion=$(_MSTestSourceGenerationVersion);MSTestVersion=$(Version);MicrosoftTestingPlatformVersion=$(Version.Replace('$(VersionPrefix)', '$(TestingPlatformVersionPrefix)'));MicrosoftNETTestSdkVersion=$(MicrosoftNETTestSdkVersion);MicrosoftTestingExtensionsCodeCoverageVersion=$(MicrosoftTestingExtensionsCodeCoverageVersion);MicrosoftPlaywrightVersion=$(MicrosoftPlaywrightVersion);AspireHostingTestingVersion=$(AspireHostingTestingVersion);MicrosoftTestingExtensionsFakesVersion=$(MicrosoftTestingExtensionsFakesVersion);MicrosoftTestingExtensionsJUnitReportVersion=$(_MicrosoftTestingExtensionsJUnitReportVersion)</_TemplateProperties>
     </PropertyGroup>
 
     <!--

--- a/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
@@ -131,6 +131,13 @@
     </PackageReference>
     <PackageVersion Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="$(MicrosoftTestingExtensionsAzureDevOpsReportVersion)"
                     Condition=" '$(EnableMicrosoftTestingExtensionsAzureDevOpsReport)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true' " />
+
+    <PackageReference Include="Microsoft.Testing.Extensions.JUnitReport" Sdk="MSTest"
+                      Condition=" '$(EnableMicrosoftTestingExtensionsJUnitReport)' == 'true' ">
+      <Version Condition=" '$(ManagePackageVersionsCentrally)' != 'true' ">$(MicrosoftTestingExtensionsJUnitReportVersion)</Version>
+    </PackageReference>
+    <PackageVersion Include="Microsoft.Testing.Extensions.JUnitReport" Version="$(MicrosoftTestingExtensionsJUnitReportVersion)"
+                    Condition=" '$(EnableMicrosoftTestingExtensionsJUnitReport)' == 'true' and '$(ManagePackageVersionsCentrally)' == 'true' " />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../Features/Aspire.targets" Condition=" '$(EnableAspireTesting)' == 'true' " />

--- a/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
@@ -24,6 +24,8 @@
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsHangDump)' == 'true' " Text="Hang dump extension might not be working well under Native AOT." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsHotReload)' == 'true' " Text="Hot reload extension might not be working well under Native AOT." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsRetry)' == 'true' " Text="Hot reload extension might not be working well under Native AOT." />
+    <Warning Condition=" '$(EnableMicrosoftTestingExtensionsAzureDevOpsReport)' == 'true' " Text="Azure DevOps report extension is not supported in NativeAOT mode." />
+    <Warning Condition=" '$(EnableMicrosoftTestingExtensionsJUnitReport)' == 'true' " Text="JUnit report extension is not supported in NativeAOT mode." />
   </Target>
 
   <!-- Core -->

--- a/src/Package/MSTest.Sdk/Sdk/Sdk.props.template
+++ b/src/Package/MSTest.Sdk/Sdk/Sdk.props.template
@@ -21,6 +21,7 @@
     <MicrosoftPlaywrightVersion Condition=" '$(MicrosoftPlaywrightVersion)' == '' ">${MicrosoftPlaywrightVersion}</MicrosoftPlaywrightVersion>
     <MicrosoftTestingExtensionsCodeCoverageVersion Condition=" '$(MicrosoftTestingExtensionsCodeCoverageVersion)' == '' " >${MicrosoftTestingExtensionsCodeCoverageVersion}</MicrosoftTestingExtensionsCodeCoverageVersion>
     <MicrosoftTestingExtensionsFakesVersion Condition=" '$(MicrosoftTestingExtensionsFakesVersion)' == '' " >${MicrosoftTestingExtensionsFakesVersion}</MicrosoftTestingExtensionsFakesVersion>
+    <MicrosoftTestingExtensionsJUnitReportVersion Condition=" '$(MicrosoftTestingExtensionsJUnitReportVersion)' == '' " >${MicrosoftTestingExtensionsJUnitReportVersion}</MicrosoftTestingExtensionsJUnitReportVersion>
     <MicrosoftTestingPlatformVersion Condition=" '$(MicrosoftTestingPlatformVersion)' == '' " >${MicrosoftTestingPlatformVersion}</MicrosoftTestingPlatformVersion>
     <MSTestSourceGenerationVersion Condition=" '$(MSTestSourceGenerationVersion)' == '' ">${MSTestSourceGenerationVersion}</MSTestSourceGenerationVersion>
     <MSTestVersion Condition=" '$(MSTestVersion)' == '' ">${MSTestVersion}</MSTestVersion>

--- a/src/Package/MSTest.Sdk/Sdk/VSTest/VSTest.targets
+++ b/src/Package/MSTest.Sdk/Sdk/VSTest/VSTest.targets
@@ -6,6 +6,7 @@
     <Error Condition=" '$(EnableMicrosoftTestingExtensionsCrashDump)' != '' " Text="'EnableMicrosoftTestingExtensionsCrashDump' is not supported by VSTest." />
     <Error Condition=" '$(EnableMicrosoftTestingExtensionsHangDump)' != '' " Text="'EnableMicrosoftTestingExtensionsHangDump' is not supported by VSTest." />
     <Error Condition=" '$(EnableMicrosoftTestingExtensionsHotReload)' != '' " Text="'EnableMicrosoftTestingExtensionsHotReload' is not supported by VSTest." />
+    <Error Condition=" '$(EnableMicrosoftTestingExtensionsJUnitReport)' != '' " Text="'EnableMicrosoftTestingExtensionsJUnitReport' is not supported by VSTest." />
     <Error Condition=" '$(EnableMicrosoftTestingExtensionsRetry)' != '' " Text="'EnableMicrosoftTestingExtensionsRetry' is not supported by VSTest." />
     <Error Condition=" '$(EnableMicrosoftTestingExtensionsTrxReport)' != '' " Text="'EnableMicrosoftTestingExtensionsTrxReport' is not supported by VSTest." />
     <Error Condition=" '$(EnableMSTestRunner)' == 'true' " Text="'EnableMSTestRunner' cannot be combined with 'UseVSTest'." />

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(SupportedNetFrameworks)</TargetFrameworks>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <VersionPrefix>$(MicrosoftTestingExtensionsJUnitReportVersionPrefix)</VersionPrefix>
+    <PreReleaseVersionLabel>$(MicrosoftTestingExtensionsJUnitReportPreReleaseVersionLabel)</PreReleaseVersionLabel>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <GenerateBuildInfo>true</GenerateBuildInfo>
     <BuildInfoTemplateFile>$(RepoRoot)src\Platform\SharedExtensionHelpers\BuildInfo.cs.template</BuildInfoTemplateFile>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -200,6 +200,11 @@ namespace MSTestSdkTest
               "<EnableMicrosoftTestingExtensionsAzureDevOpsReport>true</EnableMicrosoftTestingExtensionsAzureDevOpsReport>",
               "--report-azdo",
               "--crashdump"));
+
+            yield return new((buildConfig.MultiTfm, buildConfig.BuildConfiguration,
+              "<EnableMicrosoftTestingExtensionsJUnitReport>true</EnableMicrosoftTestingExtensionsJUnitReport>",
+              "--report-junit",
+              "--crashdump"));
         }
     }
 


### PR DESCRIPTION
Closes the gap where the new `Microsoft.Testing.Extensions.JUnitReport` package was shipped (#8850) but never wired into `MSTest.Sdk`, so MSTest.Sdk consumers had no way to enable JUnit output through the standard SDK switch pattern they use for the other extensions.

## What this PR does
Adds opt-in support for the JUnit XML report extension through `MSTest.Sdk` via the standard `EnableMicrosoftTestingExtensionsJUnitReport` MSBuild property:

```xml
<Project Sdk="MSTest.Sdk/x.y.z">
  <PropertyGroup>
    <TargetFramework>net9.0</TargetFramework>
    <EnableMicrosoftTestingExtensionsJUnitReport>true</EnableMicrosoftTestingExtensionsJUnitReport>
  </PropertyGroup>
</Project>
```

Then `dotnet run -- --report-junit` produces the JUnit XML.

## Profile decision
JUnitReport is **opt-in only** in this PR and is **not** added to the `Default` or `AllMicrosoft` profile. The extension is still marked experimental in the glossary ("Currently experimental — the API, CLI options, and on-disk format may change without notice."), so we follow a conservative integration. We can promote it into `AllMicrosoft` in a follow-up once it stabilizes.

## Changes
- `Sdk/Runner/ClassicEngine.targets`: add `PackageReference` / `PackageVersion` gated on `EnableMicrosoftTestingExtensionsJUnitReport == ''true''`, mirroring the `AzureDevOpsReport` block.
- `Sdk/VSTest/VSTest.targets`: emit a build error when `EnableMicrosoftTestingExtensionsJUnitReport` is used together with `UseVSTest`, matching the validation for the other Testing-Platform-only extensions.
- `MSTest.Sdk.csproj` + `Sdk/Sdk.props.template`: flow `MicrosoftTestingExtensionsJUnitReportVersion` through the template-substitution pipeline (the extension has its own version line independent of `MicrosoftTestingPlatformVersion`).
- `Directory.Build.props`: centralize the JUnit version prefix/label (`1.0.0` / `alpha`) so both the JUnit csproj and the MSTest.Sdk template share one source of truth (mirrors the existing `MSTest.SourceGeneration` pattern).
- `Microsoft.Testing.Extensions.JUnitReport.csproj`: consume the centralized properties (no behavior change — verified the package still packs as `1.0.0-dev` locally and would still pack as `1.0.0-alpha` for official builds and `1.0.0-ci.<buildNumber>` for CI builds).
- `SdkTests.cs`: add a selective-enable acceptance test row for `--report-junit`, asserting both that JUnit works when enabled and that an unrelated CLI arg (`--crashdump`) fails when only JUnit is enabled.

## What this PR does not do
- Does not add JUnit to `NativeAOT.targets` (consistent with `AzureDevOpsReport`, `CrashDump`, `HangDump`, `HotReload`, `Retry`, `Fakes` — only `TrxReport` + `CodeCoverage` are wired into NativeAOT today).
- Does not enable JUnit in the AllMicrosoft `EnableAll_Extensions` test (`--report-junit` is not in the combined command line) — because we deliberately do not auto-enable in `AllMicrosoft`.

## Validation
- `build.cmd -projects src/Platform/Microsoft.Testing.Extensions.JUnitReport/...csproj -c Debug` → 0 warnings, 0 errors; package still produced as `Microsoft.Testing.Extensions.JUnitReport.1.0.0-dev.nupkg` (identical to pre-refactor output for the same build context).
- `build.cmd -projects src/Package/MSTest.Sdk/MSTest.Sdk.csproj -c Debug` → 0 warnings, 0 errors; `Sdk/Sdk.props` regenerated with the new `<MicrosoftTestingExtensionsJUnitReportVersion>1.0.0-dev</MicrosoftTestingExtensionsJUnitReportVersion>` line at the correct alphabetical position.