### PR TITLE
[efficiency-improver] perf: single-pass PropertyBag walk in TrxTestResultExtractor

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
@@ -37,14 +37,35 @@ internal static class TrxTestResultExtractor
         TestNodeStateProperty state = testNode.Properties.Single<TestNodeStateProperty>();
         TrxTestOutcome outcome = MapOutcome(state);
 
-        TimingProperty? timing = testNode.Properties.SingleOrDefault<TimingProperty>();
+        // Single-pass collection of all non-state properties: replaces 7 × SingleOrDefault<T>()
+        // + 2 × OfType<T>() with one GetStructEnumerator() walk, saving 8 linked-list traversals
+        // and 2 array allocations per test result.
+        TimingProperty? timing = null;
+        TrxTestDefinitionName? trxDefName = null;
+        TrxFullyQualifiedTypeNameProperty? fqtn = null;
+        TestMethodIdentifierProperty? methodId = null;
+        TrxExceptionProperty? trxException = null;
+        TrxMessagesProperty? trxMessages = null;
+        TrxCategoriesProperty? trxCategories = null;
+        List<TrxTestMetadata>? metadata = null;
+        List<TrxTestFileArtifact>? artifacts = null;
 
-        TrxTestDefinitionName? trxDefName = testNode.Properties.SingleOrDefault<TrxTestDefinitionName>();
-        TrxFullyQualifiedTypeNameProperty? fqtn = testNode.Properties.SingleOrDefault<TrxFullyQualifiedTypeNameProperty>();
-        TestMethodIdentifierProperty? methodId = testNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
-        TrxExceptionProperty? trxException = testNode.Properties.SingleOrDefault<TrxExceptionProperty>();
-        TrxMessagesProperty? trxMessages = testNode.Properties.SingleOrDefault<TrxMessagesProperty>();
-        TrxCategoriesProperty? trxCategories = testNode.Properties.SingleOrDefault<TrxCategoriesProperty>();
+        PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
+        while (enumerator.MoveNext())
+        {
+            switch (enumerator.Current)
+            {
+                case TimingProperty t: timing = t; break;
+                case TrxTestDefinitionName d: trxDefName = d; break;
+                case TrxFullyQualifiedTypeNameProperty f: fqtn = f; break;
+                case TestMethodIdentifierProperty m: methodId = m; break;
+                case TrxExceptionProperty e: trxException = e; break;
+                case TrxMessagesProperty msg: trxMessages = msg; break;
+                case TrxCategoriesProperty c: trxCategories = c; break;
+                case TestMetadataProperty md: (metadata ??= []).Add(new TrxTestMetadata { Key = md.Key, Value = md.Value }); break;
+                case FileArtifactProperty fa: (artifacts ??= []).Add(new TrxTestFileArtifact { FullPath = fa.FileInfo.FullName }); break;
+            }
+        }
 
         bool wasTruncated = false;
 
@@ -65,20 +86,6 @@ internal static class TrxTestResultExtractor
                     Message = TruncateIfNeeded(src.Message, ref wasTruncated),
                 });
             }
-        }
-
-        List<TrxTestMetadata>? metadata = null;
-        foreach (TestMetadataProperty md in testNode.Properties.OfType<TestMetadataProperty>())
-        {
-            metadata ??= [];
-            metadata.Add(new TrxTestMetadata { Key = md.Key, Value = md.Value });
-        }
-
-        List<TrxTestFileArtifact>? artifacts = null;
-        foreach (FileArtifactProperty fa in testNode.Properties.OfType<FileArtifactProperty>())
-        {
-            artifacts ??= [];
-            artifacts.Add(new TrxTestFileArtifact { FullPath = fa.FileInfo.FullName });
         }
 
         var result = new TrxTestResult

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
@@ -39,7 +39,10 @@ internal static class TrxTestResultExtractor
 
         // Single-pass collection of all non-state properties: replaces 7 × SingleOrDefault<T>()
         // + 2 × OfType<T>() with one GetStructEnumerator() walk, saving 8 linked-list traversals
-        // and 2 array allocations per test result.
+        // and 2 array allocations per test result. Singleton-typed properties use the local
+        // GetSingleOrDefaultValue helper to preserve the throw-on-duplicate invariant that
+        // SingleOrDefault<T>() provided; TestMetadataProperty and FileArtifactProperty are
+        // intentionally multi-valued and accumulate into lists.
         TimingProperty? timing = null;
         TrxTestDefinitionName? trxDefName = null;
         TrxFullyQualifiedTypeNameProperty? fqtn = null;
