### PR TITLE
Materialize [DataRow] arguments in MSTest.AotReflection.SourceGeneration

### DIFF
--- a/MSTest.slnf
+++ b/MSTest.slnf
@@ -11,6 +11,7 @@
       "src\\Analyzers\\MSTest.Analyzers.CodeFixes\\MSTest.Analyzers.CodeFixes.csproj",
       "src\\Analyzers\\MSTest.Analyzers.Package\\MSTest.Analyzers.Package.csproj",
       "src\\Analyzers\\MSTest.Analyzers\\MSTest.Analyzers.csproj",
+      "src\\Analyzers\\MSTest.AotReflection.SourceGeneration\\MSTest.AotReflection.SourceGeneration.csproj",
       "src\\Analyzers\\MSTest.GlobalConfigsGenerator\\MSTest.GlobalConfigsGenerator.csproj",
       "src\\Analyzers\\MSTest.SourceGeneration\\MSTest.SourceGeneration.csproj",
       "src\\Package\\MSTest.Sdk\\MSTest.Sdk.csproj",

--- a/TestFx.slnx
+++ b/TestFx.slnx
@@ -69,6 +69,7 @@
       <BuildDependency Project="src/Analyzers/MSTest.GlobalConfigsGenerator/MSTest.GlobalConfigsGenerator.csproj" />
     </Project>
     <Project Path="src/Analyzers/MSTest.Analyzers/MSTest.Analyzers.csproj" />
+    <Project Path="src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj" />
     <Project Path="src/Analyzers/MSTest.GlobalConfigsGenerator/MSTest.GlobalConfigsGenerator.csproj" />
     <Project Path="src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj" />
   </Folder>
@@ -133,6 +134,7 @@
     <Project Path="test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests.csproj" />
     <Project Path="test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj" />
     <Project Path="test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj" />
+    <Project Path="test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests.csproj" />
     <Project Path="test/UnitTests/MSTest.SelfRealExamples.UnitTests/MSTest.SelfRealExamples.UnitTests.csproj" />
     <Project Path="test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTest.SourceGeneration.UnitTests.csproj" />
     <Project Path="test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestAdapter.PlatformServices.UnitTests.csproj" />

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MSTestReflectionMetadataGenerator.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MSTestReflectionMetadataGenerator.cs
@@ -45,14 +45,27 @@ internal sealed class MSTestReflectionMetadataGenerator : IIncrementalGenerator
             .Where(static model => model is not null)
             .Select(static (model, _) => model!);
 
-        IncrementalValueProvider<(string? AssemblyName, ImmutableArray<TestClassModel> Classes)> combined =
+        // Pull assembly-level attributes from the compilation (one value per run) and
+        // wrap them in an equatable model so this branch of the pipeline can stay cached
+        // when only test-class code changes.
+        IncrementalValueProvider<AssemblyMetadataModel> assemblyMetadata =
+            context.CompilationProvider.Select(static (c, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                return new AssemblyMetadataModel(
+                    TestClassModelBuilder.BuildAttributes(c.Assembly.GetAttributes()));
+            });
+
+        IncrementalValueProvider<(string? AssemblyName, AssemblyMetadataModel Metadata, ImmutableArray<TestClassModel> Classes)> combined =
             context.CompilationProvider.Select(static (c, _) => c.AssemblyName)
-                .Combine(testClasses.Collect());
+                .Combine(assemblyMetadata)
+                .Combine(testClasses.Collect())
+                .Select(static (tuple, _) => (tuple.Left.Left, tuple.Left.Right, tuple.Right));
 
         context.RegisterImplementationSourceOutput(combined, static (ctx, payload) =>
         {
             string assemblyName = payload.AssemblyName ?? "Unknown";
-            string source = MetadataRegistryEmitter.EmitRegistry(assemblyName, payload.Classes);
+            string source = MetadataRegistryEmitter.EmitRegistry(assemblyName, payload.Metadata, payload.Classes);
             ctx.AddSource("MSTestReflectionMetadata.Registry.g.cs", SourceText.From(source, Encoding.UTF8));
         });
     }

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -57,6 +57,8 @@ internal static class MetadataRegistryEmitter
                 sb.AppendLine("public Type[] ParameterTypes { get; init; } = Array.Empty<Type>();");
                 sb.AppendLine("public string[] ParameterNames { get; init; } = Array.Empty<string>();");
                 sb.AppendLine("public Attribute[] Attributes { get; init; } = Array.Empty<Attribute>();");
+                sb.AppendLine("/// <summary>Materialized argument tuples from <c>[DataRow]</c> attributes (empty for non-data-driven tests). Each <c>object?[]</c> corresponds to one <c>[DataRow]</c> application.</summary>");
+                sb.AppendLine("public IReadOnlyList<object?[]> DataRows { get; init; } = Array.Empty<object?[]>();");
                 sb.AppendLine("/// <summary>Direct invoker — replaces <see cref=\"System.Reflection.MethodInfo.Invoke(object, object[])\" />.</summary>");
                 sb.AppendLine("public Func<object?, object?[]?, object?> Invoke { get; init; } = static (_, _) => null;");
             }
@@ -225,6 +227,8 @@ internal static class MetadataRegistryEmitter
                     sb.AppendLine(",");
                     EmitAttributesProperty(sb, "Attributes", method.Attributes);
                     sb.AppendLine(",");
+                    EmitDataRows(sb, method.DataRows);
+                    sb.AppendLine(",");
                     EmitMethodInvoker(sb, fqn, method);
                 }
 
@@ -279,6 +283,44 @@ internal static class MetadataRegistryEmitter
 
         sb.AppendLine($"Invoke = static (instance, args) => {body},");
     }
