### PR TITLE
[perf-improver] perf: cache ANSI cursor-positioning strings in AnsiTerminalTestProgressFrame hot path

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -10,6 +10,26 @@ internal sealed class AnsiTerminalTestProgressFrame
 {
     private const int MaxColumn = 250;
 
+    // Pre-computed ANSI escape sequences for the duration-only update hot path.
+    // Re-computing them via AnsiCodes methods on every render tick allocates a new string each time.
+    private static readonly string SetCursorHorizontalMaxColumn = AnsiCodes.SetCursorHorizontal(MaxColumn);
+    private static readonly string[] MoveCursorBackwardCache = CreateMoveCursorBackwardCache();
+
+    private static string[] CreateMoveCursorBackwardCache()
+    {
+        // Duration strings are at most ~15 chars ("1d 23h 59m 59s" with parens).
+        // A cache of 16 slots (indices 0-15) covers every realistic case with zero allocation.
+        const int maxLength = 16;
+        string[] cache = new string[maxLength];
+        cache[0] = string.Empty;
+        for (int i = 1; i < maxLength; i++)
+        {
+            cache[i] = AnsiCodes.MoveCursorBackward(i);
+        }
+
+        return cache;
+    }
+
     public int Width { get; private set; }
 
     public int Height { get; private set; }
@@ -245,10 +265,13 @@ internal sealed class AnsiTerminalTestProgressFrame
 
                         if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
                         {
-                            // Duration is the same length rewrite just it.
-                            terminal.SetCursorHorizontal(MaxColumn);
-                            terminal.Append($"{AnsiCodes.SetCursorHorizontal(MaxColumn)}{AnsiCodes.MoveCursorBackward(durationString.Length)}{durationString}");
-                            currentLine.RenderedDurationLength = durationString.Length;
+                            // Duration is the same length: rewrite just the duration cell.
+                            // Use pre-computed escape sequences to avoid per-tick string allocations.
+                            int durLen = durationString.Length;
+                            terminal.Append(SetCursorHorizontalMaxColumn);
+                            terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
+                            terminal.Append(durationString);
+                            currentLine.RenderedDurationLength = durLen;
                         }
                         else
                         {
@@ -280,10 +303,13 @@ internal sealed class AnsiTerminalTestProgressFrame
 
                         if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
                         {
-                            // Duration is the same length rewrite just it.
-                            terminal.SetCursorHorizontal(MaxColumn);
-                            terminal.Append($"{AnsiCodes.SetCursorHorizontal(MaxColumn)}{AnsiCodes.MoveCursorBackward(durationString.Length)}{durationString}");
-                            currentLine.RenderedDurationLength = durationString.Length;
+                            // Duration is the same length: rewrite just the duration cell.
+                            // Use pre-computed escape sequences to avoid per-tick string allocations.
+                            int durLen = durationString.Length;
+                            terminal.Append(SetCursorHorizontalMaxColumn);
+                            terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
+                            terminal.Append(durationString);
+                            currentLine.RenderedDurationLength = durLen;
                         }
                         else
                         {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -17,12 +17,12 @@ internal sealed class AnsiTerminalTestProgressFrame
 
     private static string[] CreateMoveCursorBackwardCache()
     {
-        // Duration strings are at most ~15 chars ("1d 23h 59m 59s" with parens).
-        // A cache of 16 slots (indices 0-15) covers every realistic case with zero allocation.
-        const int maxLength = 16;
-        string[] cache = new string[maxLength];
+        // Duration strings are at most 16 chars ("(1d 23h 59m 59s)" with parens).
+        // A cache of 17 slots (indices 0-16) covers every realistic case with zero allocation.
+        const int cacheSize = 17;
+        string[] cache = new string[cacheSize];
         cache[0] = string.Empty;
-        for (int i = 1; i < maxLength; i++)
+        for (int i = 1; i < cacheSize; i++)
         {
             cache[i] = AnsiCodes.MoveCursorBackward(i);
         }


### PR DESCRIPTION
🤖 *This is an automated contribution from [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27212472807).*

## Goal and Rationale

In the **duration-only update** branch of `AnsiTerminalTestProgressFrame.Render()` — the fast path taken on every render tick when only the elapsed-time cell changes — the current code performs four string allocations per progress item per tick:

1. `terminal.SetCursorHorizontal(MaxColumn)` → `AnsiCodes.SetCursorHorizontal(MaxColumn)` → `$"\x1b[{250}G"` (allocates `"\x1b[250G"`)
2. Inside the string interpolation, **same call again**: `AnsiCodes.SetCursorHorizontal(MaxColumn)` → `"\x1b[250G"` (duplicate allocation **and** duplicate cursor-positioning escape on the wire)
3. `AnsiCodes.MoveCursorBackward(durationString.Length)` → `$"\x1b[{N}D"` (allocates `"\x1b[ND"`)
4. The composite interpolated string itself: `$"\x1b[250G\x1b[ND<duration>"`

Both `"\x1b[250G"` allocations are wasteful because `MaxColumn = 250` is a **compile-time constant** — the result is always the same string. The `MoveCursorBackward(N)` result also repeats for the same `N` across consecutive ticks (while the duration length is stable).

The redundant standalone `terminal.SetCursorHorizontal(MaxColumn)` call was also writing `\x1b[250G` to the output buffer *twice* per item per tick.

## Approach

Add two static readonly fields to `AnsiTerminalTestProgressFrame`:

```csharp
private static readonly string SetCursorHorizontalMaxColumn =
    AnsiCodes.SetCursorHorizontal(MaxColumn);        // "\x1b[250G"

private static readonly string[] MoveCursorBackwardCache =
    CreateMoveCursorBackwardCache();                  // ["\x1b[1D".."\x1b[15D"]
```

Replace each of the two hot-path occurrences (one for `TestProgressState` items, one for `TestDetailState` items) with three zero-allocation `terminal.Append()` calls:

```csharp
// Before
terminal.SetCursorHorizontal(MaxColumn);
terminal.Append($"{AnsiCodes.SetCursorHorizontal(MaxColumn)}{AnsiCodes.MoveCursorBackward(durationString.Length)}{durationString}");

// After
int durLen = durationString.Length;
terminal.Append(SetCursorHorizontalMaxColumn);
terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
terminal.Append(durationString);
```

The MoveCursorBackward cache covers lengths 0–15. Duration strings are `"(Xs)"` to `"(1h 23m 45s)"` (4–12 chars typically), so the fallback `AnsiCodes.MoveCursorBackward(durLen)` is essentially unreachable in practice.

## Performance Evidence

| Metric | Before | After |
|---|---|---|
| Allocations per item per tick (unchanged-duration path) | **4** (`\x1b[250G` × 2, `\x1b[ND`, composite) | **0** (all cached) |
| Cursor-positioning escape writes per item per tick | **2** (duplicate) | **1** |

For a 5-minute run with N=4 assemblies at ~5 fps (all items in the stable-duration path):
- **~24 000 allocations eliminated** (4 allocs × 2 items/assembly × 4 assemblies × 300 s × 5 fps)

**Methodology**: code inspection + allocation analysis. The hot path runs ~5 fps × (number of active progress rows) regardless of test count.

## Trade-offs

- Adds 16 strings × ~7 bytes each ≈ 112 bytes of static memory for the backward-cursor cache (negligible).
- `SetCursorHorizontalMaxColumn` is one string of 6 bytes (also negligible).
- The fallback path (`AnsiCodes.MoveCursorBackward`) is preserved for lengths ≥ 16, which do not occur in practice.

## Test Status

- `Microsoft.Testing.Platform.UnitTests` (net8.0): **1106 passed, 0 failed, 3 skipped** ✅
- Build (all TFMs): **0 warnings, 0 errors** ✅

## Reproducibility

```bash
./build.sh -build -c Debug
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
```

> Generated by [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27212472807)




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27212472807/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27212472807, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27212472807 -->

<!-- gh-aw-workflow-id: perf-improver -->