### PR TITLE
[test-improver] test: add edge case tests for DoNotUseSystemDescriptionAttributeAnalyzer (MSTEST0031)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseSystemDescriptionAttributeAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseSystemDescriptionAttributeAnalyzerTests.cs
@@ -165,4 +165,65 @@ public sealed class DoNotUseSystemDescriptionAttributeAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenDataTestMethodHasSystemDescriptionAttribute_Diagnostic()
+    {
+        // DataTestMethodAttribute inherits from TestMethodAttribute, so the Inherits() check should
+        // catch it and report the same diagnostic as for [TestMethod].
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                [System.ComponentModel.Description("Description")]
+                public void [|MyTestMethod|](int x)
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                [Description("Description")]
+                public void MyTestMethod(int x)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasMSTestDescriptionAttribute_NoDiagnostic()
+    {
+        // When only the MSTest namespace is in scope, the short-form [Description] resolves to
+        // Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute, not
+        // System.ComponentModel.DescriptionAttribute. The analyzer must not fire.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Description("Description")]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant focused on improving tests for this repository.*

## Goal and Rationale

`DoNotUseSystemDescriptionAttributeAnalyzer` (MSTEST0031) had 5 tests covering the main diagnostic and code-fix paths, but two real-world behaviors were undocumented:

1. **`[DataTestMethod]` + `[System.ComponentModel.Description]` → diagnostic** — `DataTestMethodAttribute` inherits from `TestMethodAttribute`. The analyzer detects test methods via `attribute.AttributeClass.Inherits(testMethodAttributeSymbol)`, so `[DataTestMethod]` should trigger the same diagnostic as `[TestMethod]`. No test confirmed this inheritance path.

2. **`[TestMethod]` + MSTest's `[Description]` → no diagnostic** — When `using Microsoft.VisualStudio.TestTools.UnitTesting` is in scope (without `using System.ComponentModel`), the short-form `[Description]` resolves to `Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute` — the *correct* attribute. The analyzer checks via `SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, systemDescriptionAttributeSymbol)` (not `Inherits()`), so it must not fire here. This test guards against a future regression that might accidentally flag the correct usage.

## Approach

Added 2 new `[TestMethod]` test cases to `DoNotUseSystemDescriptionAttributeAnalyzerTests`. No production code changes.

## Test Status

```
Test run summary: Passed!
  total: 7
  failed: 0
  succeeded: 7
  skipped: 0
  duration: 8s 605ms
```

✅ All 7 tests pass (`MSTest.Analyzers.UnitTests`, net8.0, Debug — 5 original + 2 new).

## Reproducibility

```bash
./build.sh --restore   # first run only
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "ClassName=MSTest.Analyzers.Test.DoNotUseSystemDescriptionAttributeAnalyzerTests"
```

## Trade-offs

- Tests exercise existing code paths only — no production changes, no maintenance burden beyond the tests.
- The `[DataTestMethod]` test pins the `Inherits()` check behavior for derived test-method attributes.
- The MSTest `[Description]` test guards against accidentally flagging the correct usage.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27312771236/agentic_workflow) workflow.{ai_credits_suffix} · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.52, model: claude-sonnet-4.6, id: 27312771236, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27312771236 -->

<!-- gh-aw-workflow-id: test-improver -->