### PR TITLE
Flag bootstrap-only CLI options when set in testconfig.json

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.cs
@@ -11,6 +11,23 @@ namespace Microsoft.Testing.Platform.CommandLine;
 
 internal static class CommandLineOptionsValidator
 {
+    // Options whose values are read directly from CommandLineParseResult during platform
+    // bootstrap, before IConfiguration (and therefore testconfig.json) is built. Setting them
+    // under "commandLineOptions" in testconfig.json would silently have no effect — fail fast
+    // with a clear error instead. Keep this list in sync with the call sites that pull values
+    // out of CommandLineParseResult before configuration is built (see TestApplication.cs and
+    // JsonConfigurationProvider.cs).
+    private static readonly HashSet<string> BootstrapOnlyOptions = new(
+        [
+            PlatformCommandLineProvider.ConfigFileOptionKey,
+            PlatformCommandLineProvider.DiagnosticOptionKey,
+            PlatformCommandLineProvider.DiagnosticOutputDirectoryOptionKey,
+            PlatformCommandLineProvider.DiagnosticOutputFilePrefixOptionKey,
+            PlatformCommandLineProvider.DiagnosticVerbosityOptionKey,
+            PlatformCommandLineProvider.DiagnosticFileLoggerSynchronousWriteOptionKey,
+        ],
+        StringComparer.OrdinalIgnoreCase);
+
     public static async Task<ValidationResult> ValidateAsync(
         CommandLineParseResult commandLineParseResult,
         IEnumerable<ICommandLineOptionsProvider> systemCommandLineOptionsProviders,
@@ -50,6 +67,11 @@ internal static class CommandLineOptionsValidator
         if (ValidateNoUnknownOptions(commandLineParseResult, jsonCommandLineOptions, extensionOptionsByProvider, systemOptionsByProvider) is { IsValid: false } result4)
         {
             return AddCommandLine(commandLineParseResult, result4);
+        }
+
+        if (ValidateNoBootstrapOnlyOptionsInJson(jsonCommandLineOptions) is { IsValid: false } resultBootstrap)
+        {
+            return AddCommandLine(commandLineParseResult, resultBootstrap);
         }
 
         // Option names from the platform side are unique (validated above) and lookups against this
@@ -248,6 +270,32 @@ internal static class CommandLineOptionsValidator
                     stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.JsonCommandLineOptionsValidationErrorPrefix, innerError));
                 }
             }
+        }
+
+        return stringBuilder?.Length > 0
+            ? ValidationResult.Invalid(stringBuilder.ToTrimmedString())
+            : ValidationResult.Valid();
+    }
+
+    private static ValidationResult ValidateNoBootstrapOnlyOptionsInJson(
+        IReadOnlyList<JsonCommandLineOptionEntry>? jsonCommandLineOptions)
+    {
+        if (jsonCommandLineOptions is not { Count: > 0 })
+        {
+            return ValidationResult.Valid();
+        }
+
+        StringBuilder? stringBuilder = null;
+        foreach (JsonCommandLineOptionEntry entry in jsonCommandLineOptions)
+        {
+            if (!BootstrapOnlyOptions.Contains(entry.OptionName))
+            {
+                continue;
+            }
+
+            stringBuilder ??= new();
+            string innerError = string.Format(CultureInfo.InvariantCulture, PlatformResources.JsonCommandLineOptionIsBootstrapOnlyErrorMessage, entry.OptionName);
+            stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.JsonCommandLineOptionsValidationErrorPrefix, innerError));
         }
 
         return stringBuilder?.Length > 0

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -174,8 +174,8 @@
     <comment>{0} is the underlying validation error message (unknown option, arity mismatch, invalid arguments...). {Locked="testconfig.json"}{Locked="commandLineOptions"}</comment>
   </data>
   <data name="JsonCommandLineOptionIsBootstrapOnlyErrorMessage" xml:space="preserve">
-    <value>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</value>
-    <comment>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</comment>
+    <value>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</value>
+    <comment>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</comment>
   </data>
   <data name="TestConfigurationEnvironmentVariableProviderDisplayName" xml:space="preserve">
     <value>testconfig.json environment variables provider</value>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -173,6 +173,10 @@
     <value>In testconfig.json under 'commandLineOptions': {0}</value>
     <comment>{0} is the underlying validation error message (unknown option, arity mismatch, invalid arguments...). {Locked="testconfig.json"}{Locked="commandLineOptions"}</comment>
   </data>
