### PR TITLE
Add regression test for MSTEST0005 with primary-constructor TestContext field capture (#8984)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
@@ -119,6 +119,33 @@ public sealed class TestContextShouldBeValidAnalyzerTests
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
 
+    [TestMethod]
+    public async Task WhenTestContextPrimaryConstructorParameterAssignedToField_NoDiagnostic()
+    {
+        // Regression test for https://github.com/microsoft/testfx/issues/8984:
+        // capturing a TestContext primary-constructor parameter in a readonly field
+        // must not trigger MSTEST0005. Fields of type TestContext are not validated
+        // by MSTEST0005 (see WhenTestContextCaseInsensitiveIsField_NoDiagnostic), so
+        // this pattern is allowed regardless of whether the constructor is primary or not.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTest(TestContext testContext)
+            {
+                private readonly TestContext _testContext = testContext;
+
+                [TestMethod]
+                public void TestMethod1()
+                {
+                    _testContext.CancellationTokenSource.Cancel();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
     [DataRow("TestContext", "private")]
     [DataRow("TestContext", "internal")]
     [DataRow("testcontext", "private")]


### PR DESCRIPTION
Adds a regression test for #8984.

The scenario reported in the issue — capturing a TestContext primary-constructor parameter into a private readonly TestContext _testContext = testContext; field — no longer triggers MSTEST0005. This was fixed implicitly by #8629 (`MSTEST0005: Stop reporting on fields of type TestContext`), which removed all TestContext-field validation from the analyzer.

This PR just locks the behavior in with a dedicated test that mirrors the exact snippet from the issue, so we don't regress the user-facing pattern again.

Verified locally: the new test plus the entire TestContextShouldBeValidAnalyzerTests class (67/67) pass on net8.0.

Fixes #8984.