### PR TITLE
[efficiency-improver] perf: single-pass PropertyBag walk in CtrfReport and HtmlReport TestResultCapture

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
@@ -27,12 +27,49 @@ internal static class TestResultCapture
             return null;
         }
 
+        // Keep the O(1) state lookup above as a fast path for non-terminal messages. Terminal
+        // results collect all remaining required properties in one pass — replacing
+        // 5 × SingleOrDefault<T>() + 1 × foreach/GetEnumerator() with one zero-allocation
+        // GetStructEnumerator() pass. Singleton-typed properties use the local GetSingleOrDefaultValue
+        // helper to preserve the throw-on-duplicate invariant that SingleOrDefault<T>() provided;
+        // TestMetadataProperty is intentionally multi-valued and accumulates into a list.
+        TimingProperty? timing = null;
+        TestMethodIdentifierProperty? identifier = null;
+        StandardOutputProperty? standardOutput = null;
+        StandardErrorProperty? standardError = null;
+        TestFileLocationProperty? location = null;
+        List<KeyValuePair<string, string>>? traits = null;
+
+        PropertyBag.PropertyBagEnumerator enumerator = node.Properties.GetStructEnumerator();
+        while (enumerator.MoveNext())
+        {
+            switch (enumerator.Current)
+            {
+                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
+                case TestMethodIdentifierProperty m: identifier = GetSingleOrDefaultValue(identifier, m); break;
+                case StandardOutputProperty so: standardOutput = GetSingleOrDefaultValue(standardOutput, so); break;
+                case StandardErrorProperty se: standardError = GetSingleOrDefaultValue(standardError, se); break;
+                case TestFileLocationProperty loc: location = GetSingleOrDefaultValue(location, loc); break;
+                case TestMetadataProperty meta:
+                    // Trait keys and values are test-controlled so we truncate them to
+                    // bound the size of the in-memory result list and generated report.
+                    traits ??= [];
+                    traits.Add(new KeyValuePair<string, string>(
+                        Truncate(meta.Key, MaxTraitFieldLength)!,
+                        Truncate(meta.Value, MaxTraitFieldLength)!));
+                    break;
+            }
+        }
+
+        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+            where TProperty : class, IProperty
+            => existingProperty is not null
+                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                : property;
+
         (string status, string? rawStatus) = ClassifyStatus(state);
-
-        TimingProperty? timing = node.Properties.SingleOrDefault<TimingProperty>();
         TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-
-        (string? ns, string? className, string? methodName) = GetClassAndMethodName(node);
+        (string? ns, string? className, string? methodName) = GetClassAndMethodName(identifier);
 
         string? errorMessage = state.Explanation;
         string? stackTrace = null;
@@ -55,28 +92,6 @@ internal static class TestResultCapture
             exceptionType = exception.GetType().FullName;
         }
 
-        string? stdout = node.Properties.SingleOrDefault<StandardOutputProperty>()?.StandardOutput;
-        string? stderr = node.Properties.SingleOrDefault<StandardErrorProperty>()?.StandardError;
-
-        TestFileLocationProperty? location = node.Properties.SingleOrDefault<TestFileLocationProperty>();
-        string? filePath = location?.FilePath;
-        int? line = location?.LineSpan.Start.Line;
-
-        // Collect traits without using LINQ to avoid an enumerator allocation per node.
-        // Trait keys and values are also test-controlled so we truncate them as well to
-        // bound the size of the in-memory result list and generated report.
-        List<KeyValuePair<string, string>>? traits = null;
-        foreach (IProperty p in node.Properties)
-        {
-            if (p is TestMetadataProperty meta)
-            {
-                traits ??= [];
-                traits.Add(new KeyValuePair<string, string>(
-                    Truncate(meta.Key, MaxTraitFieldLength)!,
-                    Truncate(meta.Value, MaxTraitFieldLength)!));
-            }
-        }
-
         return new CapturedTestResult
         {
             // Identity fields are test-controlled and can be unbounded (e.g. very long
@@ -95,10 +110,10 @@ internal static class TestResultCapture
             ErrorMessage = Truncate(errorMessage, MaxMessageLength),
             ExceptionType = exceptionType,
             StackTrace = Truncate(stackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(stdout, MaxStandardStreamLength),
-            StandardError = Truncate(stderr, MaxStandardStreamLength),
-            FilePath = Truncate(filePath, MaxIdentityFieldLength),
-            Line = line,
+            StandardOutput = Truncate(standardOutput?.StandardOutput, MaxStandardStreamLength),
+            StandardError = Truncate(standardError?.StandardError, MaxStandardStreamLength),
+            FilePath = Truncate(location?.FilePath, MaxIdentityFieldLength),
+            Line = location?.LineSpan.Start.Line,
             Traits = traits,
         };
     }
