### PR TITLE
[test-improver] test: add edge case tests for UseDeploymentItemWithTestMethodOrTestClass (MSTEST0035)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests.cs
@@ -154,4 +154,61 @@ public sealed class UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenStaticClassHasDeploymentItem_Diagnostic()
+    {
+        // Unlike abstract classes (which are skipped because [DeploymentItem] is inherited by subclasses),
+        // static classes are NOT skipped. A static class with [DeploymentItem] but no [TestClass] is flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [DeploymentItem("")]
+            public static class [|MyStaticHelper|]
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenDataTestMethodHasDeploymentItem_NoDiagnostic()
+    {
+        // [DataTestMethod] inherits from [TestMethod], so the Inherits() check passes
+        // and [DeploymentItem] on a [DataTestMethod] method should not be flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DataTestMethod]
+                [DeploymentItem("")]
+                public void MyDataTest()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestClassHasMultipleDeploymentItems_OneDiagnostic()
+    {
+        // Multiple [DeploymentItem] attributes on a non-test class produce exactly one
+        // diagnostic for the class (the analyzer uses a boolean flag, not a per-attribute count).
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [DeploymentItem("file1.txt")]
+            [DeploymentItem("file2.txt")]
+            public class [|MyClass|]
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`UseDeploymentItemWithTestMethodOrTestClassAnalyzer` (MSTEST0035) had 8 tests covering the basic paths, but three real-world behaviors were undocumented by tests:

1. **Static class with `[DeploymentItem]`** — A developer familiar with the abstract-class exemption might assume static classes are also exempt. They are not: static classes have `IsStatic=true` but `IsAbstract=false` in Roslyn, so the early-return guard does not apply. The test makes this distinction explicit.

2. **`[DataTestMethod]` + `[DeploymentItem]`** — `DataTestMethodAttribute` inherits from `TestMethodAttribute`. The analyzer checks test-method presence via `Inherits()`, so `[DataTestMethod]` should suppress the diagnostic. No test confirmed this inheritance path for the test-method branch.

3. **Multiple `[DeploymentItem]` on a non-test class → exactly one diagnostic** — The analyzer uses a boolean flag (`hasDeploymentItemAttribute = true`) rather than counting attributes, so the report fires once per symbol regardless of how many `[DeploymentItem]` attrs are present. The test documents and pins this per-symbol (not per-attribute) diagnostic behavior.

## Approach

Added 3 new `[TestMethod]` test cases to `UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests`, following the existing `VerifyCS.VerifyAnalyzerAsync` pattern. No production code changes.

## Test Status

```
Test run summary: Passed!
  total: 11
  failed: 0
  succeeded: 11
  skipped: 0
  duration: 5s 690ms
```

✅ All 11 tests pass (`MSTest.Analyzers.UnitTests`, net8.0, Debug — 8 original + 3 new).

## Reproducibility

```bash
./build.sh --restore   # first run only
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "ClassName=MSTest.Analyzers.Test.UseDeploymentItemWithTestMethodOrTestClassAnalyzerTests"
```

## Trade-offs

- Tests only exercise existing code paths — no production changes, no maintenance burden beyond the tests themselves.
- The static-class test explicitly documents the asymmetry between abstract and static class handling, guarding against future refactors that might accidentally unify them.


> Generated by [Test Improver](https://github.com/microsoft/testfx/actions/runs/27242146130) · [◷](https://github.com/search?q=repo:microsoft%2Ftestfx+%22gh-aw-workflow-id:+test-improver%22&type=pullrequests)




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27242146130/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27242146130, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27242146130 -->

<!-- gh-aw-workflow-id: test-improver -->