### PR TITLE
Strengthen guidance against legacy type/bug, type/feature, type/task labels

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -128,13 +128,13 @@ When creating new issues — or triaging existing ones — through **any** surfa
 - Use the `Bug` issue type for an unexpected problem or regression.
 - Use the `Feature` issue type for a new capability or enhancement.
 - Use the `Task` issue type for a piece of work that is neither a bug nor a feature (refactor, follow-up, chore, RFC follow-up, …).
-- `type/bug`, `type/feature`, and `type/task` labels are **deprecated and forbidden**. They duplicate the Issue Type field, make triage queries inconsistent, and are now auto-stripped by the LabelManagement policy (`.github/policies/LabelManagement.IssueUpdated.yml`). Do not re-add them — set the Issue Type field instead.
+- `type/bug`, `type/feature`, and `type/task` labels are **deprecated and forbidden**. They duplicate the Issue Type field and make triage queries inconsistent. Do not add them — set the Issue Type field instead.
 - Other `type/*` labels (`type/automation`, `type/tech-debt`, `type/test-gap`, `type/regression`, `type/breaking-change`, `type/rfc`, `type/pr-fix`, `type/qa`, `type/ai-inspected`, `type/announcement`, `type/discussion`, `type/flaky-test`, `type/partner-request`, `type/question`) are **not** covered by native issue types and MUST continue to be used as labels.
 
 How to set the Issue Type from each surface:
 
 - **Issue templates** (`.github/ISSUE_TEMPLATE/*.md`): set `type:` in the frontmatter (already done for `bug-report.md` and `feature-request.md`). New templates that map to a native type MUST include the matching `type:` field and MUST NOT list `type/bug` / `type/feature` / `type/task` under `labels:`.