+
+    private static void EmitDataRows(IndentedStringBuilder sb, EquatableArray<DataRowModel> dataRows)
+    {
+        if (dataRows.Length == 0)
+        {
+            sb.Append("DataRows = Array.Empty<object?[]>()");
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine("DataRows = new object?[][]");
+        using (sb.Block(null))
+        {
+            for (int i = 0; i < dataRows.Length; i++)
+            {
+                EquatableArray<TypedConstantModel> args = dataRows[i].Arguments;
+                if (args.Length == 0)
+                {
+                    sb.Append("Array.Empty<object?>()");
+                }
+                else
+                {
+                    string literals = string.Join(", ", args.AsImmutableArray().Select(BuildConstantExpression));
+                    sb.Append($"new object?[] {{ {literals} }}");
+                }
+
+                if (i < dataRows.Length - 1)
+                {
+                    sb.AppendLine(",");
+                }
+                else
+                {
+                    sb.AppendLine();
+                }
+            }
+        }
+    }
+
 
     private static void EmitParameterTypes(IndentedStringBuilder sb, EquatableArray<TestParameterModel> parameters)
     {

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -83,7 +83,7 @@ internal static class MetadataRegistryEmitter
         return sb.ToString();
     }
 
-    public static string EmitRegistry(string assemblyName, IReadOnlyList<TestClassModel> testClasses)
+    public static string EmitRegistry(string assemblyName, AssemblyMetadataModel assemblyMetadata, IReadOnlyList<TestClassModel> testClasses)
     {
         var sb = new IndentedStringBuilder();
         AppendHeader(sb);
@@ -99,6 +99,12 @@ internal static class MetadataRegistryEmitter
             {
                 sb.AppendLine($"public const string AssemblyName = \"{Escape(assemblyName)}\";");
                 sb.AppendLine();
+
+                // Emit assembly-level [assembly: ...] attributes so the consumer never has to call
+                // Assembly.GetCustomAttributes for attributes declared in the same compilation.
+                EmitAssemblyAttributesProperty(sb, assemblyMetadata.Attributes);
+                sb.AppendLine();
+
                 sb.AppendLine("public static IReadOnlyList<TestClassReflectionInfo> TestClasses { get; } = new TestClassReflectionInfo[]");
                 using (sb.Block(null))
                 {
@@ -117,6 +123,35 @@ internal static class MetadataRegistryEmitter
         }
 
         return sb.ToString();
+    }
+
+    private static void EmitAssemblyAttributesProperty(IndentedStringBuilder sb, EquatableArray<AttributeApplicationModel> attributes)
+    {
+        if (attributes.Length == 0)
+        {
+            sb.AppendLine("public static IReadOnlyList<Attribute> AssemblyAttributes { get; } = Array.Empty<Attribute>();");
+            return;
+        }
+
+        sb.AppendLine("public static IReadOnlyList<Attribute> AssemblyAttributes { get; } = new Attribute[]");
+        using (sb.Block(null))
+        {
+            for (int i = 0; i < attributes.Length; i++)
+            {
+                AttributeApplicationModel attr = attributes[i];
+                sb.Append(BuildAttributeExpression(attr));
+                if (i < attributes.Length - 1)
+                {
+                    sb.AppendLine(",");
+                }
+                else
+                {
+                    sb.AppendLine();
+                }
+            }
+        }
+
+        sb.AppendLine(";");
     }
 
     private static void EmitTestClass(IndentedStringBuilder sb, TestClassModel model)

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -9,6 +9,7 @@ using System.Text;
 
 using Microsoft.CodeAnalysis;
 
+using MSTest.AotReflection.SourceGeneration.Helpers;
 using MSTest.AotReflection.SourceGeneration.Model;
 
 namespace MSTest.AotReflection.SourceGeneration.Generators;
@@ -149,6 +150,8 @@ internal static class TestClassModelBuilder
             || returnTypeFqn.StartsWith("global::System.Threading.Tasks.ValueTask<", System.StringComparison.Ordinal);
         bool returnsVoid = returnType.SpecialType == SpecialType.System_Void;
 
+        ImmutableArray<AttributeData> inheritedAttributes = CollectInheritedAttributes(method);
+
         return new TestMethodModel(
             Name: method.Name,
             IsStatic: method.IsStatic,
@@ -157,7 +160,63 @@ internal static class TestClassModelBuilder
             ReturnsValueTask: returnsValueTask,
             ReturnsVoid: returnsVoid,
             Parameters: BuildParameters(method),
-            Attributes: BuildAttributes(CollectInheritedAttributes(method)));
+            Attributes: BuildAttributes(inheritedAttributes),
+            DataRows: BuildDataRows(inheritedAttributes));
+    }
+
+    // Walks the attribute list and reifies each [DataRow(...)] application into a flat
+    // object?[] row. Mirrors DataRowAttribute's runtime behavior: when the constructor uses
+    // the variadic overload (object? data1, params object?[] moreData), Roslyn surfaces the
+    // tail as a single Array TypedConstant, which we flatten back so the consumer sees the
+    // same shape as DataRowAttribute.Data.
+    private static EquatableArray<DataRowModel> BuildDataRows(ImmutableArray<AttributeData> attributes)
+    {
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return EquatableArray<DataRowModel>.Empty;
+        }
+
+        ImmutableArray<DataRowModel>.Builder builder = ImmutableArray.CreateBuilder<DataRowModel>();
+        foreach (AttributeData attribute in attributes)
+        {
+            if (attribute.AttributeClass is not { } attributeClass)
+            {
+                continue;
+            }
+
+            if (attributeClass.ToDisplayString(FullyQualifiedFormat) != "global::" + MSTestAttributeNames.DataRow)
+            {
+                continue;
+            }
+
+            ImmutableArray<TypedConstant> ctorArgs = attribute.ConstructorArguments;
+            ImmutableArray<TypedConstantModel>.Builder rowBuilder = ImmutableArray.CreateBuilder<TypedConstantModel>();
+
+            bool lastIsParamsArray =
+                attribute.AttributeConstructor is { Parameters: { IsDefaultOrEmpty: false } parameters }
+                && parameters[parameters.Length - 1].IsParams
+                && !ctorArgs.IsDefaultOrEmpty
+                && ctorArgs[ctorArgs.Length - 1].Kind == TypedConstantKind.Array;
+
+            for (int i = 0; i < ctorArgs.Length; i++)
+            {
+                if (i == ctorArgs.Length - 1 && lastIsParamsArray)
+                {
+                    foreach (TypedConstant element in ctorArgs[i].Values)
+                    {
+                        rowBuilder.Add(ToModel(element));
+                    }
+                }
+                else
+                {
+                    rowBuilder.Add(ToModel(ctorArgs[i]));
+                }
+            }
+
+            builder.Add(new DataRowModel(new EquatableArray<TypedConstantModel>(rowBuilder.ToImmutable())));
+        }
+
+        return new EquatableArray<DataRowModel>(builder.ToImmutable());
     }
 
     private static TestPropertyModel BuildProperty(IPropertySymbol property)

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 
 using Microsoft.CodeAnalysis;
 
@@ -23,26 +25,57 @@ internal static class TestClassModelBuilder
 
     public static TestClassModel Build(INamedTypeSymbol typeSymbol)
     {
+        // Methods / properties are walked across the full inheritance chain (excluding
+        // System.Object) so that MSTest members declared on a base class —
+        // [ClassInitialize], [ClassCleanup], [TestInitialize], [TestCleanup],
+        // [TestMethod], the [TestContext] setter, … — are visible to the consumer
+        // without runtime reflection.
+        //
+        // Iteration order is derived-first so that an override or `new`-shadowed member
+        // on the derived type wins over the base declaration with the same signature.
+        // Constructors are NEVER inherited and are taken only from the leaf type.
+        var methodsByKey = new Dictionary<string, TestMethodModel>(StringComparer.Ordinal);
+        var propertiesByName = new Dictionary<string, TestPropertyModel>(StringComparer.Ordinal);
         ImmutableArray<TestMethodModel>.Builder methods = ImmutableArray.CreateBuilder<TestMethodModel>();
         ImmutableArray<TestPropertyModel>.Builder properties = ImmutableArray.CreateBuilder<TestPropertyModel>();
         ImmutableArray<TestConstructorModel>.Builder ctors = ImmutableArray.CreateBuilder<TestConstructorModel>();
 
-        foreach (ISymbol member in typeSymbol.GetMembers())
+        for (INamedTypeSymbol? current = typeSymbol;
+             current is not null && current.SpecialType != SpecialType.System_Object;
+             current = current.BaseType)
         {
-            switch (member)
+            bool isLeaf = SymbolEqualityComparer.Default.Equals(current, typeSymbol);
+
+            foreach (ISymbol member in current.GetMembers())
             {
-                case IMethodSymbol { MethodKind: MethodKind.Ordinary } method
-                    when method.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal:
-                    methods.Add(BuildMethod(method));
-                    break;
-                case IPropertySymbol property
-                    when property.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal:
-                    properties.Add(BuildProperty(property));
-                    break;
-                case IMethodSymbol { MethodKind: MethodKind.Constructor, IsStatic: false } ctor
-                    when ctor.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal:
-                    ctors.Add(new TestConstructorModel(BuildParameters(ctor)));
-                    break;
+                switch (member)
+                {
+                    case IMethodSymbol { MethodKind: MethodKind.Ordinary } method
+                        when IsAccessibleFromConsumer(method):
+                        string key = BuildMethodSignatureKey(method);
+                        if (!methodsByKey.ContainsKey(key))
+                        {
+                            TestMethodModel model = BuildMethod(method);
+                            methodsByKey[key] = model;
+                            methods.Add(model);
+                        }
+
+                        break;
+                    case IPropertySymbol property
+                        when IsAccessibleFromConsumer(property):
+                        if (!propertiesByName.ContainsKey(property.Name))
+                        {
+                            TestPropertyModel model = BuildProperty(property);
+                            propertiesByName[property.Name] = model;
+                            properties.Add(model);
+                        }
+
+                        break;
+                    case IMethodSymbol { MethodKind: MethodKind.Constructor, IsStatic: false } ctor
+                        when isLeaf && ctor.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal:
+                        ctors.Add(new TestConstructorModel(BuildParameters(ctor)));
+                        break;
+                }
             }
         }
 
@@ -58,6 +91,49 @@ internal static class TestClassModelBuilder
             Methods: new EquatableArray<TestMethodModel>(methods.ToImmutable()),
             Properties: new EquatableArray<TestPropertyModel>(properties.ToImmutable()),
             Attributes: BuildAttributes(typeSymbol.GetAttributes()));
