### PR TITLE
[code-simplifier] simplify: use indexer-style dict initializer and inline lambdas in SerializerUtilities

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
@@ -30,27 +30,17 @@ internal static partial class SerializerUtilities
             [JsonRpcStrings.Attachments] = res.Artifacts.Select(f => Serialize(f)).ToList<object>(),
         });
 
-        Serializers[typeof(TestNodeUpdateMessage)] = new ObjectSerializer<TestNodeUpdateMessage>(ev =>
+        Serializers[typeof(TestNodeUpdateMessage)] = new ObjectSerializer<TestNodeUpdateMessage>(ev => new Dictionary<string, object?>
         {
-            Dictionary<string, object?> values = new()
-            {
-                [JsonRpcStrings.Node] = Serialize(ev.TestNode),
-                [JsonRpcStrings.Parent] = ev.ParentTestNodeUid?.Value,
-            };
-
-            return values;
+            [JsonRpcStrings.Node] = Serialize(ev.TestNode),
+            [JsonRpcStrings.Parent] = ev.ParentTestNodeUid?.Value,
         });
 
         // Serialize event types.
-        Serializers[typeof(TestNodeStateChangedEventArgs)] = new ObjectSerializer<TestNodeStateChangedEventArgs>(ev =>
+        Serializers[typeof(TestNodeStateChangedEventArgs)] = new ObjectSerializer<TestNodeStateChangedEventArgs>(ev => new Dictionary<string, object?>
         {
-            Dictionary<string, object?> values = new()
-            {
-                [JsonRpcStrings.RunId] = ev.RunId,
-                [JsonRpcStrings.Changes] = ev.Changes?.Select(ch => Serialize(ch)).ToList<object>(),
-            };
-
-            return values;
+            [JsonRpcStrings.RunId] = ev.RunId,
+            [JsonRpcStrings.Changes] = ev.Changes?.Select(ch => Serialize(ch)).ToList<object>(),
         });
 
         Serializers[typeof(TestNode)] = new ObjectSerializer<TestNode>(

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs
@@ -19,14 +19,8 @@ internal static partial class SerializerUtilities
         Deserializers = [];
 
         Serializers[typeof(object)] = new ObjectSerializer<object>(_ => new Dictionary<string, object?>());
-        Serializers[typeof(KeyValuePair<string, string>)] = new ObjectSerializer<KeyValuePair<string, string>>(o =>
-        {
-            Dictionary<string, object?> values = new()
-            {
-                { o.Key, o.Value },
-            };
-            return values;
-        });
+        Serializers[typeof(KeyValuePair<string, string>)] = new ObjectSerializer<KeyValuePair<string, string>>(
+            o => new Dictionary<string, object?> { [o.Key] = o.Value });
 
         RegisterRpcMessageSerializers();
         RegisterTestNodeSerializers();


### PR DESCRIPTION
## Code Simplification — 2026-06-10

This PR simplifies recently modified code from [#8974](https://github.com/microsoft/testfx/pull/8974) (SerializerUtilities refactoring) to improve clarity, consistency, and alignment with project coding standards.

### Files Simplified

- `src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.cs` — fix dictionary initializer coding standard violation, eliminate local variable
- `src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs` — standardize two lambdas to match the expression-body pattern used by other serializers in the same file

### Improvements Made

**1. Fix `Add`-style dictionary initializer (coding standard violation)**

`SerializerUtilities.cs` contained the only `Add`-style `{ { key, value } }` dictionary initializer across the four serializer files. The project coding standards explicitly require the indexer syntax `[key] = value` for dictionary initializers. Replaced and removed the unnecessary local variable:

```csharp
// Before
Serializers[typeof(KeyValuePair<string, string>)] = new ObjectSerializer<KeyValuePair<string, string>>(o =>
{
    Dictionary<string, object?> values = new()
    {
        { o.Key, o.Value },
    };
    return values;
});

// After
Serializers[typeof(KeyValuePair<string, string>)] = new ObjectSerializer<KeyValuePair<string, string>>(
    o => new Dictionary<string, object?> { [o.Key] = o.Value });
```

**2. Standardize verbose lambdas in `SerializerUtilities.TestNodeSerializers.cs`**

`TestNodeUpdateMessage` and `TestNodeStateChangedEventArgs` serializers used a verbose block-body pattern with a local `values` variable and an explicit `return`, while `Artifact` and `RunResponseArgs` in the same file already used the cleaner expression-body pattern. Aligned them:

```csharp
// Before
Serializers[typeof(TestNodeUpdateMessage)] = new ObjectSerializer<TestNodeUpdateMessage>(ev =>
{
    Dictionary<string, object?> values = new()
    {
        [JsonRpcStrings.Node] = Serialize(ev.TestNode),
        [JsonRpcStrings.Parent] = ev.ParentTestNodeUid?.Value,
    };
    return values;
});

// After
Serializers[typeof(TestNodeUpdateMessage)] = new ObjectSerializer<TestNodeUpdateMessage>(ev => new Dictionary<string, object?>
{
    [JsonRpcStrings.Node] = Serialize(ev.TestNode),
    [JsonRpcStrings.Parent] = ev.ParentTestNodeUid?.Value,
});
```

### Changes Based On

Recent changes from:
- #8974 — Refactor SerializerUtilities.cs into focused partial class files (merged 2026-06-10)

### Testing

- ✅ No functional changes — behavior is identical
- ✅ The `KeyValuePair<string, string>` serializer still produces `{ key: value }` (indexer setter has same semantics as `Add` for non-duplicate keys)
- ✅ Both lambdas produce the same `Dictionary<string, object?>` as before

### Review Focus

Please verify:
- Functionality is preserved (indexer vs `Add` produces same result for non-duplicate keys)
- Simplifications improve consistency within the files
- Changes align with project conventions (indexer-style dict initializers, expression-body lambdas)


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27282436318/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-11T14:28:29.798Z --> on Jun 11, 2026, 2:28 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27282436318, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27282436318 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->