### PR TITLE
Refactor fixture lifecycle analyzers to share validation helper

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AssemblyCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyCleanupShouldBeValidAnalyzer.cs
@@ -40,7 +40,7 @@ public sealed class AssemblyCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyCleanupAttribute,
-                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols)));
+                AnalyzeSymbol));
     }
 
     private static void AnalyzeSymbol(

--- a/src/Analyzers/MSTest.Analyzers/AssemblyCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyCleanupShouldBeValidAnalyzer.cs
@@ -37,34 +37,24 @@ public sealed class AssemblyCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(context =>
-        {
-            if (FixtureMethodAnalyzerHelper.TryGetFixtureMethodSymbols(context.Compilation, WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyCleanupAttribute, out FixtureMethodAnalyzerHelper.FixtureMethodSymbols symbols))
-            {
-                INamedTypeSymbol? testContextSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext);
-                context.RegisterSymbolAction(
-                    symbolContext => AnalyzeSymbol(symbolContext, symbols.FixtureAttributeSymbol, symbols.TestClassAttributeSymbol, symbols.TaskSymbol, symbols.ValueTaskSymbol, testContextSymbol, symbols.CanDiscoverInternals),
-                    SymbolKind.Method);
-            }
-        });
+            FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
+                context,
+                WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyCleanupAttribute,
+                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols)));
     }
 
     private static void AnalyzeSymbol(
         SymbolAnalysisContext context,
-        INamedTypeSymbol assemblyCleanupAttributeSymbol,
-        INamedTypeSymbol testClassAttributeSymbol,
-        INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol,
-        INamedTypeSymbol? testContextSymbol,
-        bool canDiscoverInternals)
+        FixtureMethodAnalyzerHelper.FixtureMethodSymbols symbols)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
 
-        if (!methodSymbol.HasAttribute(assemblyCleanupAttributeSymbol))
+        if (!methodSymbol.HasAttribute(symbols.FixtureAttributeSymbol))
         {
             return;
         }
 
-        if (!methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: true, allowGenericType: false, FixtureParameterMode.OptionalTestContext, testContextSymbol, testClassAttributeSymbol, fixtureAllowInheritedTestClass: false, out bool isFixable))
+        if (!methodSymbol.HasValidFixtureMethodSignature(symbols.TaskSymbol, symbols.ValueTaskSymbol, symbols.CanDiscoverInternals, shouldBeStatic: true, allowGenericType: false, FixtureParameterMode.OptionalTestContext, symbols.TestContextSymbol, symbols.TestClassAttributeSymbol, fixtureAllowInheritedTestClass: false, out bool isFixable))
         {
             context.ReportDiagnostic(isFixable
                 ? methodSymbol.CreateDiagnostic(Rule, methodSymbol.Name)

--- a/src/Analyzers/MSTest.Analyzers/AssemblyInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyInitializeShouldBeValidAnalyzer.cs
@@ -37,29 +37,20 @@ public sealed class AssemblyInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(context =>
-        {
-            if (context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyInitializeAttribute, out INamedTypeSymbol? assemblyInitializeAttributeSymbol)
-                && context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext, out INamedTypeSymbol? testContextSymbol)
-                && context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestClassAttribute, out INamedTypeSymbol? testClassAttributeSymbol))
-            {
-                INamedTypeSymbol? taskSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask);
-                INamedTypeSymbol? valueTaskSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksValueTask);
-                bool canDiscoverInternals = context.Compilation.CanDiscoverInternals();
-                context.RegisterSymbolAction(
-                    context => AnalyzeSymbol(context, assemblyInitializeAttributeSymbol, taskSymbol, valueTaskSymbol, testContextSymbol, testClassAttributeSymbol, canDiscoverInternals),
-                    SymbolKind.Method);
-            }
-        });
+            FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
+                context,
+                WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyInitializeAttribute,
+                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols),
+                requireTestContextSymbol: true));
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol assemblyInitializeAttributeSymbol, INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol, INamedTypeSymbol testContextSymbol, INamedTypeSymbol testClassAttributeSymbol, bool canDiscoverInternals)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, FixtureMethodAnalyzerHelper.FixtureMethodSymbols symbols)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
 
