### PR TITLE
Remove UseDotNet@2 step from CodeQL pipeline

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -48,10 +48,12 @@ jobs:
 
   steps:
 
-  - task: UseDotNet@2
-    displayName: Install Correct .NET Version
-    inputs:
-      useGlobalJson: true
+  # NOTE: Do not add an explicit `UseDotNet@2` with `useGlobalJson: true` here.
+  # global.json pins a preview SDK (11.0.x-preview.*) and the `UseDotNet@2` task
+  # does not search preview channels by default, so it fails with
+  # "sdk version matching: 11.0.x could not be found". `eng\common\cibuild.cmd`
+  # (invoked below) restores the correct SDK from global.json via `dotnet-install.ps1`,
+  # which handles preview versions correctly.
 
   - task: PowerShell@2
     displayName: 'Install Windows SDK'


### PR DESCRIPTION
## Why

CodeQL has been failing on `main` since the daily run for 2026-06-09 ([build 2995679](https://dnceng.visualstudio.com/internal/_build/results?buildId=2995679&view=logs&j=eb2c8817-e906-5459-8080-1a4c8ed1e2e2&t=28c238bb-05af-592b-c7bc-f66a71cdb9fb)) at the `Install Correct .NET Version` step:

```
Found a global.json at path: D:\a\_work\1\s\global.json
SDK version: 11.0.100-preview.5.26227.104 is specified by global.json at path: D:\a\_work\1\s\global.json
...
Applying rollForward policy 'latestFeature' to version '11.0.100-preview.5.26227.104', resolved version spec: '11.0.x'
No matching sdk version could be found for specified version: 11.0.x Kindly note the preview versions are only considered in latest version searches if Include Preview Versions checkbox is checked.
##[error]sdk version matching: 11.0.x could not be found
```

The explicit `UseDotNet@2` task added by #8935 reads the pinned preview SDK (`11.0.100-preview.5.26227.104`) from `global.json` but the task does not search preview channels by default, so it cannot find any matching `11.0.x`.

## What

Remove the explicit `UseDotNet@2 / useGlobalJson: true` step. `eng\common\cibuild.cmd` already restores the correct SDK from `global.json` via Arcade's `dotnet-install.ps1`, which handles preview versions correctly.

A NOTE comment is added to document why we deliberately don't have a `UseDotNet@2` step here, to avoid this regressing in future cleanups.