### PR TITLE
Fix IDE/SA build errors in MSTest.AotReflection.SourceGeneration

### DIFF
--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MSTestReflectionMetadataGenerator.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MSTestReflectionMetadataGenerator.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -80,11 +77,8 @@ internal sealed class MSTestReflectionMetadataGenerator : IIncrementalGenerator
         }
 
         // Skip abstract / static / generic classes for this PoC — they need extra wiring.
-        if (typeSymbol.IsAbstract || typeSymbol.IsStatic || typeSymbol.IsGenericType)
-        {
-            return null;
-        }
-
-        return TestClassModelBuilder.Build(typeSymbol);
+        return typeSymbol.IsAbstract || typeSymbol.IsStatic || typeSymbol.IsGenericType
+            ? null
+            : TestClassModelBuilder.Build(typeSymbol);
     }
 }

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-
 using MSTest.AotReflection.SourceGeneration.Helpers;
 using MSTest.AotReflection.SourceGeneration.Model;
 
@@ -321,7 +317,6 @@ internal static class MetadataRegistryEmitter
         }
     }
 
-
     private static void EmitParameterTypes(IndentedStringBuilder sb, EquatableArray<TestParameterModel> parameters)
     {
         if (parameters.Length == 0)
@@ -455,15 +450,10 @@ internal static class MetadataRegistryEmitter
         };
 
     private static string BuildArgumentsFromObjectArray(EquatableArray<TestParameterModel> parameters)
-    {
-        if (parameters.Length == 0)
-        {
-            return string.Empty;
-        }
-
-        return string.Join(", ", parameters.AsImmutableArray()
-            .Select((p, i) => $"({p.FullyQualifiedType})args![{i}]!"));
-    }
+        => parameters.Length == 0
+            ? string.Empty
+            : string.Join(", ", parameters.AsImmutableArray()
+                .Select((p, i) => $"({p.FullyQualifiedType})args![{i}]!"));
 
     private static string Bool(bool value) => value ? "true" : "false";
 

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 
 using Microsoft.CodeAnalysis;
 
@@ -358,7 +354,7 @@ internal static class TestClassModelBuilder
             return EquatableArray<TestParameterModel>.Empty;
         }
 