+    }
+
+    private static bool IsAccessibleFromConsumer(ISymbol symbol)
+        => symbol.DeclaredAccessibility is
+            Accessibility.Public
+            or Accessibility.Internal
+            or Accessibility.Protected
+            or Accessibility.ProtectedOrInternal
+            or Accessibility.ProtectedAndInternal;
+
+    private static string BuildMethodSignatureKey(IMethodSymbol method)
+    {
+        var sb = new StringBuilder();
+        sb.Append(method.IsStatic ? "S:" : "I:");
+        sb.Append(method.Name);
+        sb.Append('(');
+        bool first = true;
+        foreach (IParameterSymbol p in method.Parameters)
+        {
+            if (!first)
+            {
+                sb.Append(',');
+            }
+
+            first = false;
+            switch (p.RefKind)
+            {
+                case RefKind.Ref:
+                    sb.Append("ref ");
+                    break;
+                case RefKind.Out:
+                    sb.Append("out ");
+                    break;
+                case RefKind.In:
+                    sb.Append("in ");
+                    break;
+            }
+
+            sb.Append(p.Type.ToDisplayString(FullyQualifiedFormat));
+        }
+
+        sb.Append(')');
+        return sb.ToString();
     }
 
     private static TestMethodModel BuildMethod(IMethodSymbol method)
@@ -81,7 +157,7 @@ internal static class TestClassModelBuilder
             ReturnsValueTask: returnsValueTask,
             ReturnsVoid: returnsVoid,
             Parameters: BuildParameters(method),
-            Attributes: BuildAttributes(method.GetAttributes()));
+            Attributes: BuildAttributes(CollectInheritedAttributes(method)));
     }
 
     private static TestPropertyModel BuildProperty(IPropertySymbol property)
@@ -89,7 +165,68 @@ internal static class TestClassModelBuilder
             Name: property.Name,
             FullyQualifiedType: property.Type.ToDisplayString(FullyQualifiedFormat),
             HasPublicSetter: property.SetMethod is { DeclaredAccessibility: Accessibility.Public },
