### PR TITLE
Fix CI failures: include OpenTelemetry in NonWindowsTests.slnf and register Ctrf/JUnit providers in AOT test host

### DIFF
--- a/NonWindowsTests.slnf
+++ b/NonWindowsTests.slnf
@@ -21,6 +21,7 @@
       "src\\Platform\\Microsoft.Testing.Extensions.JUnitReport\\Microsoft.Testing.Extensions.JUnitReport.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.Logging\\Microsoft.Testing.Extensions.Logging.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.MSBuild\\Microsoft.Testing.Extensions.MSBuild.csproj",
+      "src\\Platform\\Microsoft.Testing.Extensions.OpenTelemetry\\Microsoft.Testing.Extensions.OpenTelemetry.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.Retry\\Microsoft.Testing.Extensions.Retry.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.Telemetry\\Microsoft.Testing.Extensions.Telemetry.csproj",
       "src\\Platform\\Microsoft.Testing.Extensions.TrxReport.Abstractions\\Microsoft.Testing.Extensions.TrxReport.Abstractions.csproj",

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/Program.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/Program.cs
@@ -12,8 +12,10 @@ builder.AddCodeCoverageProvider();
 builder.AddHangDumpProvider();
 builder.AddCrashDumpProvider(ignoreIfNotSupported: true);
 builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
 builder.AddAppInsightsTelemetryProvider();
 builder.AddAzureDevOpsProvider();
+builder.AddCtrfReportProvider();
 
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();


### PR DESCRIPTION
Fixes two distinct test failures observed on `main` in [internal build 2997792](https://dnceng.visualstudio.com/internal/_build/results?buildId=2997792&view=results).

## 1. Linux `Tests` job — `NU1101: Unable to find package Microsoft.Testing.Extensions.OpenTelemetry`

The new `SdkTests` data row added in #8903 (commit c451c6b83) exercises the OpenTelemetry extension, but `Microsoft.Testing.Extensions.OpenTelemetry` was not listed in `NonWindowsTests.slnf`. The non-Windows CI builds and packs only the projects listed in this slnf, so the package was never produced. The acceptance test does not pass `addPublicFeeds: true`, so the package could not be restored from nuget.org either.

**Fix**: Add `Microsoft.Testing.Extensions.OpenTelemetry` to `NonWindowsTests.slnf` (alphabetically placed between `MSBuild` and `Retry`).

## 2. Windows Release `Test` job — `Unknown option '--report-ctrf'` / `'--report-junit'`

`azure-pipelines.yml` invokes every UnitTests host found by the `--test-modules` glob with `--report-ctrf` and `--report-junit`. `MSTest.AotReflection.SourceGeneration.UnitTests/Program.cs` was missing the corresponding provider registrations, so MTP rejected the unknown options and aborted the run. Other UnitTests hosts (e.g., `MSTest.SourceGeneration.UnitTests/Program.cs`) already register both providers.

**Fix**: Add `builder.AddCtrfReportProvider()` and `builder.AddJUnitReportProvider()` calls to the AOT reflection test host.

## Validation

- `dotnet build test\UnitTests\MSTest.AotReflection.SourceGeneration.UnitTests\MSTest.AotReflection.SourceGeneration.UnitTests.csproj -c Release` → 0 warnings, 0 errors.
- Running `MSTest.AotReflection.SourceGeneration.UnitTests.exe --help` now lists `--report-ctrf` / `--report-ctrf-filename` / `--report-junit` / `--report-junit-filename`.
- Passing `--report-ctrf --report-junit --list-tests` returns the proper provider validation error (instead of `Unknown option`), confirming the providers are registered.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>