### PR TITLE
Dogfood --report-junit and OpenTelemetry processing in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,6 +117,11 @@ stages:
           #   --report-azdo-summary — writes a Markdown job summary and uploads it via ##vso[task.uploadsummary]
           #     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD;
           #     emits a warning if the option is set but TF_BUILD is not 'true').
+          #   --report-junit + --report-junit-filename "{asm}_{tfm}.xml" — JUnit XML per (assembly x TFM),
+          #     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper. Dogfoods the
+          #     Microsoft.Testing.Extensions.JUnitReport extension; the .xml output is published alongside
+          #     the .trx files and can be consumed by AzDO PublishTestResults@2 (testResultsFormat: 'JUnit'),
+          #     Jenkins, GitLab, GitHub Actions test reporters, etc.
           #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
           #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
           #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
@@ -127,7 +132,7 @@ stages:
           #     and this glob mixes net4x and net8+/net9+ hosts.
           #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
           #     below), so collecting coverage in Release would just write unused .coverage files.
-          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --report-azdo-progress --report-azdo-summary --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace
+          - script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --report-azdo-progress --report-azdo-summary --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -34,6 +34,11 @@ steps:
 #   --report-azdo-summary — writes a Markdown job summary and uploads it via ##vso[task.uploadsummary]
 #     so failure context shows up on the build's summary tab. No-op outside AzDO (gated on TF_BUILD;
 #     emits a warning if the option is set but TF_BUILD is not 'true').
+#   --report-junit + --report-junit-filename "{asm}_{tfm}.xml" — JUnit XML per (assembly x TFM),
+#     resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper. Dogfoods the
+#     Microsoft.Testing.Extensions.JUnitReport extension; the .xml output is published alongside
+#     the .trx files and can be consumed by AzDO PublishTestResults@2 (testResultsFormat: 'JUnit'),
+#     Jenkins, GitLab, GitHub Actions test reporters, etc.
 #   --hangdump --hangdump-timeout 15m — captures a dump if a module hangs past 15 minutes.
 #   --diagnostic + --diagnostic-verbosity trace — produces per-host diagnostic logs;
 #     directory is published by the Arcade jobs.yml template (artifacts.publish.logs: true).
@@ -44,7 +49,7 @@ steps:
 #     Skipped here too for cross-platform parity with the Windows script (mixed net4x+netcoreapp glob).
 #   --coverage — Codecov upload is Debug-only (see "Upload coverage to codecov.io" step
 #     in azure-pipelines.yml), so collecting coverage in Release would just write unused .coverage files.
-- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --report-azdo-progress --report-azdo-summary --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
+- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) --no-progress --output detailed --report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-azdo --report-azdo-progress --report-azdo-summary --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
   name: TestRelease
   displayName: Test (unit tests only)
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -20,6 +20,10 @@
          warning on the output device when TF_BUILD is not 'true', unlike the silent report-azdo. Gate them
          on $(TF_BUILD) so local 'dotnet test' runs stay quiet and only CI pipelines opt into the AzDO output. -->
     <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-progress --report-azdo-summary</TestingPlatformCommandLineArguments>
+    <!-- Dogfood the JUnit report extension (Microsoft.Testing.Extensions.JUnitReport). The .xml files end up in
+         $(ResultsDirectory) (Arcade default) alongside the TRX files so they are picked up by the AzDO
+         PublishTestResults task and any external JUnit consumer. -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-junit</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>
 
   </PropertyGroup>
@@ -34,6 +38,8 @@
     <_TestArchitecture>$(PlatformTarget)</_TestArchitecture>
     <_TestArchitecture Condition="'$(PlatformTarget)' == '' or '$(PlatformTarget)' == 'AnyCpu'">x64</_TestArchitecture>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-trx --report-trx-filename $(MSBuildProjectName)_$(TargetFramework)_$(_TestArchitecture).trx --results-directory $(ArtifactsTestResultsDir)</TestingPlatformCommandLineArguments>