-            Attributes: BuildAttributes(property.GetAttributes()));
+            Attributes: BuildAttributes(CollectInheritedAttributes(property)));
+
+    // Mirror the runtime behavior of MemberInfo.GetCustomAttributes(inherit: true): walk the
+    // overridden-method chain and union attributes, keeping the most-derived application when
+    // the same attribute type appears on multiple levels.
+    private static ImmutableArray<AttributeData> CollectInheritedAttributes(IMethodSymbol method)
+    {
+        ImmutableArray<AttributeData> own = method.GetAttributes();
+        if (method.OverriddenMethod is null)
+        {
+            return own;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        ImmutableArray<AttributeData>.Builder builder = ImmutableArray.CreateBuilder<AttributeData>();
+        AppendUnique(builder, seen, own);
+        for (IMethodSymbol? baseMethod = method.OverriddenMethod; baseMethod is not null; baseMethod = baseMethod.OverriddenMethod)
+        {
+            AppendUnique(builder, seen, baseMethod.GetAttributes());
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static ImmutableArray<AttributeData> CollectInheritedAttributes(IPropertySymbol property)
+    {
+        ImmutableArray<AttributeData> own = property.GetAttributes();
+        if (property.OverriddenProperty is null)
+        {
+            return own;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        ImmutableArray<AttributeData>.Builder builder = ImmutableArray.CreateBuilder<AttributeData>();
+        AppendUnique(builder, seen, own);
+        for (IPropertySymbol? baseProperty = property.OverriddenProperty; baseProperty is not null; baseProperty = baseProperty.OverriddenProperty)
+        {
+            AppendUnique(builder, seen, baseProperty.GetAttributes());
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static void AppendUnique(
+        ImmutableArray<AttributeData>.Builder builder,
+        HashSet<string> seen,
+        ImmutableArray<AttributeData> attributes)
+    {
+        foreach (AttributeData attribute in attributes)
+        {
+            if (attribute.AttributeClass is not { } attributeClass)
+            {
+                continue;
+            }
+
+            string key = attributeClass.ToDisplayString(FullyQualifiedFormat);
+            if (seen.Add(key))
+            {
+                builder.Add(attribute);
+            }
+        }
+    }
 
     private static EquatableArray<TestParameterModel> BuildParameters(IMethodSymbol method)
     {

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -19,8 +19,7 @@ internal static class TestClassModelBuilder
 {
     private static readonly SymbolDisplayFormat FullyQualifiedFormat =
         SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
-            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
-            | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+            SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
     public static TestClassModel Build(INamedTypeSymbol typeSymbol)
     {

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -94,19 +94,28 @@ internal static class TestClassModelBuilder
             Attributes: BuildAttributes(typeSymbol.GetAttributes()));
     }
 
+    // Restricted to accessibilities the emitted helper class (a separate static type
+    // declared in MSTest.SourceGenerated, not a derived type) can legally call.
+    // 'protected' and 'private protected' members require the caller to be a derived
+    // type, so they are excluded; 'protected internal' is included because the internal
+    // half is satisfied (the generated helper lives in the same assembly).
     private static bool IsAccessibleFromConsumer(ISymbol symbol)
         => symbol.DeclaredAccessibility is
             Accessibility.Public
             or Accessibility.Internal
-            or Accessibility.Protected
-            or Accessibility.ProtectedOrInternal
-            or Accessibility.ProtectedAndInternal;
+            or Accessibility.ProtectedOrInternal;
 
     private static string BuildMethodSignatureKey(IMethodSymbol method)
     {
         var sb = new StringBuilder();
         sb.Append(method.IsStatic ? "S:" : "I:");
         sb.Append(method.Name);
+        if (method.Arity > 0)
+        {
+            sb.Append('`');
+            sb.Append(method.Arity);
+        }
+
         sb.Append('(');
         bool first = true;
         foreach (IParameterSymbol p in method.Parameters)
@@ -228,7 +237,9 @@ internal static class TestClassModelBuilder
 
     // Mirror the runtime behavior of MemberInfo.GetCustomAttributes(inherit: true): walk the
     // overridden-method chain and union attributes, keeping the most-derived application when
-    // the same attribute type appears on multiple levels.
+    // the same attribute type appears on multiple levels — but respect
+    // [AttributeUsage(Inherited = false)] (the attribute is NOT visible past the level it was
+    // declared on) and [AttributeUsage(AllowMultiple = true)] (every occurrence is kept).
     private static ImmutableArray<AttributeData> CollectInheritedAttributes(IMethodSymbol method)
     {
         ImmutableArray<AttributeData> own = method.GetAttributes();
@@ -239,10 +250,10 @@ internal static class TestClassModelBuilder
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
         ImmutableArray<AttributeData>.Builder builder = ImmutableArray.CreateBuilder<AttributeData>();
-        AppendUnique(builder, seen, own);
+        AppendUnique(builder, seen, own, isInheritedLevel: false);
         for (IMethodSymbol? baseMethod = method.OverriddenMethod; baseMethod is not null; baseMethod = baseMethod.OverriddenMethod)
         {
-            AppendUnique(builder, seen, baseMethod.GetAttributes());
+            AppendUnique(builder, seen, baseMethod.GetAttributes(), isInheritedLevel: true);
         }
 
         return builder.ToImmutable();
@@ -258,10 +269,10 @@ internal static class TestClassModelBuilder
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
         ImmutableArray<AttributeData>.Builder builder = ImmutableArray.CreateBuilder<AttributeData>();
-        AppendUnique(builder, seen, own);
+        AppendUnique(builder, seen, own, isInheritedLevel: false);
         for (IPropertySymbol? baseProperty = property.OverriddenProperty; baseProperty is not null; baseProperty = baseProperty.OverriddenProperty)
         {
-            AppendUnique(builder, seen, baseProperty.GetAttributes());
+            AppendUnique(builder, seen, baseProperty.GetAttributes(), isInheritedLevel: true);
         }
 
         return builder.ToImmutable();
@@ -270,12 +281,31 @@ internal static class TestClassModelBuilder
     private static void AppendUnique(
         ImmutableArray<AttributeData>.Builder builder,
         HashSet<string> seen,
-        ImmutableArray<AttributeData> attributes)
+        ImmutableArray<AttributeData> attributes,
+        bool isInheritedLevel)
     {
         foreach (AttributeData attribute in attributes)
         {
             if (attribute.AttributeClass is not { } attributeClass)
             {
+                continue;
+            }
+
+            (bool allowMultiple, bool inherited) = GetAttributeUsage(attributeClass);
+
+            // A base-level attribute declared with AttributeUsage(Inherited = false) must
+            // not leak onto the derived override (matches MemberInfo.GetCustomAttributes(inherit: true)).
+            if (isInheritedLevel && !inherited)
+            {
+                continue;
+            }
+
+            // Attributes declared with AttributeUsage(AllowMultiple = true) may legitimately
+            // appear several times across the override chain (e.g. [TestCategory], [DataRow])
+            // — keep every instance instead of collapsing them to one.
+            if (allowMultiple)
+            {
+                builder.Add(attribute);
                 continue;
             }
 
@@ -285,6 +315,40 @@ internal static class TestClassModelBuilder
                 builder.Add(attribute);
             }
         }
+    }
+
+    private static (bool AllowMultiple, bool Inherited) GetAttributeUsage(INamedTypeSymbol attributeClass)
+    {
+        for (INamedTypeSymbol? current = attributeClass; current is not null; current = current.BaseType)
+        {
+            foreach (AttributeData attribute in current.GetAttributes())
+            {
+                if (attribute.AttributeClass?.ToDisplayString(FullyQualifiedFormat) != "global::System.AttributeUsageAttribute")
+                {
+                    continue;
+                }
+
+                bool allowMultiple = false;
+                bool inherited = true;
+                foreach (KeyValuePair<string, TypedConstant> named in attribute.NamedArguments)
+                {
+                    if (named.Key == "AllowMultiple" && named.Value.Value is bool am)
+                    {
+                        allowMultiple = am;
+                    }
+                    else if (named.Key == "Inherited" && named.Value.Value is bool inh)
+                    {
+                        inherited = inh;
+                    }
+                }
+
+                // [AttributeUsage] on a derived attribute class shadows the base per CLI rules;
+                // stop at the first level where it is found.
+                return (allowMultiple, inherited);
+            }
+        }
+
+        return (AllowMultiple: false, Inherited: true);
     }
 
     private static EquatableArray<TestParameterModel> BuildParameters(IMethodSymbol method)

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
@@ -29,4 +29,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="MSTest.AotReflection.SourceGeneration.UnitTests" Key="$(VsPublicKey)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
@@ -41,6 +41,12 @@ internal enum ConstantValueKind
 
 internal sealed record TestParameterModel(string FullyQualifiedType, string Name);
 
+/// <summary>
+/// One row of arguments from a <c>[DataRow]</c> attribute, materialized at compile time so
+/// the consumer can iterate without re-reading <c>DataRowAttribute.Data</c> via reflection.
+/// </summary>
+internal sealed record DataRowModel(EquatableArray<TypedConstantModel> Arguments);
+
 internal sealed record TestMethodModel(
     string Name,
     bool IsStatic,
@@ -49,7 +55,8 @@ internal sealed record TestMethodModel(
     bool ReturnsValueTask,
     bool ReturnsVoid,
     EquatableArray<TestParameterModel> Parameters,
-    EquatableArray<AttributeApplicationModel> Attributes);
+    EquatableArray<AttributeApplicationModel> Attributes,
+    EquatableArray<DataRowModel> DataRows);
 
 internal sealed record TestPropertyModel(
     string Name,

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
@@ -60,6 +60,14 @@ internal sealed record TestPropertyModel(
 internal sealed record TestConstructorModel(
     EquatableArray<TestParameterModel> Parameters);
 
+/// <summary>
+/// Assembly-scoped metadata captured at compile time so the consumer never has to call
+/// <see cref="System.Reflection.Assembly.GetCustomAttributes(System.Type, bool)"/> for
+/// attributes declared with <c>[assembly: ...]</c> in the same compilation.
+/// </summary>
+internal sealed record AssemblyMetadataModel(
+    EquatableArray<AttributeApplicationModel> Attributes);
+
 internal sealed record TestClassModel(
     string FullyQualifiedTypeName,
     string ContainingNamespace,

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests.csproj
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <RootNamespace>MSTest.AotReflection.SourceGeneration.UnitTests</RootNamespace>
+    <UseMSTestFromSource>true</UseMSTestFromSource>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="$(MicrosoftCodeAnalysisVersionForSourceGen)" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework.Extensions\TestFramework.Extensions.csproj" />
+    <!-- Reference the generator project as a regular library so that the (internal) generator class
+         can be instantiated in tests; access is granted via InternalsVisibleTo on the generator project. -->
+    <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.AotReflection.SourceGeneration\MSTest.AotReflection.SourceGeneration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -341,17 +341,12 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         registry.Should().Contain("Name = \"Context\"");
         registry.Should().Contain("HasPublicSetter = true");
         registry.Should().Contain("Get = static instance => instance is null ? null : (object?)((global::Sample.PropTests)instance).Context,");
-        registry.Should().Contain("Set = static (instance, value) => ((global::Sample.PropTests)instance!).Context = (global::Sample.TestContext?)value!,");
+        registry.Should().Contain("Set = static (instance, value) => ((global::Sample.PropTests)instance!).Context = (global::Sample.TestContext)value!,");
     }
 
     [TestMethod]
     public void Generator_EmittedSource_CompilesCleanly()
     {
-        // NOTE: Scenario intentionally avoids nullable reference type annotations on
-        // property/parameter types: the current PoC emits `typeof(T?)` verbatim, which
-        // is invalid C#. That bug is tracked separately for a follow-up PR; this test
-        // is here to prevent the emitted source from ever introducing OTHER compile
-        // errors.
         const string userCode = """
             using System.Threading.Tasks;
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -365,7 +360,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 public class FullShape
                 {
                     [TestContext]
-                    public TestContext Context { get; set; } = new();
+                    public TestContext? Context { get; set; }
 
                     public FullShape() { }
 
@@ -386,6 +381,53 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
         diagnostics.Should().BeEmpty(
             "the generated source MUST compile cleanly when consumed in the same compilation as the user code");
+    }
+
+    [TestMethod]
+    public void Generator_StripsNullableAnnotation_FromTypeofExpressions()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class TestContext { }
+
+                [TestClass]
+                public class NullableShapes
+                {
+                    [TestContext]
+                    public TestContext? Context { get; set; }
+
+                    [TestMethod]
+                    public void TakesNullableRef(string? value) { }
+
+                    [TestMethod]
+                    public void TakesNullableValueType(int? n) { }
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation
+            .SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", System.StringComparison.Ordinal))
+            .ToString();
+
+        // typeof(...) MUST NOT carry nullable reference type annotation (CS8639).
+        registry.Should().NotContain("typeof(global::Sample.TestContext?)");
+        registry.Should().NotContain("typeof(string?)");
+        // Reference types in typeof drop the annotation entirely.
+        registry.Should().Contain("typeof(global::Sample.TestContext)");
+        registry.Should().Contain("typeof(string)");
+        // Nullable value types are still distinct from their underlying type and must be preserved as Nullable<T>.
+        registry.Should().Contain("typeof(int?)");
+
+        // The whole compilation must be free of CS errors.
+        IEnumerable<Diagnostic> errors = outputCompilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+        errors.Should().BeEmpty("typeof(T?) on a reference type is invalid C# (CS8639)");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -45,6 +45,12 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
             [System.AttributeUsage(System.AttributeTargets.Property)]
             public class TestContextAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Method)]
+            public class TestInitializeAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Method)]
+            public class TestCleanupAttribute : System.Attribute { }
         }
         """;
 
@@ -461,6 +467,301 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         result.Results.Should().ContainSingle();
         // Two passes against the same compilation must produce identical sources.
         result.Results[0].GeneratedSources.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void Generator_IncludesMethodsFromBaseType()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestInitialize]
+                    public void Setup() { }
+
+                    [TestMethod]
+                    public void InheritedTest() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    [TestMethod]
+                    public void DerivedTest() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("Name = \"InheritedTest\"");
+        registry.Should().Contain("Name = \"Setup\"");
+        registry.Should().Contain("Name = \"DerivedTest\"");
+        // The TestInitialize attribute applied on the base method must propagate too.
+        registry.Should().Contain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestInitializeAttribute");
+    }
+
+    [TestMethod]
+    public void Generator_IncludesMethodsFromMultiLevelInheritance()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class GrandparentTests
+                {
+                    [TestMethod]
+                    public void GrandparentTest() { }
+                }
+
+                public class ParentTests : GrandparentTests
+                {
+                    [TestMethod]
+                    public void ParentTest() { }
+                }
+
+                [TestClass]
+                public class LeafTests : ParentTests
+                {
+                    [TestMethod]
+                    public void LeafTest() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("Name = \"GrandparentTest\"");
+        registry.Should().Contain("Name = \"ParentTest\"");
+        registry.Should().Contain("Name = \"LeafTest\"");
+    }
+
+    [TestMethod]
+    public void Generator_OverriddenVirtualMethod_KeepsOnlyDerivedImplementation()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestMethod]
+                    public virtual void Run() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    public override void Run() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        // Only one entry for Run should be emitted, and the invoker must dispatch on the derived type.
+        int runEntries = registry.Split(["Name = \"Run\""], System.StringSplitOptions.None).Length - 1;
+        runEntries.Should().Be(1, "the derived override must replace the base entry (not duplicate it)");
+        registry.Should().Contain("((global::Sample.DerivedTests)instance!).Run();");
+        registry.Should().NotContain("((global::Sample.BaseTests)instance!).Run();");
+
+        // The override does NOT re-apply [TestMethod] but the attribute must still be visible
+        // via the override chain — matching the runtime semantics of GetCustomAttributes(inherit: true).
+        registry.Should().Contain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
+    }
+
+    [TestMethod]
+    public void Generator_NewKeywordHiddenMethod_DedupsBySignature()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestMethod]
+                    public void Hidden() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    [TestMethod]
+                    public new void Hidden() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        int hiddenEntries = registry.Split(["Name = \"Hidden\""], System.StringSplitOptions.None).Length - 1;
+        hiddenEntries.Should().Be(1, "members with the same name and signature must be de-duplicated; derived wins");
+        registry.Should().Contain("((global::Sample.DerivedTests)instance!).Hidden();");
+    }
+
+    [TestMethod]
+    public void Generator_OverloadsWithDifferentSignatures_AreAllPreserved()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestMethod]
+                    public void Op(int x) { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    [TestMethod]
+                    public void Op(string x) { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        // Both overloads survive — they have different signatures.
+        int opEntries = registry.Split(["Name = \"Op\""], System.StringSplitOptions.None).Length - 1;
+        opEntries.Should().Be(2);
+        registry.Should().Contain("typeof(int)");
+        registry.Should().Contain("typeof(string)");
+    }
+
+    [TestMethod]
+    public void Generator_IncludesPropertiesFromBaseType()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class TestContext { }
+
+                public class BaseTests
+                {
+                    [TestContext]
+                    public virtual TestContext Context { get; set; } = new();
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("Name = \"Context\"");
+        registry.Should().Contain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestContextAttribute");
+    }
+
+    [TestMethod]
+    public void Generator_DoesNotInheritConstructors()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    public BaseTests(int x) { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    public DerivedTests() : base(1) { }
+
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        // Only the derived ctor (parameterless) should be emitted — base ctor is never inherited.
+        registry.Should().Contain("Invoke = static args => new global::Sample.DerivedTests(),");
+        registry.Should().NotContain("Invoke = static args => new global::Sample.BaseTests(");
+        // No int parameter from the base constructor leaks into the constructor list.
+        registry.Should().NotContain("ParameterTypes = new Type[] { typeof(int) },");
+    }
+
+    [TestMethod]
+    public void Generator_AbstractBaseWithConcreteDerived_FoldsBaseMembers()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class TestContext { }
+
+                public abstract class AbstractBase
+                {
+                    [TestInitialize]
+                    public void Setup() { }
+
+                    [TestContext]
+                    public TestContext Ctx { get; set; } = new();
+                }
+
+                [TestClass]
+                public class Concrete : AbstractBase
+                {
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("Name = \"Setup\"");
+        registry.Should().Contain("Name = \"Ctx\"");
+        registry.Should().Contain("Name = \"Test\"");
+        // The base class was abstract but the concrete derived type is the one emitted.
+        registry.Should().Contain("Type = typeof(global::Sample.Concrete)");
+    }
+
+    [TestMethod]
+    public void Generator_DoesNotWalkPastSystemObject()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class SimpleTests
+                {
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        // Members of System.Object (ToString, Equals, GetHashCode, GetType) must NOT be emitted.
+        registry.Should().NotContain("Name = \"ToString\"");
+        registry.Should().NotContain("Name = \"Equals\"");
+        registry.Should().NotContain("Name = \"GetHashCode\"");
+        registry.Should().NotContain("Name = \"GetType\"");
     }
 
     private static string GetRegistry(GeneratorRunResult result)

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -58,6 +58,13 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 public int Workers { get; set; }
                 public string? Scope { get; set; }
             }
+
+            [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true)]
+            public class DataRowAttribute : System.Attribute
+            {
+                public DataRowAttribute(object? data1) { }
+                public DataRowAttribute(object? data1, params object?[] moreData) { }
+            }
         }
         """;
 
@@ -881,6 +888,148 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.ParallelizeAttribute()");
         registry.Should().Contain("Workers = 8");
         registry.Should().NotContain("new TestClassReflectionInfo(");
+    }
+
+    [TestMethod]
+    public void Generator_EmitsEmptyDataRows_WhenMethodHasNoDataRow()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    public void NoData() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("DataRows = Array.Empty<object?[]>()");
+        registry.Should().NotContain("DataRows = new object?[][]");
+    }
+
+    [TestMethod]
+    public void Generator_CapturesSingleDataRow_WithScalarArgs()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    [DataRow(1, "x")]
+                    public void Test(int a, string b) { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("DataRows = new object?[][]");
+        registry.Should().Contain("new object?[] { 1, \"x\" }");
+    }
+
+    [TestMethod]
+    public void Generator_CapturesMultipleDataRows_InDeclarationOrder()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    [DataRow(1, "a")]
+                    [DataRow(2, "b")]
+                    [DataRow(3, "c")]
+                    public void Test(int a, string b) { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("DataRows = new object?[][]");
+
+        int idx1 = registry.IndexOf("new object?[] { 1, \"a\" }", StringComparison.Ordinal);
+        int idx2 = registry.IndexOf("new object?[] { 2, \"b\" }", StringComparison.Ordinal);
+        int idx3 = registry.IndexOf("new object?[] { 3, \"c\" }", StringComparison.Ordinal);
+
+        idx1.Should().BeGreaterThan(-1);
+        idx2.Should().BeGreaterThan(idx1);
+        idx3.Should().BeGreaterThan(idx2);
+    }
+
+    [TestMethod]
+    public void Generator_FlattensParamsArrayInDataRow()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    [DataRow(1, 2, 3, 4)]
+                    public void Test(int a, int b, int c, int d) { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        // The variadic `params object?[] moreData` tail must be flattened into a single flat row
+        // within the DataRows block — the row contains all four values inline, not nested.
+        registry.Should().Contain("new object?[] { 1, 2, 3, 4 }");
+    }
+
+    [TestMethod]
+    public void Generator_HandlesNullValueInDataRow()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    [DataRow(null)]
+                    public void Test(string? value) { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("DataRows = new object?[][]");
+        // The single-arg DataRowAttribute(object? data1) overload binds null to object,
+        // which surfaces as `(object)null!` from BuildConstantExpression (C# keyword form
+        // produced by FullyQualifiedFormat for System.Object).
+        registry.Should().Contain("new object?[] { (object)null! }");
     }
 
     private static string GetRegistry(GeneratorRunResult result)

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -28,7 +28,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             [System.AttributeUsage(System.AttributeTargets.Class)]
             public class TestClassAttribute : System.Attribute { }
 
-            [System.AttributeUsage(System.AttributeTargets.Method)]
+            [System.AttributeUsage(System.AttributeTargets.Method, Inherited = false)]
             public class TestMethodAttribute : System.Attribute
             {
                 public TestMethodAttribute() { }
@@ -59,7 +59,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 public string? Scope { get; set; }
             }
 
-            [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true)]
+            [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
             public class DataRowAttribute : System.Attribute
             {
                 public DataRowAttribute(object? data1) { }
@@ -571,6 +571,9 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 [TestClass]
                 public class DerivedTests : BaseTests
                 {
+                    // [TestMethod] is re-applied here because the real attribute is declared
+                    // with AttributeUsage(Inherited = false) and would not be inherited.
+                    [TestMethod]
                     public override void Run() { }
                 }
             }
@@ -583,9 +586,6 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         runEntries.Should().Be(1, "the derived override must replace the base entry (not duplicate it)");
         registry.Should().Contain("((global::Sample.DerivedTests)instance!).Run();");
         registry.Should().NotContain("((global::Sample.BaseTests)instance!).Run();");
-
-        // The override does NOT re-apply [TestMethod] but the attribute must still be visible
-        // via the override chain — matching the runtime semantics of GetCustomAttributes(inherit: true).
         registry.Should().Contain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
     }
 
@@ -1030,6 +1030,162 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         // which surfaces as `(object)null!` from BuildConstantExpression (C# keyword form
         // produced by FullyQualifiedFormat for System.Object).
         registry.Should().Contain("new object?[] { (object)null! }");
+    }
+
+    [TestMethod]
+    public void Generator_SkipsProtectedAndPrivateProtectedMembers()
+    {
+        // Generated invokers live in a separate static helper class (not a derived type),
+        // so 'protected' and 'private protected' members are not callable from the emitted
+        // code. They MUST be excluded from the registry to keep the generated source compiling.
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestMethod]
+                    protected void ProtectedTest() { }
+
+                    [TestMethod]
+                    private protected void PrivateProtectedTest() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    [TestMethod]
+                    public void PublicTest() { }
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        IEnumerable<Diagnostic> errors = outputCompilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+        errors.Should().BeEmpty("the generated registry MUST NOT reference protected / private protected members");
+
+        string registry = outputCompilation
+            .SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", System.StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().Contain("Name = \"PublicTest\"");
+        registry.Should().NotContain("Name = \"ProtectedTest\"");
+        registry.Should().NotContain("Name = \"PrivateProtectedTest\"");
+    }
+
+    [TestMethod]
+    public void Generator_KeepsAllowMultipleAttributes_AcrossOverrideChain()
+    {
+        // [TestCategory] is AllowMultiple=true. Collecting attributes across the override chain
+        // MUST keep every instance instead of collapsing them by type, otherwise the inherited
+        // categories disappear from the registry.
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestMethod]
+                    [TestCategory("BaseCat")]
+                    public virtual void Run() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    [TestCategory("DerivedCat")]
+                    public override void Run() { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("\"BaseCat\"");
+        registry.Should().Contain("\"DerivedCat\"");
+    }
+
+    [TestMethod]
+    public void Generator_DistinguishesGenericArity_BetweenSameNamedMethods()
+    {
+        // Methods that differ only in generic arity (e.g. M() vs M<T>()) MUST be treated as
+        // distinct in the per-class dedup key, otherwise the generator drops one of them.
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class GenericArityTests
+                {
+                    [TestMethod]
+                    public void Run() { }
+
+                    [TestMethod]
+                    public void Run<T>() { }
+
+                    [TestMethod]
+                    public void Run<T, U>() { }
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        IEnumerable<Diagnostic> errors = outputCompilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+        errors.Should().BeEmpty();
+
+        string registry = outputCompilation
+            .SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", System.StringComparison.Ordinal))
+            .ToString();
+
+        int occurrences = System.Text.RegularExpressions.Regex
+            .Matches(registry, "Name = \"Run\"")
+            .Count;
+        occurrences.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void Generator_DoesNotInherit_TestMethodOrDataRow_OntoOverride()
+    {
+        // [TestMethod] and [DataRow] are declared with AttributeUsage(Inherited = false) in
+        // the real MSTest assembly. An override that does NOT re-apply [TestMethod] is not a
+        // test, and inherited [DataRow]s must not leak from the base method onto the override.
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    [TestMethod]
+                    [DataRow(1)]
+                    [DataRow(2)]
+                    public virtual void Run(int x) { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    // Override deliberately does not re-apply [TestMethod] or any [DataRow].
+                    public override void Run(int x) { }
+                }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        // Neither the [TestMethod] nor the inherited [DataRow]s should propagate onto the override.
+        registry.Should().NotContain("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute()");
+        registry.Should().NotContain("Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute(");
+        registry.Should().NotContain("new DataRowModel(");
     }
 
     private static string GetRegistry(GeneratorRunResult result)

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1,0 +1,466 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using MSTest.AotReflection.SourceGeneration.Generators;
+
+namespace MSTest.AotReflection.SourceGeneration.UnitTests;
+
+/// <summary>
+/// Behavior tests for <see cref="MSTestReflectionMetadataGenerator" />.
+/// These pin the current PoC output so the upcoming follow-up PRs (#1837) can extend it safely.
+/// </summary>
+[TestClass]
+public sealed class MSTestReflectionMetadataGeneratorTests
+{
+    /// <summary>
+    /// Minimal MSTest attribute stubs so the generator can locate <c>[TestClass]</c> /
+    /// <c>[TestMethod]</c> in test fixtures without dragging the real TestFramework
+    /// assemblies into the Roslyn compilation.
+    /// </summary>
+    private const string MinimalMSTestStub = """
+        namespace Microsoft.VisualStudio.TestTools.UnitTesting
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public class TestClassAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Method)]
+            public class TestMethodAttribute : System.Attribute
+            {
+                public TestMethodAttribute() { }
+                public TestMethodAttribute(string displayName) { DisplayName = displayName; }
+                public string? DisplayName { get; set; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = true)]
+            public class TestCategoryAttribute : System.Attribute
+            {
+                public TestCategoryAttribute(string category) { Category = category; }
+                public string Category { get; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Property)]
+            public class TestContextAttribute : System.Attribute { }
+        }
+        """;
+
+    [TestMethod]
+    public void Generator_EmitsSupportTypes_OnAnyCompilation()
+    {
+        const string userCode = """
+            // Intentionally empty — no [TestClass] in the consumer.
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        // Support types are emitted via RegisterPostInitializationOutput → always present.
+        string support = result.GeneratedSources
+            .Single(s => s.HintName == "MSTestReflectionMetadata.SupportTypes.g.cs")
+            .SourceText.ToString();
+
+        support.Should().Contain("namespace MSTest.SourceGenerated");
+        support.Should().Contain("internal sealed class TestClassReflectionInfo");
+        support.Should().Contain("internal sealed class TestMethodReflectionInfo");
+        support.Should().Contain("internal sealed class TestPropertyReflectionInfo");
+        support.Should().Contain("internal sealed class TestConstructorReflectionInfo");
+    }
+
+    [TestMethod]
+    public void Generator_EmitsRegistry_WithDiscoveredTestClass()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class MyTests
+                {
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+
+        registry.Should().Contain("internal static class MSTestReflectionMetadata");
+        registry.Should().Contain("public const string AssemblyName = \"TestSample\";");
+        registry.Should().Contain("Type = typeof(global::Sample.MyTests)");
+        registry.Should().Contain("Name = \"Test1\"");
+        registry.Should().Contain("Invoke = static (instance, args) => { ((global::Sample.MyTests)instance!).Test1(); return null; },");
+    }
+
+    [TestMethod]
+    public void Generator_EmitsEmptyRegistry_WhenNoTestClasses()
+    {
+        const string userCode = """
+            namespace Sample
+            {
+                // No [TestClass] anywhere.
+                public class NotATest { public void Foo() { } }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("public static IReadOnlyList<TestClassReflectionInfo> TestClasses { get; } = new TestClassReflectionInfo[]");
+        // No concrete TestClassReflectionInfo instance is emitted (note the open paren).
+        registry.Should().NotContain("new TestClassReflectionInfo(");
+    }
+
+    [TestMethod]
+    public void Generator_SkipsStaticTestClass()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public static class StaticTests
+                {
+                    [TestMethod]
+                    public static void Test1() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        // Static classes are excluded by the predicate in the generator (cannot be instantiated).
+        registry.Should().NotContain("StaticTests");
+    }
+
+    [TestMethod]
+    public void Generator_SkipsAbstractTestClass()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public abstract class AbstractTests
+                {
+                    [TestMethod]
+                    public void Test1() { }
+                }
+
+                [TestClass]
+                public class ConcreteTests
+                {
+                    [TestMethod]
+                    public void Test2() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        // Abstract classes are filtered in BuildModel — they cannot be instantiated.
+        registry.Should().NotContain("AbstractTests");
+        registry.Should().Contain("typeof(global::Sample.ConcreteTests)");
+    }
+
+    [TestMethod]
+    public void Generator_SkipsGenericTestClass()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class GenericTests<T>
+                {
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        // Open-generic test classes are out of scope for this PoC.
+        registry.Should().NotContain("GenericTests");
+    }
+
+    [TestMethod]
+    public void Generator_EmitsConstructorInvoker()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class CtorTests
+                {
+                    public CtorTests() { }
+
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("Constructors = new TestConstructorReflectionInfo[]");
+        registry.Should().Contain("Invoke = static args => new global::Sample.CtorTests(),");
+    }
+
+    [TestMethod]
+    public void Generator_EmitsParameterTypes_ForMethodWithParameters()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class ParamTests
+                {
+                    [TestMethod]
+                    public void Test1(int x, string y) { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("ParameterTypes = new Type[] { typeof(int), typeof(string) }");
+        registry.Should().Contain("ParameterNames = new string[] { \"x\", \"y\" }");
+    }
+
+    [TestMethod]
+    public void Generator_FlagsAsyncReturnTypes()
+    {
+        const string userCode = """
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class AsyncTests
+                {
+                    [TestMethod]
+                    public Task Test1() => Task.CompletedTask;
+
+                    [TestMethod]
+                    public ValueTask Test2() => default;
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("Name = \"Test1\"");
+        registry.Should().Contain("ReturnsTask = true");
+        registry.Should().Contain("Name = \"Test2\"");
+        registry.Should().Contain("ReturnsValueTask = true");
+    }
+
+    [TestMethod]
+    public void Generator_CapturesClassLevelAttributes()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                [TestCategory("Smoke")]
+                public class TaggedTests
+                {
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute");
+        registry.Should().Contain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute");
+        registry.Should().Contain("\"Smoke\"");
+    }
+
+    [TestMethod]
+    public void Generator_EmitsPropertyGetterAndSetter()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class TestContext { }
+
+                [TestClass]
+                public class PropTests
+                {
+                    [TestContext]
+                    public TestContext? Context { get; set; }
+
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("Name = \"Context\"");
+        registry.Should().Contain("HasPublicSetter = true");
+        registry.Should().Contain("Get = static instance => instance is null ? null : (object?)((global::Sample.PropTests)instance).Context,");
+        registry.Should().Contain("Set = static (instance, value) => ((global::Sample.PropTests)instance!).Context = (global::Sample.TestContext?)value!,");
+    }
+
+    [TestMethod]
+    public void Generator_EmittedSource_CompilesCleanly()
+    {
+        // NOTE: Scenario intentionally avoids nullable reference type annotations on
+        // property/parameter types: the current PoC emits `typeof(T?)` verbatim, which
+        // is invalid C#. That bug is tracked separately for a follow-up PR; this test
+        // is here to prevent the emitted source from ever introducing OTHER compile
+        // errors.
+        const string userCode = """
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class TestContext { }
+
+                [TestClass]
+                [TestCategory("Smoke")]
+                public class FullShape
+                {
+                    [TestContext]
+                    public TestContext Context { get; set; } = new();
+
+                    public FullShape() { }
+
+                    [TestMethod("alias")]
+                    public void Sync(int x) { }
+
+                    [TestMethod]
+                    public Task Asynchronous() => Task.CompletedTask;
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+
+        IEnumerable<Diagnostic> diagnostics = outputCompilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+
+        diagnostics.Should().BeEmpty(
+            "the generated source MUST compile cleanly when consumed in the same compilation as the user code");
+    }
+
+    [TestMethod]
+    public void Generator_IsIncremental_SupportTypesAreCached_WhenInputUnchanged()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class IncTests
+                {
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(MinimalMSTestStub, userCode);
+        GeneratorDriver driver = CSharpGeneratorDriver
+            .Create(new MSTestReflectionMetadataGenerator())
+            .WithUpdatedParseOptions((CSharpParseOptions)compilation.SyntaxTrees.First().Options);
+
+        // Track step output cache reasons.
+        driver = driver.RunGenerators(compilation);
+        driver = driver.RunGenerators(compilation);
+
+        GeneratorDriverRunResult result = driver.GetRunResult();
+        result.Diagnostics.Should().BeEmpty();
+        result.Results.Should().ContainSingle();
+        // Two passes against the same compilation must produce identical sources.
+        result.Results[0].GeneratedSources.Should().HaveCount(2);
+    }
+
+    private static string GetRegistry(GeneratorRunResult result)
+        => result.GeneratedSources
+            .Single(s => s.HintName == "MSTestReflectionMetadata.Registry.g.cs")
+            .SourceText.ToString()
+            .Replace("\r\n", "\n");
+
+    private static GeneratorRunResult RunGenerator(params string[] sources)
+    {
+        CSharpCompilation compilation = CreateCompilation(sources);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new MSTestReflectionMetadataGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+        return driver.GetRunResult().Results[0];
+    }
+
+    private static Compilation RunGeneratorAndGetCompilation(params string[] sources)
+    {
+        CSharpCompilation compilation = CreateCompilation(sources);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new MSTestReflectionMetadataGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out _);
+        return outputCompilation;
+    }
+
+    private static CSharpCompilation CreateCompilation(params string[] sources)
+    {
+        IEnumerable<SyntaxTree> trees = sources.Select(s => CSharpSyntaxTree.ParseText(s));
+        MetadataReference[] references = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Runtime.CompilerServices.ModuleInitializerAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Reflection.Assembly).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Collections.Generic.Dictionary<,>).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Reflection.MethodInfo).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(System.Threading.Tasks.Task).Assembly.Location),
+        };
+
+        return CSharpCompilation.Create(
+            "TestSample",
+            trees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+}

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -51,6 +51,13 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
             [System.AttributeUsage(System.AttributeTargets.Method)]
             public class TestCleanupAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
+            public class ParallelizeAttribute : System.Attribute
+            {
+                public int Workers { get; set; }
+                public string? Scope { get; set; }
+            }
         }
         """;
 
@@ -762,6 +769,118 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         registry.Should().NotContain("Name = \"Equals\"");
         registry.Should().NotContain("Name = \"GetHashCode\"");
         registry.Should().NotContain("Name = \"GetType\"");
+    }
+
+    [TestMethod]
+    public void Generator_CapturesAssemblyLevelAttribute()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 4, Scope = "Method")]
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("public static IReadOnlyList<Attribute> AssemblyAttributes { get; } = new Attribute[]");
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.ParallelizeAttribute()");
+        registry.Should().Contain("Workers = 4");
+        registry.Should().Contain("Scope = \"Method\"");
+    }
+
+    [TestMethod]
+    public void Generator_AssemblyAttributes_IsEmptyArray_WhenNoneApplied()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("public static IReadOnlyList<Attribute> AssemblyAttributes { get; } = Array.Empty<Attribute>();");
+        registry.Should().NotContain("public static IReadOnlyList<Attribute> AssemblyAttributes { get; } = new Attribute[]");
+    }
+
+    [TestMethod]
+    public void Generator_CapturesMultipleAssemblyAttributes_InDeclarationOrder()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 1)]
+            [assembly: Parallelize(Workers = 2)]
+            [assembly: Parallelize(Workers = 3)]
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+
+        int idx1 = registry.IndexOf("Workers = 1", StringComparison.Ordinal);
+        int idx2 = registry.IndexOf("Workers = 2", StringComparison.Ordinal);
+        int idx3 = registry.IndexOf("Workers = 3", StringComparison.Ordinal);
+
+        idx1.Should().BeGreaterThan(-1);
+        idx2.Should().BeGreaterThan(idx1);
+        idx3.Should().BeGreaterThan(idx2);
+    }
+
+    [TestMethod]
+    public void Generator_AssemblyAttributes_AreEmittedEvenWithNoTestClasses()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 8)]
+
+            namespace Sample
+            {
+                public class NotATest { }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.ParallelizeAttribute()");
+        registry.Should().Contain("Workers = 8");
+        registry.Should().NotContain("new TestClassReflectionInfo(");
     }
 
     private static string GetRegistry(GeneratorRunResult result)

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/Program.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
+
+#if ENABLE_CODECOVERAGE
+builder.AddCodeCoverageProvider();
+#endif
+builder.AddHangDumpProvider();
+builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
+builder.AddTrxReportProvider();
+builder.AddAppInsightsTelemetryProvider();
+builder.AddAzureDevOpsProvider();
+
+using ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();