-        TestParameterModel[] parameters = new TestParameterModel[method.Parameters.Length];
+        var parameters = new TestParameterModel[method.Parameters.Length];
         for (int i = 0; i < method.Parameters.Length; i++)
         {
             IParameterSymbol p = method.Parameters[i];
@@ -370,17 +366,12 @@ internal static class TestClassModelBuilder
 
     public static EquatableArray<AttributeApplicationModel> BuildAttributes(
         ImmutableArray<AttributeData> attributes)
-    {
-        if (attributes.IsDefaultOrEmpty)
-        {
-            return EquatableArray<AttributeApplicationModel>.Empty;
-        }
-
-        return attributes
-            .Select(BuildAttribute)
-            .WhereNotNull()
-            .ToEquatableArray();
-    }
+        => attributes.IsDefaultOrEmpty
+            ? EquatableArray<AttributeApplicationModel>.Empty
+            : attributes
+                .Select(BuildAttribute)
+                .WhereNotNull()
+                .ToEquatableArray();
 
     private static AttributeApplicationModel? BuildAttribute(AttributeData attribute)
     {
@@ -399,25 +390,24 @@ internal static class TestClassModelBuilder
     }
 
     private static TypedConstantModel ToModel(TypedConstant constant)
-    {
-        if (constant.IsNull)
+        => constant switch
         {
-            return new TypedConstantModel(ConstantValueKind.Null, constant.Type?.ToDisplayString(FullyQualifiedFormat), null, EquatableArray<TypedConstantModel>.Empty);
-        }
-
-        return constant.Kind switch
-        {
-            TypedConstantKind.Array => new TypedConstantModel(
+            { IsNull: true } => new TypedConstantModel(
+                ConstantValueKind.Null,
+                constant.Type?.ToDisplayString(FullyQualifiedFormat),
+                null,
+                EquatableArray<TypedConstantModel>.Empty),
+            { Kind: TypedConstantKind.Array } => new TypedConstantModel(
                 ConstantValueKind.Array,
                 constant.Type?.ToDisplayString(FullyQualifiedFormat),
                 null,
                 constant.Values.Select(ToModel).ToEquatableArray()),
-            TypedConstantKind.Enum => new TypedConstantModel(
+            { Kind: TypedConstantKind.Enum } => new TypedConstantModel(
                 ConstantValueKind.Enum,
                 constant.Type?.ToDisplayString(FullyQualifiedFormat),
                 constant.Value,
                 EquatableArray<TypedConstantModel>.Empty),
-            TypedConstantKind.Type => new TypedConstantModel(
+            { Kind: TypedConstantKind.Type } => new TypedConstantModel(
                 ConstantValueKind.Type,
                 (constant.Value as ITypeSymbol)?.ToDisplayString(FullyQualifiedFormat),
                 null,
@@ -428,5 +418,4 @@ internal static class TestClassModelBuilder
                 constant.Value,
                 EquatableArray<TypedConstantModel>.Empty),
         };
-    }
 }

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Helpers/IndentedStringBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Helpers/IndentedStringBuilder.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace MSTest.AotReflection.SourceGeneration.Helpers;
 
 /// <summary>

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace MSTest.AotReflection.SourceGeneration.Model;
 
@@ -90,6 +87,7 @@ internal sealed record TestClassModel(
 /// Value-equatable wrapper around <see cref="ImmutableArray{T}"/> so incremental generation
 /// can cache results between runs. Kept minimal — we don't need indexing in this PoC.
 /// </summary>
+/// <typeparam name="T">Element type stored in the underlying <see cref="ImmutableArray{T}"/>.</typeparam>
 internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>
     where T : IEquatable<T>
 {


### PR DESCRIPTION
## Why

Latest `main` (after #9011) fails to build with 15 `IDE`/`SA` errors in the `MSTest.AotReflection.SourceGeneration` project. Sample (from CI):

```
MetadataRegistryEmitter.cs(323,1):           error IDE2000 / SA1507  multiple blank lines
TestClassModel.cs(93,41):                    error SA1618             missing T doc
TestClassModelBuilder.cs(361,9):             error IDE0007            use 'var'
TestClassModelBuilder.cs(374,9):             error IDE0046            'if' can be simplified
TestClassModelBuilder.cs(403,9):             error IDE0046            'if' can be simplified
MSTestReflectionMetadataGenerator.cs(83,9):  error IDE0046            'if' can be simplified
MetadataRegistryEmitter.cs(459,9):           error IDE0046            'if' can be simplified
… plus 7 IDE0005 "using directive is unnecessary" errors
```

The IDE0005 errors come from the repo-wide global usings declared in `Directory.Build.props` (`ImplicitUsings` + extra `<Using>` items) already importing every `System.*` namespace used by these files, so the explicit `using System.*;` directives are redundant.

## What

- **IDE0005** — drop the redundant `System.*` `using` directives across `MetadataRegistryEmitter.cs`, `MSTestReflectionMetadataGenerator.cs`, `TestClassModelBuilder.cs`, `IndentedStringBuilder.cs`, and `TestClassModel.cs` (everything except `System.Collections.Immutable`, which is not in the global set).
- **IDE2000 / SA1507** — remove the extra blank line between `EmitAttributeInitialization` and `EmitParameterTypes` in `MetadataRegistryEmitter.cs`.
- **SA1618** — add `<typeparam name="T">` documentation on `EquatableArray<T>` in `TestClassModel.cs`.
- **IDE0007** — change `TestParameterModel[] parameters = …` to `var parameters = …` in `BuildParameters`.
- **IDE0046** — convert the remaining `if (…) { return X; } return Y;` patterns to ternary / expression-bodied members in `BuildAttributes`, `BuildModel`, and `BuildArgumentsFromObjectArray`. `ToModel` is rewritten as a single `switch` expression with property patterns (`{ IsNull: true }`, `{ Kind: … }`) so the simplification doesn't fall into a nested `ternary + switch` shape that triggers `IDE0055` formatting violations.

## Verification

```powershell
.\build.cmd -projects src\Analyzers\MSTest.AotReflection.SourceGeneration\MSTest.AotReflection.SourceGeneration.csproj -c Release
# Build succeeded.

.\build.cmd -projects test\UnitTests\MSTest.AotReflection.SourceGeneration.UnitTests\MSTest.AotReflection.SourceGeneration.UnitTests.csproj -c Release
# Build succeeded.

.\build.cmd -projects src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj -c Release
# Build succeeded.
```

## Notes

- Pure style / refactor: no runtime behavior change in the emitted source generator.
- The unit-test project (added in #9004) does not register the CTRF / JUnit report extensions, so `-test` run-time fails with `Unknown option '--report-ctrf'`. That is a pre-existing infrastructure mismatch unrelated to this PR and is not addressed here.
