### PR TITLE
[test-improver] test: add DataTestMethod edge cases for TypeContainingTestMethodShouldBeATestClassAnalyzer (MSTEST0030)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TypeContainingTestMethodShouldBeATestClassAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TypeContainingTestMethodShouldBeATestClassAnalyzerTests.cs
@@ -464,7 +464,7 @@ public sealed class TypeContainingTestMethodShouldBeATestClassAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenNonTestClassHasDataTestMethod_Diagnostic()
+    public async Task WhenClassWithoutTestAttribute_HasDataTestMethod_Diagnostic()
     {
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -493,7 +493,7 @@ public sealed class TypeContainingTestMethodShouldBeATestClassAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenNonTestClassInheritsDataTestMethodFromAbstractBase_Diagnostic()
+    public async Task WhenClassWithoutTestAttribute_InheritsDataTestMethodFromAbstractBase_Diagnostic()
     {
         // Abstract base is exempt from the diagnostic; derived non-test class
         // that inherits [DataTestMethod] via the inheritance walk should fire.

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TypeContainingTestMethodShouldBeATestClassAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TypeContainingTestMethodShouldBeATestClassAnalyzerTests.cs
@@ -462,4 +462,72 @@ public sealed class TypeContainingTestMethodShouldBeATestClassAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenNonTestClassHasDataTestMethod_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class [|MyTestClass|]
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                public void TestMethod1(int value) {}
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                public void TestMethod1(int value) {}
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestClassInheritsDataTestMethodFromAbstractBase_Diagnostic()
+    {
+        // Abstract base is exempt from the diagnostic; derived non-test class
+        // that inherits [DataTestMethod] via the inheritance walk should fire.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public abstract class AbstractBase
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                public void TestMethod1(int value) {}
+            }
+
+            public class [|MyTestClass|] : AbstractBase
+            {
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public abstract class AbstractBase
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                public void TestMethod1(int value) {}
+            }
+
+            [TestClass]
+            public class MyTestClass : AbstractBase
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`TypeContainingTestMethodShouldBeATestClassAnalyzer` (MSTEST0030) flags non-test classes that contain test methods (direct or inherited). The analyzer detects test methods via `attribute.AttributeClass.Inherits(testMethodAttributeSymbol)`, which should recognize `DataTestMethodAttribute` since it inherits from `TestMethodAttribute`. Two concrete scenarios were not explicitly tested:

1. **`DataTestMethod` directly on a method in a non-test class** — the `Inherits()` check should recognize `DataTestMethodAttribute` as a test method, triggering the diagnostic.

2. **`DataTestMethod` inherited from an abstract base class** — the inheritance walk (`while (currentType is not null)`) should traverse up to the abstract base and detect the `DataTestMethod`. The abstract base is exempt (per the `IsAbstract` guard), but the concrete derived class should fire the diagnostic.

## Approach

Added two new `[TestMethod]` test cases to `TypeContainingTestMethodShouldBeATestClassAnalyzerTests.cs`:

- `WhenNonTestClassHasDataTestMethod_Diagnostic` — confirms `[DataTestMethod]` (first-party `TestMethodAttribute` subclass) triggers the diagnostic and the code fix correctly adds `[TestClass]`
- `WhenNonTestClassInheritsDataTestMethodFromAbstractBase_Diagnostic` — confirms the inheritance walk detects `[DataTestMethod]` from an abstract base, firing only on the concrete derived class (abstract base is exempt)

## Test Status

```
Test run summary: Passed!
  total: 16
  failed: 0
  succeeded: 16
  skipped: 0
  duration: 7s 373ms
```

✅ All 16 tests pass (`MSTest.Analyzers.UnitTests`, net8.0, Debug — 14 original + 2 new).

## Reproducibility

```bash
./build.sh --restore   # first run only
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "ClassName=MSTest.Analyzers.Test.TypeContainingTestMethodShouldBeATestClassAnalyzerTests"
```

## Trade-offs

- Tests exercise existing code paths only — no production changes, no maintenance burden beyond the tests.
- Both tests document how the `Inherits()` check handles `DataTestMethodAttribute` (the built-in `TestMethodAttribute` subclass), complementing the existing test for custom subclasses.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27448662574/agentic_workflow) workflow. · 1K AIC · ⌖ 23 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27448662574, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27448662574 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->