### PR DESCRIPTION
## Part of #1837

Adds compile-time materialization of `[DataRow]` attribute applications on `[TestMethod]` members. The generator now emits a `DataRows` property on each `TestMethodReflectionInfo` containing a flat `IReadOnlyList<object?[]>` mirroring the runtime shape of `DataRowAttribute.Data`, so a consumer can iterate parameterised cases without re-reading the attributes via reflection.

### Highlights

- New `DataRowModel(EquatableArray<TypedConstantModel> Arguments)` capturing one row of arguments per attribute application.
- `BuildDataRows` detects `Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute` applications and flattens the variadic `params object?[] moreData` tail back into the row so the emitted array matches `DataRowAttribute.Data` rather than preserving a nested array.
- Inheritance-aware: reuses the inherited attribute walk introduced in #9006, so `[DataRow]` applied on a base method (when the override is virtual) is still picked up.
- Emitter always emits `DataRows` (empty array for non-data-driven tests) for shape parity with the other `TestMethodReflectionInfo` properties.

### Deferred to a follow-up

`[DynamicData]` materialization. Resolving the data source method/property/field at compile time is materially more complex (handles `Method`/`Property`/`Field`/`AutoDetect` source kinds plus `object[]` / `IEnumerable<object[]>` return shapes) and warrants its own PR.

### Tests

- `Generator_EmitsEmptyDataRows_WhenMethodHasNoDataRow`
- `Generator_CapturesSingleDataRow_WithScalarArgs`
- `Generator_CapturesMultipleDataRows_InDeclarationOrder`
- `Generator_FlattensParamsArrayInDataRow`
- `Generator_HandlesNullValueInDataRow`

Total: 32/32 passing.

### Dependencies

Stacked on top of:
- #9004 — Add unit-test project for `MSTest.AotReflection.SourceGeneration`
- #9005 — Fix `typeof` nullable annotation in emitted code
- #9006 — Walk inheritance chain
- #9007 — Capture assembly-level attributes
