### PR TITLE
Remove non-conforming top-level 'code' from JSON-RPC error envelope

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Serializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Serializers.cs
@@ -46,7 +46,6 @@ internal sealed partial class Json
             return
             [
                 (JsonRpcStrings.JsonRpc, "2.0"),
-                 (JsonRpcStrings.Code, error.ErrorCode),
                  (JsonRpcStrings.Id, error.Id),
                  (JsonRpcStrings.Error, errorMsg)
             ];

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.RpcMessageSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.RpcMessageSerializers.cs
@@ -56,7 +56,6 @@ internal static partial class SerializerUtilities
             Dictionary<string, object?> values = new()
             {
                 [JsonRpcStrings.JsonRpc] = "2.0",
-                [JsonRpcStrings.Code] = error.ErrorCode,
                 [JsonRpcStrings.Id] = error.Id,
                 [JsonRpcStrings.Error] = new Dictionary<string, object?>
                 {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -317,7 +317,9 @@ public sealed class FormatterUtilitiesTests
 
         if (type == typeof(ErrorMessage))
         {
-            Assert.AreEqual("""{"jsonrpc":"2.0","code":2,"id":1,"error":{"code":2,"data":{},"message":"This is error"}}""".Replace(" ", string.Empty), instanceSerialized, because);
+            // Per JSON-RPC 2.0 §5.1, "code" must only appear inside the nested "error" object,
+            // never at the top level of the response envelope.
+            Assert.AreEqual("""{"jsonrpc":"2.0","id":1,"error":{"code":2,"data":{},"message":"This is error"}}""".Replace(" ", string.Empty), instanceSerialized, because);
             return;
         }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
@@ -5,6 +5,9 @@ using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.ServerMode;
 using Microsoft.Testing.Platform.ServerMode.Json;
 
+using JsonDocument = System.Text.Json.JsonDocument;
+using JsonElement = System.Text.Json.JsonElement;
+
 using TestNode = Microsoft.Testing.Platform.Extensions.Messages.TestNode;
 
 namespace Microsoft.Testing.Platform.UnitTests;
@@ -114,6 +117,56 @@ public sealed class JsonTests
 
         // Assert
         Assert.AreEqual("""[{"name":"Thomas","children":[{"name":"Ruth","children":null}]},[2],3]""", actual);
+    }
+
+    [TestMethod]
+    public async Task Serialize_ErrorMessage_EmitsJsonRpc20CompliantShape()
+    {
+        // Arrange
+        ErrorMessage errorMessage = new(
+            Id: 42,
+            ErrorCode: -32601,
+            Message: "Method not found",
+            Data: null);
+
+        // Act
+        string actual = await _json.SerializeAsync(errorMessage);
+
+        // Assert
+        // Per JSON-RPC 2.0 §5.1, "code" MUST live inside the "error" object and MUST NOT
+        // appear at the top level of the response envelope.
+        using var document = JsonDocument.Parse(actual);
+        JsonElement root = document.RootElement;
+
+        Assert.AreEqual("2.0", root.GetProperty("jsonrpc").GetString());
+        Assert.AreEqual(42, root.GetProperty("id").GetInt32());
+        Assert.IsFalse(
+            root.TryGetProperty("code", out _),
+            "Top-level 'code' must not be present; it belongs inside the 'error' object per JSON-RPC 2.0 §5.1.");
+
+        JsonElement error = root.GetProperty("error");
+        Assert.AreEqual(-32601, error.GetProperty("code").GetInt32());
+        Assert.AreEqual("Method not found", error.GetProperty("message").GetString());
+    }
+
+    [TestMethod]
+    public async Task Serialize_ErrorMessage_RoundTripsViaDeserializer()
+    {
+        // Arrange
+        ErrorMessage original = new(
+            Id: 7,
+            ErrorCode: -32000,
+            Message: "Server error",
+            Data: null);
+
+        // Act
+        string serialized = await _json.SerializeAsync(original);
+        ErrorMessage roundTripped = _json.Deserialize<ErrorMessage>(serialized.AsMemory());
+
+        // Assert
+        Assert.AreEqual(original.Id, roundTripped.Id);
+        Assert.AreEqual(original.ErrorCode, roundTripped.ErrorCode);
+        Assert.AreEqual(original.Message, roundTripped.Message);
     }
 
     [TestMethod]


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/testfx/pull/9040#discussion_r3395659613.

## Problem

Per JSON-RPC 2.0 §5.1, the `code` field belongs only inside the nested `error` object, never at the top level of the response envelope. Both serialization paths emitted a stray top-level `code` that duplicated the one inside `error`:

- `src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Serializers.cs` (System.Text.Json path, .NET Core)
- `src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.RpcMessageSerializers.cs` (Jsonite, .NET Framework / netstandard2.0)

The deserializer side already reads `code` only from within the nested `error` object, so removing the stray top-level field is purely spec-cleanup with **no impact on round-trip behavior**.

## Before / after

Before (non-conforming):
```json
{"jsonrpc":"2.0","code":2,"id":1,"error":{"code":2,"data":{},"message":"This is error"}}
```

After (JSON-RPC 2.0 compliant):
```json
{"jsonrpc":"2.0","id":1,"error":{"code":2,"data":{},"message":"This is error"}}
```

## Tests

- Updated `FormatterUtilitiesTests.AssertSerialize` expectation for `ErrorMessage` to match the compliant shape (covers both Jsonite and System.Text.Json paths via the existing parameterized harness).
- Added two new tests in `JsonTests`:
  - `Serialize_ErrorMessage_EmitsJsonRpc20CompliantShape` — asserts no top-level `code` and `code` inside `error`.
  - `Serialize_ErrorMessage_RoundTripsViaDeserializer` — confirms serialize ↔ deserialize behavior is preserved.

Verified passing on both `net8.0` (System.Text.Json) and `net462` (Jsonite).