### PR TITLE
Fix Invoke_TestTarget_With_Incompatible_Arch on Linux

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -180,30 +180,40 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             failIfReturnValueIsNotZero: false,
             cancellationToken: TestContext.CancellationToken);
 
-        // On Windows, we run the exe directly.
-        // On other OSes, we run with dotnet exec.
-        // This yields two different outputs, pointing to the same issue.
-        string executableName = OperatingSystem.IsWindows() ? "MSBuild Tests.exe" : "MSBuild Tests";
+        // The build should fail and the failure should mention the incompatible target architecture
+        // so we know the build/launch reached the apphost rather than failing for an unrelated reason.
+        result.AssertExitCodeIsNot(0);
+        result.AssertOutputContains($"[{TargetFrameworks.NetCurrent}|{incompatibleArchitecture}]");
 
-        result.AssertOutputContains($"error MSB6003: The specified task executable \"{executableName}\" could not be run. System.ComponentModel.Win32Exception");
-        result.AssertOutputContains("An error occurred trying to start process");
-
-        if (OperatingSystem.IsWindows())
+        if (OperatingSystem.IsLinux())
         {
-            result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
-        }
-        else if (OperatingSystem.IsMacOS())
-        {
-            result.AssertOutputContains("Bad CPU type in executable");
-        }
-        else if (OperatingSystem.IsLinux())
-        {
-            result.AssertOutputContains("Exec format error");
+            // On Linux, launching a non-native-architecture apphost no longer surfaces as a
+            // Win32Exception from ToolTask, so no MSB6003 is emitted. The failure is instead
+            // reported by InvokeTestingPlatformTask.HandleTaskExecutionErrors as the captured
+            // tool output (often a shell-parse error like "Syntax error: word unexpected").
+            result.AssertOutputContains("error run failed: Tests failed:");
         }
         else
         {
-            // Unexpected OS.
-            throw ApplicationStateGuard.Unreachable();
+            // On Windows we run the exe directly; on macOS we run the apphost.
+            string executableName = OperatingSystem.IsWindows() ? "MSBuild Tests.exe" : "MSBuild Tests";
+
+            result.AssertOutputContains($"error MSB6003: The specified task executable \"{executableName}\" could not be run. System.ComponentModel.Win32Exception");
+            result.AssertOutputContains("An error occurred trying to start process");
+
+            if (OperatingSystem.IsWindows())
+            {
+                result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                result.AssertOutputContains("Bad CPU type in executable");
+            }
+            else
+            {
+                // Unexpected OS.
+                throw ApplicationStateGuard.Unreachable();
+            }
         }
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -187,11 +187,21 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
 
         if (OperatingSystem.IsLinux())
         {
-            // On Linux, launching a non-native-architecture apphost no longer surfaces as a
-            // Win32Exception from ToolTask, so no MSB6003 is emitted. The failure is instead
-            // reported by InvokeTestingPlatformTask.HandleTaskExecutionErrors as the captured
-            // tool output (often a shell-parse error like "Syntax error: word unexpected").
-            result.AssertOutputContains("error run failed: Tests failed:");
+            // On Linux, the apphost launch failure can surface in two different ways depending on
+            // whether the kernel/runtime path rejects the binary up-front or falls back to a shell:
+            //   1) ToolTask catches a Win32Exception ("Exec format error") and emits MSB6003.
+            //   2) The apphost falls back to /bin/sh which then fails to parse the binary, and
+            //      InvokeTestingPlatformTask.HandleTaskExecutionErrors reports the captured tool
+            //      output via "error run failed: Tests failed:" (often a shell-parse error like
+            //      "Syntax error: word unexpected").
+            // Either shape is acceptable — both prove we attempted to launch the incompatible-arch
+            // apphost and failed.
+            bool hasMsb6003 = result.StandardOutput.Contains("error MSB6003:", StringComparison.Ordinal)
+                && result.StandardOutput.Contains("Exec format error", StringComparison.Ordinal);
+            bool hasRunFailed = result.StandardOutput.Contains("error run failed: Tests failed:", StringComparison.Ordinal);
+            Assert.IsTrue(
+                hasMsb6003 || hasRunFailed,
+                $"Expected output to contain either MSB6003+\"Exec format error\" or \"error run failed: Tests failed:\". Actual output: {result.StandardOutput}");
         }
         else
         {


### PR DESCRIPTION
The Linux pipeline on `main` is failing on `Invoke_TestTarget_With_Incompatible_Arch`:

```
Assertion failed. Expected string to contain the specified substring.
Expression 'AssertOutputContains' failed for member 'Invoke_TestTarget_With_Incompatible_Arch' at line 188
```

## What changed

On Linux, launching an arm64 ELF apphost from a linux-x64 host no longer surfaces as a `Win32Exception` from MSBuild's `ToolTask`. As a result, the `error MSB6003: ... could not be run. System.ComponentModel.Win32Exception` message that the test expected on line 188 is never emitted on Linux.

What we see now in CI is the failure being reported by `InvokeTestingPlatformTask.HandleTaskExecutionErrors` as the captured tool output instead:

```
.../MSBuild Tests.dll : error run failed: Tests failed: .../MSBuild Tests: 1: Syntax error: word unexpected (expecting `)`)
.../MSBuild Tests.dll : error run failed:
.../MSBuild Tests.dll : error run failed: === COMMAND LINE ===
.../MSBuild Tests.dll : error run failed: /path/MSBuild Tests --internal-msbuild-node /tmp/...
```

(The shell-parse error comes from `/bin/sh` trying to interpret the arm64 ELF binary as a shell script.)

Windows and macOS still go through the `MSB6003 + Win32Exception` path and continue to pass.

## The fix

Rework the OS-specific assertions in `Invoke_TestTarget_With_Incompatible_Arch`:

- For every OS, first assert non-zero exit and that the run banner mentions the incompatible TFM/architecture (`[net10.0|arm64]`) so we still verify the build/launch actually reached the architecture-mismatched apphost.
- Keep the existing `MSB6003` + `An error occurred trying to start process` assertions and the platform-specific OS error strings for Windows and macOS.
- For Linux, assert only the `error run failed: Tests failed:` line emitted by `InvokeTestingPlatformTask` when the tool exits non-zero (paired with the arch-banner check above, which is what guarantees we're actually exercising the incompatible-arch code path).

Fixes the green Linux pipeline on main.
