### PR TITLE
[perf-improver] perf: single-pass PropertyBag walk in AzureDevOps extension

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -142,9 +142,9 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
             // Single-pass collection of TimingProperty and the FQN SerializableKeyValuePairStringProperty:
             // replaces 1 × SingleOrDefault<TimingProperty>() + 1 × OfType<>().FirstOrDefault() with one
             // GetStructEnumerator() walk, saving 1 linked-list traversal and 1 LINQ allocation per terminal result.
-            // Preserve PropertyBag.SingleOrDefault's throw-on-duplicate invariant for TimingProperty so
-            // malformed messages still fail fast, and the original FirstOrDefault semantics for the FQN
-            // key (first match wins) so we don't silently overwrite earlier values.
+            // Singleton-typed properties use the local GetSingleOrDefaultValue helper to preserve the
+            // throw-on-duplicate invariant that SingleOrDefault<T>() provided; the FQN key keeps the
+            // prior FirstOrDefault semantics (first match wins) so we don't silently overwrite earlier values.
             TimingProperty? timing = null;
             string? fqnValue = null;
             PropertyBag.PropertyBagEnumerator enumerator = update.TestNode.Properties.GetStructEnumerator();
@@ -152,19 +152,18 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
             {
                 switch (enumerator.Current)
                 {
-                    case TimingProperty t:
-                        if (timing is not null)
-                        {
-                            throw new InvalidOperationException($"Found multiple properties of type '{typeof(TimingProperty)}'.");
-                        }
-
-                        timing = t;
-                        break;
+                    case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
                     case SerializableKeyValuePairStringProperty kv when kv.Key == FullyQualifiedNamePropertyKey && fqnValue is null:
                         fqnValue = kv.Value;
                         break;
                 }
             }
+
+            static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+                where TProperty : class, IProperty
+                => existingProperty is not null
+                    ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                    : property;
 
             string fullyQualifiedName = fqnValue ?? displayName;
             TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -138,8 +138,28 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
 
             string uid = update.TestNode.Uid;
             string displayName = update.TestNode.DisplayName;
-            string fullyQualifiedName = GetFullyQualifiedName(update.TestNode);
-            TimeSpan duration = GetDuration(update.TestNode);
+
+            // Single-pass collection of TimingProperty and the FQN SerializableKeyValuePairStringProperty:
+            // replaces 1 × SingleOrDefault<TimingProperty>() + 1 × OfType<>().FirstOrDefault() with one
+            // GetStructEnumerator() walk, saving 1 linked-list traversal and 1 LINQ allocation per terminal result.
+            TimingProperty? timing = null;
+            string? fqnValue = null;
+            PropertyBag.PropertyBagEnumerator enumerator = update.TestNode.Properties.GetStructEnumerator();
+            while (enumerator.MoveNext())
+            {
+                switch (enumerator.Current)
+                {
+                    case TimingProperty t:
+                        timing = t;
+                        break;
+                    case SerializableKeyValuePairStringProperty kv when kv.Key == FullyQualifiedNamePropertyKey:
+                        fqnValue = kv.Value;
+                        break;
+                }
+            }
+
+            string fullyQualifiedName = fqnValue ?? displayName;
+            TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
 
             lock (_stateLock)
             {
@@ -408,18 +428,6 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
         }
 
         return sb.ToString();
-    }
-
-    private static string GetFullyQualifiedName(TestNode testNode)
-        => testNode.Properties
-            .OfType<SerializableKeyValuePairStringProperty>()
-            .FirstOrDefault(static property => property.Key == FullyQualifiedNamePropertyKey)?.Value
-            ?? testNode.DisplayName;
-
-    private static TimeSpan GetDuration(TestNode testNode)
-    {
-        TimingProperty? timing = testNode.Properties.SingleOrDefault<TimingProperty>();
-        return timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
     }
 
     private static TerminalKind GetTerminalKind(TestNodeStateProperty? state)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -142,6 +142,9 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
             // Single-pass collection of TimingProperty and the FQN SerializableKeyValuePairStringProperty:
             // replaces 1 × SingleOrDefault<TimingProperty>() + 1 × OfType<>().FirstOrDefault() with one
             // GetStructEnumerator() walk, saving 1 linked-list traversal and 1 LINQ allocation per terminal result.
+            // Preserve PropertyBag.SingleOrDefault's throw-on-duplicate invariant for TimingProperty so
+            // malformed messages still fail fast, and the original FirstOrDefault semantics for the FQN
+            // key (first match wins) so we don't silently overwrite earlier values.
             TimingProperty? timing = null;
             string? fqnValue = null;
             PropertyBag.PropertyBagEnumerator enumerator = update.TestNode.Properties.GetStructEnumerator();
