### PR TITLE
Document Assert interpolated-string-handler structs (#9060)

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.InterpolatedStringHandlers.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.InterpolatedStringHandlers.cs
@@ -12,16 +12,31 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.AreEqual</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of value being asserted.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertAreEqualInterpolatedStringHandler<TArgument>
     {
         private readonly StringBuilder? _builder;
         private readonly object? _expected;
         private readonly object? _actual;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertAreEqualInterpolatedStringHandler{TArgument}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, TArgument? expected, TArgument? actual, out bool shouldAppend)
         {
             _expected = expected!;
@@ -34,6 +49,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertAreEqualInterpolatedStringHandler{TArgument}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="comparer">The equality comparer used to compare values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, TArgument? expected, TArgument? actual, IEqualityComparer<TArgument>? comparer, out bool shouldAppend)
         {
             shouldAppend = AreEqualFailing(expected, actual, comparer);
@@ -53,14 +77,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string? value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -70,23 +107,56 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.AreNotEqual</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of value being asserted.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -96,11 +166,28 @@ public sealed partial class Assert
         private readonly object? _notExpected;
         private readonly object? _actual;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertAreNotEqualInterpolatedStringHandler{TArgument}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, TArgument? notExpected, TArgument? actual, out bool shouldAppend)
             : this(literalLength, formattedCount, notExpected, actual, null, out shouldAppend)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertAreNotEqualInterpolatedStringHandler{TArgument}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="comparer">The equality comparer used to compare values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, TArgument? notExpected, TArgument? actual, IEqualityComparer<TArgument>? comparer, out bool shouldAppend)
         {
             shouldAppend = AreNotEqualFailing(notExpected, actual, comparer);
@@ -120,14 +207,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -137,23 +237,55 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.AreEqual</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -162,6 +294,15 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly Action<string, string, string>? _failAction;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, float expected, float actual, float delta, out bool shouldAppend)
         {
             shouldAppend = AreEqualFailing(expected, actual, delta);
@@ -173,6 +314,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, decimal expected, decimal actual, decimal delta, out bool shouldAppend)
         {
             shouldAppend = AreEqualFailing(expected, actual, delta);
@@ -184,6 +334,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, long expected, long actual, long delta, out bool shouldAppend)
         {
             shouldAppend = AreEqualFailing(expected, actual, delta);
@@ -195,6 +354,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, double expected, double actual, double delta, out bool shouldAppend)
         {
             shouldAppend = AreEqualFailing(expected, actual, delta);
@@ -206,6 +374,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="ignoreCase">A value indicating whether the comparison ignores case.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? expected, string? actual, bool ignoreCase, out bool shouldAppend)
         {
             shouldAppend = AreEqualFailing(expected, actual, ignoreCase, CultureInfo.InvariantCulture);
@@ -217,6 +394,16 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="ignoreCase">A value indicating whether the comparison ignores case.</param>
+        /// <param name="culture">The culture used for the string comparison.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? expected, string? actual, bool ignoreCase, CultureInfo culture, out bool shouldAppend)
         {
             _ = culture ?? throw new ArgumentNullException(nameof(culture));
@@ -232,14 +419,27 @@ public sealed partial class Assert
         internal void ComputeAssertion(string expectedExpression, string actualExpression)
             => _failAction?.Invoke(_builder!.ToString(), expectedExpression, actualExpression);
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -249,23 +449,55 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.AreNotEqual</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -274,6 +506,15 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly Action<string, string, string>? _failAction;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreNotEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, float notExpected, float actual, float delta, out bool shouldAppend)
         {
             shouldAppend = AreNotEqualFailing(notExpected, actual, delta);
@@ -285,6 +526,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreNotEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, decimal notExpected, decimal actual, decimal delta, out bool shouldAppend)
         {
             shouldAppend = AreNotEqualFailing(notExpected, actual, delta);
@@ -296,6 +546,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreNotEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, long notExpected, long actual, long delta, out bool shouldAppend)
         {
             shouldAppend = AreNotEqualFailing(notExpected, actual, delta);
@@ -307,6 +566,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreNotEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="delta">The maximum allowed difference between the expected and actual values.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, double notExpected, double actual, double delta, out bool shouldAppend)
         {
             shouldAppend = AreNotEqualFailing(notExpected, actual, delta);
@@ -318,6 +586,15 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreNotEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="ignoreCase">A value indicating whether the comparison ignores case.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? notExpected, string? actual, bool ignoreCase, out bool shouldAppend)
         {
             shouldAppend = AreNotEqualFailing(notExpected, actual, ignoreCase, CultureInfo.InvariantCulture);
@@ -329,6 +606,16 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonGenericAreNotEqualInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="ignoreCase">A value indicating whether the comparison ignores case.</param>
+        /// <param name="culture">The culture used for the string comparison.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonGenericAreNotEqualInterpolatedStringHandler(int literalLength, int formattedCount, string? notExpected, string? actual, bool ignoreCase, CultureInfo culture, out bool shouldAppend)
         {
             _ = culture ?? throw new ArgumentNullException(nameof(culture));
@@ -344,14 +631,27 @@ public sealed partial class Assert
         internal void ComputeAssertion(string notExpectedExpression, string actualExpression)
             => _failAction?.Invoke(_builder!.ToString(), notExpectedExpression, actualExpression);
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -361,21 +661,45 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.AreSame.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AreSame.cs
@@ -14,16 +14,31 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.AreSame</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of value being asserted.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertAreSameInterpolatedStringHandler<TArgument>
     {
         private readonly StringBuilder? _builder;
         private readonly TArgument? _expected;
         private readonly TArgument? _actual;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertAreSameInterpolatedStringHandler{TArgument}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="expected">The expected value being asserted.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertAreSameInterpolatedStringHandler(int literalLength, int formattedCount, TArgument? expected, TArgument? actual, out bool shouldAppend)
         {
             _expected = expected;
@@ -43,14 +58,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -60,21 +88,54 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.AreNotSame</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArgument">The type of value being asserted.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -84,6 +145,14 @@ public sealed partial class Assert
         private readonly TArgument? _notExpected;
         private readonly TArgument? _actual;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertAreNotSameInterpolatedStringHandler{TArgument}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="notExpected">The value that is not expected.</param>
+        /// <param name="actual">The actual value being asserted.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertAreNotSameInterpolatedStringHandler(int literalLength, int formattedCount, TArgument? notExpected, TArgument? actual, out bool shouldAppend)
         {
             _notExpected = notExpected;
@@ -103,14 +172,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -120,21 +202,45 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <inheritdoc cref="AreSame{T}(T, T, string?, string, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578

--- a/src/TestFramework/TestFramework/Assertions/Assert.ContainsSingle.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ContainsSingle.cs
@@ -7,16 +7,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.ContainsSingle</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TItem">The type of item in the collection.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertSingleInterpolatedStringHandler<TItem>
     {
         private readonly StringBuilder? _builder;
         private readonly int _actualCount;
         private readonly TItem? _item;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertSingleInterpolatedStringHandler{TItem}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="collection">The collection being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertSingleInterpolatedStringHandler(int literalLength, int formattedCount, IEnumerable<TItem> collection, out bool shouldAppend)
         {
             _actualCount = collection.Count();
@@ -41,16 +55,28 @@ public sealed partial class Assert
             return _item!;
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value)
             => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value)
             => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value)
             => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
             => AppendFormatted(value.ToString(), alignment, format);
 #endif
@@ -60,27 +86,51 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format)
             => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment)
             => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value)
             => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 

--- a/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
@@ -13,7 +13,8 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 public sealed partial class Assert
 {
     /// <summary>
-    /// Provides an interpolated string handler used by <c>Assert.Count</c> and <c>Assert.HasCount</c> overloads
+    /// Provides an interpolated string handler used by <see cref="Assert.HasCount{T}(int, IEnumerable{T}, ref AssertCountInterpolatedStringHandler{T}, string)"/>
+    /// and <see cref="Assert.IsEmpty{T}(IEnumerable{T}, ref AssertCountInterpolatedStringHandler{T}, string)"/>
     /// that only allocates and formats the message when the assertion is failing.
     /// </summary>
     /// <typeparam name="TItem">The type of item in the collection.</typeparam>

--- a/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Count.cs
@@ -12,16 +12,31 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.Count</c> and <c>Assert.HasCount</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TItem">The type of item in the collection.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertCountInterpolatedStringHandler<TItem>
     {
         private readonly StringBuilder? _builder;
         private readonly int _expectedCount;
         private readonly int _actualCount;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertCountInterpolatedStringHandler{TItem}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="count">The expected item count.</param>
+        /// <param name="collection">The collection being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertCountInterpolatedStringHandler(int literalLength, int formattedCount, int count, IEnumerable<TItem> collection, out bool shouldAppend)
         {
             _actualCount = collection.Count();
@@ -33,6 +48,13 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertCountInterpolatedStringHandler{TItem}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="collection">The collection being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertCountInterpolatedStringHandler(int literalLength, int formattedCount, IEnumerable<TItem> collection, out bool shouldAppend)
         {
             _actualCount = collection.Count();
@@ -52,17 +74,30 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value)
             => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value)
             => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value)
             => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
             => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
@@ -73,29 +108,62 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format)
             => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment)
             => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value)
             => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNotEmpty</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TItem">The type of item in the collection.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -103,6 +171,13 @@ public sealed partial class Assert
     {
         private readonly StringBuilder? _builder;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsNotEmptyInterpolatedStringHandler{TItem}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="collection">The collection being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsNotEmptyInterpolatedStringHandler(int literalLength, int formattedCount, IEnumerable<TItem> collection, out bool shouldAppend)
         {
             shouldAppend = !collection.Any();
@@ -120,17 +195,30 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value)
             => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value)
             => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value)
             => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
             => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
