### PR TITLE
[perf-improver] perf: pool RenderedProgressItem instances in AnsiTerminalTestProgressFrame

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -258,12 +258,12 @@ internal sealed class AnsiTerminal : ITerminal
     /// </summary>
     public void EraseProgress()
     {
-        if (_currentFrame.RenderedLines == null || _currentFrame.RenderedLines.Count == 0)
+        if (_currentFrame.RenderedLinesCount == 0)
         {
             return;
         }
 
-        AppendLine($"{AnsiCodes.CSI}{_currentFrame.RenderedLines.Count + 2}{AnsiCodes.MoveUpToLineStart}");
+        AppendLine($"{AnsiCodes.CSI}{_currentFrame.RenderedLinesCount + 2}{AnsiCodes.MoveUpToLineStart}");
         Append(AnsiCodes.CsiEraseInDisplay);
         _currentFrame.Clear();
     }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -38,11 +38,16 @@ internal sealed class AnsiTerminalTestProgressFrame
     private int[] _sortedIndicesBuffer = [];
     private List<TestDetailState>?[] _detailItemsBuffer = [];
 
+    // Pooled RenderedProgressItem instances — reused across render ticks to avoid per-line heap allocations.
+    // RenderedLinesCount tracks how many entries are valid in the current frame; the array itself is never
+    // shrunk so slots from previous (higher-watermark) ticks remain available for reuse.
+    private RenderedProgressItem[] _renderedLines = [];
+
     public int Width { get; private set; }
 
     public int Height { get; private set; }
 
-    public List<RenderedProgressItem>? RenderedLines { get; set; }
+    public int RenderedLinesCount { get; private set; }
 
     public AnsiTerminalTestProgressFrame(int width, int height)
     {
@@ -57,8 +62,30 @@ internal sealed class AnsiTerminalTestProgressFrame
     {
         Width = Math.Min(width, MaxColumn);
         Height = height;
-        RenderedLines?.Clear();
+        RenderedLinesCount = 0;
         _linesToRenderBuffer.Clear();
+    }
+
+    /// <summary>
+    /// Returns the next available <see cref="RenderedProgressItem"/> slot, growing the pool on demand.
+    /// Increments <see cref="RenderedLinesCount"/> so the slot is considered active.
+    /// </summary>
+    private RenderedProgressItem GetOrAllocateNextSlot()
+    {
+        int idx = RenderedLinesCount++;
+        if ((uint)idx >= (uint)_renderedLines.Length)
+        {
+            int newSize = _renderedLines.Length == 0 ? 8 : _renderedLines.Length * 2;
+            if (newSize <= idx)
+            {
+                newSize = idx + 1;
+            }
+
+            Array.Resize(ref _renderedLines, newSize);
+        }
+
+        _renderedLines[idx] ??= new RenderedProgressItem();
+        return _renderedLines[idx];
     }
 
     public void AppendTestWorkerProgress(TestProgressState progress, RenderedProgressItem currentLine, AnsiTerminal terminal)
@@ -235,11 +262,11 @@ internal sealed class AnsiTerminalTestProgressFrame
         //   quickly determine if the detail has changed since the last render.
 
         // Don't go up if we did not render any lines in previous frame or we already cleared them.
-        if (previousFrame.RenderedLines != null && previousFrame.RenderedLines.Count > 0)
+        if (previousFrame.RenderedLinesCount > 0)
         {
             // Move cursor back to 1st line of progress.
             // + 2 because we output and empty line right below.
-            terminal.MoveCursorUp(previousFrame.RenderedLines.Count + 2);
+            terminal.MoveCursorUp(previousFrame.RenderedLinesCount + 2);
         }
 
         // When there is nothing to render, don't write empty lines, e.g. when we start the test run, and then we kick off build
@@ -250,23 +277,21 @@ internal sealed class AnsiTerminalTestProgressFrame
         }
 
         int i;
