### PR TITLE
Address review feedback on #9047 (GetRunningTasks buffer reuse)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
@@ -71,11 +71,15 @@ internal sealed class TestNodeResultsState
     /// running" summary detail when truncation occurs).
     /// </summary>
     /// <remarks>
-    /// The returned <see cref="List{T}"/> is a cached buffer reused across calls to avoid
-    /// per-render-tick allocation. Callers MUST consume it immediately and MUST NOT store
-    /// the reference, mutate it, or hand it to other code that might cache it — the next
-    /// call to <see cref="GetRunningTasks"/> will <see cref="List{T}.Clear"/> and rebuild
-    /// the same instance, silently invalidating prior callers' views.
+    /// The returned <see cref="List{T}"/> is a cached buffer reused across calls on the same
+    /// <see cref="TestNodeResultsState"/> instance to avoid per-render-tick allocation.
+    /// Callers MUST NOT call <see cref="GetRunningTasks"/> on the same instance again before
+    /// finishing use of the previously-returned buffer — the next call on that instance will
+    /// <see cref="List{T}.Clear"/> and rebuild it in place, silently invalidating the prior
+    /// caller's view. Buffers from different instances are independent and may be held
+    /// concurrently. This type is not designed for concurrent calls on the same instance;
+    /// the production caller (<c>AnsiTerminalTestProgressFrame</c>) only invokes this from
+    /// the single-threaded render loop.
     /// </remarks>
     public List<TestDetailState> GetRunningTasks(int maxCount)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
@@ -39,6 +39,8 @@ internal static partial class PlatformResources
 #if IS_MTP_UNIT_TESTS
     internal static string @ActiveTestsRunning_FullTestsCount => GetResourceString("ActiveTestsRunning_FullTestsCount");
 
+    internal static string @ActiveTestsRunning_MoreTestsCount => GetResourceString("ActiveTestsRunning_MoreTestsCount");
+
     internal static string @PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage => GetResourceString("PlatformCommandLineDiagnosticOptionExpectsSingleArgumentErrorMessage");
 
     internal static string @PlatformCommandLineDiscoverTestsInvalidArgument => GetResourceString("PlatformCommandLineDiscoverTestsInvalidArgument");

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1067,7 +1067,10 @@ public sealed class TerminalTestReporterTests
         Assert.AreEqual("Test0", tasks[0].Text);
         Assert.AreEqual("Test1", tasks[1].Text);
         // The trailing summary mentions how many tasks are NOT shown (5 - 2 = 3).
-        Assert.Contains("3", tasks[2].Text);
+        // Assert exact text (matching the maxCount=1 test's pattern) so this can't accidentally
+        // pass for unrelated reasons (any '3' anywhere in a localized/format-changed string).
+        string expectedSummary = $"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, 3)}";
+        Assert.AreEqual(expectedSummary, tasks[2].Text);
     }
 
     [TestMethod]


### PR DESCRIPTION
Follow-up to #9047 (already merged) addressing review feedback that arrived on the merged PR:

- **Documentation**: Clarify the `<remarks>` on `GetRunningTasks` so the contract reflects the actual invariant — the hazard is calling it again on the *same instance* before consuming the prior buffer (buffers from different instances are independent and may be held concurrently). Also note that the production caller (`AnsiTerminalTestProgressFrame`) is single-threaded, addressing the thread-safety concern raised by `copilot-pull-request-reviewer`.
- **Test assertion**: Replace `Assert.Contains("3", tasks[2].Text)` with an exact-text assertion that matches the `maxCount=1` test's pattern. The previous loose substring match could pass for unrelated reasons if the resource format ever changes (any `'3'` anywhere in a localized string).
- **Resource accessor**: Expose `ActiveTestsRunning_MoreTestsCount` to the unit-test project via the `IS_MTP_UNIT_TESTS` block in `PlatformResources.cs` (hand-maintained accessor).

No behavior change — pure docs + test tightening + a hand-maintained resource accessor.