+    <!-- Match the TRX filename pattern so the JUnit XML report sits next to its TRX twin per (project x TFM x arch). -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-junit-filename $(MSBuildProjectName)_$(TargetFramework)_$(_TestArchitecture).xml</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(EnableMSTestRunner)' == 'true' OR '$(UseInternalTestFramework)' == 'true' ">
@@ -41,7 +47,12 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.HangDump\Microsoft.Testing.Extensions.HangDump.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Retry\Microsoft.Testing.Extensions.Retry.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.JUnitReport\Microsoft.Testing.Extensions.JUnitReport.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.AzureDevOpsReport\Microsoft.Testing.Extensions.AzureDevOpsReport.csproj" />
+    <!-- Microsoft.Testing.Extensions.OpenTelemetry is referenced so the per-project Program.cs can wire
+         AddOpenTelemetryProvider with AddTestingPlatformInstrumentation, exercising the platform's
+         OpenTelemetryResultHandler pipeline end-to-end in CI. -->
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.OpenTelemetry\Microsoft.Testing.Extensions.OpenTelemetry.csproj" />
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Condition="'$(UseMSTestFromSource)' == 'true'" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" GeneratePathProperty="True" />
   </ItemGroup>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
 
 // Opt-out telemetry
@@ -19,7 +22,16 @@ builder.AddCodeCoverageProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 // Custom suite tools
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory

--- a/test/IntegrationTests/MSTest.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 [assembly: Parallelize(Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel, Workers = 0)]
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
@@ -11,10 +14,19 @@ ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args)
 builder.AddCodeCoverageProvider();
 #endif
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 [assembly: DoNotParallelize]
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
@@ -11,10 +14,19 @@ ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args)
 builder.AddCodeCoverageProvider();
 #endif
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
 
 // Opt-out telemetry
@@ -19,8 +22,17 @@ builder.AddCodeCoverageProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 // Custom suite tools
 CompositeExtensionFactory<SlowestTestsConsumer> slowestTestCompositeServiceFactory

--- a/test/IntegrationTests/PlatformServices.Desktop.IntegrationTests/Program.cs
+++ b/test/IntegrationTests/PlatformServices.Desktop.IntegrationTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using TestFramework.ForTestingMSTest;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
@@ -11,10 +14,19 @@ ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args)
 builder.AddCodeCoverageProvider();
 #endif
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 builder.AddInternalTestFramework();
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
 
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
@@ -17,7 +20,16 @@ builder.AddCodeCoverageProvider();
 builder.AddCrashDumpProvider();
 builder.AddHangDumpProvider();
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/MSTest.SelfRealExamples.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.SelfRealExamples.UnitTests/Program.cs
@@ -3,12 +3,16 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 [assembly: Parallelize(Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel, Workers = 0)]
 
 ITestApplicationBuilder testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
 
 testApplicationBuilder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 testApplicationBuilder.AddTrxReportProvider();
+testApplicationBuilder.AddJUnitReportProvider();
 testApplicationBuilder.AddAppInsightsTelemetryProvider();
 testApplicationBuilder.AddCrashDumpProvider();
 testApplicationBuilder.AddHangDumpProvider();
@@ -17,5 +21,14 @@ testApplicationBuilder.AddCodeCoverageProvider();
 #endif
 
 testApplicationBuilder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+testApplicationBuilder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
+
 using ITestApplication testApplication = await testApplicationBuilder.BuildAsync();
 return await testApplication.RunAsync();

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
 builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
 
@@ -12,8 +15,17 @@ builder.AddCodeCoverageProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAppInsightsTelemetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Program.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using TestFramework.ForTestingMSTest;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
@@ -11,10 +14,19 @@ ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args)
 builder.AddCodeCoverageProvider();
 #endif
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 builder.AddInternalTestFramework();
 

--- a/test/UnitTests/MSTestAdapter.UnitTests/Program.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using TestFramework.ForTestingMSTest;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
@@ -11,10 +14,19 @@ ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args)
 builder.AddCodeCoverageProvider();
 #endif
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 builder.AddInternalTestFramework();
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
 
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
@@ -16,8 +19,17 @@ builder.AddCodeCoverageProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAppInsightsTelemetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Program.cs
@@ -3,6 +3,11 @@
 
 using Microsoft.Testing.Extensions;
 