-        // Reuse the list if it was already cleared by Reset(); only allocate on first use of each frame object.
-        RenderedLines ??= [with(progress.Length * 2)];
         List<object> progresses = GenerateLinesToRender(progress);
 
         for (i = 0; i < progresses.Count; i++)
         {
             object item = progresses[i];
 
-            if (previousFrame.RenderedLines != null && previousFrame.RenderedLines.Count > i)
+            if (previousFrame.RenderedLinesCount > i)
             {
                 if (item is TestProgressState progressItem)
                 {
-                    var currentLine = new RenderedProgressItem(progressItem.Id, progressItem.Version);
-                    RenderedLines.Add(currentLine);
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(progressItem.Id, progressItem.Version);
 
                     // We have a line that was rendered previously, compare it and decide how to render.
-                    RenderedProgressItem previouslyRenderedLine = previousFrame.RenderedLines[i];
+                    RenderedProgressItem previouslyRenderedLine = previousFrame._renderedLines[i];
                     if (previouslyRenderedLine.ProgressId == progressItem.Id && previouslyRenderedLine.ProgressVersion == progressItem.Version)
                     {
                         // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
@@ -300,11 +325,11 @@ internal sealed class AnsiTerminalTestProgressFrame
 
                 if (item is TestDetailState detailItem)
                 {
-                    var currentLine = new RenderedProgressItem(detailItem.Id, detailItem.Version);
-                    RenderedLines.Add(currentLine);
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(detailItem.Id, detailItem.Version);
 
                     // We have a line that was rendered previously, compare it and decide how to render.
-                    RenderedProgressItem previouslyRenderedLine = previousFrame.RenderedLines[i];
+                    RenderedProgressItem previouslyRenderedLine = previousFrame._renderedLines[i];
                     if (previouslyRenderedLine.ProgressId == detailItem.Id && previouslyRenderedLine.ProgressVersion == detailItem.Version)
                     {
                         // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
@@ -341,15 +366,15 @@ internal sealed class AnsiTerminalTestProgressFrame
                 // We are rendering more lines than we rendered in previous frame
                 if (item is TestProgressState progressItem)
                 {
-                    var currentLine = new RenderedProgressItem(progressItem.Id, progressItem.Version);
-                    RenderedLines.Add(currentLine);
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(progressItem.Id, progressItem.Version);
                     AppendTestWorkerProgress(progressItem, currentLine, terminal);
                 }
 
                 if (item is TestDetailState detailItem)
                 {
-                    var currentLine = new RenderedProgressItem(detailItem.Id, detailItem.Version);
-                    RenderedLines.Add(currentLine);
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(detailItem.Id, detailItem.Version);
                     AppendTestWorkerDetail(detailItem, currentLine, terminal);
                 }
             }
@@ -361,7 +386,7 @@ internal sealed class AnsiTerminalTestProgressFrame
         }
 
         // We rendered more lines in previous frame. Clear them.
-        if (previousFrame.RenderedLines != null && i < previousFrame.RenderedLines.Count)
+        if (i < previousFrame.RenderedLinesCount)
         {
             terminal.Append(AnsiCodes.CsiEraseInDisplay);
         }
@@ -443,7 +468,7 @@ internal sealed class AnsiTerminalTestProgressFrame
         return _linesToRenderBuffer;
     }
 
-    public void Clear() => RenderedLines?.Clear();
+    public void Clear() => RenderedLinesCount = 0;
 
     /// <summary>
     /// Reusable comparer for sorting progress-item indices by running-task count.
@@ -460,15 +485,17 @@ internal sealed class AnsiTerminalTestProgressFrame
 
     internal sealed class RenderedProgressItem
     {
-        public RenderedProgressItem(long id, long version)
+        /// <summary>Resets this instance for reuse with new identity and version values.</summary>
+        internal void Reset(long id, long version)
         {
             ProgressId = id;
             ProgressVersion = version;
+            RenderedDurationLength = 0;
         }
 
-        public long ProgressId { get; }
+        public long ProgressId { get; private set; }
 
-        public long ProgressVersion { get; }
+        public long ProgressVersion { get; private set; }
 
         public int RenderedDurationLength { get; set; }
     }


### PR DESCRIPTION
## Goal and Rationale

Each render tick (~2 fps) of the ANSI terminal progress display previously created a **new `RenderedProgressItem` object for every rendered line** — one per assembly progress row and one per each running-test detail row.

With 5 assemblies running concurrently and 2 detail lines each, that is **15 allocations per tick × 2 fps × 300 s ≈ 9,000 short-lived object allocations per 5-minute run**. At higher assembly/detail counts the numbers scale linearly.

## Approach

Replace the per-tick `new RenderedProgressItem(id, version)` + `List.Add(...)` pattern with a **pre-allocated pool array** per `AnsiTerminalTestProgressFrame` instance:

| Before | After |
|---|---|
| `new RenderedProgressItem(id, version)` on every rendered line | `GetOrAllocateNextSlot()` — returns an existing slot, grows array only when the high-water mark is exceeded |
| `List<RenderedProgressItem>? RenderedLines` (null-checked, `.Count`, `.Add`, `.Clear()`) | `RenderedProgressItem[] _renderedLines` (pool) + `int RenderedLinesCount` |
| `RenderedLines?.Clear()` in `Reset()` | `RenderedLinesCount = 0` — zeroes the count; pooled objects remain alive and are reused |
| `RenderedProgressItem(long id, long version)` constructor | `Reset(long id, long version)` method on a reusable instance |

The pool array is never shrunk, so it reaches steady state at the high-water mark of simultaneous rendered lines (bounded by terminal height × 0.7) and allocates nothing thereafter.

`AnsiTerminal.EraseProgress()` is updated to use `RenderedLinesCount` instead of the removed `RenderedLines` property.

## Performance Evidence

| Scenario | Before | After |
|---|---|------|
| 5 assemblies × 2 detail lines × 2 fps × 5 min | ~9,000 `RenderedProgressItem` allocs | 0 (after first tick) |
| 10 assemblies × 3 detail lines × 2 fps × 5 min | ~18,000 `RenderedProgressItem` allocs | 0 (after first tick) |

Methodology: static code analysis — every code path through `Render()` that produces a rendered line now calls `GetOrAllocateNextSlot()` instead of `new RenderedProgressItem(...)`.

## Trade-offs

- The `RenderedProgressItem.ProgressId` and `RenderedProgressItem.ProgressVersion` properties change from `{ get; }` (readonly) to `{ get; private set; }` (mutable via internal `Reset`). The class remains `internal sealed`, so this has no API-surface impact.
- Pooled instances live as long as the `AnsiTerminalTestProgressFrame` that owns them. Frames are long-lived (double-buffer swap), so this is at most 2 × `Height * 0.7` ≈ 24 live `RenderedProgressItem` objects — negligible.

## Reproducibility

```bash
dotnet-trace collect -- artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
# Compare Microsoft.Testing.Platform.OutputDevice.Terminal.AnsiTerminalTestProgressFrame+RenderedProgressItem allocation counts
```

## Test Status

✅ Build: 0 warnings, 0 errors (all TFMs).
✅ Unit tests: 1125 passed, 0 failed, 3 skipped (net8.0).




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27421716933/agentic_workflow) workflow. · 2.1K AIC · ⌖ 38.7 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27421716933, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27421716933 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->