### PR TITLE
Deduplicate report engine boilerplate + CTRF validator (#9066, #9065)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
@@ -10,22 +10,11 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
-internal sealed partial class CtrfReportEngine
+internal sealed partial class CtrfReportEngine : ReportEngineBase
 {
     // CTRF spec: https://github.com/ctrf-io/ctrf
     private const string CtrfReportFormat = "CTRF";
     private const string CtrfSpecVersion = "0.0.0";
-
-    private readonly IFileSystem _fileSystem;
-    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    private readonly IEnvironment _environment;
-    private readonly ICommandLineOptions _commandLineOptions;
-    private readonly IConfiguration _configuration;
-    private readonly IClock _clock;
-    private readonly ITestFramework _testFramework;
-    private readonly DateTimeOffset _testStartTime;
-    private readonly int _exitCode;
-    private readonly CancellationToken _cancellationToken;
 
     public CtrfReportEngine(
         IFileSystem fileSystem,
@@ -38,17 +27,18 @@ internal sealed partial class CtrfReportEngine
         DateTimeOffset testStartTime,
         int exitCode,
         CancellationToken cancellationToken)
+        : base(
+            fileSystem,
+            testApplicationModuleInfo,
+            environment,
+            commandLineOptions,
+            configuration,
+            clock,
+            testFramework,
+            testStartTime,
+            exitCode,
+            cancellationToken)
     {
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
-        _environment = environment;
-        _commandLineOptions = commandLineOptions;
-        _configuration = configuration;
-        _clock = clock;
-        _testFramework = testFramework;
-        _testStartTime = testStartTime;
-        _exitCode = exitCode;
-        _cancellationToken = cancellationToken;
     }
 
     public Task<(string FileName, string? Warning)> GenerateReportAsync(CapturedTestResult[] results)
@@ -81,9 +71,4 @@ internal sealed partial class CtrfReportEngine
 
         return await WriteWithRetryAsync(finalPath, bytes, fileNameExplicitlyProvided).ConfigureAwait(false);
     }
-
-    private static string GetProvidedFileName(string[]? providedFileName)
-        => providedFileName is { Length: > 0 }
-            ? providedFileName[0]
-            : throw ApplicationStateGuard.Unreachable();
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGeneratorCommandLine.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.CtrfReport.Resources;
-using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
@@ -13,8 +12,6 @@ internal sealed class CtrfReportGeneratorCommandLine : CommandLineOptionsProvide
 {
     public const string CtrfReportOptionName = "report-ctrf";
     public const string CtrfReportFileNameOptionName = "report-ctrf-filename";
-
-    private static readonly char[] DirectorySeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
 
     public CtrfReportGeneratorCommandLine()
         : base(
@@ -30,101 +27,21 @@ internal sealed class CtrfReportGeneratorCommandLine : CommandLineOptionsProvide
     }
 
     public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
-    {
-        if (commandOption.Name == CtrfReportFileNameOptionName)
-        {
-            if (arguments.Length is 0)
-            {
-                return ValidationResult.InvalidTask(ExtensionResources.CtrfReportFileNameMustNotBeEmpty);
-            }
-
-            string argument = arguments[0];
-
-            string fileNamePart = Path.GetFileName(argument);
-            if (RoslynString.IsNullOrWhiteSpace(fileNamePart))
-            {
-                return ValidationResult.InvalidTask(ExtensionResources.CtrfReportFileNameMustNotBeEmpty);
-            }
-
-            if (!fileNamePart.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-            {
-                return ValidationResult.InvalidTask(ExtensionResources.CtrfReportFileNameExtensionIsNotJson);
-            }
-
-            if (EscapesResultsDirectory(argument))
-            {
-                return ValidationResult.InvalidTask(ExtensionResources.CtrfReportFileNameRelativePathMustStayUnderResultsDirectory);
-            }
-        }
-
-        return ValidationResult.ValidTask;
-    }
+        => commandOption.Name == CtrfReportFileNameOptionName
+            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
+                arguments,
+                ".json",
+                ExtensionResources.CtrfReportFileNameMustNotBeEmpty,
+                ExtensionResources.CtrfReportFileNameExtensionIsNotJson,
+                ExtensionResources.CtrfReportFileNameRelativePathMustStayUnderResultsDirectory)
+            : ValidationResult.ValidTask;
 
     public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => commandLineOptions.IsOptionSet(CtrfReportFileNameOptionName) && !commandLineOptions.IsOptionSet(CtrfReportOptionName)
-            ? ValidationResult.InvalidTask(ExtensionResources.CtrfReportFileNameRequiresCtrfReport)
-            : commandLineOptions.IsOptionSet(CtrfReportOptionName) && commandLineOptions.IsOptionSet(PlatformCommandLineProvider.DiscoverTestsOptionKey)
-                ? ValidationResult.InvalidTask(ExtensionResources.CtrfReportIsNotValidForDiscovery)
-                : ValidationResult.ValidTask;
-
-    private static bool EscapesResultsDirectory(string path)
-    {
-        // Fully-qualified paths (e.g. "C:\foo.json", "\\server\share\foo.json" or "/foo.json") are
-        // accepted as-is and validated by the OS when we open the file - the user explicitly opted
-        // out of writing under the test results directory.
-        if (IsPathFullyQualified(path))
-        {
-            return false;
-        }
-
-        // Drive-relative paths on Windows such as "C:foo.json" are "rooted" but not fully qualified -
-        // they resolve against the current directory of the drive, which is unpredictable and would
-        // silently escape the test results directory. Reject them. On non-Windows OSes
-        // Path.IsPathRooted only returns true for paths starting with "/", which are already handled
-        // above, so this check is effectively Windows-only and matches the TRX option behavior.
-        if (Path.IsPathRooted(path))
-        {
-            return true;
-        }
-
-        // Any remaining ".." segment in a relative path would escape the test results directory.
-        return path.Split(DirectorySeparators, StringSplitOptions.RemoveEmptyEntries).Any(segment => segment == "..");
-    }
-
-    private static bool IsPathFullyQualified(string path)
-    {
-#if NETCOREAPP
-        return Path.IsPathFullyQualified(path);
-#else
-        // Mirrors the runtime implementation that is missing on .NET Framework and netstandard2.0.
-        if (path.Length < 2)
-        {
-            return false;
-        }
-
-        // UNC paths like "\\server\share" (or with forward slashes).
-        if (IsDirectorySeparator(path[0]) && IsDirectorySeparator(path[1]))
-        {
-            return true;
-        }
-
-        // On Unix, only paths starting with "/" are fully qualified.
-        if (Path.DirectorySeparatorChar == '/')
-        {
-            return path[0] == '/';
-        }
-
-        // On Windows, fully qualified drive paths must be "X:\" or "X:/".
-        return path.Length >= 3
-            && IsValidDriveLetter(path[0])
-            && path[1] == ':'
-            && IsDirectorySeparator(path[2]);
-
-        static bool IsDirectorySeparator(char c)
-            => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
-
-        static bool IsValidDriveLetter(char c)
-            => c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z');
-#endif
-    }
+        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
+            commandLineOptions,
+            CtrfReportOptionName,
+            CtrfReportFileNameOptionName,
+            ExtensionResources.CtrfReportFileNameRequiresCtrfReport,
+            ExtensionResources.CtrfReportIsNotValidForDiscovery,
+            PlatformCommandLineProvider.DiscoverTestsOptionKey);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -54,6 +54,8 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -11,22 +11,11 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
-internal sealed class HtmlReportEngine
+internal sealed class HtmlReportEngine : ReportEngineBase
 {
     private const string TemplateResourceName = "Microsoft.Testing.Extensions.HtmlReport.Templates.report-template.html";
     private const string DataPlaceholder = "/*__MTP_DATA__*/null";
     private const string GeneratorVersionPlaceholder = "__MTP_GENERATOR_VERSION__";
-
-    private readonly IFileSystem _fileSystem;
-    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    private readonly IEnvironment _environment;
-    private readonly ICommandLineOptions _commandLineOptions;
-    private readonly IConfiguration _configuration;
-    private readonly IClock _clock;
-    private readonly ITestFramework _testFramework;
-    private readonly DateTimeOffset _testStartTime;
-    private readonly int _exitCode;
-    private readonly CancellationToken _cancellationToken;
 
     public HtmlReportEngine(
         IFileSystem fileSystem,
@@ -39,17 +28,18 @@ internal sealed class HtmlReportEngine
         DateTimeOffset testStartTime,
         int exitCode,
         CancellationToken cancellationToken)
+        : base(
+            fileSystem,
+            testApplicationModuleInfo,
+            environment,
+            commandLineOptions,
+            configuration,
+            clock,
+            testFramework,
+            testStartTime,
+            exitCode,
+            cancellationToken)
     {
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
-        _environment = environment;
-        _commandLineOptions = commandLineOptions;
-        _configuration = configuration;
-        _clock = clock;
-        _testFramework = testFramework;
-        _testStartTime = testStartTime;
-        _exitCode = exitCode;
-        _cancellationToken = cancellationToken;
     }
 
     public Task<(string FileName, string? Warning)> GenerateReportAsync(CapturedTestResult[] results)
@@ -89,11 +79,6 @@ internal sealed class HtmlReportEngine
 
         return await WriteAsync(finalPath, bytes).ConfigureAwait(false);
     }
-
-    private static string GetProvidedFileName(string[]? providedFileName)
-        => providedFileName is { Length: > 0 }
-            ? providedFileName[0]
-            : throw ApplicationStateGuard.Unreachable();
 
     private async Task<(string FileName, string? Warning)> WriteAsync(string finalPath, byte[] bytes)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -52,6 +52,7 @@ This package extends Microsoft Testing Platform to produce self-contained HTML t
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TargetFrameworkMonikerHelper.cs" Link="Helpers\TargetFrameworkMonikerHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
@@ -11,7 +11,7 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
-internal sealed class JUnitReportEngine
+internal sealed class JUnitReportEngine : ReportEngineBase
 {
     // Default cap on the rendered testpath property. Test trees can in theory be very
     // deep, and each level contributes a (capped) display name to the path, so we put
@@ -24,17 +24,6 @@ internal sealed class JUnitReportEngine
 
     private const string TestPathSeparator = "/";
 
-    private readonly IFileSystem _fileSystem;
-    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    private readonly IEnvironment _environment;
-    private readonly ICommandLineOptions _commandLineOptions;
-    private readonly IConfiguration _configuration;
-    private readonly IClock _clock;
-    private readonly ITestFramework _testFramework;
-    private readonly DateTimeOffset _testStartTime;
-    private readonly int _exitCode;
-    private readonly CancellationToken _cancellationToken;
-
     public JUnitReportEngine(
         IFileSystem fileSystem,
         ITestApplicationModuleInfo testApplicationModuleInfo,
@@ -46,17 +35,18 @@ internal sealed class JUnitReportEngine
         DateTimeOffset testStartTime,
         int exitCode,
         CancellationToken cancellationToken)
+        : base(
+            fileSystem,
+            testApplicationModuleInfo,
+            environment,
+            commandLineOptions,
+            configuration,
+            clock,
+            testFramework,
+            testStartTime,
+            exitCode,
+            cancellationToken)
     {
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
-        _environment = environment;
-        _commandLineOptions = commandLineOptions;
-        _configuration = configuration;
-        _clock = clock;
-        _testFramework = testFramework;
-        _testStartTime = testStartTime;
-        _exitCode = exitCode;
-        _cancellationToken = cancellationToken;
     }
 
     public Task<(string FileName, string? Warning)> GenerateReportAsync(
@@ -97,11 +87,6 @@ internal sealed class JUnitReportEngine
 
         return await WriteOutputAsync(finalPath, suites).ConfigureAwait(false);
     }
-
-    private static string GetProvidedFileName(string[]? providedFileName)
-        => providedFileName is { Length: > 0 }
-            ? providedFileName[0]
-            : throw ApplicationStateGuard.Unreachable();
 
     private async Task<(string FileName, string? Warning)> WriteOutputAsync(
         string finalPath,

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -50,6 +50,7 @@ This package extends Microsoft Testing Platform to produce JUnit XML test report
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameHelper.cs" Link="Helpers\ReportFileNameHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />

--- a/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Extensions;
+
+/// <summary>
+/// Shared base class for report engine implementations (CTRF, JUnit, HTML, ...) that all consume
+/// the same set of platform services (file system, configuration, clock, ...) and need a common
+/// way to extract the user-provided report file name from a parsed command-line argument list.
+/// </summary>
+internal abstract class ReportEngineBase
+{
+#pragma warning disable SA1401 // Fields should be private - intentional: derived report engines access these directly through their partial files.
+    protected readonly IFileSystem _fileSystem;
+    protected readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
+    protected readonly IEnvironment _environment;
+    protected readonly ICommandLineOptions _commandLineOptions;
+    protected readonly IConfiguration _configuration;
+    protected readonly IClock _clock;
+    protected readonly ITestFramework _testFramework;
+    protected readonly DateTimeOffset _testStartTime;
+    protected readonly int _exitCode;
+    protected readonly CancellationToken _cancellationToken;
+#pragma warning restore SA1401
+
+    protected ReportEngineBase(
+        IFileSystem fileSystem,
+        ITestApplicationModuleInfo testApplicationModuleInfo,
+        IEnvironment environment,
+        ICommandLineOptions commandLineOptions,
+        IConfiguration configuration,
+        IClock clock,
+        ITestFramework testFramework,
+        DateTimeOffset testStartTime,
+        int exitCode,
+        CancellationToken cancellationToken)
+    {
+        _fileSystem = fileSystem;
+        _testApplicationModuleInfo = testApplicationModuleInfo;
+        _environment = environment;
+        _commandLineOptions = commandLineOptions;
+        _configuration = configuration;
+        _clock = clock;
+        _testFramework = testFramework;
+        _testStartTime = testStartTime;
+        _exitCode = exitCode;
+        _cancellationToken = cancellationToken;
+    }
+
+    protected static string GetProvidedFileName(string[]? providedFileName)
+        => providedFileName is { Length: > 0 }
+            ? providedFileName[0]
+            : throw ApplicationStateGuard.Unreachable();
+}


### PR DESCRIPTION
Fixes #9066 and fixes #9065.

## #9066 - Deduplicate ReportEngine constructor + fields + `GetProvidedFileName`

Extracted the 10-field constructor, the shared `protected` fields, and the `GetProvidedFileName` helper from `CtrfReportEngine` / `JUnitReportEngine` / `HtmlReportEngine` into a new `ReportEngineBase` under `src/Platform/SharedExtensionHelpers/`. Each engine now derives from `ReportEngineBase` and chains its constructor via `: base(...)`. Field names are preserved (`_fileSystem`, `_clock`, ...) so all partial files in `Microsoft.Testing.Extensions.CtrfReport` keep working unchanged.

## #9065 - Use shared `ReportFileNameValidator` from CTRF cmdline

Linked `ReportFileNameValidator.cs` into `Microsoft.Testing.Extensions.CtrfReport` and rewrote `CtrfReportGeneratorCommandLine.ValidateOptionArgumentsAsync` / `ValidateCommandLineOptionsAsync` to delegate to the shared validator (same pattern already used by JUnit and HTML). Removed the duplicated `EscapesResultsDirectory`, `IsPathFullyQualified`, and `DirectorySeparators` helpers.

## Validation

- `dotnet build` on all three extension projects: clean (0 warnings, 0 errors).
- `dotnet test test/UnitTests/Microsoft.Testing.Extensions.UnitTests -f net8.0`: 507 passed / 4 skipped / 0 failed (the 4 skipped are pre-existing Crash report Windows skips).

## Net change

8 files changed, 116 insertions(+), 180 deletions(-).