### PR TITLE
Flag `Assert.AreEqual(x, x)` / `AreSame(x, x)` / `AreNotEqual(x, x)` / `AreNotSame(x, x)` (#9087)

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
@@ -92,11 +92,18 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : Diagnost
             "IsTrue" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
             "IsFalse" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "AreEqual" => GetEqualityStatus(operation, ExpectedParameterName) == EqualityStatus.NotEqual,
-            "AreNotEqual" => GetEqualityStatus(operation, NotExpectedParameterName) == EqualityStatus.Equal,
+            "AreNotEqual" => GetEqualityStatus(operation, NotExpectedParameterName) == EqualityStatus.Equal
+                || HasIdenticalExpectedAndActual(operation, NotExpectedParameterName),
+            "AreNotSame" => HasIdenticalExpectedAndActual(operation, NotExpectedParameterName),
             "IsNotNull" => GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
             "IsNull" => GetValueArgument(operation) is { } valueArgumentOperation && IsNotNullableType(valueArgumentOperation),
             _ => false,
         };
+
+    private static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+        => GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
+        && GetArgumentWithName(operation, ActualParameterName) is { } actualArgument
+        && expectedArgument.IsEquivalentReferenceTo(actualArgument);
 
     private static bool IsNotNullableType(IOperation valueArgumentOperation)
     {

--- a/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
@@ -101,9 +101,12 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : Diagnost
         };
 
     private static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-        => GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
-        && GetArgumentWithName(operation, ActualParameterName) is { } actualArgument
+        => GetRawArgumentValueWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
+        && GetRawArgumentValueWithName(operation, ActualParameterName) is { } actualArgument
         && expectedArgument.IsEquivalentReferenceTo(actualArgument);
+
+    private static IOperation? GetRawArgumentValueWithName(IInvocationOperation operation, string name)
+        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value;
 
     private static bool IsNotNullableType(IOperation valueArgumentOperation)
     {

--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -91,9 +91,12 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
         };
 
     private static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-        => GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
-        && GetArgumentWithName(operation, ActualParameterName) is { } actualArgument
+        => GetRawArgumentValueWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
+        && GetRawArgumentValueWithName(operation, ActualParameterName) is { } actualArgument
         && expectedArgument.IsEquivalentReferenceTo(actualArgument);
