### PR TITLE
[test-improver] test: add edge case tests for UseConditionBaseWithTestClassAnalyzer (MSTEST0041)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseConditionBaseWithTestClassAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseConditionBaseWithTestClassAnalyzerTests.cs
@@ -175,4 +175,80 @@ public sealed class UseConditionBaseWithTestClassAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenNonTestClassHasMultipleConditionAttributes_SingleDiagnostic()
+    {
+        // The analyzer uses FirstOrDefault, so only one diagnostic fires (for the first found
+        // ConditionBase attribute), regardless of how many condition attributes are present.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [OSCondition(OperatingSystems.Windows)]
+            [CICondition(ConditionMode.Include)]
+            public class {|#0:MyClass|}
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic()
+                .WithLocation(0)
+                .WithArguments("OSConditionAttribute"));
+    }
+
+    [TestMethod]
+    public async Task WhenAbstractNonTestClassHasConditionAttribute_Diagnostic()
+    {
+        // This analyzer has no abstract-class exemption (unlike some other analyzers);
+        // an abstract class that is not a TestClass should still fire the diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [OSCondition(OperatingSystems.Windows)]
+            public abstract class {|#0:MyAbstractClass|}
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic()
+                .WithLocation(0)
+                .WithArguments("OSConditionAttribute"));
+    }
+
+    [TestMethod]
+    public async Task WhenTwoLevelDerivedConditionAttributeOnNonTestClass_Diagnostic()
+    {
+        // The Inherits() check is recursive: an attribute that is a 2nd-level subclass of
+        // ConditionBaseAttribute should still trigger the diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Level1ConditionAttribute : ConditionBaseAttribute
+            {
+                public Level1ConditionAttribute() : base(ConditionMode.Include) { }
+                public override string GroupName => nameof(Level1ConditionAttribute);
+                public override bool IsConditionMet => true;
+            }
+
+            public class Level2ConditionAttribute : Level1ConditionAttribute
+            {
+                public override string GroupName => nameof(Level2ConditionAttribute);
+            }
+
+            [Level2Condition]
+            public class {|#0:MyClass|}
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic()
+                .WithLocation(0)
+                .WithArguments("Level2ConditionAttribute"));
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`UseConditionBaseWithTestClassAnalyzer` (MSTEST0041) flags classes that have a `ConditionBaseAttribute` subclass (e.g. `[OSCondition]`, `[CICondition]`, custom conditions) but are not marked as `[TestClass]`. Three code paths were untested:

1. **Multiple condition attributes on a non-test class** — the analyzer uses `FirstOrDefault`, so only one diagnostic fires regardless of how many `ConditionBase` attributes are present. The message uses the first attribute's name.

2. **Abstract class without `[TestClass]`** — unlike some other analyzers in this repo, `UseConditionBaseWithTestClassAnalyzer` has no abstract-class exemption. An abstract class with a condition attribute but no `[TestClass]` should trigger the diagnostic.

3. **Two-level derived condition attribute** — the `Inherits()` check is recursive. An attribute that is a 2nd-level subclass of `ConditionBaseAttribute` should still trigger the diagnostic on a non-test class.

## Approach

Added three new `[TestMethod]` test cases to `UseConditionBaseWithTestClassAnalyzerTests.cs`:

- `WhenNonTestClassHasMultipleConditionAttributes_SingleDiagnostic` — verifies `FirstOrDefault` behavior: one diagnostic, named after the first attribute.
- `WhenAbstractNonTestClassHasConditionAttribute_Diagnostic` — confirms no abstract exemption exists in this analyzer.
- `WhenTwoLevelDerivedConditionAttributeOnNonTestClass_Diagnostic` — confirms `Inherits()` is recursive for condition attribute detection.

## Test Status

```
Test run summary: Passed!
  total: 12
  failed: 0
  succeeded: 12
  skipped: 0
  duration: 7s 141ms
```

✅ All 12 tests pass (`MSTest.Analyzers.UnitTests`, net8.0, Debug — 9 original + 3 new).

## Reproducibility

```bash
./build.sh --restore   # first run only
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "ClassName=MSTest.Analyzers.Test.UseConditionBaseWithTestClassAnalyzerTests"
```

## Trade-offs

- Tests exercise existing code paths only — no production changes, no maintenance burden beyond the tests.
- Each test documents a specific invariant of the analyzer (FirstOrDefault behavior, no abstract guard, recursive Inherits check).




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27482056628/agentic_workflow) workflow. · 1K AIC · ⌖ 24.6 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27482056628, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27482056628 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->