-        if (methodSymbol.HasAttribute(assemblyInitializeAttributeSymbol)
-            && !methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: true,
-                allowGenericType: false, FixtureParameterMode.MustHaveTestContext, testContextSymbol, testClassAttributeSymbol, fixtureAllowInheritedTestClass: false, out bool isFixable))
+        if (methodSymbol.HasAttribute(symbols.FixtureAttributeSymbol)
+            && !methodSymbol.HasValidFixtureMethodSignature(symbols.TaskSymbol, symbols.ValueTaskSymbol, symbols.CanDiscoverInternals, shouldBeStatic: true,
+                allowGenericType: false, FixtureParameterMode.MustHaveTestContext, symbols.TestContextSymbol, symbols.TestClassAttributeSymbol, fixtureAllowInheritedTestClass: false, out bool isFixable))
         {
             context.ReportDiagnostic(isFixable
                 ? methodSymbol.CreateDiagnostic(Rule, methodSymbol.Name)

--- a/src/Analyzers/MSTest.Analyzers/AssemblyInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyInitializeShouldBeValidAnalyzer.cs
@@ -40,7 +40,7 @@ public sealed class AssemblyInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyInitializeAttribute,
-                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols),
+                AnalyzeSymbol,
                 requireTestContextSymbol: true));
     }
 

--- a/src/Analyzers/MSTest.Analyzers/ClassCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ClassCleanupShouldBeValidAnalyzer.cs
@@ -37,34 +37,22 @@ public sealed class ClassCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(context =>
-        {
-            if (FixtureMethodAnalyzerHelper.TryGetFixtureMethodSymbols(context.Compilation, WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassCleanupAttribute, out FixtureMethodAnalyzerHelper.FixtureMethodSymbols symbols))
-            {
-                INamedTypeSymbol? inheritanceBehaviorSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingInheritanceBehavior);
-                INamedTypeSymbol? testContextSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext);
-                context.RegisterSymbolAction(
-                    symbolContext => AnalyzeSymbol(symbolContext, symbols.FixtureAttributeSymbol, symbols.TaskSymbol, symbols.ValueTaskSymbol, inheritanceBehaviorSymbol, symbols.TestClassAttributeSymbol, testContextSymbol, symbols.CanDiscoverInternals),
-                    SymbolKind.Method);
-            }
-        });
+            FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
+                context,
+                WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassCleanupAttribute,
+                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols)));
     }
 
     private static void AnalyzeSymbol(
         SymbolAnalysisContext context,
-        INamedTypeSymbol classCleanupAttributeSymbol,
-        INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol,
-        INamedTypeSymbol? inheritanceBehaviorSymbol,
-        INamedTypeSymbol testClassAttributeSymbol,
-        INamedTypeSymbol? testContextSymbol,
-        bool canDiscoverInternals)
+        FixtureMethodAnalyzerHelper.FixtureMethodSymbols symbols)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
-        bool isInheritanceModeSet = methodSymbol.IsInheritanceModeSet(inheritanceBehaviorSymbol, classCleanupAttributeSymbol);
-        if (methodSymbol.HasAttribute(classCleanupAttributeSymbol)
-            && (!methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: true,
-                allowGenericType: isInheritanceModeSet, FixtureParameterMode.OptionalTestContext, testContextSymbol,
-                testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable)
+        bool isInheritanceModeSet = methodSymbol.IsInheritanceModeSet(symbols.InheritanceBehaviorSymbol, symbols.FixtureAttributeSymbol);
+        if (methodSymbol.HasAttribute(symbols.FixtureAttributeSymbol)
+            && (!methodSymbol.HasValidFixtureMethodSignature(symbols.TaskSymbol, symbols.ValueTaskSymbol, symbols.CanDiscoverInternals, shouldBeStatic: true,
+                allowGenericType: isInheritanceModeSet, FixtureParameterMode.OptionalTestContext, symbols.TestContextSymbol,
+                symbols.TestClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable)
                 || (!isInheritanceModeSet && methodSymbol.ContainingType.IsAbstract)
                 || (isInheritanceModeSet && methodSymbol.ContainingType.IsSealed)))
         {

--- a/src/Analyzers/MSTest.Analyzers/ClassCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ClassCleanupShouldBeValidAnalyzer.cs
@@ -40,7 +40,7 @@ public sealed class ClassCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassCleanupAttribute,
-                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols)));
+                AnalyzeSymbol));
     }
 
     private static void AnalyzeSymbol(

--- a/src/Analyzers/MSTest.Analyzers/ClassInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ClassInitializeShouldBeValidAnalyzer.cs
@@ -41,7 +41,7 @@ public sealed class ClassInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassInitializeAttribute,
-                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols),
+                AnalyzeSymbol,
                 requireTestContextSymbol: true));
     }
 

