### PR TITLE
Treat CS1591 as a build error in MTP and TestFramework (#9060)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -5,6 +5,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateBuildInfo>true</GenerateBuildInfo>
     <DefineConstants>$(DefineConstants);IS_CORE_MTP</DefineConstants>
+
+    <!-- Treat "missing XML doc comment for publicly visible type or member" as a build error so
+         the public API stays fully documented. See #9060. -->
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestFramework/TestFramework/TestFramework.csproj
+++ b/src/TestFramework/TestFramework/TestFramework.csproj
@@ -14,6 +14,10 @@
     <PackageId>NotPublishable</PackageId>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);EXCLUDE_RANGE_INDEX_POLYFILL;EXCLUDE_OS_POLYFILL</DefineConstants>
+
+    <!-- Treat "missing XML doc comment for publicly visible type or member" as a build error so
+         the public API stays fully documented. See #9060. -->
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses task 5 of #9060: enforce CS1591 (missing XML doc comment on publicly visible type or member) as a build error for the two main public-API projects.

### Changes

Adds `<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>` to:

- `src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj`
- `src/TestFramework/TestFramework/TestFramework.csproj`

### Why this is safe today

Both projects already build with **0 CS1591 warnings** on `main`:

- MTP has no `#pragma warning disable CS1591` anywhere in the project.
- TestFramework has a handful of `#pragma warning disable CS1591` blocks around `[EditorBrowsable(EditorBrowsableState.Never)]` `InterpolatedStringHandler` structs; those pragmas continue to suppress the warning even when CS1591 is treated as an error. (#9072 documents those handlers and removes the pragmas so they can't be re-applied silently.)

### What this prevents going forward

Any new public type or member added to these two projects without an XML `///` summary will now fail the build instead of producing a warning that is easy to miss. The repo already has `<GenerateDocumentationFile>true</GenerateDocumentationFile>` globally and `<SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>` for `src/`, so this is purely a tightening of the existing policy.

### Verification

- `dotnet build src/TestFramework/TestFramework/TestFramework.csproj` → 0 warnings / 0 errors (4 TFMs)
- `dotnet build src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj` → 0 warnings / 0 errors (3 TFMs)

Part of #9060.
