### PR TITLE
[code-simplifier] Remove unnecessary `global::` qualifier on `ReportFileNameValidator` references

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs
@@ -28,7 +28,7 @@ internal sealed class HtmlReportGeneratorCommandLine : CommandLineOptionsProvide
 
     public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
         => commandOption.Name == HtmlReportFileNameOptionName
-            ? global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
+            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
                 arguments,
                 ".html",
                 ExtensionResources.HtmlReportFileNameMustNotBeEmpty,
@@ -37,7 +37,7 @@ internal sealed class HtmlReportGeneratorCommandLine : CommandLineOptionsProvide
             : ValidationResult.ValidTask;
 
     public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
+        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
             commandLineOptions,
             HtmlReportOptionName,
             HtmlReportFileNameOptionName,

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs
@@ -28,7 +28,7 @@ internal sealed class JUnitReportGeneratorCommandLine : CommandLineOptionsProvid
 
     public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
         => commandOption.Name == JUnitReportFileNameOptionName
-            ? global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
+            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
                 arguments,
                 ".xml",
                 ExtensionResources.JUnitReportFileNameMustNotBeEmpty,
@@ -37,7 +37,7 @@ internal sealed class JUnitReportGeneratorCommandLine : CommandLineOptionsProvid
             : ValidationResult.ValidTask;
 
     public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
+        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
             commandLineOptions,
             JUnitReportOptionName,
             JUnitReportFileNameOptionName,

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCommandLine.cs
@@ -28,7 +28,7 @@ internal sealed class TrxReportGeneratorCommandLine : CommandLineOptionsProvider
 
     public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
         => commandOption.Name == TrxReportFileNameOptionName
-            ? global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
+            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
                 arguments,
                 ".trx",
                 ExtensionResources.TrxReportFileNameMustNotBeEmpty,
@@ -37,7 +37,7 @@ internal sealed class TrxReportGeneratorCommandLine : CommandLineOptionsProvider
             : ValidationResult.ValidTask;
 
     public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
+        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
             commandLineOptions,
             TrxReportOptionName,
             TrxReportFileNameOptionName,


### PR DESCRIPTION
## Code Simplification - 2026-06-09

This PR removes the unnecessary `global::Microsoft.Testing.Extensions.` prefix from `ReportFileNameValidator` calls in the three report command-line option providers (JUnit, HTML, TRX).

### Files Simplified

- `src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs` — remove `global::Microsoft.Testing.Extensions.` prefix (4 occurrences across 2 methods)
- `src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs` — same, for HTML report
- `src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCommandLine.cs` — same, for TRX report

### Improvements Made

**Removed unnecessary `global::` qualifier**

Before (in each of the three files):
```csharp
public override Task<ValidationResult> ValidateOptionArgumentsAsync(...)
    => commandOption.Name == JUnitReportFileNameOptionName
        ? global::Microsoft.Testing.Extensions.ReportFileNameValidator.ValidateReportFileNameArgumentAsync(...)
        : ValidationResult.ValidTask;
```

After:
```csharp
public override Task<ValidationResult> ValidateOptionArgumentsAsync(...)
    => commandOption.Name == JUnitReportFileNameOptionName
        ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(...)
        : ValidationResult.ValidTask;
```

`ReportFileNameValidator` lives in the **parent namespace** `Microsoft.Testing.Extensions`. C#'s namespace lookup rules resolve types from parent namespaces without any qualifier or `using` directive. The same pattern already works throughout the codebase — for example, `JUnitReportEngine.cs` (in `namespace Microsoft.Testing.Extensions.JUnitReport;`) freely uses `ReportFileNameSanitizer`, `ReportFileNameHelper`, and `TargetFrameworkMonikerHelper` (all in the parent `Microsoft.Testing.Extensions` namespace) without any qualifier or `using` directive.

The `global::` was introduced when the shared `ReportFileNameValidator` helper was extracted and started being used in `JUnitReportGeneratorCommandLine.cs` (PR #8949) and its HTML and TRX counterparts. It is safe to remove.

### Changes Based On

Recent changes from:
- #8949 — JUnit report command-line refactoring (introduced the pattern to the JUnit provider)

### Testing

- ✅ No functional changes — all three files delegate to the same `ReportFileNameValidator` methods as before
- ✅ Verified by analogy: `JUnitReportEngine.cs` already uses other types from the same parent namespace (`ReportFileNameSanitizer`, `ReportFileNameHelper`, `TargetFrameworkMonikerHelper`) without any qualifier

### Review Focus

Please verify:
- Namespace resolution is correct (parent namespace lookup from `Microsoft.Testing.Extensions.JUnitReport`, `.HtmlReport`, and `.TrxReport.Abstractions` to `Microsoft.Testing.Extensions`)
- No unintended side effects from removing the `global::` prefix

---

*Automated by Code Simplifier Agent*


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27211265519/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-10T14:15:08.595Z --> on Jun 10, 2026, 2:15 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27211265519, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27211265519 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->