### PR TITLE
[perf-improver] perf: cache `GetRunningTasks` list buffer in `TestNodeResultsState`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
@@ -65,10 +65,32 @@ internal sealed class TestNodeResultsState
         return _summaryDetail;
     }
 
+    /// <summary>
+    /// Returns a snapshot of currently running tasks, sorted by elapsed time descending and
+    /// truncated to <paramref name="maxCount"/> entries (the last entry becomes a "... N more
+    /// running" summary detail when truncation occurs).
+    /// </summary>
+    /// <remarks>
+    /// The returned <see cref="List{T}"/> is a cached buffer reused across calls to avoid
+    /// per-render-tick allocation. Callers MUST consume it immediately and MUST NOT store
+    /// the reference, mutate it, or hand it to other code that might cache it — the next
+    /// call to <see cref="GetRunningTasks"/> will <see cref="List{T}.Clear"/> and rebuild
+    /// the same instance, silently invalidating prior callers' views.
+    /// </remarks>
     public List<TestDetailState> GetRunningTasks(int maxCount)
     {
         // Reuse the cached buffer to avoid allocating a new List on every render tick.
         _runningTasksBuffer.Clear();
+
+        // Pre-size the buffer to the current snapshot size so the first calls (and any
+        // call that grows past the previous high-water mark) don't trigger multiple
+        // internal array reallocations as items are added. Capacity only grows.
+        int snapshotCount = _testNodeProgressStates.Count;
+        if (_runningTasksBuffer.Capacity < snapshotCount)
+        {
+            _runningTasksBuffer.Capacity = snapshotCount;
+        }
+
         foreach (KeyValuePair<string, TestDetailState> kvp in _testNodeProgressStates)
         {
             _runningTasksBuffer.Add(kvp.Value);

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
@@ -19,6 +19,9 @@ internal sealed class TestNodeResultsState
     private readonly TestDetailState _summaryDetail;
     private readonly ConcurrentDictionary<string, TestDetailState> _testNodeProgressStates = new();
 
+    // Reusable buffer for GetRunningTasks — cleared and rebuilt each call to avoid per-tick list allocation.
+    private readonly List<TestDetailState> _runningTasksBuffer = [];
+
     public int Count => _testNodeProgressStates.Count;
 
     public void AddRunningTestNode(int id, string uid, string name, IStopwatch stopwatch) => _testNodeProgressStates[uid] = new TestDetailState(id, stopwatch, name);
@@ -64,17 +67,17 @@ internal sealed class TestNodeResultsState
 
     public List<TestDetailState> GetRunningTasks(int maxCount)
     {
-        // Build the list directly from the dictionary to avoid LINQ iterator chain allocations.
-        var sortedDetails = new List<TestDetailState>(_testNodeProgressStates.Count);
+        // Reuse the cached buffer to avoid allocating a new List on every render tick.
+        _runningTasksBuffer.Clear();
         foreach (KeyValuePair<string, TestDetailState> kvp in _testNodeProgressStates)
         {
-            sortedDetails.Add(kvp.Value);
+            _runningTasksBuffer.Add(kvp.Value);
         }
 
         // Sort descending by elapsed time without LINQ overhead.
-        sortedDetails.Sort(static (a, b) => (b.Stopwatch?.Elapsed ?? TimeSpan.Zero).CompareTo(a.Stopwatch?.Elapsed ?? TimeSpan.Zero));
+        _runningTasksBuffer.Sort(static (a, b) => (b.Stopwatch?.Elapsed ?? TimeSpan.Zero).CompareTo(a.Stopwatch?.Elapsed ?? TimeSpan.Zero));
 
-        bool tooManyItems = sortedDetails.Count > maxCount;
+        bool tooManyItems = _runningTasksBuffer.Count > maxCount;
 
         if (tooManyItems)
         {
@@ -84,19 +87,19 @@ internal sealed class TestNodeResultsState
             _summaryDetail.Text =
                 itemsToTake == 0
                     // Note: If itemsToTake is 0, then we only show two lines, the project summary and the number of running tests.
-                    ? string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, sortedDetails.Count)
+                    ? string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, _runningTasksBuffer.Count)
                     // If itemsToTake is larger, then we show the project summary, active tests, and the number of active tests that are not shown.
-                    : $"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, sortedDetails.Count - itemsToTake)}";
+                    : $"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, _runningTasksBuffer.Count - itemsToTake)}";
 
             // Truncate in-place to avoid allocating a second list/array.
-            if (itemsToTake < sortedDetails.Count)
+            if (itemsToTake < _runningTasksBuffer.Count)
             {
-                sortedDetails.RemoveRange(itemsToTake, sortedDetails.Count - itemsToTake);
+                _runningTasksBuffer.RemoveRange(itemsToTake, _runningTasksBuffer.Count - itemsToTake);
             }
 
-            sortedDetails.Add(_summaryDetail);
+            _runningTasksBuffer.Add(_summaryDetail);
         }
 
-        return sortedDetails;
+        return _runningTasksBuffer;
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1018,6 +1018,91 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_WhenEmpty_ReturnsEmptyList()
+    {
+        var state = new TestNodeResultsState(1);
+
+        List<TestDetailState> tasks = state.GetRunningTasks(maxCount: 5);
+
+        Assert.IsEmpty(tasks);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_WhenFewerThanMax_ReturnsAllSortedByElapsedDescending()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        // Create the stopwatches in age order so we know what "elapsed descending" should look like:
+        // "OldTest" runs the longest, "MiddleTest" next, "YoungTest" shortest.
+        state.AddRunningTestNode(id: 10, uid: "uid-old", name: "OldTest", stopwatchFactory.CreateStopwatch());
+        stopwatchFactory.AddTime(TimeSpan.FromSeconds(2));
+        state.AddRunningTestNode(id: 11, uid: "uid-middle", name: "MiddleTest", stopwatchFactory.CreateStopwatch());
+        stopwatchFactory.AddTime(TimeSpan.FromSeconds(2));
+        state.AddRunningTestNode(id: 12, uid: "uid-young", name: "YoungTest", stopwatchFactory.CreateStopwatch());
+
+        List<TestDetailState> tasks = state.GetRunningTasks(maxCount: 5);
+
+        Assert.HasCount(3, tasks);
+        Assert.AreEqual("OldTest", tasks[0].Text);
+        Assert.AreEqual("MiddleTest", tasks[1].Text);
+        Assert.AreEqual("YoungTest", tasks[2].Text);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_WhenMoreThanMax_TruncatesAndAppendsSummary()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        // 5 running tasks, ages decreasing so "Test0" is oldest, "Test4" is youngest.
+        for (int i = 0; i < 5; i++)
+        {
+            state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+            stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+        }
+
+        List<TestDetailState> tasks = state.GetRunningTasks(maxCount: 3);
+
+        // Expect exactly maxCount entries: (maxCount - 1) oldest tasks + 1 summary line.
+        Assert.HasCount(3, tasks);
+        Assert.AreEqual("Test0", tasks[0].Text);
+        Assert.AreEqual("Test1", tasks[1].Text);
+        // The trailing summary mentions how many tasks are NOT shown (5 - 2 = 3).
+        Assert.Contains("3", tasks[2].Text);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_WhenMaxCountIsOneAndMultipleRunning_ReturnsOnlySummary()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        state.AddRunningTestNode(id: 10, uid: "uid-1", name: "FirstTest", stopwatchFactory.CreateStopwatch());
+        state.AddRunningTestNode(id: 11, uid: "uid-2", name: "SecondTest", stopwatchFactory.CreateStopwatch());
+
+        List<TestDetailState> tasks = state.GetRunningTasks(maxCount: 1);
+
+        Assert.HasCount(1, tasks);
+        // When maxCount is 1 and we're over budget, no individual test fits — we only show the summary.
+        string expectedSummary = string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, 2);
+        Assert.AreEqual(expectedSummary, tasks[0].Text);
+        Assert.DoesNotContain("FirstTest", tasks[0].Text);
+        Assert.DoesNotContain("SecondTest", tasks[0].Text);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_ReturnsCachedBufferReusedAcrossCalls()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        state.AddRunningTestNode(id: 10, uid: "uid-1", name: "T1", stopwatchFactory.CreateStopwatch());
+
+        List<TestDetailState> first = state.GetRunningTasks(maxCount: 5);
+        List<TestDetailState> second = state.GetRunningTasks(maxCount: 5);
+
+        // The buffer is intentionally reused (documented contract) — same reference across calls.
+        Assert.AreSame(first, second);
+    }
+
+    [TestMethod]
     public void TerminalTestReporter_WhenInDiscoveryMode_ShouldIncrementDiscoveredTests()
     {
         // Arrange


### PR DESCRIPTION
## Goal and Rationale

`TestNodeResultsState.GetRunningTasks(int maxCount)` previously constructed a fresh `List<TestDetailState>` on every call:

```csharp
var sortedDetails = new List<TestDetailState>(_testNodeProgressStates.Count);
```

This method is called once per assembly per render tick (every 500 ms). With 5 concurrent assemblies and 2 fps, that is **~600 short-lived list allocations per minute** — all unnecessary.

## Approach

Add a reusable `_runningTasksBuffer` field (`List<TestDetailState>`) to `TestNodeResultsState`. The method now calls `Clear()` on it and rebuilds in-place instead of allocating a new instance.

```csharp
// Before
var sortedDetails = new List<TestDetailState>(_testNodeProgressStates.Count);

// After
_runningTasksBuffer.Clear();
List<TestDetailState> sortedDetails = _runningTasksBuffer;
```

The buffer is a cached field used via the single-threaded render loop, so no thread-safety concern is introduced.

## Performance Evidence

| Scenario | Before | After |
|---|---|---|
| 5 assemblies × 2 fps (5 min run) | ~3,000 `List` allocations | 0 |
| 10 assemblies × 2 fps (5 min run) | ~6,000 `List` allocations | 0 |

Methodology: static code analysis + tick-rate arithmetic (`Height * 0.7` line budget, 500 ms cadence, `GetRunningTasks` called once per non-null progress slot per tick).

## Trade-offs

- Callers must not hold the returned list reference past the next tick (they don't — `_detailItemsBuffer[progressI]` is set to `null` immediately after `AddRange`).
- The `_runningTasksBuffer` List's internal array will grow to the high-water mark of running tests, but this is bounded and expected.

## Reproducibility

```bash
dotnet-trace collect -- artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
# Compare allocations for Microsoft.Testing.Platform.OutputDevice.Terminal.TestNodeResultsState+List
```

## Test Status

✅ Build succeeded (all TFMs).  
✅ Unit tests: 1107 passed, 0 failed, 3 skipped (net8.0).




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27355058423/agentic_workflow) workflow. · 1K AIC · ⌖ 24.7 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27355058423, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27355058423 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->