--- a/src/Analyzers/MSTest.Analyzers/ClassInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ClassInitializeShouldBeValidAnalyzer.cs
@@ -38,34 +38,21 @@ public sealed class ClassInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(context =>
-        {
-            if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassInitializeAttribute, out INamedTypeSymbol? classInitializeAttributeSymbol)
-                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext, out INamedTypeSymbol? testContextSymbol)
-                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestClassAttribute, out INamedTypeSymbol? testClassAttributeSymbol))
-            {
-                return;
-            }
-
-            INamedTypeSymbol? taskSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask);
-            INamedTypeSymbol? inheritanceBehaviorSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingInheritanceBehavior);
-            INamedTypeSymbol? valueTaskSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksValueTask);
-            bool canDiscoverInternals = context.Compilation.CanDiscoverInternals();
-            context.RegisterSymbolAction(
-                context => AnalyzeSymbol(context, classInitializeAttributeSymbol, taskSymbol, valueTaskSymbol, testContextSymbol, inheritanceBehaviorSymbol, testClassAttributeSymbol, canDiscoverInternals),
-                SymbolKind.Method);
-        });
+            FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
+                context,
+                WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassInitializeAttribute,
+                static (symbolContext, symbols) => AnalyzeSymbol(symbolContext, symbols),
+                requireTestContextSymbol: true));
     }
 
