### PR TITLE
Fix HtmlReport `Truncate` to not split surrogate pairs at cut boundary

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -124,8 +124,20 @@ internal static class TestResultCapture
     }
 
     internal static string? Truncate(string? value, int maxLength)
-        => value is null || value.Length <= maxLength
-            ? value
-            : value.Substring(0, maxLength)
-                + $"\n…[truncated, original length: {value.Length.ToString(CultureInfo.InvariantCulture)}]";
+    {
+        if (value is null || value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        // Don't split a surrogate pair when truncating: drop the high surrogate too.
+        int cut = maxLength;
+        if (cut > 0 && char.IsHighSurrogate(value[cut - 1]))
+        {
+            cut--;
+        }
+
+        return value.Substring(0, cut)
+            + $"\n…[truncated, original length: {value.Length.ToString(CultureInfo.InvariantCulture)}]";
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -131,8 +131,11 @@ internal static class TestResultCapture
         }
 
         // Don't split a surrogate pair when truncating: drop the high surrogate too.
+        // The early return above guarantees cut < value.Length here, but we keep the
+        // explicit guard so the invariant is locally self-documenting and survives
+        // any future refactor that might call this block with cut == value.Length.
         int cut = maxLength;
-        if (cut > 0 && char.IsHighSurrogate(value[cut - 1]))
+        if (cut > 0 && cut < value.Length && char.IsHighSurrogate(value[cut - 1]))
         {
             cut--;
         }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -140,6 +140,28 @@ public class HtmlReportEngineTests
     }
 
     [TestMethod]
+    public void TestResultCapture_DoesNotSplitSurrogatePair_AtTruncationBoundary()
+    {
+        // Build a string whose (maxLength-1)-th char is the high surrogate of a pair.
+        // After truncation the high surrogate must be dropped so the result is valid UTF-16.
+        string prefix = new('a', TestResultCapture.MaxStandardStreamLength - 1);
+        const string surrogatePair = "\uD83D\uDE00"; // 😀 — high surrogate at index maxLength-1
+        string input = prefix + surrogatePair + new string('z', 10);
+
+        var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
+        bag.Add(new StandardOutputProperty(input));
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = bag };
+
+        CapturedTestResult result = TestResultCapture.TryCapture(node)!;
+
+        Assert.IsNotNull(result.StandardOutput);
+        // The truncated prefix must not end with a lone high surrogate.
+        Assert.IsFalse(char.IsHighSurrogate(result.StandardOutput![result.StandardOutput.IndexOf('\n') - 1]),
+            "Truncate must not leave a lone high surrogate at the cut boundary.");
+        Assert.Contains("[truncated, original length:", result.StandardOutput);
+    }
+
+    [TestMethod]
     public void TestResultCapture_Returns_Null_For_NonTerminalStates()
     {
         TestNode discovered = new() { Uid = "a", DisplayName = "x", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) };

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -155,10 +155,24 @@ public class HtmlReportEngineTests
         CapturedTestResult result = TestResultCapture.TryCapture(node)!;
 
         Assert.IsNotNull(result.StandardOutput);
-        // The truncated prefix must not end with a lone high surrogate.
-        Assert.IsFalse(char.IsHighSurrogate(result.StandardOutput![result.StandardOutput.IndexOf('\n') - 1]),
-            "Truncate must not leave a lone high surrogate at the cut boundary.");
+
+        // Verify truncation happened (also establishes that '\n' is present in the output).
         Assert.Contains("[truncated, original length:", result.StandardOutput);
+
+        // Now safely index back from the truncation marker '\n'.
+        int newlineIdx = result.StandardOutput!.IndexOf('\n');
+        Assert.IsGreaterThan(0, newlineIdx, "Newline marker must not be at position 0 or absent.");
+
+        // The truncated prefix must not end with a lone high surrogate.
+        Assert.IsFalse(
+            char.IsHighSurrogate(result.StandardOutput[newlineIdx - 1]),
+            "Truncate must not leave a lone high surrogate at the cut boundary.");
+
+        // Confirm we backed off exactly one char over the high surrogate.
+        Assert.AreEqual(
+            TestResultCapture.MaxStandardStreamLength - 1,
+            newlineIdx,
+            "Prefix should be maxLength-1 chars (backed off over the high surrogate).");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Problem

`HtmlReport/TestResultCapture.Truncate` used a simple `Substring(0, maxLength)` cut, which can produce **invalid UTF-16** when the character at position `maxLength - 1` is the high surrogate of a surrogate pair.

This bug was identified while reviewing the JUnitReport refactoring (`#8950`) — the JUnit copy of `Truncate` already includes the defensive surrogate-pair guard, but the HtmlReport copy was never updated. Tracked in `#8986` ("Backport the safer `Truncate()` to `HtmlReport/TestResultCapture.cs`").

## Fix

Add the same surrogate-pair guard that already exists in `JUnitReport/TestResultCapture.cs`:

```csharp
// Don't split a surrogate pair when truncating: drop the high surrogate too.
int cut = maxLength;
if (cut > 0 && char.IsHighSurrogate(value[cut - 1]))
{
    cut--;
}
```

## Test

Added `TestResultCapture_DoesNotSplitSurrogatePair_AtTruncationBoundary` to `HtmlReportEngineTests.cs`. The test constructs a string where the high surrogate of an emoji (`😀`) sits at index `maxLength - 1` and asserts that the resulting truncated string does not end with a lone high surrogate.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/27259205047/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27259205047, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/27259205047 -->

<!-- gh-aw-workflow-id: adhoc-qa -->