@@ -150,9 +153,14 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
                 switch (enumerator.Current)
                 {
                     case TimingProperty t:
+                        if (timing is not null)
+                        {
+                            throw new InvalidOperationException($"Found multiple properties of type '{typeof(TimingProperty)}'.");
+                        }
+
                         timing = t;
                         break;
-                    case SerializableKeyValuePairStringProperty kv when kv.Key == FullyQualifiedNamePropertyKey:
+                    case SerializableKeyValuePairStringProperty kv when kv.Key == FullyQualifiedNamePropertyKey && fqnValue is null:
                         fqnValue = kv.Value;
                         break;
                 }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
@@ -64,8 +64,9 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
         // Single-pass collection: replaces 1 × OfType<FileArtifactProperty>() loop + 2 × SingleOrDefault<T>()
         // with one GetStructEnumerator() walk, saving 2 linked-list traversals + 1 LINQ allocation per failure.
-        // Preserve PropertyBag.SingleOrDefault's throw-on-duplicate invariant for the stdout/stderr
-        // properties so a malformed message still fails fast instead of silently dropping data.
+        // Singleton-typed properties (stdout/stderr) use the local GetSingleOrDefaultValue helper to preserve
+        // the throw-on-duplicate invariant that SingleOrDefault<T>() provided; FileArtifactProperty is
+        // intentionally multi-valued and accumulates into a list.
         PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
         {
@@ -88,24 +89,16 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                         AzureDevOpsAttachmentTypes.GeneralAttachment,
                         comment: fileArtifact.Description ?? fileArtifact.DisplayName));
                     break;
-                case StandardOutputProperty so:
-                    if (stdout is not null)
-                    {
-                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(StandardOutputProperty)}'.");
-                    }
-
-                    stdout = so;
-                    break;
-                case StandardErrorProperty se:
-                    if (stderr is not null)
-                    {
-                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(StandardErrorProperty)}'.");
-                    }
-
-                    stderr = se;
-                    break;
+                case StandardOutputProperty so: stdout = GetSingleOrDefaultValue(stdout, so); break;
+                case StandardErrorProperty se: stderr = GetSingleOrDefaultValue(stderr, se); break;
             }
         }
+
+        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+            where TProperty : class, IProperty
+            => existingProperty is not null
+                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                : property;
 
         if (stdout is not null && !RoslynString.IsNullOrEmpty(stdout.StandardOutput))
         {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
@@ -64,6 +64,8 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
         // Single-pass collection: replaces 1 × OfType<FileArtifactProperty>() loop + 2 × SingleOrDefault<T>()
         // with one GetStructEnumerator() walk, saving 2 linked-list traversals + 1 LINQ allocation per failure.
+        // Preserve PropertyBag.SingleOrDefault's throw-on-duplicate invariant for the stdout/stderr
+        // properties so a malformed message still fails fast instead of silently dropping data.
         PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
         {
@@ -87,9 +89,19 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                         comment: fileArtifact.Description ?? fileArtifact.DisplayName));
                     break;
                 case StandardOutputProperty so:
+                    if (stdout is not null)
+                    {
+                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(StandardOutputProperty)}'.");
+                    }
+
                     stdout = so;
                     break;
                 case StandardErrorProperty se:
+                    if (stderr is not null)
+                    {
+                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(StandardErrorProperty)}'.");
+                    }
+
                     stderr = se;
                     break;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
@@ -59,27 +59,42 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
     private static IReadOnlyList<AzureDevOpsTestResultAttachment> BuildAttachmentsFromTestNode(TestNode testNode)
     {
         List<AzureDevOpsTestResultAttachment>? attachments = null;
+        StandardOutputProperty? stdout = null;
+        StandardErrorProperty? stderr = null;
 
-        foreach (FileArtifactProperty fileArtifact in testNode.Properties.OfType<FileArtifactProperty>())
+        // Single-pass collection: replaces 1 × OfType<FileArtifactProperty>() loop + 2 × SingleOrDefault<T>()
+        // with one GetStructEnumerator() walk, saving 2 linked-list traversals + 1 LINQ allocation per failure.
+        PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
+        while (enumerator.MoveNext())
         {
-            string? fullPath;
-            try
+            switch (enumerator.Current)
             {
-                fullPath = fileArtifact.FileInfo.FullName;
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or PathTooLongException)
-            {
-                continue;
-            }
+                case FileArtifactProperty fileArtifact:
+                    string? fullPath;
+                    try
+                    {
+                        fullPath = fileArtifact.FileInfo.FullName;
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or PathTooLongException)
+                    {
+                        break;
+                    }
 
-            attachments ??= [];
-            attachments.Add(AzureDevOpsTestResultAttachment.FromFile(
-                fullPath,
-                AzureDevOpsAttachmentTypes.GeneralAttachment,
-                comment: fileArtifact.Description ?? fileArtifact.DisplayName));
+                    attachments ??= [];
+                    attachments.Add(AzureDevOpsTestResultAttachment.FromFile(
+                        fullPath,
+                        AzureDevOpsAttachmentTypes.GeneralAttachment,
+                        comment: fileArtifact.Description ?? fileArtifact.DisplayName));
+                    break;
+                case StandardOutputProperty so:
+                    stdout = so;
+                    break;
+                case StandardErrorProperty se:
+                    stderr = se;
+                    break;
+            }
         }
 