+  <data name="JsonCommandLineOptionIsBootstrapOnlyErrorMessage" xml:space="preserve">
+    <value>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</value>
+    <comment>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</comment>
+  </data>
   <data name="TestConfigurationEnvironmentVariableProviderDisplayName" xml:space="preserve">
     <value>testconfig.json environment variables provider</value>
     <comment>{Locked="testconfig.json"}</comment>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Neplatné argumenty příkazového řádku:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">Položka {0} v oddílu {1} v souboru testconfig.json ({2}) musí být buď skalární hodnota (řetězec, číslo, logická hodnota), nebo pole skalárních hodnot. Vnořené objekty nejsou podporovány.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Ungültige Befehlszeilenargumente:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">Der Eintrag „{0}“ unter Abschnitt „{1}“ in der testconfig.json-Datei („{2}“) muss entweder ein Skalarwert (Zeichenfolge, Zahl, boolescher Wert) oder ein Array von Skalarwerten sein. Geschachtelte Objekte werden nicht unterstützt.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Argumentos de línea de comandos no válidos:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">La entrada "{0}" de la sección "{1}" del archivo testconfig.json ("{2}") debe ser un valor escalar (cadena, número, booleano) o una matriz de valores escalares. No se admiten objetos anidados.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Arguments de ligne de commande non valides :</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">L’entrée « {0} » dans la section « {1} » du fichier testconfig.json (« {2} ») doit être soit une valeur scalaire (chaîne, nombre, booléen), soit un tableau de valeurs scalaires. Les objets imbriqués ne sont pas pris en charge.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Argomenti della riga di comando non validi:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">La voce '{0}' nella sezione '{1}' del file testconfig.json ('{2}') deve essere un valore scalare (stringa, numero, booleano) oppure una matrice di valori scalari. Gli oggetti annidati non sono supportati.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -374,6 +374,11 @@
         <target state="translated">コマンド ラインの引数が無効です:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">testconfig.json ファイル ('{0}') のセクション '{1}' にあるエントリ '{2}' は、スカラー値 (文字列、数値、ブール値) またはスカラー値の配列のいずれかである必要があります。入れ子になったオブジェクトはサポートされていません。</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -374,6 +374,11 @@
         <target state="translated">잘못된 명령줄 인수:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">testconfig.json 파일의 '{1}' 섹션 아래에 있는 항목 '{0}'('{2}')은(는) 스칼라 값(문자열, 숫자, 부울) 또는 스칼라 값의 배열이어야 합니다. 중첩된 개체는 지원되지 않습니다.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Nieprawidłowe argumenty wiersza polecenia:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">Wpis „{0}” w sekcji „{1}” w pliku testconfig.json („{2}”) musi być wartością skalarną (ciąg, liczba, wartość logiczna) lub tablicą wartości skalarnych. Obiekty zagnieżdżone nie są obsługiwane.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Argumentos de linha de comando inválidos:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">A entrada '{0}' na seção '{1}' no arquivo testconfig.json ('{2}') deve ser um valor escalar (cadeia de caracteres, número, booliano) ou uma matriz de valores escalares. Não há suporte para objetos aninhados.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Недопустимые аргументы командной строки:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">Запись "{0}" в разделе "{1}" файла testconfig.json ("{2}") должна быть либо скалярным значением (строка, число, логическое значение), либо массивом скалярных значений. Вложенные объекты не поддерживаются.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -374,6 +374,11 @@
         <target state="translated">Geçersiz komut satırı bağımsız değişkenleri:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">testconfig.json dosyasında ('{2}') '{1}' bölümü altındaki '{0}' girdisi ya bir skaler değer (dize, sayı, boole) ya da skaler değerlerden oluşan bir dizi olmalıdır. İç içe nesneler desteklenmez.</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -374,6 +374,11 @@
         <target state="translated">无效的命令行参数:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">testconfig.json 文件(“{2}”)中节“{1}”下的条目“{0}”必须为标量值(字符串、数字、布尔)或标量值数组。不支持嵌套对象。</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -375,9 +375,9 @@
         <note />
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
-        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
-        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
-        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+        <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {Locked="--"}{Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -374,6 +374,11 @@
         <target state="translated">命令列引數無效:</target>
         <note />
       </trans-unit>
+      <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
+        <source>The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</source>
+        <target state="new">The option '{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.</target>
+        <note>{0} is the bootstrap-only option name (e.g. config-file, diagnostic, diagnostic-verbosity). {Locked="commandLineOptions"}{Locked="testconfig.json"}</note>
+      </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must be either a scalar value (string, number, boolean) or an array of scalar values. Nested objects are not supported.</source>
         <target state="translated">testconfig.json 檔案 ('{2}') 中的區段 '{1}' 之下的 '{0}' 項目必須是純量值 (字串、數字、布林值) 或純量值的陣列。不支援巢狀物件。</target>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
@@ -356,6 +356,146 @@ public sealed class JsonCommandLineOptionsTests
         Assert.IsTrue(result.IsValid, result.ErrorMessage);
     }
 