-    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol classInitializeAttributeSymbol, INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol, INamedTypeSymbol testContextSymbol, INamedTypeSymbol? inheritanceBehaviorSymbol, INamedTypeSymbol testClassAttributeSymbol,
-        bool canDiscoverInternals)
+    private static void AnalyzeSymbol(SymbolAnalysisContext context, FixtureMethodAnalyzerHelper.FixtureMethodSymbols symbols)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
-        bool isInheritanceModeSet = methodSymbol.IsInheritanceModeSet(inheritanceBehaviorSymbol, classInitializeAttributeSymbol);
-        if (methodSymbol.HasAttribute(classInitializeAttributeSymbol)
-            && ((!methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: true,
-                allowGenericType: isInheritanceModeSet, FixtureParameterMode.MustHaveTestContext, testContextSymbol,
-                testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
+        bool isInheritanceModeSet = methodSymbol.IsInheritanceModeSet(symbols.InheritanceBehaviorSymbol, symbols.FixtureAttributeSymbol);
+        if (methodSymbol.HasAttribute(symbols.FixtureAttributeSymbol)
+            && ((!methodSymbol.HasValidFixtureMethodSignature(symbols.TaskSymbol, symbols.ValueTaskSymbol, symbols.CanDiscoverInternals, shouldBeStatic: true,
+                allowGenericType: isInheritanceModeSet, FixtureParameterMode.MustHaveTestContext, symbols.TestContextSymbol,
+                symbols.TestClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
                 || (!isInheritanceModeSet && methodSymbol.ContainingType.IsAbstract)
                 || (isInheritanceModeSet && methodSymbol.ContainingType.IsSealed)))
         {

--- a/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
@@ -53,18 +53,14 @@ internal static class FixtureMethodAnalyzerHelper
 
     internal static void AnalyzeInstanceFixtureMethod(
         SymbolAnalysisContext context,
-        INamedTypeSymbol fixtureAttributeSymbol,
-        INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol,
-        INamedTypeSymbol testClassAttributeSymbol,
-        bool canDiscoverInternals,
+        FixtureMethodSymbols symbols,
         DiagnosticDescriptor rule)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
-        if (methodSymbol.HasAttribute(fixtureAttributeSymbol)
-            && !methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: false,
+        if (methodSymbol.HasAttribute(symbols.FixtureAttributeSymbol)
+            && !methodSymbol.HasValidFixtureMethodSignature(symbols.TaskSymbol, symbols.ValueTaskSymbol, symbols.CanDiscoverInternals, shouldBeStatic: false,
                 allowGenericType: true, FixtureParameterMode.MustNotHaveTestContext, testContextSymbol: null,
-                testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
+                symbols.TestClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
         {
             context.ReportDiagnostic(isFixable
                 ? methodSymbol.CreateDiagnostic(rule, methodSymbol.Name)

--- a/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
@@ -27,6 +27,8 @@ internal static class FixtureMethodAnalyzerHelper
             testClassAttributeSymbol,
             compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask),
             compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksValueTask),
+            compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext),
+            compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingInheritanceBehavior),
             compilation.CanDiscoverInternals());
 
         return true;
@@ -35,9 +37,11 @@ internal static class FixtureMethodAnalyzerHelper
     internal static void RegisterFixtureMethodSymbolAction(
         CompilationStartAnalysisContext context,
         string fixtureAttributeMetadataName,
-        Action<SymbolAnalysisContext, FixtureMethodSymbols> analyzeSymbolAction)
+        Action<SymbolAnalysisContext, FixtureMethodSymbols> analyzeSymbolAction,
+        bool requireTestContextSymbol = false)
     {
-        if (!TryGetFixtureMethodSymbols(context.Compilation, fixtureAttributeMetadataName, out FixtureMethodSymbols symbols))
+        if (!TryGetFixtureMethodSymbols(context.Compilation, fixtureAttributeMetadataName, out FixtureMethodSymbols symbols)
+            || (requireTestContextSymbol && symbols.TestContextSymbol is null))
         {
             return;
         }
@@ -47,10 +51,32 @@ internal static class FixtureMethodAnalyzerHelper
             SymbolKind.Method);
     }
 
+    internal static void AnalyzeInstanceFixtureMethod(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol fixtureAttributeSymbol,
+        INamedTypeSymbol? taskSymbol,
+        INamedTypeSymbol? valueTaskSymbol,
+        INamedTypeSymbol testClassAttributeSymbol,
+        bool canDiscoverInternals,
+        DiagnosticDescriptor rule)
+    {
+        var methodSymbol = (IMethodSymbol)context.Symbol;
+        if (methodSymbol.HasAttribute(fixtureAttributeSymbol)
+            && !methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: false,
+                allowGenericType: true, FixtureParameterMode.MustNotHaveTestContext, testContextSymbol: null, testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
+        {
+            context.ReportDiagnostic(isFixable
+                ? methodSymbol.CreateDiagnostic(rule, methodSymbol.Name)
+                : methodSymbol.CreateDiagnostic(rule, DiagnosticDescriptorHelper.CannotFixProperties, methodSymbol.Name));
+        }
+    }
+
     internal readonly record struct FixtureMethodSymbols(
         INamedTypeSymbol FixtureAttributeSymbol,
         INamedTypeSymbol TestClassAttributeSymbol,
         INamedTypeSymbol? TaskSymbol,
         INamedTypeSymbol? ValueTaskSymbol,
+        INamedTypeSymbol? TestContextSymbol,
+        INamedTypeSymbol? InheritanceBehaviorSymbol,
         bool CanDiscoverInternals);
 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
@@ -63,7 +63,8 @@ internal static class FixtureMethodAnalyzerHelper
         var methodSymbol = (IMethodSymbol)context.Symbol;
         if (methodSymbol.HasAttribute(fixtureAttributeSymbol)
             && !methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: false,
-                allowGenericType: true, FixtureParameterMode.MustNotHaveTestContext, testContextSymbol: null, testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
+                allowGenericType: true, FixtureParameterMode.MustNotHaveTestContext, testContextSymbol: null,
+                testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
         {
             context.ReportDiagnostic(isFixable
                 ? methodSymbol.CreateDiagnostic(rule, methodSymbol.Name)

--- a/src/Analyzers/MSTest.Analyzers/TestCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestCleanupShouldBeValidAnalyzer.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Immutable;
 
-using Analyzer.Utilities.Extensions;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -41,26 +39,13 @@ public sealed class TestCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestCleanupAttribute,
-                static (symbolContext, symbols) => AnalyzeSymbol(
+                static (symbolContext, symbols) => FixtureMethodAnalyzerHelper.AnalyzeInstanceFixtureMethod(
                     symbolContext,
                     symbols.FixtureAttributeSymbol,
                     symbols.TaskSymbol,
                     symbols.ValueTaskSymbol,
                     symbols.TestClassAttributeSymbol,
-                    symbols.CanDiscoverInternals)));
-    }
-
-    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol testCleanupAttributeSymbol, INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol, INamedTypeSymbol testClassAttributeSymbol, bool canDiscoverInternals)
-    {
-        var methodSymbol = (IMethodSymbol)context.Symbol;
-        if (methodSymbol.HasAttribute(testCleanupAttributeSymbol)
-            && !methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: false,
-                allowGenericType: true, FixtureParameterMode.MustNotHaveTestContext, testContextSymbol: null, testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
-        {
-            context.ReportDiagnostic(isFixable
-                ? methodSymbol.CreateDiagnostic(Rule, methodSymbol.Name)
-                : methodSymbol.CreateDiagnostic(Rule, DiagnosticDescriptorHelper.CannotFixProperties, methodSymbol.Name));
-        }
+                    symbols.CanDiscoverInternals,
+                    Rule)));
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/TestCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestCleanupShouldBeValidAnalyzer.cs
@@ -39,13 +39,6 @@ public sealed class TestCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestCleanupAttribute,
-                static (symbolContext, symbols) => FixtureMethodAnalyzerHelper.AnalyzeInstanceFixtureMethod(
-                    symbolContext,
-                    symbols.FixtureAttributeSymbol,
-                    symbols.TaskSymbol,
-                    symbols.ValueTaskSymbol,
-                    symbols.TestClassAttributeSymbol,
-                    symbols.CanDiscoverInternals,
-                    Rule)));
+                static (symbolContext, symbols) => FixtureMethodAnalyzerHelper.AnalyzeInstanceFixtureMethod(symbolContext, symbols, Rule)));
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/TestInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestInitializeShouldBeValidAnalyzer.cs
@@ -39,13 +39,6 @@ public sealed class TestInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestInitializeAttribute,
-                static (symbolContext, symbols) => FixtureMethodAnalyzerHelper.AnalyzeInstanceFixtureMethod(
-                    symbolContext,
-                    symbols.FixtureAttributeSymbol,
-                    symbols.TaskSymbol,
-                    symbols.ValueTaskSymbol,
-                    symbols.TestClassAttributeSymbol,
-                    symbols.CanDiscoverInternals,
-                    Rule)));
+                static (symbolContext, symbols) => FixtureMethodAnalyzerHelper.AnalyzeInstanceFixtureMethod(symbolContext, symbols, Rule)));
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/TestInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestInitializeShouldBeValidAnalyzer.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Immutable;
 
