### PR TITLE
[link-checker] Fix broken documentation links

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -837,9 +837,9 @@ See full log [of v1.4.2...v1.4.3](https://github.com/microsoft/testanywhere/comp
 
 ### Fixed
 
-* Fix live output with HotReload by @nohwnd in [#3983](https://github.com/microsoft/testfx/pull//3983)
-* Fix hangdump space in dump path by @nohwnd in [#3994](https://github.com/microsoft/testfx/pull//3994)
-* Fix hangdump not showing tests in progress by @nohwnd in [#3992](https://github.com/microsoft/testfx/pull//3992)
+* Fix live output with HotReload by @nohwnd in [#3983](https://github.com/microsoft/testfx/pull/3983)
+* Fix hangdump space in dump path by @nohwnd in [#3994](https://github.com/microsoft/testfx/pull/3994)
+* Fix hangdump not showing tests in progress by @nohwnd in [#3992](https://github.com/microsoft/testfx/pull/3992)
 
 ### Artifacts
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1075,7 +1075,7 @@ See full log [of v3.6.2...v3.6.3](https://github.com/microsoft/testfx/compare/v3
 
 ### Fixed
 
-* Only ship TestAdapter related resources by @nohwnd in [#4013](https://github.com/microsoft/testfx/pull//4013)
+* Only ship TestAdapter related resources by @nohwnd in [#4013](https://github.com/microsoft/testfx/pull/4013)
 
 ### Artifacts
 


### PR DESCRIPTION
## Summary

Fixed 4 malformed pull request URLs in changelog files that had double slashes (`pull//NNNN`) instead of correct single slash (`pull/NNNN`) format.

## Links Fixed

| File | PR | Old URL | New URL |
|------|-----|---------|---------|
| `docs/Changelog-Platform.md` | #3983 | `pull//3983` | `pull/3983` |
| `docs/Changelog-Platform.md` | #3992 | `pull//3992` | `pull/3992` |
| `docs/Changelog-Platform.md` | #3994 | `pull//3994` | `pull/3994` |
| `docs/Changelog.md` | #4013 | `pull//4013` | `pull/4013` |

## Known Unfixable Links (skipped)

The following links remain broken but are intentional or historical and cannot be fixed:
- `(localhost/redacted) — intentional localhost example URL
- `https://github.com/microsoft/testanywhere/compare/...` — retired repo, historical changelog entries
- Historical `github.com/microsoft/testfx/compare/` entries for old tags (v1.x–v2.x) that no longer exist
- Azure DevOps build badge endpoint no longer accessible

> Note: ~2,800 additional "broken" links reported by the link checker are false positives caused by the link extractor appending trailing `)` from markdown syntax to URLs. The actual markdown files are correct.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Daily Link Checker & Fixer](https://github.com/microsoft/testfx/actions/runs/27346729783/agentic_workflow) workflow. · 304.7 AIC · ⌖ 23.5 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+link-checker%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/link-checker.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Daily Link Checker & Fixer, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27346729783, workflow_id: link-checker, run: https://github.com/microsoft/testfx/actions/runs/27346729783 -->

<!-- gh-aw-workflow-id: link-checker -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/link-checker -->