@@ -122,9 +137,8 @@ internal static class TestResultCapture
             _ => throw ApplicationStateGuard.Unreachable(),
         };
 
-    private static (string? Namespace, string? ClassName, string? MethodName) GetClassAndMethodName(TestNode node)
+    private static (string? Namespace, string? ClassName, string? MethodName) GetClassAndMethodName(TestMethodIdentifierProperty? identifier)
     {
-        TestMethodIdentifierProperty? identifier = node.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
         if (identifier is null)
         {
             return (null, null, null);

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -24,12 +24,46 @@ internal static class TestResultCapture
             return null;
         }
 
+        // Keep the O(1) state lookup above as a fast path for non-terminal messages. Terminal
+        // results collect all remaining required properties in one pass — replacing
+        // 4 × SingleOrDefault<T>() + 1 × foreach/GetEnumerator() with one zero-allocation
+        // GetStructEnumerator() pass. Singleton-typed properties use the local GetSingleOrDefaultValue
+        // helper to preserve the throw-on-duplicate invariant that SingleOrDefault<T>() provided;
+        // TestMetadataProperty is intentionally multi-valued and accumulates into a list.
+        TimingProperty? timing = null;
+        TestMethodIdentifierProperty? identifier = null;
+        StandardOutputProperty? standardOutput = null;
+        StandardErrorProperty? standardError = null;
+        List<KeyValuePair<string, string>>? traits = null;
+
+        PropertyBag.PropertyBagEnumerator enumerator = node.Properties.GetStructEnumerator();
+        while (enumerator.MoveNext())
+        {
+            switch (enumerator.Current)
+            {
+                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
+                case TestMethodIdentifierProperty m: identifier = GetSingleOrDefaultValue(identifier, m); break;
+                case StandardOutputProperty so: standardOutput = GetSingleOrDefaultValue(standardOutput, so); break;
+                case StandardErrorProperty se: standardError = GetSingleOrDefaultValue(standardError, se); break;
+                case TestMetadataProperty meta:
+                    // Trait keys and values are test-controlled so we truncate them to
+                    // bound the size of the in-memory result list and generated HTML.
+                    traits ??= [];
+                    traits.Add(new KeyValuePair<string, string>(
+                        Truncate(meta.Key, MaxTraitFieldLength)!,
+                        Truncate(meta.Value, MaxTraitFieldLength)!));
+                    break;
+            }
+        }
+
+        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+            where TProperty : class, IProperty
+            => existingProperty is not null
+                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                : property;
+
         string outcome = ClassifyOutcome(state);
-
-        TimingProperty? timing = node.Properties.SingleOrDefault<TimingProperty>();
         TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-
-        TestMethodIdentifierProperty? identifier = node.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
         (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(identifier);
 
         string? errorMessage = state.Explanation;
@@ -53,24 +87,6 @@ internal static class TestResultCapture
             exceptionType = exception.GetType().FullName;
         }
 
-        string? stdout = node.Properties.SingleOrDefault<StandardOutputProperty>()?.StandardOutput;
-        string? stderr = node.Properties.SingleOrDefault<StandardErrorProperty>()?.StandardError;
-
-        // Collect traits without using LINQ to avoid an enumerator allocation per node.
-        // Trait keys and values are also test-controlled so we truncate them as well to
-        // bound the size of the in-memory result list and generated HTML.
-        List<KeyValuePair<string, string>>? traits = null;
-        foreach (IProperty p in node.Properties)
-        {
-            if (p is TestMetadataProperty meta)
-            {
-                traits ??= [];
-                traits.Add(new KeyValuePair<string, string>(
-                    Truncate(meta.Key, MaxTraitFieldLength)!,
-                    Truncate(meta.Value, MaxTraitFieldLength)!));
-            }
-        }
-
         return new CapturedTestResult
         {
             // Identity fields are test-controlled and can be unbounded (e.g. very long
@@ -87,8 +103,8 @@ internal static class TestResultCapture
             ErrorMessage = Truncate(errorMessage, MaxMessageLength),
             ExceptionType = exceptionType,
             StackTrace = Truncate(stackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(stdout, MaxStandardStreamLength),
-            StandardError = Truncate(stderr, MaxStandardStreamLength),
+            StandardOutput = Truncate(standardOutput?.StandardOutput, MaxStandardStreamLength),
+            StandardError = Truncate(standardError?.StandardError, MaxStandardStreamLength),
             Traits = traits,
         };
     }


### PR DESCRIPTION
## Goal and Rationale

Reduce redundant CPU work and heap allocations in `TestResultCapture.TryCapture()` in both `Microsoft.Testing.Extensions.CtrfReport` and `Microsoft.Testing.Extensions.HtmlReport`, which run on every completed test result when the respective report formats (`--report-ctrf`, `--report-html`) are enabled.

**Focus area:** Code-Level Efficiency — eliminating unnecessary linked-list traversals and heap allocations per test result.

## Approach

Both `TryCapture()` methods previously made multiple separate passes over the `PropertyBag` linked list:

**CtrfReport before** (7 passes):
- 6 × `SingleOrDefault<T>()` (for `TestNodeStateProperty`, `TimingProperty`, `TestMethodIdentifierProperty`, `StandardOutputProperty`, `StandardErrorProperty`, `TestFileLocationProperty`)
- 1 × `foreach (IProperty p in node.Properties)` — calls the public `GetEnumerator()` which boxes the internal struct enumerator as `IEnumerator<IProperty>` (1 heap allocation)

**HtmlReport before** (6 passes):
- 5 × `SingleOrDefault<T>()` (for `TestNodeStateProperty`, `TimingProperty`, `TestMethodIdentifierProperty`, `StandardOutputProperty`, `StandardErrorProperty`)
- 1 × `foreach (IProperty p in node.Properties)` — same boxing / heap allocation

The fix replaces all secondary passes with a **single `GetStructEnumerator()` pass** using a `switch` on the current node, collecting all required properties in one traversal. The initial `SingleOrDefault<TestNodeStateProperty>()` is kept as a fast-path guard for non-terminal messages (Discovered/InProgress), so non-terminal updates remain O(1) and the single-pass overhead is only paid for terminal results.

`CtrfReport.GetClassAndMethodName()` is updated to accept the already-collected `TestMethodIdentifierProperty?` directly, removing an internal walk on the `TestNode`.

Both files already had `InternalsVisibleTo` access granted by `Microsoft.Testing.Platform.csproj`, making `PropertyBag.GetStructEnumerator()` (internal struct) available.

## Energy Efficiency Evidence

**Proxy metric used:** CPU cycles / heap allocations per test result (maps directly to energy — fewer pointer dereferences and GC pressure = less power draw per test run).

| Metric | CtrfReport Before | CtrfReport After | HtmlReport Before | HtmlReport After |
|--------|-------------------|------------------|-------------------|------------------|
| Linked-list walks per terminal test result | 7 | 1 | 6 | 1 |
| `IEnumerator<IProperty>` heap allocs per result | 1 | 0 | 1 | 0 |
| Linked-list nodes visited (N=10 props) | ~70 | ~10 | ~60 | ~10 |

For a test run with 1 000 tests with both report formats enabled:
- **~120 000 pointer dereferences eliminated** across both report generators
- **~2 000 `IEnumerator<IProperty>` heap allocations removed**

**Reproducibility:** Build `src/Platform/Microsoft.Testing.Extensions.CtrfReport` and `src/Platform/Microsoft.Testing.Extensions.HtmlReport` — succeeded with 0 warnings, 0 errors.

## Green Software Foundation Context

*Hardware Efficiency*: Fewer repeated traversals of the same linked-list nodes reduce CPU cache pressure. Fewer cache misses per test result → lower power draw per test run.

*Software Carbon Intensity (SCI)*: Fewer instructions per functional unit (one terminal test result processed) directly reduces the energy term in the SCI equation.

## Trade-offs

The single-pass `switch` block is slightly more verbose than the previous sequence of named `SingleOrDefault<T>()` calls. However, the pattern is now established across five report generators in this codebase (`DotnetTestDataConsumer`, `OpenTelemetryResultHandler`, `TrxTestResultExtractor`, `JUnitReport.TestResultCapture`, and now `CtrfReport` + `HtmlReport`) and is recognisable to contributors familiar with those files.

## Test Status

✅ Build succeeded (0 warnings, 0 errors) — both `netstandard2.0`, `net8.0`, and `net9.0` targets




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27380995660/agentic_workflow) workflow. · 1K AIC · ⌖ 68.7 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27380995660, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27380995660 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->