-using Analyzer.Utilities.Extensions;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -41,26 +39,13 @@ public sealed class TestInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
             FixtureMethodAnalyzerHelper.RegisterFixtureMethodSymbolAction(
                 context,
                 WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestInitializeAttribute,
-                static (symbolContext, symbols) => AnalyzeSymbol(
+                static (symbolContext, symbols) => FixtureMethodAnalyzerHelper.AnalyzeInstanceFixtureMethod(
                     symbolContext,
                     symbols.FixtureAttributeSymbol,
                     symbols.TaskSymbol,
                     symbols.ValueTaskSymbol,
                     symbols.TestClassAttributeSymbol,
-                    symbols.CanDiscoverInternals)));
-    }
-
-    private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol testInitializeAttributeSymbol, INamedTypeSymbol? taskSymbol,
-        INamedTypeSymbol? valueTaskSymbol, INamedTypeSymbol testClassAttributeSymbol, bool canDiscoverInternals)
-    {
-        var methodSymbol = (IMethodSymbol)context.Symbol;
-        if (methodSymbol.HasAttribute(testInitializeAttributeSymbol)
-            && !methodSymbol.HasValidFixtureMethodSignature(taskSymbol, valueTaskSymbol, canDiscoverInternals, shouldBeStatic: false,
-                allowGenericType: true, FixtureParameterMode.MustNotHaveTestContext, testContextSymbol: null, testClassAttributeSymbol, fixtureAllowInheritedTestClass: true, out bool isFixable))
-        {
-            context.ReportDiagnostic(isFixable
-                ? methodSymbol.CreateDiagnostic(Rule, methodSymbol.Name)
-                : methodSymbol.CreateDiagnostic(Rule, DiagnosticDescriptorHelper.CannotFixProperties, methodSymbol.Name));
-        }
+                    symbols.CanDiscoverInternals,
+                    Rule)));
     }
 }


### PR DESCRIPTION
## Summary
- share validation for TestInitialize/TestCleanup analyzer methods
- extend fixture method symbol resolution for TestContext and InheritanceBehavior
- migrate assembly/class initialize/cleanup analyzers to RegisterFixtureMethodSymbolAction

Fixes #9025
Fixes #9026

## Validation
- `Q:\src\testfx\.dotnet\dotnet.exe build src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj -v minimal -bl:{}`
- `Q:\src\testfx\.dotnet\dotnet.exe test test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj -f net8.0 -p:UsingDotNetTest=true -bl:{}`
- `Q:\src\testfx\.dotnet\dotnet.exe test test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj -f net8.0 -p:UsingDotNetTest=true --no-build -bl:{}` (1223 passed)