+#if !NATIVE_AOT
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+#endif
+
 using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
 
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
@@ -21,6 +26,14 @@ builder.AddCodeCoverageProvider();
 #endif
 builder.AddAppInsightsTelemetryProvider();
 builder.AddHangDumpProvider();
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline. Gated on !NATIVE_AOT
+// because the OpenTelemetry SDK relies on reflection-heavy patterns that may not work under AOT.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 Console.WriteLine("NATIVE_AOT disabled");
 #else
 Console.WriteLine("NATIVE_AOT enabled");
@@ -28,6 +41,7 @@ Console.WriteLine("NATIVE_AOT enabled");
 
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAzureDevOpsProvider();
 
 using ITestApplication app = await builder.BuildAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
 
 // DebuggerUtility.AttachVSToCurrentProcess();
@@ -14,7 +17,16 @@ builder.AddCodeCoverageProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
 
 [assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
@@ -28,7 +31,16 @@ if (!OperatingSystem.IsBrowser())
 }
 
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/test/UnitTests/TestFramework.UnitTests/Program.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Program.cs
@@ -3,6 +3,9 @@
 
 using Microsoft.Testing.Extensions;
 
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
 using TestFramework.ForTestingMSTest;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
@@ -11,10 +14,19 @@ ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args)
 builder.AddCodeCoverageProvider();
 #endif
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddRetryProvider();
 builder.AddAzureDevOpsProvider();
+
+// Dogfood the OpenTelemetry extension: subscribe to the Microsoft.Testing.Platform activity source
+// and meter so the OpenTelemetryResultHandler pipeline is exercised end-to-end in CI. No exporter
+// is registered, so the recorded data is dropped by the SDK at the export stage — this keeps CI
+// logs clean while still flowing every test event through the OTel pipeline.
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
 
 builder.AddInternalTestFramework();
 


### PR DESCRIPTION
Follow up to the AzDO/TRX dogfooding pattern (#0028908d): now also exercise the **newest report extension** (JUnitReport, #8850) and the **OpenTelemetry processing** pipeline end-to-end as part of our own CI test runs.

## JUnit Report (`--report-junit`)
- `test/Directory.Build.targets` adds `Microsoft.Testing.Extensions.JUnitReport` as a `ProjectReference` for every test project that opts into MTP and wires `--report-junit` / `--report-junit-filename` into the MSBuild path.
- `azure-pipelines.yml` and `eng/pipelines/steps/test-non-windows.yml` also pass `--report-junit --report-junit-filename "{asm}_{tfm}.xml"` on the Release `dotnet test --test-modules` path (which bypasses MSBuild evaluation).
- Each test project's `Program.cs` explicitly calls `AddJUnitReportProvider()`. `TestingPlatformBuilderHook` auto-registration only fires for NuGet consumers, not source `ProjectReference` consumers.

## OpenTelemetry processing
- `test/Directory.Build.targets` adds `Microsoft.Testing.Extensions.OpenTelemetry` as a `ProjectReference`.
- Each test project's `Program.cs` registers `AddOpenTelemetryProvider` with `AddTestingPlatformInstrumentation` on both the tracer and meter builders.
- **No exporter is wired.** The SDK still creates real `Activity`/`Counter` instances because the sources/meters now have listeners, so data flows through the full `OpenTelemetryResultHandler` pipeline and is then dropped at the export stage. That's sufficient to exercise the handler (which has been actively optimised recently, e.g. #8938) without polluting CI logs. We can wire an actual exporter later if we want to publish the data anywhere.
- `VSTestBridge.UnitTests` gates OTel registration on `!NATIVE_AOT` to match the existing AOT-aware `Program.cs` pattern there (the OTel SDK uses reflection).

## Verification
- Built all 10 affected test projects locally (Debug).
- Smoke-ran `Microsoft.Testing.Extensions.UnitTests` end-to-end with both extensions registered: 431 tests pass and a ~230 KB JUnit XML report is emitted (`<testsuites name="Microsoft.Testing.Extensions.UnitTests" tests="431" failures="0" ...>`).