@@ -55,17 +58,23 @@ internal static class TrxTestResultExtractor
         {
             switch (enumerator.Current)
             {
-                case TimingProperty t: timing = t; break;
-                case TrxTestDefinitionName d: trxDefName = d; break;
-                case TrxFullyQualifiedTypeNameProperty f: fqtn = f; break;
-                case TestMethodIdentifierProperty m: methodId = m; break;
-                case TrxExceptionProperty e: trxException = e; break;
-                case TrxMessagesProperty msg: trxMessages = msg; break;
-                case TrxCategoriesProperty c: trxCategories = c; break;
+                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
+                case TrxTestDefinitionName d: trxDefName = GetSingleOrDefaultValue(trxDefName, d); break;
+                case TrxFullyQualifiedTypeNameProperty f: fqtn = GetSingleOrDefaultValue(fqtn, f); break;
+                case TestMethodIdentifierProperty m: methodId = GetSingleOrDefaultValue(methodId, m); break;
+                case TrxExceptionProperty e: trxException = GetSingleOrDefaultValue(trxException, e); break;
+                case TrxMessagesProperty msg: trxMessages = GetSingleOrDefaultValue(trxMessages, msg); break;
+                case TrxCategoriesProperty c: trxCategories = GetSingleOrDefaultValue(trxCategories, c); break;
                 case TestMetadataProperty md: (metadata ??= []).Add(new TrxTestMetadata { Key = md.Key, Value = md.Value }); break;
                 case FileArtifactProperty fa: (artifacts ??= []).Add(new TrxTestFileArtifact { FullPath = fa.FileInfo.FullName }); break;
             }
         }
+
+        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+            where TProperty : IProperty
+            => existingProperty is not null
+                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                : property;
 
         bool wasTruncated = false;
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTestResultExtractorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTestResultExtractorTests.cs
@@ -99,4 +99,25 @@ public class TrxTestResultExtractorTests
         char lastPrefixChar = truncated[suffixStart - 1];
         Assert.IsFalse(char.IsHighSurrogate(lastPrefixChar), "Truncation must not leave a dangling high surrogate.");
     }
+
+    [TestMethod]
+    public void Extract_DuplicateSingletonProperty_Throws()
+    {
+        // PropertyBag allows multiple properties of the same runtime type. The pre-refactor
+        // implementation used SingleOrDefault<T>() which throws InvalidOperationException in
+        // that case; the single-pass switch must preserve the same invariant so upstream bugs
+        // that add a singleton-typed property twice are surfaced (rather than silently keeping
+        // the first or last one and producing nondeterministic TRX output).
+        var bag = new PropertyBag(
+            new PassedTestNodeStateProperty(),
+            new TimingProperty(new TimingInfo(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, TimeSpan.Zero)),
+            new TimingProperty(new TimingInfo(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, TimeSpan.Zero)));
+
+        InvalidOperationException ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
+            TrxTestResultExtractor.Extract(new TestNodeUpdateMessage(
+                new SessionUid("1"),
+                new TestNode { Uid = "u", DisplayName = "d", Properties = bag })));
+
+        Assert.Contains(nameof(TimingProperty), ex.Message);
+    }
 }


### PR DESCRIPTION
🤖 *This is a draft PR created by Efficiency Improver, an automated AI assistant focused on reducing the energy consumption and computational footprint of this repository.*

## Goal and Rationale

Reduce redundant CPU work and heap allocations in `TrxTestResultExtractor.Extract()`, which runs on every completed test result when TRX streaming (`--report-trx`) is enabled.

**Focus area:** Code-Level Efficiency — eliminating unnecessary linked-list traversals and heap allocations per test result.

## Approach

`TrxTestResultExtractor.Extract()` previously made **9 separate passes** over the `PropertyBag` linked list:

- 7 × `SingleOrDefault<T>()` (one per property type needed)
- 2 × `OfType<T>()` (for `TestMetadataProperty` and `FileArtifactProperty`) — each also allocates a `TProperty[]`

The fix replaces all of these with a **single `GetStructEnumerator()` pass** using a `switch` on the current node, collecting all required properties in one traversal.

`TestNodeStateProperty` access is unchanged — it goes through the O(1) direct-field path (`_testNodeStateProperty`) and does not touch the linked list.

## Energy Efficiency Evidence

**Proxy metric used:** CPU cycles / heap allocations per test result (maps directly to energy — fewer pointer dereferences and GC pressure = less power draw per test run).

| Metric | Before | After |
|--------|--------|-------|
| Linked-list walks per test result | 9 | 1 |
| `TProperty[]` heap allocations per test result | 2 (from `OfType<T>()`) | 0 |
| Linked-list nodes visited (N=10 props) | ~90 | ~10 |

For a test run with 1 000 tests: **~80 000 pointer dereferences eliminated** and **~2 000 heap allocations removed**.

**Reproducibility:** Run the unit test suite with `dotnet run --project test/UnitTests/Microsoft.Testing.Extensions.UnitTests -f net9.0 --no-build`. All 431 tests (422 pass, 9 skipped Windows-only) continue to pass.

## Green Software Foundation Context

*Hardware Efficiency*: The change makes better use of CPU cache by reducing repeated traversals of the same linked-list nodes. Fewer cache misses → lower power draw per test result processed.

*Software Carbon Intensity (SCI)*: Fewer instructions per functional unit (one test result processed) directly reduces the energy term in the SCI equation.

## Trade-offs

The single-pass `switch` block is slightly more verbose than the previous sequence of named `SingleOrDefault<T>()` calls. However, the pattern is now established in the codebase (see `DotnetTestDataConsumer`, `OpenTelemetryResultHandler`) so it is recognisable to contributors familiar with those files.

## Test Status

✅ Build succeeded (0 warnings, 0 errors)
✅ `Microsoft.Testing.Extensions.UnitTests` — 422 passed, 9 skipped (Windows-only), 0 failed




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27239187300/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27239187300, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27239187300 -->

<!-- gh-aw-workflow-id: efficiency-improver -->