### PR TITLE
[code-simplifier] Simplify nested ternary in EmitProperties to if/else chain

### DIFF
--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -259,19 +259,12 @@ internal static class MetadataRegistryEmitter
                     // Static members are accessed through the type name; instance members through
                     // the cast receiver. Indexers are filtered out earlier because the name-based
                     // Get/Set delegate shape cannot represent them.
-                    string getBody;
-                    if (!prop.HasGettableValue)
+                    string getBody = (prop.HasGettableValue, prop.IsStatic) switch
                     {
-                        getBody = $"throw new InvalidOperationException(\"Property '{prop.Name}' has no accessible getter.\")";
-                    }
-                    else if (prop.IsStatic)
-                    {
-                        getBody = $"(object?){fqn}.{prop.Name}";
-                    }
-                    else
-                    {
-                        getBody = $"instance is null ? null : (object?)(({fqn})instance).{prop.Name}";
-                    }
+                        (false, _) => $"throw new InvalidOperationException(\"Property '{prop.Name}' has no accessible getter.\")",
+                        (true, true) => $"(object?){fqn}.{prop.Name}",
+                        (true, false) => $"instance is null ? null : (object?)(({fqn})instance).{prop.Name}",
+                    };
 
                     sb.AppendLine($"Get = static instance => {getBody},");
 

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -259,11 +259,20 @@ internal static class MetadataRegistryEmitter
                     // Static members are accessed through the type name; instance members through
                     // the cast receiver. Indexers are filtered out earlier because the name-based
                     // Get/Set delegate shape cannot represent them.
-                    string getBody = prop.HasGettableValue
-                        ? prop.IsStatic
-                            ? $"(object?){fqn}.{prop.Name}"
-                            : $"instance is null ? null : (object?)(({fqn})instance).{prop.Name}"
-                        : $"throw new InvalidOperationException(\"Property '{prop.Name}' has no accessible getter.\")";
+                    string getBody;
+                    if (!prop.HasGettableValue)
+                    {
+                        getBody = $"throw new InvalidOperationException(\"Property '{prop.Name}' has no accessible getter.\")";
+                    }
+                    else if (prop.IsStatic)
+                    {
+                        getBody = $"(object?){fqn}.{prop.Name}";
+                    }
+                    else
+                    {
+                        getBody = $"instance is null ? null : (object?)(({fqn})instance).{prop.Name}";
+                    }
+
                     sb.AppendLine($"Get = static instance => {getBody},");
 
                     string setTarget = prop.IsStatic ? fqn : $"(({fqn})instance!)";


### PR DESCRIPTION
## Code Simplification - 2026-06-12

This PR simplifies a nested ternary operator introduced in #9077 to improve code clarity and comply with the project's coding standards.

### Files Simplified

- `src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs` — Replace nested ternary for `getBody` with an explicit `if/else` chain

### Improvement Made

**Eliminated nested ternary operator**

The `EmitProperties` method computed `getBody` using a two-level ternary:

```csharp
string getBody = prop.HasGettableValue
    ? prop.IsStatic
        ? $"(object?){fqn}.{prop.Name}"
        : $"instance is null ? null : (object?)(({fqn})instance).{prop.Name}"
    : $"throw new InvalidOperationException(\"Property '{prop.Name}' has no accessible getter.\")";
```

Replaced with an explicit `if/else` chain that matches the existing style of the adjacent `EmitMethodInvoker` method and complies with the project's coding standard:

> IMPORTANT: Avoid nested ternary operators — prefer switch statements or if/else chains.

```csharp
string getBody;
if (!prop.HasGettableValue)
{
    getBody = $"throw new InvalidOperationException(\"Property '{prop.Name}' has no accessible getter.\")";
}
else if (prop.IsStatic)
{
    getBody = $"(object?){fqn}.{prop.Name}";
}
else
{
    getBody = $"instance is null ? null : (object?)(({fqn})instance).{prop.Name}";
}
```

### Changes Based On

Recent changes from:
- #9077 — Fix property lowering (static/indexer/set-only) in MSTest.AotReflection.SourceGeneration

### Testing

- ✅ No functional changes — behavior is identical (same branching logic, same output strings)
- ✅ Consistent with the style of `EmitMethodInvoker` in the same file, which already uses `if/else` chains for analogous multi-branch body selection

### Review Focus

Please verify:
- Logic is fully preserved (all three `getBody` branches produce the same strings as before)
- Style matches `EmitMethodInvoker`'s existing `if/else` pattern


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27420951229/agentic_workflow) workflow. · 637.2 AIC · ⌖ 24.5 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-13T14:20:03.269Z --> on Jun 13, 2026, 2:20 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27420951229, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27420951229 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->