### PR TITLE
Make AOT generator functional: emit the proven [ModuleInitializer] wiring

### DIFF
--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
@@ -41,6 +41,15 @@
   <ItemGroup>
     <Compile Include="..\MSTest.SourceGeneration\Helpers\Constants.cs" Link="Helpers\Constants.cs" />
     <Compile Include="..\MSTest.SourceGeneration\Helpers\IndentedStringBuilder.cs" Link="Helpers\IndentedStringBuilder.cs" />
+
+    <!-- Share the shipping generator's proven runtime-wiring source (ModuleInitializer + Register +
+         DynamicDependency rooting) so a project that references ONLY this AOT package is fully
+         functional today, on top of the reflection-free registry this generator also emits. This is
+         intentionally shared source (not a fork) so the wiring cannot drift from MSTest.SourceGeneration
+         until the reflection-free execution path is wired up and the two generators are consolidated. -->
+    <Compile Include="..\MSTest.SourceGeneration\Generators\ReflectionMetadataGenerator.cs" Link="Generators\ReflectionMetadataGenerator.cs" />
+    <Compile Include="..\MSTest.SourceGeneration\Emitters\ReflectionMetadataEmitter.cs" Link="Emitters\ReflectionMetadataEmitter.cs" />
+    <Compile Include="..\MSTest.SourceGeneration\Models\TestAssemblyMetadata.cs" Link="Models\TestAssemblyMetadata.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.AotReflection.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -68,6 +68,21 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         }
         """;
 
+    /// <summary>
+    /// Minimal stub of the adapter's runtime hook so the emitted <c>[ModuleInitializer]</c> wiring
+    /// (shared from MSTest.SourceGeneration) compiles in the Roslyn test compilation without
+    /// referencing MSTestAdapter.PlatformServices.
+    /// </summary>
+    private const string RuntimeHookStub = """
+        namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration
+        {
+            public static class ReflectionMetadataHook
+            {
+                public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods) { }
+            }
+        }
+        """;
+
     [TestMethod]
     public void Generator_EmitsSupportTypes_OnAnyCompilation()
     {
@@ -2107,6 +2122,49 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         // into the consumer assembly) MUST NOT use `init` accessors. Guard against accidental
         // reintroduction.
         support.Should().NotContain("{ get; init; }");
+    }
+
+    [TestMethod]
+    public void WiringGenerator_EmitsModuleInitializer_RegisteringAssembly_AndCompilesAgainstHook()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class MyTests
+                {
+                    [TestMethod]
+                    public void Test1() { }
+                }
+            }
+            """;
+
+        // The AOT generator package shares MSTest.SourceGeneration's proven runtime-wiring
+        // generator so that referencing ONLY this package makes a test assembly discoverable and
+        // runnable today (via ReflectionMetadataHook.Register), in addition to emitting the
+        // reflection-free registry the future 0%-reflection path will consume.
+        var wiringGenerator = new Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Generators.ReflectionMetadataGenerator();
+        CSharpCompilation compilation = CreateCompilation(MinimalMSTestStub, RuntimeHookStub, userCode);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(wiringGenerator);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out _);
+
+        GeneratorRunResult result = driver.GetRunResult().Results[0];
+        result.Diagnostics.Should().BeEmpty();
+
+        string wiring = result.GeneratedSources
+            .Single(s => s.HintName.EndsWith(".MSTestReflectionMetadata.g.cs", System.StringComparison.Ordinal))
+            .SourceText.ToString();
+
+        wiring.Should().Contain("[ModuleInitializer]");
+        wiring.Should().Contain("[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.MyTests))]");
+        wiring.Should().Contain(".ReflectionMetadataHook.Register(assembly, types, testMethods);");
+
+        IEnumerable<Diagnostic> errors = outputCompilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+        errors.Should().BeEmpty("the emitted module initializer must compile against the adapter's ReflectionMetadataHook");
     }
 
     private static string GetRegistry(GeneratorRunResult result)


### PR DESCRIPTION
Stacked on #9077.

## Problem
`MSTest.AotReflection.SourceGeneration` emitted a reflection-free metadata registry (`MSTest.SourceGenerated.MSTestReflectionMetadata`) but **no `[ModuleInitializer]`**, so referencing the package did nothing at runtime — there was no path that registered the assembly with the adapter. The package was not functional on its own.

## Change
Share `MSTest.SourceGeneration`'s proven runtime-wiring source into the AOT generator via `<Compile>` links (not a fork):

- `Generators/ReflectionMetadataGenerator.cs`
- `Emitters/ReflectionMetadataEmitter.cs`
- `Models/TestAssemblyMetadata.cs`

(`Helpers/Constants.cs` and `Helpers/IndentedStringBuilder.cs` were already linked.)

Now a project referencing **only** the AOT package emits the `[ModuleInitializer]` + `ReflectionMetadataHook.Register(...)` + `[DynamicDependency]` rooting — so it discovers and runs tests today, on par with `MSTest.SourceGeneration` — **in addition to** the reflection-free registry the future 0%-reflection execution path will consume.

Using **shared source** (rather than copy-paste) keeps the wiring from drifting from `MSTest.SourceGeneration` until the reflection-free execution path is built and the two generators are consolidated at cutover.

## Tests
Adds `WiringGenerator_EmitsModuleInitializer_RegisteringAssembly_AndCompilesAgainstHook` (verifies the emitted initializer registers the assembly and compiles against a `ReflectionMetadataHook` stub). **66/66** generator unit tests pass; full build clean.

## Not in this PR (remaining for full 0%-reflection support)
- Route instantiation / method invocation / attribute reads through the generated delegate registry instead of `MethodInfo.Invoke`/`Activator`/`GetCustomAttributes` (the `IReflectionOperations` model + execution engine are `MethodInfo`-centric today).
- Make the generator packable + add an end-to-end acceptance test.
- Consolidate into `MSTest.SourceGeneration` / `MSTest.Sdk` at cutover.

Part of #1837.