### PR TITLE
[code-simplifier] Simplify BuildEvaluators with Array.ConvertAll method group

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/TestMethod/MemberConditionAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/MemberConditionAttribute.cs
@@ -228,15 +228,7 @@ public sealed class MemberConditionAttribute : ConditionBaseAttribute
     }
 
     private Func<bool>[] BuildEvaluators()
-    {
-        var evaluators = new Func<bool>[_conditionMemberNames.Length];
-        for (int i = 0; i < _conditionMemberNames.Length; i++)
-        {
-            evaluators[i] = BuildEvaluator(_conditionMemberNames[i]);
-        }
-
-        return evaluators;
-    }
+        => Array.ConvertAll(_conditionMemberNames, BuildEvaluator);
 
     private Func<bool> BuildEvaluator(string memberName)
     {


### PR DESCRIPTION
## Code Simplification — 2026-06-13

This PR simplifies code introduced in #9071 (`MemberConditionAttribute`) to improve clarity and conciseness while preserving all functionality.

### File Simplified

- `src/TestFramework/TestFramework/Attributes/TestMethod/MemberConditionAttribute.cs` — Replace manual for-loop in `BuildEvaluators` with `Array.ConvertAll` + method group

### Improvement Made

**Replaced manual array-fill loop with `Array.ConvertAll`**

The `BuildEvaluators` method allocated a new `Func<bool>[]`, then filled it with a for-loop. `Array.ConvertAll` expresses the same intent in one line using a method group:

```csharp
// Before (9 lines)
private Func<bool>[] BuildEvaluators()
{
    var evaluators = new Func<bool>[_conditionMemberNames.Length];
    for (int i = 0; i < _conditionMemberNames.Length; i++)
    {
        evaluators[i] = BuildEvaluator(_conditionMemberNames[i]);
    }
    return evaluators;
}

// After (2 lines)
private Func<bool>[] BuildEvaluators()
    => Array.ConvertAll(_conditionMemberNames, BuildEvaluator);
```

`Array.ConvertAll` is available on `netstandard2.0`, uses a method group instead of a lambda (avoids a delegate wrapper allocation), and makes the transform intent immediately clear.

### Changes Based On

Recent changes from:
- #9071 — Add [MemberCondition] attribute for static-member-based test conditions

### Testing

- ✅ Build succeeds (`dotnet build src/TestFramework/TestFramework/TestFramework.csproj`)
- ✅ No IDE0046 or other style-rule violations
- ✅ No functional changes — behavior is identical (same array output, same exception paths)

### Review Focus

Please verify:
- `Array.ConvertAll` output is equivalent to the for-loop
- Method group `BuildEvaluator` correctly binds to `Func<bool> BuildEvaluator(string)`
- No unintended side effects


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27468404462/agentic_workflow) workflow. · 1.7K AIC · ⌖ 34 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-14T14:05:42.515Z --> on Jun 14, 2026, 2:05 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27468404462, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27468404462 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->