### PR TITLE
Switch CodeQL pipeline to dotnet msbuild and skip UAP TFM

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -79,7 +79,7 @@ jobs:
   # Disable Pack/Sign/Publish because cibuild.cmd implies all three, and they cascade-fail
   # when UAP is skipped (.nuspec files reference absent uap10.0.16299 outputs; Sign then
   # errors with "List of files to sign is empty"). CodeQL only needs source compilation.
-  - script: eng\common\cibuild.cmd
+  - script: eng\common\CIBuild.cmd
       -configuration $(_BuildConfig)
       -prepareMachine
       -msbuildEngine dotnet

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -99,3 +99,4 @@ jobs:
       PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
       ArtifactName: Build_Binlogs_$(_BuildConfig)_Attempt$(System.JobAttempt)
     condition: always()
+    continueOnError: true

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -51,7 +51,7 @@ jobs:
   # NOTE: Do not add an explicit `UseDotNet@2` with `useGlobalJson: true` here.
   # global.json pins a preview SDK (11.0.x-preview.*) and the `UseDotNet@2` task
   # does not search preview channels by default, so it fails with
-  # "sdk version matching: 11.0.x could not be found". `eng\common\cibuild.cmd`
+  # "sdk version matching: 11.0.x could not be found". `eng\common\CIBuild.cmd`
   # (invoked below) restores the correct SDK from global.json via `dotnet-install.ps1`,
   # which handles preview versions correctly.
 
@@ -76,7 +76,7 @@ jobs:
   # UAP-specific code paths are still scanned via the other TFMs the affected projects
   # multi-target (net462, net8.0, net9.0).
   #
-  # Disable Pack/Sign/Publish because cibuild.cmd implies all three, and they cascade-fail
+  # Disable Pack/Sign/Publish because CIBuild.cmd implies all three, and they cascade-fail
   # when UAP is skipped (.nuspec files reference absent uap10.0.16299 outputs; Sign then
   # errors with "List of files to sign is empty"). CodeQL only needs source compilation.
   - script: eng\common\CIBuild.cmd

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -66,11 +66,36 @@ jobs:
   - task: CodeQL3000Init@0
     displayName: CodeQL Initialize
 
+  # Force the .NET SDK MSBuild (x64) instead of the default VS x86 MSBuild on the
+  # windows.vs2026.amd64 image. Since image version 2026.0529.211646 (deployed 2026-06-05),
+  # the bundled VS MSBuild fails to spin up an x86 .NET task host for Arcade tasks declared
+  # with Runtime="NET", producing MSB4216 on InstallDotNetCore. See dotnet/msbuild#13739.
+  #
+  # Skip the uap10.0.16299 target framework on this pipeline because MSBuild.Sdk.Extras'
+  # Workarounds.targets refuses to build full-MSBuild targets under 'dotnet msbuild'.
+  # UAP-specific code paths are still scanned via the other TFMs the affected projects
+  # multi-target (net462, net8.0, net9.0).
+  #
+  # Disable Pack/Sign/Publish because cibuild.cmd implies all three, and they cascade-fail
+  # when UAP is skipped (.nuspec files reference absent uap10.0.16299 outputs; Sign then
+  # errors with "List of files to sign is empty"). CodeQL only needs source compilation.
   - script: eng\common\cibuild.cmd
       -configuration $(_BuildConfig)
       -prepareMachine
+      -msbuildEngine dotnet
       /p:Test=false
+      /p:Pack=false
+      /p:Sign=false
+      /p:Publish=false
+      /p:SkipUapTargetFramework=true
     displayName: Windows Build
 
   - task: CodeQL3000Finalize@0
     displayName: CodeQL Finalize
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish build binlogs'
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)'
+      ArtifactName: Build_Binlogs_$(_BuildConfig)_Attempt$(System.JobAttempt)
+    condition: always()

--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -96,6 +96,6 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish build binlogs'
     inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)'
+      PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
       ArtifactName: Build_Binlogs_$(_BuildConfig)_Attempt$(System.JobAttempt)
     condition: always()


### PR DESCRIPTION
Mirrors the validated fix from the internal AzDO PR (microsoft-testfx#62041) that already passed the CodeQL pipeline.

## Why

The CodeQL pipeline (`azure-pipelines-codeql.yml`) currently fails on the `windows.vs2026.amd64` image (since image version `2026.0529.211646`, deployed 2026-06-05) with `MSB4216` on `InstallDotNetCore`. The default VS x86 MSBuild fails to spin up an x86 .NET task host for Arcade tasks declared with `Runtime=""NET""`. See [dotnet/msbuild#13739](https://github.com/dotnet/msbuild/issues/13739).

## What

Pass three flags to `cibuild.cmd`:

1. `-msbuildEngine dotnet` — use the .NET SDK MSBuild (x64) to sidestep the cross-runtime task-host issue entirely.
2. `/p:SkipUapTargetFramework=true` — drop `uap10.0.16299`, because `MSBuild.Sdk.Extras`' `Workarounds.targets` refuses to build full-MSBuild targets under `dotnet msbuild`. UAP-specific code paths are still scanned via the other TFMs the affected projects multi-target (`net462`, `net8.0`, `net9.0`).
3. `/p:Pack=false /p:Sign=false /p:Publish=false` — `cibuild.cmd` implies all three, and they cascade-fail when UAP is skipped: `.nuspec` files reference absent `uap10.0.16299` outputs, then Sign errors with *""List of files to sign is empty""*. CodeQL only needs source compilation.

Also adds a `PublishBuildArtifacts` step for the build binlogs to make future pipeline diagnostics easier.

## Verification

- Locally: `cibuild.cmd -msbuildEngine dotnet /p:Test=false /p:Pack=false /p:Sign=false /p:Publish=false /p:SkipUapTargetFramework=true` succeeds from a wiped `artifacts/` (2m52s, 0 warnings, 0 errors).
- Internal CodeQL pipeline run on the mirrored AzDO PR (62041) succeeded.