+
+    private static IOperation? GetRawArgumentValueWithName(IInvocationOperation operation, string name)
+        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value;
 
     private static bool IsNotNullableType(IOperation valueArgumentOperation)
     {

--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -81,12 +81,19 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
         {
             "IsTrue" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "IsFalse" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
-            "AreEqual" => GetEqualityStatus(operation, ExpectedParameterName) == EqualityStatus.Equal,
+            "AreEqual" => GetEqualityStatus(operation, ExpectedParameterName) == EqualityStatus.Equal
+                || HasIdenticalExpectedAndActual(operation, ExpectedParameterName),
             "AreNotEqual" => GetEqualityStatus(operation, NotExpectedParameterName) == EqualityStatus.NotEqual,
+            "AreSame" => HasIdenticalExpectedAndActual(operation, ExpectedParameterName),
             "IsNull" => GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
             "IsNotNull" => GetValueArgument(operation) is { } valueArgumentOperation && IsNotNullableType(valueArgumentOperation),
             _ => false,
         };
+
+    private static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+        => GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
+        && GetArgumentWithName(operation, ActualParameterName) is { } actualArgument
+        && expectedArgument.IsEquivalentReferenceTo(actualArgument);
 
     private static bool IsNotNullableType(IOperation valueArgumentOperation)
     {

--- a/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/IOperationExtensions.cs
+++ b/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/IOperationExtensions.cs
@@ -64,7 +64,9 @@ internal static class IOperationExtensions
     /// <remarks>
     /// This intentionally excludes method invocations and indexer accesses, since those may
     /// have side effects or return different values on repeated evaluation. Parenthesized
-    /// expressions and conversions are skipped transparently.
+    /// expressions and <em>built-in</em> conversions are skipped transparently, but
+    /// user-defined conversions are treated as opaque because their operators may execute
+    /// arbitrary code with side effects.
     /// </remarks>
     public static bool IsEquivalentReferenceTo(this IOperation? left, IOperation? right)
     {
@@ -106,7 +108,7 @@ internal static class IOperationExtensions
                     case IParenthesizedOperation parenthesized:
                         operation = parenthesized.Operand;
                         break;
-                    case IConversionOperation conversion:
+                    case IConversionOperation conversion when !conversion.Conversion.IsUserDefined:
                         operation = conversion.Operand;
                         break;
                     default:

--- a/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/IOperationExtensions.cs
+++ b/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/IOperationExtensions.cs
@@ -91,6 +91,7 @@ internal static class IOperationExtensions
                 AreInstancesEquivalent(fa.Instance, fb.Instance),
 
             (IPropertyReferenceOperation pra, IPropertyReferenceOperation prb) =>
+                !pra.Property.IsIndexer &&
                 SymbolEqualityComparer.Default.Equals(pra.Property, prb.Property) &&
                 AreInstancesEquivalent(pra.Instance, prb.Instance),
 

--- a/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/IOperationExtensions.cs
+++ b/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/IOperationExtensions.cs
@@ -56,4 +56,66 @@ internal static class IOperationExtensions
 
         return operation;
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the two operations are structurally equivalent
+    /// side-effect-free references to the same local, parameter, field, property, or <c>this</c>.
+    /// </summary>
+    /// <remarks>
+    /// This intentionally excludes method invocations and indexer accesses, since those may
+    /// have side effects or return different values on repeated evaluation. Parenthesized
+    /// expressions and conversions are skipped transparently.
+    /// </remarks>
+    public static bool IsEquivalentReferenceTo(this IOperation? left, IOperation? right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        left = Unwrap(left);
+        right = Unwrap(right);
+
+        return (left, right) switch
+        {
+            (ILocalReferenceOperation la, ILocalReferenceOperation lb) =>
+                SymbolEqualityComparer.Default.Equals(la.Local, lb.Local),
+
+            (IParameterReferenceOperation pa, IParameterReferenceOperation pb) =>
+                SymbolEqualityComparer.Default.Equals(pa.Parameter, pb.Parameter),
+
+            (IFieldReferenceOperation fa, IFieldReferenceOperation fb) =>
+                SymbolEqualityComparer.Default.Equals(fa.Field, fb.Field) &&
+                AreInstancesEquivalent(fa.Instance, fb.Instance),
+
+            (IPropertyReferenceOperation pra, IPropertyReferenceOperation prb) =>
+                SymbolEqualityComparer.Default.Equals(pra.Property, prb.Property) &&
+                AreInstancesEquivalent(pra.Instance, prb.Instance),
+
+            (IInstanceReferenceOperation, IInstanceReferenceOperation) => true,
+
+            _ => false,
+        };
+
+        static IOperation Unwrap(IOperation operation)
+        {
+            while (true)
+            {
+                switch (operation)
+                {
+                    case IParenthesizedOperation parenthesized:
+                        operation = parenthesized.Operand;
+                        break;
+                    case IConversionOperation conversion:
+                        operation = conversion.Operand;
+                        break;
+                    default:
+                        return operation;
+                }
+            }
+        }
+
+        static bool AreInstancesEquivalent(IOperation? a, IOperation? b)
+            => (a is null && b is null) || IsEquivalentReferenceTo(a, b);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -1816,6 +1816,94 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenAssertAreNotSameIsPassedSameLocalWithMessage_Diagnostic()
+    {
+        // Mirror the AreNotEqual(..., "should differ") test below so the code fix's
+        // message-forwarding path is exercised for AreNotSame too.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    [|Assert.AreNotSame(x, x, "references must differ")|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    Assert.Fail("references must differ");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameProperty_Diagnostic()
+    {
+        // Exercises IsEquivalentReferenceTo's IPropertyReferenceOperation arm directly so a
+        // regression that breaks property equivalence detection is caught here.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Holder
+            {
+                public int Value { get; set; }
+                public Holder Inner { get; set; } = new Holder();
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var h = new Holder();
+                    [|Assert.AreNotEqual(h.Value, h.Value)|];
+                    [|Assert.AreNotEqual(h.Inner.Value, h.Inner.Value)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Holder
+            {
+                public int Value { get; set; }
+                public Holder Inner { get; set; } = new Holder();
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var h = new Holder();
+                    Assert.Fail();
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
     public async Task WhenAssertAreNotSameIsPassedDifferentLocals_NoDiagnostic()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -1836,4 +1836,31 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithUserDefinedConversion_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new Wrapper();
+                    Assert.AreNotEqual((int)x, (int)x);
+                }
+
+                private sealed class Wrapper
+                {
+                    private static int _counter;
+                    public static explicit operator int(Wrapper value) => ++_counter;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -1560,4 +1560,280 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocal_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreNotEqual(x, x)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameParameter_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod(int x)
+                {
+                    [|Assert.AreNotEqual(x, x)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod(int x)
+                {
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameField_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private int _value;
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    [|Assert.AreNotEqual(_value, _value)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private int _value;
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreNotEqual(x, x, "should differ")|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    Assert.Fail("should differ");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedDifferentLocals_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    int y = 2;
+                    Assert.AreNotEqual(x, y);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameMethodCall_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreNotEqual(GetValue(), GetValue());
+                }
+
+                private int GetValue() => 1;
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotSameIsPassedSameLocal_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    [|Assert.AreNotSame(x, x)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotSameIsPassedSameLocalNamed_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    [|Assert.AreNotSame(actual: x, notExpected: x)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotSameIsPassedDifferentLocals_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    var y = new object();
+                    Assert.AreNotSame(x, y);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1435,4 +1435,52 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithUserDefinedConversion_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new Wrapper();
+                    Assert.AreEqual((int)x, (int)x);
+                }
+
+                private sealed class Wrapper
+                {
+                    private static int _counter;
+                    public static explicit operator int(Wrapper value) => ++_counter;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithBuiltInConversion_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreEqual((long)x, (long)x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1483,4 +1483,31 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedIndexerAccess_NoDiagnostic()
+    {
+        // list[0] and list[1] are IPropertyReferenceOperation on the same Item indexer + same
+        // receiver, but the index arguments differ -- and the analyzer doesn't compare those.
+        // We must NOT flag this as always-equal.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var list = new List<string> { "a", "b" };
+                    Assert.AreEqual(list[0], list[1]);
+                    Assert.AreEqual(list[0], list[0]);
+                    Assert.AreSame(list[0], list[1]);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1167,4 +1167,272 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocal_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreEqual(x, x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameParameter_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod(int x)
+                {
+                    [|Assert.AreEqual(x, x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameField_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private int _value;
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    [|Assert.AreEqual(_value, _value)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameProperty_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private int Value { get; set; }
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    [|Assert.AreEqual(Value, Value)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSamePropertyChain_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private SomeType _value = new SomeType();
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    [|Assert.AreEqual(_value.Inner, _value.Inner)|];
+                }
+
+                private sealed class SomeType
+                {
+                    public int Inner { get; set; }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedDifferentInstances_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var a = new SomeType();
+                    var b = new SomeType();
+                    Assert.AreEqual(a.Inner, b.Inner);
+                }
+
+                private sealed class SomeType
+                {
+                    public int Inner { get; set; }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedDifferentLocals_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    int y = 1;
+                    Assert.AreEqual(x, y);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameMethodCall_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreEqual(GetValue(), GetValue());
+                }
+
+                private int GetValue() => 1;
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreSameIsPassedSameLocal_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    [|Assert.AreSame(x, x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreSameIsPassedSameLocalWithNamedArgs_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    [|Assert.AreSame(actual: x, expected: x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreSameIsPassedSameLocalParenthesized_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    [|Assert.AreSame((x), x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreSameIsPassedDifferentLocals_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new object();
+                    var y = new object();
+                    Assert.AreSame(x, y);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
Fixes #9087.

Extends two existing analyzers so they no longer require both operands to be compile-time constants:

| Bug pattern               | Diagnostic                       |
| ------------------------- | -------------------------------- |
| `Assert.AreEqual(x, x)` | MSTEST0032 -- always-true        |
| `Assert.AreSame(x, x)`  | MSTEST0032 -- always-true        |
| `Assert.AreNotEqual(x, x)` | MSTEST0025 -- always-false   |
| `Assert.AreNotSame(x, x)`  | MSTEST0025 -- always-false   |

## How it works

Added a new `IsEquivalentReferenceTo` extension method on `IOperation` that:

1. Walks down conversions and parentheses on both sides.
2. Returns `true` when both operations reference the same:
   - `ILocalReferenceOperation` (local variable)
   - `IParameterReferenceOperation` (parameter)
   - `IFieldReferenceOperation` (field, with matching receiver chain)
   - `IPropertyReferenceOperation` (property, with matching receiver chain)
   - `IInstanceReferenceOperation` (`this` / `base`)

Method invocations, indexer accesses, and any non-reference expression are intentionally excluded so that `Assert.AreEqual(GetX(), GetX())` (which may have side effects) is **not** flagged. Existing diagnostic messages (""always true"" / ""always false"") already fit this case; no new diagnostic IDs are introduced.

## Tests

- Added 12 tests to `ReviewAlwaysTrueAssertConditionAnalyzerTests` (MSTEST0032) covering same local / parameter / field / property / chained property accesses for both `AreEqual` and `AreSame`, plus no-diagnostic cases for different operands and method invocations.
- Added 9 tests to `PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests` (MSTEST0025) covering the same matrix for `AreNotEqual` / `AreNotSame`, including the existing code-fix path that rewrites them to `Assert.Fail()`.
- Full suite: `1244 / 1244` analyzer unit tests pass.