@@ -141,29 +229,53 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format)
             => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment)
             => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value)
             => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null)
             => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsExactInstanceOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsExactInstanceOfType.cs
@@ -14,16 +14,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsExactInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsExactInstanceOfTypeInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
         private readonly object? _value;
         private readonly Type? _expectedType;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsExactInstanceOfTypeInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="expectedType">The expected type for the value being asserted.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsExactInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, Type? expectedType, out bool shouldAppend)
         {
             _value = value;
@@ -43,14 +57,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -60,23 +87,56 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsExactInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArg">The type the value is expected to be related to.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -85,6 +145,13 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly object? _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertGenericIsExactInstanceOfTypeInterpolatedStringHandler{TArg}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertGenericIsExactInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, out bool shouldAppend)
         {
             _value = value;
@@ -103,14 +170,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -120,23 +200,55 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNotExactInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -146,6 +258,14 @@ public sealed partial class Assert
         private readonly object? _value;
         private readonly Type? _wrongType;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsNotExactInstanceOfTypeInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="wrongType">The type the value is not expected to be an instance of.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsNotExactInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, Type? wrongType, out bool shouldAppend)
         {
             _value = value;
@@ -165,14 +285,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -182,23 +315,56 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNotExactInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArg">The type the value is expected to be related to.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -207,6 +373,13 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly object? _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertGenericIsNotExactInstanceOfTypeInterpolatedStringHandler{TArg}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertGenericIsNotExactInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, out bool shouldAppend)
         {
             _value = value;
@@ -225,14 +398,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -242,23 +428,47 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsInstanceOfType.cs
@@ -14,16 +14,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsInstanceOfTypeInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
         private readonly object? _value;
         private readonly Type? _expectedType;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsInstanceOfTypeInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="expectedType">The expected type for the value being asserted.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, Type? expectedType, out bool shouldAppend)
         {
             _value = value;
@@ -43,14 +57,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -60,23 +87,56 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArg">The type the value is expected to be related to.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -85,6 +145,13 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly object? _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertGenericIsInstanceOfTypeInterpolatedStringHandler{TArg}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertGenericIsInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, out bool shouldAppend)
         {
             _value = value;
@@ -103,14 +170,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -120,23 +200,55 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNotInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -146,6 +258,14 @@ public sealed partial class Assert
         private readonly object? _value;
         private readonly Type? _wrongType;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsNotInstanceOfTypeInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="wrongType">The type the value is not expected to be an instance of.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsNotInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, Type? wrongType, out bool shouldAppend)
         {
             _value = value;
@@ -165,14 +285,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -182,23 +315,56 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNotInstanceOfType</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TArg">The type the value is expected to be related to.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -207,6 +373,13 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly object? _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertGenericIsNotInstanceOfTypeInterpolatedStringHandler{TArg}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertGenericIsNotInstanceOfTypeInterpolatedStringHandler(int literalLength, int formattedCount, object? value, out bool shouldAppend)
         {
             _value = value;
@@ -225,14 +398,27 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -242,23 +428,47 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsNull.cs
@@ -16,15 +16,28 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNull</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsNullInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
         private readonly object? _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsNullInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsNullInterpolatedStringHandler(int literalLength, int formattedCount, object? value, out bool shouldAppend)
         {
             _value = value;
@@ -43,13 +56,25 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #endif
 
@@ -58,28 +83,64 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsNotNull</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsNotNullInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsNotNullInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="value">The value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsNotNullInterpolatedStringHandler(int literalLength, int formattedCount, object? value, out bool shouldAppend)
         {
             shouldAppend = IsNotNullFailing(value);
@@ -97,13 +158,25 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #endif
 
@@ -112,19 +185,42 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <inheritdoc cref="IsNull(object?, string, string)" />
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578

--- a/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsTrue.cs
@@ -16,15 +16,28 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsTrue</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertIsTrueInterpolatedStringHandler
     {
         private readonly StringBuilder? _builder;
         private readonly bool? _condition;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsTrueInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="condition">The condition value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsTrueInterpolatedStringHandler(int literalLength, int formattedCount, bool? condition, out bool shouldAppend)
         {
             _condition = condition;
@@ -43,13 +56,25 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #endif
 
@@ -58,19 +83,50 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.IsFalse</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -79,6 +135,13 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly bool? _condition;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertIsFalseInterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="condition">The condition value being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsFalseInterpolatedStringHandler(int literalLength, int formattedCount, bool? condition, out bool shouldAppend)
         {
             _condition = condition;
@@ -97,13 +160,25 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #endif
 
@@ -112,19 +187,42 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <inheritdoc cref="IsTrue(bool?, string, string)"/>
 #pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/76578

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.cs
@@ -14,16 +14,30 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// </summary>
 public sealed partial class Assert
 {
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.Throws</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TException">The type of exception expected to be thrown.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public readonly struct AssertNonStrictThrowsInterpolatedStringHandler<TException>
         where TException : Exception
     {
         private readonly StringBuilder? _builder;
         private readonly ThrowsExceptionState _state;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonStrictThrowsInterpolatedStringHandler{TException}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="action">The delegate being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonStrictThrowsInterpolatedStringHandler(int literalLength, int formattedCount, Action action, out bool shouldAppend)
         {
             _state = IsThrowsFailing<TException>(action, isStrictType: false);
@@ -34,6 +48,13 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertNonStrictThrowsInterpolatedStringHandler{TException}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="action">The delegate being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertNonStrictThrowsInterpolatedStringHandler(int literalLength, int formattedCount, Func<object?> action, out bool shouldAppend)
             : this(literalLength, formattedCount, (Action)(() => _ = action()), out shouldAppend)
         {
@@ -54,14 +75,27 @@ public sealed partial class Assert
             return null!;
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -71,21 +105,54 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
 
+    /// <summary>
+    /// Provides an interpolated string handler used by <c>Assert.ThrowsExactly</c> overloads
+    /// that only allocates and formats the message when the assertion is failing.
+    /// </summary>
+    /// <typeparam name="TException">The type of exception expected to be thrown.</typeparam>
+    /// <remarks>
+    /// This type is intended to be used by the compiler; users should not reference it directly.
+    /// </remarks>
     [StackTraceHidden]
     [InterpolatedStringHandler]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -95,6 +162,13 @@ public sealed partial class Assert
         private readonly StringBuilder? _builder;
         private readonly ThrowsExceptionState _state;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertThrowsExactlyInterpolatedStringHandler{TException}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="action">The delegate being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertThrowsExactlyInterpolatedStringHandler(int literalLength, int formattedCount, Action action, out bool shouldAppend)
         {
             _state = IsThrowsFailing<TException>(action, isStrictType: true);
@@ -105,6 +179,13 @@ public sealed partial class Assert
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertThrowsExactlyInterpolatedStringHandler{TException}"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The number of constant characters in the interpolated string.</param>
+        /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+        /// <param name="action">The delegate being asserted; the message is only computed when the assertion fails.</param>
+        /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertThrowsExactlyInterpolatedStringHandler(int literalLength, int formattedCount, Func<object?> action, out bool shouldAppend)
             : this(literalLength, formattedCount, (Action)(() => _ = action()), out shouldAppend)
         {
@@ -125,14 +206,27 @@ public sealed partial class Assert
             return null!;
         }
 
+        /// <summary>Appends a literal string to the interpolated message.</summary>
+        /// <param name="value">The literal string to append.</param>
         public void AppendLiteral(string value) => _builder!.Append(value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted<T>(T value) => AppendFormatted(value, format: null);
 
 #if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(ReadOnlySpan<char> value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The character span to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => AppendFormatted(value.ToString(), alignment, format);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
 #endif
@@ -142,21 +236,45 @@ public sealed partial class Assert
         // and should be okay if not very optimized.
         // A more efficient implementation that can be used for .NET 6 and later is to delegate the work to
         // the BCL's StringBuilder.AppendInterpolatedStringHandler
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, string? format) => _builder!.AppendFormat(null, $"{{0:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
         public void AppendFormatted<T>(T value, int alignment) => _builder!.AppendFormat(null, $"{{0,{alignment}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <typeparam name="T">The type of the value being appended.</typeparam>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted<T>(T value, int alignment, string? format) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
         public void AppendFormatted(string? value) => _builder!.Append(value);
 
 #pragma warning disable RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 
+        /// <summary>Appends a formatted value to the interpolated message.</summary>
+        /// <param name="value">The value to append.</param>
+        /// <param name="alignment">The minimum width of the formatted value.</param>
+        /// <param name="format">The format string to use.</param>
         public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _builder!.AppendFormat(null, $"{{0,{alignment}:{format}}}", value);
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
     }
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     /// <summary>
     /// Asserts that the delegate <paramref name="action"/> throws an exception of type <typeparamref name="TException"/>


### PR DESCRIPTION
Addresses tasks 1, 2, and 4 of #9060.

The 9 `Assert.*.cs` partials in `src/TestFramework/TestFramework/Assertions/` each had a `#pragma warning disable CS1591` block wrapping an `[EditorBrowsable(EditorBrowsableState.Never)]` `InterpolatedStringHandler` struct. This PR:

1. Adds XML `<summary>` / `<param>` comments to each handler struct and its public constructors and `AppendLiteral` / `AppendFormatted` members.
2. Removes the `#pragma warning disable CS1591` / `#pragma warning restore CS1591` lines, so future undocumented public API on these types will surface again.

These types are still `EditorBrowsable(Never)`, so this doesn't change the user-facing IntelliSense surface; it just closes the doc gap so we can later promote CS1591 to a build error (task 5 of #9060).

### Verification

- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj` succeeds with 0 warnings.
- No remaining `#pragma warning disable CS1591` under `src/TestFramework/`.