+    // ---------------------------------------------------------------------
+    // Bootstrap-only options must not appear under testconfig.json's
+    // "commandLineOptions". They are read off CommandLineParseResult before
+    // IConfiguration is built (see TestApplication.cs and
+    // JsonConfigurationProvider.cs), so a JSON entry is silently ignored.
+    // The validator surfaces this with a clear error instead.
+    // ---------------------------------------------------------------------
+    [TestMethod]
+    [DataRow(PlatformCommandLineProvider.ConfigFileOptionKey)]
+    [DataRow(PlatformCommandLineProvider.DiagnosticOptionKey)]
+    [DataRow(PlatformCommandLineProvider.DiagnosticOutputDirectoryOptionKey)]
+    [DataRow(PlatformCommandLineProvider.DiagnosticOutputFilePrefixOptionKey)]
+    [DataRow(PlatformCommandLineProvider.DiagnosticVerbosityOptionKey)]
+    [DataRow(PlatformCommandLineProvider.DiagnosticFileLoggerSynchronousWriteOptionKey)]
+    public async Task Validator_JsonBootstrapOnlyOption_Fails(string optionName)
+    {
+        ICommandLineOptionsProvider provider = new TestProvider(
+            new CommandLineOption(optionName, "desc", ArgumentArity.ZeroOrOne, isHidden: false));
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            CommandLineParseResult.Empty,
+            [provider],
+            [],
+            new Mock<ICommandLineOptions>().Object,
+            jsonCommandLineOptions: [new JsonCommandLineOptionEntry(optionName, ["value"], isDisabled: false)]);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains(optionName, result.ErrorMessage);
+        Assert.Contains("testconfig.json", result.ErrorMessage);
+        Assert.Contains("bootstrap", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [TestMethod]
+    public async Task Validator_JsonBootstrapOnlyOption_CaseInsensitive_Fails()
+    {
+        // testconfig.json keys are case-insensitive everywhere else; the bootstrap-only check
+        // must match regardless of casing so "Config-File" is flagged the same as "config-file".
+        ICommandLineOptionsProvider provider = new TestProvider(
+            new CommandLineOption(PlatformCommandLineProvider.ConfigFileOptionKey, "desc", ArgumentArity.ExactlyOne, isHidden: false));
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            CommandLineParseResult.Empty,
+            [provider],
+            [],
+            new Mock<ICommandLineOptions>().Object,
+            jsonCommandLineOptions: [new JsonCommandLineOptionEntry("Config-File", ["other.json"], isDisabled: false)]);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains("Config-File", result.ErrorMessage);
+        Assert.Contains("testconfig.json", result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task Validator_JsonBootstrapOnlyOption_DisabledEntry_StillFails()
+    {
+        // "config-file": false in testconfig.json is just as misleading as setting it to a value:
+        // either way the option is read pre-config and the JSON entry has no effect. Flag both.
+        ICommandLineOptionsProvider provider = new TestProvider(
+            new CommandLineOption(PlatformCommandLineProvider.ConfigFileOptionKey, "desc", ArgumentArity.ExactlyOne, isHidden: false));
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            CommandLineParseResult.Empty,
+            [provider],
+            [],
+            new Mock<ICommandLineOptions>().Object,
+            jsonCommandLineOptions: [new JsonCommandLineOptionEntry(PlatformCommandLineProvider.ConfigFileOptionKey, [], isDisabled: true)]);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains(PlatformCommandLineProvider.ConfigFileOptionKey, result.ErrorMessage);
+        Assert.Contains("testconfig.json", result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task Validator_CliBootstrapOnlyOption_Allowed()
+    {
+        // Setting bootstrap-only options on the CLI is the supported path and must remain valid.
+        ICommandLineOptionsProvider provider = new TestProvider(
+            new CommandLineOption(PlatformCommandLineProvider.ConfigFileOptionKey, "desc", ArgumentArity.ExactlyOne, isHidden: false));
+
+        CommandLineParseResult cliParseResult = new(
+            toolName: null,
+            options: [new CommandLineParseOption(PlatformCommandLineProvider.ConfigFileOptionKey, ["other.json"])],
+            errors: []);
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            cliParseResult,
+            [provider],
+            [],
+            new Mock<ICommandLineOptions>().Object,
+            jsonCommandLineOptions: null);
+
+        Assert.IsTrue(result.IsValid, result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task Validator_JsonNonBootstrapOption_Allowed()
+    {
+        // Sanity check: non-bootstrap-only options (e.g. timeout) continue to be honored from
+        // testconfig.json. The bootstrap-only check must not regress general JSON support.
+        ICommandLineOptionsProvider provider = new TestProvider(
+            new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false));
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            CommandLineParseResult.Empty,
+            [provider],
+            [],
+            new Mock<ICommandLineOptions>().Object,
+            jsonCommandLineOptions: [new JsonCommandLineOptionEntry("timeout", ["30s"], isDisabled: false)]);
+
+        Assert.IsTrue(result.IsValid, result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task Validator_JsonMultipleBootstrapOnlyOptions_AllReported()
+    {
+        // The validator aggregates bootstrap-only violations so users see every offending entry
+        // in one pass rather than fixing them one by one across multiple runs.
+        ICommandLineOptionsProvider provider = new TestProvider(
+            new CommandLineOption(PlatformCommandLineProvider.ConfigFileOptionKey, "desc", ArgumentArity.ExactlyOne, isHidden: false),
+            new CommandLineOption(PlatformCommandLineProvider.DiagnosticOptionKey, "desc", ArgumentArity.Zero, isHidden: false),
+            new CommandLineOption(PlatformCommandLineProvider.DiagnosticVerbosityOptionKey, "desc", ArgumentArity.ExactlyOne, isHidden: false));
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            CommandLineParseResult.Empty,
+            [provider],
+            [],
+            new Mock<ICommandLineOptions>().Object,
+            jsonCommandLineOptions:
+            [
+                new JsonCommandLineOptionEntry(PlatformCommandLineProvider.ConfigFileOptionKey, ["other.json"], isDisabled: false),
+                new JsonCommandLineOptionEntry(PlatformCommandLineProvider.DiagnosticOptionKey, [], isDisabled: false),
+                new JsonCommandLineOptionEntry(PlatformCommandLineProvider.DiagnosticVerbosityOptionKey, ["trace"], isDisabled: false),
+            ]);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains(PlatformCommandLineProvider.ConfigFileOptionKey, result.ErrorMessage);
+        Assert.Contains(PlatformCommandLineProvider.DiagnosticOptionKey, result.ErrorMessage);
+        Assert.Contains(PlatformCommandLineProvider.DiagnosticVerbosityOptionKey, result.ErrorMessage);
+    }
+
     [TestMethod]
     public async Task Validator_JsonUnknownOptionCaseInsensitive_Accepted()
     {


### PR DESCRIPTION
## Description

A few platform CLI options are intentionally read off ``CommandLineParseResult`` **before** ``IConfiguration`` (and therefore ``testconfig.json``) is built, so they cannot be honored from JSON:

- ``--config-file`` – chicken-and-egg, it tells the system where to find the JSON
- ``--diagnostic``, ``--diagnostic-output-directory``, ``--diagnostic-file-prefix``, ``--diagnostic-verbosity``, ``--diagnostic-synchronous-write`` – needed before the config system is up so we can log config-build itself

Before this change, declaring any of these under ``commandLineOptions`` in ``testconfig.json`` was silently ignored, which is confusing.

## Fix

``CommandLineOptionsValidator`` now keeps a small ``BootstrapOnlyOptions`` set built from ``PlatformCommandLineProvider`` constants and runs a JSON-only validation pass right after the unknown-option check. When any bootstrap-only option appears under ``commandLineOptions`` in ``testconfig.json``, startup fails fast with:

> In testconfig.json under 'commandLineOptions': The option 'config-file' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under 'commandLineOptions' in testconfig.json.

Behavior:

- Matches case-insensitively (``Config-File`` flagged just like ``config-file``), consistent with how ``testconfig.json`` keys are handled everywhere else.
- Flags both value entries and disabled entries (``"diagnostic": false``) — either way the user clearly intended the option to take effect via JSON, which it never does.
- Aggregates every offending entry in one pass so users can fix them all in one go.
- Setting bootstrap-only options on the CLI itself remains fully supported.

## Tests

Added under ``JsonCommandLineOptionsTests``:

- ``Validator_JsonBootstrapOnlyOption_Fails`` — ``[DataRow]`` over all six bootstrap-only options.
- ``Validator_JsonBootstrapOnlyOption_CaseInsensitive_Fails``
- ``Validator_JsonBootstrapOnlyOption_DisabledEntry_StillFails``
- ``Validator_CliBootstrapOnlyOption_Allowed``
- ``Validator_JsonNonBootstrapOption_Allowed`` (non-regression for normal JSON options)
- ``Validator_JsonMultipleBootstrapOnlyOptions_AllReported``

All 321 ``CommandLine~`` unit tests pass locally.

## Localization

Added ``JsonCommandLineOptionIsBootstrapOnlyErrorMessage`` to ``PlatformResources.resx`` and regenerated all ``*.xlf`` files via ``dotnet msbuild Microsoft.Testing.Platform.csproj /t:UpdateXlf``.

Fixes #8829
