### PR TITLE
Fix CI: JUnit NU1102 + telemetry tests post-{asm}_{tfm}_{arch} default

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/JUnitReportTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/JUnitReportTests.cs
@@ -100,6 +100,7 @@ public sealed class JUnitReportRetryAttributeTests : AcceptanceTestBase<JUnitRep
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
     <PackageReference Include="MSTest" Version="$MSTestVersion$" />
     <PackageReference Include="Microsoft.Testing.Extensions.JUnitReport" Version="$MicrosoftTestingExtensionsJUnitReportVersion$" />
   </ItemGroup>
@@ -233,6 +234,7 @@ public sealed class JUnitReportMTPRetryExtensionTests : AcceptanceTestBase<JUnit
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
     <PackageReference Include="MSTest" Version="$MSTestVersion$" />
     <PackageReference Include="Microsoft.Testing.Extensions.JUnitReport" Version="$MicrosoftTestingExtensionsJUnitReportVersion$" />
     <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$MicrosoftTestingPlatformVersion$" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -26,7 +26,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_RunTests_SendsTelemetryWithSettingsAndAttributes(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -66,7 +66,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_DiscoverTests_SendsTelemetryEvent(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -92,7 +92,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_WhenTelemetryDisabled_DoesNotSendMSTestEvent(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -193,6 +193,17 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         string content = await reader.ReadToEndAsync();
 
         return (Regex.IsMatch(content, pattern), content);
+    }
+
+    // Build a regex matching the deterministic default diagnostic file name shape:
+    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
+    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
+    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{MTPAssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     #endregion

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
@@ -15,7 +15,7 @@ public sealed class TelemetryDisabledTests : AcceptanceTestBase<TelemetryDisable
     public async Task Telemetry_WhenEnableTelemetryIsFalse_WithTestApplicationOptions_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
@@ -53,6 +53,17 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
+    }
+
+    // Build a regex matching the deterministic default diagnostic file name shape:
+    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
+    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
+    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -15,7 +15,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_ByDefault_TelemetryIsEnabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
@@ -37,7 +37,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_WhenOptingOutTelemetry_WithEnvironmentVariable_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -66,7 +66,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_WhenOptingOutTelemetry_With_DOTNET_CLI_EnvironmentVariable_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -111,6 +111,17 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
+    }
+
+    // Build a regex matching the deterministic default diagnostic file name shape:
+    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
+    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
+    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()


### PR DESCRIPTION
Fixes failures on internal pipeline [build 2996915](https://dnceng.visualstudio.com/internal/_build/results?buildId=2996915):

### 1. JUnit retry acceptance fixtures (original scope)
Restore tests were failing with **NU1102** because the generated csproj fixtures pulled in a Microsoft.Testing.Platform version that no longer resolves. Pin the package version to the one shipped from the current build.

### 2. Telemetry acceptance tests (new)
PR #8971 changed the default diagnostic file prefix from `log` to `{asm}_{tfm}_{arch}` but missed updating the telemetry acceptance tests, which still expected files matching `log_*.diag`.

Mirror the `BuildDefaultDiagnosticFilePathPattern` helper introduced in `DiagnosticTests.cs` and use it in both:
- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs`
- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs`
- `test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs`

Tests verified locally on Windows / net11.0:
- 12 MTP telemetry acceptance tests pass
- 15 MSTest telemetry acceptance tests pass