-- **GitHub web UI**: pick the type from the "Type" picker in the right sidebar of the issue editor. Do not add `type/bug`, `type/feature`, or `type/task` from the labels dropdown — the policy bot will strip them.
+- **GitHub web UI**: pick the type from the "Type" picker in the right sidebar of the issue editor. Do not add `type/bug`, `type/feature`, or `type/task` from the labels dropdown.
 - **`gh` CLI / scripts** (current `gh` releases do not yet expose `--type` on `gh issue create`): create the issue, then set the type via GraphQL, e.g.:
 
   ```bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,18 +123,18 @@ Agentic workflows live in `.github/workflows/*.md` and `*.agent.md` and are comp
 
 ## GitHub issue creation guidelines
 
-When creating new issues (manually, via `gh issue create`, via the GitHub API, or from an agentic workflow), the issue category MUST be expressed through the repository's native **GitHub Issue Type** field — not through a `type/bug` / `type/feature` label.
+When creating new issues — or triaging existing ones — through **any** surface (manual edits in the GitHub UI, `gh issue create` / `gh issue edit`, the REST or GraphQL API, an agentic workflow, a webhook bot, or a label-sync rule) the issue category MUST be expressed through the repository's native **GitHub Issue Type** field. The legacy `type/bug`, `type/feature`, and `type/task` **labels** are banned and MUST NOT be added by anyone (humans, Copilot, bots, or automation).
 
-- Use `Bug` for an unexpected problem or regression.
-- Use `Feature` for a new capability or enhancement.
-- Use `Task` for a piece of work that is neither a bug nor a feature (refactor, follow-up, chore, RFC follow-up, …).
-- `type/bug` and `type/feature` labels are **deprecated** and MUST NOT be added — they duplicate the Issue Type field and make triage queries inconsistent.
+- Use the `Bug` issue type for an unexpected problem or regression.
+- Use the `Feature` issue type for a new capability or enhancement.
+- Use the `Task` issue type for a piece of work that is neither a bug nor a feature (refactor, follow-up, chore, RFC follow-up, …).
+- `type/bug`, `type/feature`, and `type/task` labels are **deprecated and forbidden**. They duplicate the Issue Type field, make triage queries inconsistent, and are now auto-stripped by the LabelManagement policy (`.github/policies/LabelManagement.IssueUpdated.yml`). Do not re-add them — set the Issue Type field instead.
 - Other `type/*` labels (`type/automation`, `type/tech-debt`, `type/test-gap`, `type/regression`, `type/breaking-change`, `type/rfc`, `type/pr-fix`, `type/qa`, `type/ai-inspected`, `type/announcement`, `type/discussion`, `type/flaky-test`, `type/partner-request`, `type/question`) are **not** covered by native issue types and MUST continue to be used as labels.
 
 How to set the Issue Type from each surface:
 
-- **Issue templates** (`.github/ISSUE_TEMPLATE/*.md`): set `type:` in the frontmatter (already done for `bug-report.md` and `feature-request.md`). New templates that map to a native type MUST include the matching `type:` field.
-- **GitHub web UI**: pick the type from the "Type" picker in the right sidebar of the issue editor. Do not add `type/bug` or `type/feature` from the labels dropdown.
+- **Issue templates** (`.github/ISSUE_TEMPLATE/*.md`): set `type:` in the frontmatter (already done for `bug-report.md` and `feature-request.md`). New templates that map to a native type MUST include the matching `type:` field and MUST NOT list `type/bug` / `type/feature` / `type/task` under `labels:`.
+- **GitHub web UI**: pick the type from the "Type" picker in the right sidebar of the issue editor. Do not add `type/bug`, `type/feature`, or `type/task` from the labels dropdown — the policy bot will strip them.
 - **`gh` CLI / scripts** (current `gh` releases do not yet expose `--type` on `gh issue create`): create the issue, then set the type via GraphQL, e.g.:
 
   ```bash
@@ -142,7 +142,7 @@ How to set the Issue Type from each surface:
   ```
 
   The available `issueTypeId` values can be listed once with `gh api graphql -f query='query{ repository(owner:"microsoft",name:"testfx"){ issueTypes(first:20){ nodes{ id name } } } }'`.
-- **Agentic workflows (`gh aw`)**: in `safe-outputs.create-issue`, set the issue type using the agent's prompt or `allowed-fields` settings; never list `type/bug` / `type/feature` under `labels`.
+- **Agentic workflows (`gh aw`)**: in `safe-outputs.create-issue`, set the issue type using the agent's prompt or `allowed-fields` settings; never list `type/bug`, `type/feature`, or `type/task` under `labels`.
 
 ## Pull Request guidelines
 

--- a/.github/policies/LabelManagement.IssueUpdated.yml
+++ b/.github/policies/LabelManagement.IssueUpdated.yml
@@ -130,39 +130,6 @@ configuration:
               author: True
           - addLabel:
               label: "needs/author-feedback"
-      - description: >-
-          Strip the legacy "type/bug" label when added — issue category MUST be expressed via the
-          native GitHub Issue Type field (`Bug`). See `.github/copilot-instructions.md` (#github-issue-creation-guidelines).
-        if:
-          - payloadType: Issues
-          - labelAdded:
-              label: "type/bug"
-        then:
-          - removeLabel:
-              label: "type/bug"
-        triggerOnOwnActions: False
-      - description: >-
-          Strip the legacy "type/feature" label when added — issue category MUST be expressed via the
-          native GitHub Issue Type field (`Feature`). See `.github/copilot-instructions.md` (#github-issue-creation-guidelines).
-        if:
-          - payloadType: Issues
-          - labelAdded:
-              label: "type/feature"
-        then:
-          - removeLabel:
-              label: "type/feature"
-        triggerOnOwnActions: False
-      - description: >-
-          Strip the legacy "type/task" label when added — issue category MUST be expressed via the
-          native GitHub Issue Type field (`Task`). See `.github/copilot-instructions.md` (#github-issue-creation-guidelines).
-        if:
-          - payloadType: Issues
-          - labelAdded:
-              label: "type/task"
-        then:
-          - removeLabel:
-              label: "type/task"
-        triggerOnOwnActions: False
       - description: Sync labels from issues on all pull request events
         if:
           - payloadType: Pull_Request

--- a/.github/policies/LabelManagement.IssueUpdated.yml
+++ b/.github/policies/LabelManagement.IssueUpdated.yml
@@ -130,6 +130,39 @@ configuration:
               author: True
           - addLabel:
               label: "needs/author-feedback"
+      - description: >-
+          Strip the legacy "type/bug" label when added — issue category MUST be expressed via the
+          native GitHub Issue Type field (`Bug`). See `.github/copilot-instructions.md` (#github-issue-creation-guidelines).
+        if:
+          - payloadType: Issues
+          - labelAdded:
+              label: "type/bug"
+        then:
+          - removeLabel:
+              label: "type/bug"
+        triggerOnOwnActions: False
+      - description: >-
+          Strip the legacy "type/feature" label when added — issue category MUST be expressed via the
+          native GitHub Issue Type field (`Feature`). See `.github/copilot-instructions.md` (#github-issue-creation-guidelines).
+        if:
+          - payloadType: Issues
+          - labelAdded:
+              label: "type/feature"
+        then:
+          - removeLabel:
+              label: "type/feature"
+        triggerOnOwnActions: False
+      - description: >-
+          Strip the legacy "type/task" label when added — issue category MUST be expressed via the
+          native GitHub Issue Type field (`Task`). See `.github/copilot-instructions.md` (#github-issue-creation-guidelines).
+        if:
+          - payloadType: Issues
+          - labelAdded:
+              label: "type/task"
+        then:
+          - removeLabel:
+              label: "type/task"
+        triggerOnOwnActions: False
       - description: Sync labels from issues on all pull request events
         if:
           - payloadType: Pull_Request


### PR DESCRIPTION
## Why

Issues should categorize via the native **GitHub Issue Type** field (`Bug` / `Feature` / `Task`), not via the deprecated `type/bug` / `type/feature` / `type/task` labels. The labels duplicate the Issue Type field and pollute triage queries.

Even with the guidance already in `copilot-instructions.md`, the labels keep getting added by hand (most recently on #8963, which already had the native `Bug` type set).

After investigation, the only remaining source of these labels is manual habit: the issue templates were already fixed to use the native `type:` field in #8763, and no bots or agentic workflows add them. So this PR keeps the fix scoped to documentation + a one-time cleanup, instead of adding noisy add-then-remove policy rules.

## What

- **`.github/copilot-instructions.md`**: strengthen the guidance — explicitly cover `type/task`, name every surface that must not add these labels (UI, `gh`, GraphQL, agentic workflows, label-sync), and tighten the wording so habit-based adds get caught at review time.
- **One-time cleanup**: removed `type/feature` from the five remaining stragglers (#8793, #8825, #8826, #8827, #8828) and set their native `Feature` issue type. Also removed the redundant `type/bug` from #8963.

Per JanKrivanek's review, the original LabelManagement policy rules were dropped in favor of this lighter approach.
