### PR TITLE
Fix telemetry tests for new default diagnostic file name shape

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -26,7 +26,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_RunTests_SendsTelemetryWithSettingsAndAttributes(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -66,7 +66,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_DiscoverTests_SendsTelemetryEvent(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -92,7 +92,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_WhenTelemetryDisabled_DoesNotSendMSTestEvent(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -193,6 +193,17 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         string content = await reader.ReadToEndAsync();
 
         return (Regex.IsMatch(content, pattern), content);
+    }
+
+    // Build a regex matching the deterministic default diagnostic file name shape:
+    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
+    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
+    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{MTPAssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     #endregion

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
@@ -15,7 +15,7 @@ public sealed class TelemetryDisabledTests : AcceptanceTestBase<TelemetryDisable
     public async Task Telemetry_WhenEnableTelemetryIsFalse_WithTestApplicationOptions_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
@@ -53,6 +53,17 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
+    }
+
+    // Build a regex matching the deterministic default diagnostic file name shape:
+    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
+    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
+    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -15,7 +15,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_ByDefault_TelemetryIsEnabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
@@ -37,7 +37,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_WhenOptingOutTelemetry_WithEnvironmentVariable_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -66,7 +66,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_WhenOptingOutTelemetry_With_DOTNET_CLI_EnvironmentVariable_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = Path.Combine(diagPath, @"log_.*.diag").Replace(@"\", @"\\");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -111,6 +111,17 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
+    }
+
+    // Build a regex matching the deterministic default diagnostic file name shape:
+    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
+    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
+    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()


### PR DESCRIPTION
PR #8971 changed the default Microsoft.Testing.Platform diagnostic log filename prefix from `log` to `<asm>_<tfm>_<arch>` (see [TestApplication.cs](https://github.com/microsoft/testfx/blob/main/src/Platform/Microsoft.Testing.Platform/Builder/TestApplication.cs)), and updated `DiagnosticTests.cs` accordingly with a new `BuildDefaultDiagnosticFilePathPattern` helper. However, three telemetry test files were missed and still asserted against the old `log_*.diag` filename, which is why main is currently red ([build 2996915](https://dnceng.visualstudio.com/internal/_build/results?buildId=2996915&view=results)).

Failing tests fixed:

- `Telemetry_ByDefault_TelemetryIsEnabled`
- `Telemetry_WhenOptingOutTelemetry_WithEnvironmentVariable_TelemetryIsDisabled`
- `Telemetry_WhenOptingOutTelemetry_With_DOTNET_CLI_EnvironmentVariable_TelemetryIsDisabled`
- `Telemetry_WhenEnableTelemetryIsFalse_WithTestApplicationOptions_TelemetryIsDisabled`
- `MTP_RunTests_SendsTelemetryWithSettingsAndAttributes`
- `MTP_DiscoverTests_SendsTelemetryEvent`
- `MTP_WhenTelemetryDisabled_DoesNotSendMSTestEvent`

Each of the three telemetry test files now gets the same `BuildDefaultDiagnosticFilePathPattern` helper that mirrors the one already present in `DiagnosticTests.cs`, so we no longer hard-code the diagnostic filename shape across multiple call sites.