-        StandardOutputProperty? stdout = testNode.Properties.SingleOrDefault<StandardOutputProperty>();
         if (stdout is not null && !RoslynString.IsNullOrEmpty(stdout.StandardOutput))
         {
             attachments ??= [];
@@ -89,7 +104,6 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 AzureDevOpsAttachmentTypes.ConsoleLog));
         }
 
-        StandardErrorProperty? stderr = testNode.Properties.SingleOrDefault<StandardErrorProperty>();
         if (stderr is not null && !RoslynString.IsNullOrEmpty(stderr.StandardError))
         {
             attachments ??= [];


### PR DESCRIPTION
## Goal and Rationale

The AzureDevOps reporting extension was performing multiple independent O(n) linked-list traversals over `PropertyBag` per test result, plus heap-allocating LINQ iterators. This adds up at scale — every test result in a large run triggers these allocations.

## Approach

Replace per-property `SingleOrDefault<T>()` / `OfType<T>().FirstOrDefault()` calls with a single `GetStructEnumerator()` pass (zero-allocation struct enumerator already used throughout the platform). Two hot paths updated:

**`AzureDevOpsSummaryReporter.ConsumeAsync`** (called for every terminal test result):
- Before: 1× `GetFullyQualifiedName()` → `OfType<SerializableKeyValuePairStringProperty>().FirstOrDefault()` (O(n) + LINQ heap alloc) + 1× `GetDuration()` → `SingleOrDefault<TimingProperty>()` (O(n))
- After: single `GetStructEnumerator()` loop; both private helper methods removed

**`AzureDevOpsTestResultsPublisher.BuildAttachmentsFromTestNode`** (called for every failing test):
- Before: `OfType<FileArtifactProperty>()` (O(n) + LINQ heap alloc) + `SingleOrDefault<StandardOutputProperty>()` (O(n)) + `SingleOrDefault<StandardErrorProperty>()` (O(n))
- After: single `GetStructEnumerator()` loop

## Performance Evidence

`PropertyBag` uses a singly-linked list as its backing store; each `SingleOrDefault<T>` call walks the entire list. In a 1000-test run (all passed/failed) with a typical PropertyBag of ~5–10 entries:

| Location | Before | After | Savings |
|---|---|---|---|
| `ConsumeAsync` per-result | 2 O(n) walks + 1 LINQ alloc | 1 O(n) walk | ~50% traversal work, 1 GC alloc |
| `BuildAttachmentsFromTestNode` per-failure | 3 O(n) walks + 1 LINQ alloc | 1 O(n) walk | ~67% traversal work, 1 GC alloc |

Micro-benchmarks are not included here; the pattern is well-established and the savings are proportional to test count. The biggest gains come from eliminating the `OfType<>` allocations which show up as GC pressure in heap profiles.

## Trade-offs

- Slightly more verbose code (switch statement instead of named helpers), but follows the existing pattern used in `TrxTestResultExtractor`, `CtrfReport`, `JUnitReport`, `HtmlReport`, `DotnetTestDataConsumer`, and `OpenTelemetryResultHandler`.
- No behavioral change — same properties are read, same outputs produced.

## Reproducibility

```sh
# Build
./build.sh -build -c Debug

# Test (511 pass, 11 skipped Windows-only)
artifacts/bin/Microsoft.Testing.Extensions.UnitTests/Debug/net8.0/Microsoft.Testing.Extensions.UnitTests
```

## Test Status

✅ Build succeeded (0 warnings, 0 errors)
✅ `Microsoft.Testing.Extensions.UnitTests`: 500 passed, 11 skipped (Windows-only), 0 failed




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27501472845/agentic_workflow) workflow. · 2K AIC · ⌖ 25.1 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27501472845, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27501472845 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->