### PR TITLE
Constrain Test column width in grade-tests PR comment

### DIFF
--- a/.github/workflows/shared/grade-tests-shared.md
+++ b/.github/workflows/shared/grade-tests-shared.md
@@ -341,12 +341,12 @@ issue, and the single most important recommendation. -->
     <col width="28%">
   </colgroup>
   <thead>
-    <tr><th></th><th>Test</th><th>Grade</th><th>Band</th><th>Notes</th></tr>
+    <tr><th>Δ</th><th>Test</th><th>Grade</th><th>Band</th><th>Notes</th></tr>
   </thead>
   <tbody>
     <tr>
       <td>new</td>
-      <td><code>ClassName.Method_<wbr>When<wbr>X_<wbr>ReturnsY</code></td>
+      <td><code>ClassName.Method_<wbr>WhenSomething_<wbr>ReturnsValue</code></td>
       <td>A</td>
       <td>90–100</td>
       <td>…</td>
@@ -377,9 +377,11 @@ Rules for the table:
   the rendered table to the PR-comment width and prevent the horizontal
   scroll-bar shown when long fully-qualified test names blow out the
   `Test` column.
-- **Column 1 (status)**: keep it tiny — `new`, `mod`, or empty (no
+- **Column 1 (Δ / status)**: keep it tiny — `new`, `mod`, or empty (no
   parentheses, no backticks). Omit (leave blank) if the diff context does
-  not make the distinction clear from `git log` on the file at HEAD.
+  not make the distinction clear from `git log` on the file at HEAD. The
+  header is the single character `Δ` (change indicator) so the column is
+  not anonymous to screen readers.
 - **Column 2 (Test)** — the `<colgroup>` already caps the column at 50%
   of the comment width, but the cell content also needs to be
   *wrap-friendly* so the constrained width is filled top-to-bottom rather
@@ -392,9 +394,8 @@ Rules for the table:
     their content literally in GFM, so a `<wbr>` inside would display
     as the literal text `<wbr>`.
   - **Insert `<wbr>` word-break hints inside the method name** after
-    each `_` (and before each upper-case run in PascalCase segments
-    longer than ~12 characters) so the browser can break the inline
-    `<code>` span on long underscored MSTest names. Example:
+    each `_` so the browser can break the inline `<code>` span on long
+    underscored MSTest names. Example:
     `<code>ClassName.TestNodeResultsState_<wbr>GetSingleActiveOrSummaryTask_<wbr>WhenEmpty_<wbr>ReturnsNull</code>`.
     Do **not** alter the actual method name — `<wbr>` is invisible and
     must not change what gets copy-pasted (apart from the soft-wrap).

--- a/.github/workflows/shared/grade-tests-shared.md
+++ b/.github/workflows/shared/grade-tests-shared.md
@@ -319,7 +319,12 @@ read `No issues found.` — do not invent weaknesses to balance the note.
 ### Step 4 — Post the comment
 
 Use **exactly one** `add-comment` call. The comment body must follow this
-structure:
+structure — note that the table is emitted as **raw HTML** (not a
+markdown pipe-table) so we can constrain each column to a fixed
+percentage of the comment width via `<colgroup>`. GitHub's HTML
+sanitizer allows the `width` attribute on `<table>`, `<col>`, `<th>`,
+and `<td>`, so the column widths below are honored in the rendered
+comment.
 
 ```markdown
 ### 🧪 Test quality grade — PR #${{ github.event.pull_request.number || github.event.issue.number }}
@@ -327,10 +332,34 @@ structure:
 <!-- 2–4 sentence summary: total graded, grade distribution, most common
 issue, and the single most important recommendation. -->
 
-| Test | Grade | Band | Notes |
-|------|-------|------|-------|
-| `Namespace.ClassName.Method` | A | 90–100 | … |
-| `Namespace.ClassName.Other`  | C | 70–79  | … |
+<table>
+  <colgroup>
+    <col width="6%">
+    <col width="50%">
+    <col width="7%">
+    <col width="9%">
+    <col width="28%">
+  </colgroup>
+  <thead>
+    <tr><th></th><th>Test</th><th>Grade</th><th>Band</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>new</td>
+      <td><code>ClassName.Method_<wbr>When<wbr>X_<wbr>ReturnsY</code></td>
+      <td>A</td>
+      <td>90–100</td>
+      <td>…</td>
+    </tr>
+    <tr>
+      <td>mod</td>
+      <td><code>ClassName.OtherMethod</code></td>
+      <td>C</td>
+      <td>70–79</td>
+      <td>…</td>
+    </tr>
+  </tbody>
+</table>
 
 <sub>This advisory comment was generated automatically. Grades are heuristic
 and informational — they do not block merging. Re-run with
@@ -343,9 +372,32 @@ Rules for the table:
 - **Caps**: if there are more than 50 rows, show all rows with grade < B
   first, then a sample of the best rows, and wrap any overflow in a
   collapsed `<details><summary>Remaining N tests</summary>…</details>` block.
-- **Prefix** each row with `(new)` or `(modified)` if the diff context
-  makes that distinction clear from `git log` on the file at HEAD; if
-  unsure, omit the prefix rather than guessing.
+- **Use raw HTML `<table>`**, not a markdown pipe-table, and keep the
+  `<colgroup>` widths above (`6% / 50% / 7% / 9% / 28%`). They constrain
+  the rendered table to the PR-comment width and prevent the horizontal
+  scroll-bar shown when long fully-qualified test names blow out the
+  `Test` column.
+- **Column 1 (status)**: keep it tiny — `new`, `mod`, or empty (no
+  parentheses, no backticks). Omit (leave blank) if the diff context does
+  not make the distinction clear from `git log` on the file at HEAD.
+- **Column 2 (Test)** — the `<colgroup>` already caps the column at 50%
+  of the comment width, but the cell content also needs to be
+  *wrap-friendly* so the constrained width is filled top-to-bottom rather
+  than overflowing:
+  - **Drop the namespace.** Show only `ClassName.MethodName`, never the
+    full `Namespace.ClassName.MethodName`. Disambiguate in the Notes
+    column only if two graded methods would otherwise collide.
+  - **Use raw `<code>…</code>` HTML tags, not backtick fences**, so
+    nested `<wbr>` actually takes effect. Backtick code spans render
+    their content literally in GFM, so a `<wbr>` inside would display
+    as the literal text `<wbr>`.
+  - **Insert `<wbr>` word-break hints inside the method name** after
+    each `_` (and before each upper-case run in PascalCase segments
+    longer than ~12 characters) so the browser can break the inline
+    `<code>` span on long underscored MSTest names. Example:
+    `<code>ClassName.TestNodeResultsState_<wbr>GetSingleActiveOrSummaryTask_<wbr>WhenEmpty_<wbr>ReturnsNull</code>`.
+    Do **not** alter the actual method name — `<wbr>` is invisible and
+    must not change what gets copy-pasted (apart from the soft-wrap).
 
 **Important**: Emit **only one** `add-comment` call. The workflow is
 configured with `hide-older-comments: true`, so re-runs will replace any


### PR DESCRIPTION
Fixes the horizontal-scroll problem in the test-quality grade PR comment that the bot posts when a PR touches tests.

### Before
The bot rendered a markdown pipe-table where the `Test` column put the fully-qualified test name (Namespace.ClassName.MethodName) inside backticks. GitHub renders backtick spans as non-wrapping `<code>`, so long MSTest names overflowed the PR-comment width and forced a horizontal scroll bar.

### After
- Switch the table from a markdown pipe-table to a raw HTML `<table>` with a `<colgroup>` that caps each column to a fixed percentage of the comment width (`6% / 50% / 7% / 9% / 28%`). GitHub's HTML sanitizer honors the `width` attribute on `<table>`, `<col>`, `<th>`, and `<td>`, so the columns stay within the PR-comment width.
- Drop the namespace prefix from the displayed name (show `ClassName.MethodName`, never `Namespace.ClassName.MethodName`). Disambiguation moves to Notes if two graded methods would otherwise collide.
- Use raw `<code>…</code>` HTML tags instead of backtick spans so nested `<wbr>` actually takes effect (backtick code spans render content literally in GFM, so a `<wbr>` inside backticks would display as the literal text `<wbr>`).
- Inject invisible `<wbr>` soft-wrap hints after each `_` in long PascalCase MSTest names so the constrained 50%-wide cell can actually wrap on long names like `TestNodeResultsState_GetSingleActiveOrSummaryTask_WhenEmpty_ReturnsNull`. `<wbr>` does not change what copy-paste yields.
- Promote the `(new) / (modified)` marker out of the `Test` cell into its own narrow first column so it no longer competes for the cell width.

### Files changed
- `.github/workflows/shared/grade-tests-shared.md` — Step 4 ("Post the comment")

The two consumer workflows (`grade-tests-on-pr.agent.md` and `grade-tests.agent.md`) pull this body at runtime via `{{#runtime-import …}}`, so the `.lock.yml` files do not change.

### Validation
- `gh aw compile grade-tests-on-pr.agent grade-tests.agent --strict` → 0 errors, 0 warnings.
