### PR TITLE
Extract ReportGeneratorBase to share report-generator infrastructure

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
@@ -4,11 +4,8 @@
 using Microsoft.Testing.Extensions.CtrfReport.Resources;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
-using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
@@ -17,28 +14,8 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
-internal sealed class CtrfReportGenerator :
-    IDataConsumer,
-    ITestSessionLifetimeHandler,
-    IDataProducer,
-    IOutputDeviceDataProducer
+internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenerator, CapturedTestResult>
 {
-    private readonly IConfiguration _configuration;
-    private readonly ICommandLineOptions _commandLineOptions;
-    private readonly IFileSystem _fileSystem;
-    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    private readonly IMessageBus _messageBus;
-    private readonly IClock _clock;
-    private readonly IEnvironment _environment;
-    private readonly IOutputDevice _outputDevice;
-    private readonly ITestFramework _testFramework;
-    private readonly ITestApplicationProcessExitCode _testApplicationProcessExitCode;
-    private readonly ILogger<CtrfReportGenerator> _logger;
-    private readonly List<CapturedTestResult> _tests = [];
-    private readonly bool _isEnabled;
-
-    private DateTimeOffset? _testStartTime;
-
     public CtrfReportGenerator(
         IConfiguration configuration,
         ICommandLineOptions commandLineOptions,
@@ -51,83 +28,47 @@ internal sealed class CtrfReportGenerator :
         ITestFramework testFramework,
         ITestApplicationProcessExitCode testApplicationProcessExitCode,
         ILogger<CtrfReportGenerator> logger)
+        : base(
+            configuration,
+            commandLineOptions,
+            fileSystem,
+            testApplicationModuleInfo,
+            messageBus,
+            clock,
+            environment,
+            outputDevice,
+            testFramework,
+            testApplicationProcessExitCode,
+            logger,
+            CtrfReportGeneratorCommandLine.CtrfReportOptionName)
     {
-        _configuration = configuration;
-        _commandLineOptions = commandLineOptions;
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
-        _messageBus = messageBus;
-        _clock = clock;
-        _environment = environment;
-        _outputDevice = outputDevice;
-        _testFramework = testFramework;
-        _testApplicationProcessExitCode = testApplicationProcessExitCode;
-        _logger = logger;
-        _isEnabled = commandLineOptions.IsOptionSet(CtrfReportGeneratorCommandLine.CtrfReportOptionName);
     }
 
-    public Type[] DataTypesConsumed { get; } =
-    [
-        typeof(TestNodeUpdateMessage),
-    ];
-
-    public Type[] DataTypesProduced { get; } = [typeof(SessionFileArtifact)];
+    /// <inheritdoc />
+    public override string Uid => nameof(CtrfReportGenerator);
 
     /// <inheritdoc />
-    public string Uid => nameof(CtrfReportGenerator);
+    public override string DisplayName { get; } = ExtensionResources.CtrfReportGeneratorDisplayName;
 
     /// <inheritdoc />
-    public string Version => ExtensionVersion.DefaultSemVer;
+    public override string Description { get; } = ExtensionResources.CtrfReportGeneratorDescription;
 
-    /// <inheritdoc />
-    public string DisplayName { get; } = ExtensionResources.CtrfReportGeneratorDisplayName;
+    protected override string ArtifactDisplayName => ExtensionResources.CtrfReportArtifactDisplayName;
 
-    /// <inheritdoc />
-    public string Description { get; } = ExtensionResources.CtrfReportGeneratorDescription;
+    protected override string ArtifactDescription => ExtensionResources.CtrfReportArtifactDescription;
 
-    /// <inheritdoc />
-    public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
+    protected override string GetGenerationLogMessage(int testResultCount)
+        => $"Generating CTRF report for {testResultCount} test result(s).";
 
-    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    protected override CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
+        => TestResultCapture.TryCapture(update.TestNode);
+
+    protected override Task<(string FileName, string? Warning)> GenerateReportAsync(
+        CapturedTestResult[] tests,
+        DateTimeOffset testStartTime,
+        int exitCode,
+        CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        if (value is TestNodeUpdateMessage update)
-        {
-            // Project to a capped DTO immediately so we don't retain the original
-            // TestNode (and its potentially huge stdout/stderr/stack trace strings)
-            // for the whole session. We capture every TestNode update as-is here; the
-            // engine later collapses captures that share the same UID into a single
-            // CTRF test entry (earlier captures become `retryAttempts[]`, marking the
-            // test as `flaky` when an earlier attempt failed). See
-            // CtrfReportEngine.CollapseAttempts for the deduplication logic.
-            CapturedTestResult? captured = TestResultCapture.TryCapture(update.TestNode);
-            if (captured is not null)
-            {
-                _tests.Add(captured);
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
-    {
-        testSessionContext.CancellationToken.ThrowIfCancellationRequested();
-        _testStartTime = _clock.UtcNow;
-        return Task.CompletedTask;
-    }
-
-    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
-    {
-        CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        cancellationToken.ThrowIfCancellationRequested();
-
-        ApplicationStateGuard.Ensure(_testStartTime is not null);
-
-        await _logger.LogTraceAsync($"Generating CTRF report for {_tests.Count} test result(s).").ConfigureAwait(false);
-
-        int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
         var engine = new CtrfReportEngine(
             _fileSystem,
             _testApplicationModuleInfo,
@@ -136,23 +77,9 @@ internal sealed class CtrfReportGenerator :
             _configuration,
             _clock,
             _testFramework,
-            _testStartTime.Value,
+            testStartTime,
             exitCode,
             cancellationToken);
-
-        (string reportFileName, string? warning) = await engine.GenerateReportAsync([.. _tests]).ConfigureAwait(false);
-
-        if (warning is not null)
-        {
-            await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
-        }
-
-        await _messageBus.PublishAsync(
-            this,
-            new SessionFileArtifact(
-                testSessionContext.SessionUid,
-                new FileInfo(reportFileName),
-                ExtensionResources.CtrfReportArtifactDisplayName,
-                ExtensionResources.CtrfReportArtifactDescription)).ConfigureAwait(false);
+        return engine.GenerateReportAsync(tests);
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
@@ -70,13 +70,13 @@ internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenera
         CancellationToken cancellationToken)
     {
         var engine = new CtrfReportEngine(
-            _fileSystem,
-            _testApplicationModuleInfo,
-            _environment,
-            _commandLineOptions,
-            _configuration,
-            _clock,
-            _testFramework,
+            FileSystem,
+            TestApplicationModuleInfo,
+            Environment,
+            CommandLineOptions,
+            Configuration,
+            Clock,
+            TestFramework,
             testStartTime,
             exitCode,
             cancellationToken);

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -55,6 +55,7 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
@@ -70,13 +70,13 @@ internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenera
         CancellationToken cancellationToken)
     {
         var engine = new HtmlReportEngine(
-            _fileSystem,
-            _testApplicationModuleInfo,
-            _environment,
-            _commandLineOptions,
-            _configuration,
-            _clock,
-            _testFramework,
+            FileSystem,
+            TestApplicationModuleInfo,
+            Environment,
+            CommandLineOptions,
+            Configuration,
+            Clock,
+            TestFramework,
             testStartTime,
             exitCode,
             cancellationToken);

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
@@ -4,11 +4,8 @@
 using Microsoft.Testing.Extensions.HtmlReport.Resources;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
-using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
@@ -17,28 +14,8 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
-internal sealed class HtmlReportGenerator :
-    IDataConsumer,
-    ITestSessionLifetimeHandler,
-    IDataProducer,
-    IOutputDeviceDataProducer
+internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenerator, CapturedTestResult>
 {
-    private readonly IConfiguration _configuration;
-    private readonly ICommandLineOptions _commandLineOptions;
-    private readonly IFileSystem _fileSystem;
-    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    private readonly IMessageBus _messageBus;
-    private readonly IClock _clock;
-    private readonly IEnvironment _environment;
-    private readonly IOutputDevice _outputDevice;
-    private readonly ITestFramework _testFramework;
-    private readonly ITestApplicationProcessExitCode _testApplicationProcessExitCode;
-    private readonly ILogger<HtmlReportGenerator> _logger;
-    private readonly List<CapturedTestResult> _tests = [];
-    private readonly bool _isEnabled;
-
-    private DateTimeOffset? _testStartTime;
-
     public HtmlReportGenerator(
         IConfiguration configuration,
         ICommandLineOptions commandLineOptions,
@@ -51,82 +28,47 @@ internal sealed class HtmlReportGenerator :
         ITestFramework testFramework,
         ITestApplicationProcessExitCode testApplicationProcessExitCode,
         ILogger<HtmlReportGenerator> logger)
+        : base(
+            configuration,
+            commandLineOptions,
+            fileSystem,
+            testApplicationModuleInfo,
+            messageBus,
+            clock,
+            environment,
+            outputDevice,
+            testFramework,
+            testApplicationProcessExitCode,
+            logger,
+            HtmlReportGeneratorCommandLine.HtmlReportOptionName)
     {
-        _configuration = configuration;
-        _commandLineOptions = commandLineOptions;
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
-        _messageBus = messageBus;
-        _clock = clock;
-        _environment = environment;
-        _outputDevice = outputDevice;
-        _testFramework = testFramework;
-        _testApplicationProcessExitCode = testApplicationProcessExitCode;
-        _logger = logger;
-        _isEnabled = commandLineOptions.IsOptionSet(HtmlReportGeneratorCommandLine.HtmlReportOptionName);
     }
 
-    public Type[] DataTypesConsumed { get; } =
-    [
-        typeof(TestNodeUpdateMessage),
-    ];
-
-    public Type[] DataTypesProduced { get; } = [typeof(SessionFileArtifact)];
+    /// <inheritdoc />
+    public override string Uid => nameof(HtmlReportGenerator);
 
     /// <inheritdoc />
-    public string Uid => nameof(HtmlReportGenerator);
+    public override string DisplayName { get; } = ExtensionResources.HtmlReportGeneratorDisplayName;
 
     /// <inheritdoc />
-    public string Version => ExtensionVersion.DefaultSemVer;
+    public override string Description { get; } = ExtensionResources.HtmlReportGeneratorDescription;
 
-    /// <inheritdoc />
-    public string DisplayName { get; } = ExtensionResources.HtmlReportGeneratorDisplayName;
+    protected override string ArtifactDisplayName => ExtensionResources.HtmlReportArtifactDisplayName;
 
-    /// <inheritdoc />
-    public string Description { get; } = ExtensionResources.HtmlReportGeneratorDescription;
+    protected override string ArtifactDescription => ExtensionResources.HtmlReportArtifactDescription;
 
-    /// <inheritdoc />
-    public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
+    protected override string GetGenerationLogMessage(int testResultCount)
+        => $"Generating HTML report for {testResultCount} test result(s).";
 
-    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    protected override CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
+        => TestResultCapture.TryCapture(update.TestNode);
+
+    protected override Task<(string FileName, string? Warning)> GenerateReportAsync(
+        CapturedTestResult[] tests,
+        DateTimeOffset testStartTime,
+        int exitCode,
+        CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        if (value is TestNodeUpdateMessage update)
-        {
-            // Project to a capped DTO immediately so we don't retain the original
-            // TestNode (and its potentially huge stdout/stderr/stack trace strings)
-            // for the whole session. We never deduplicate on TestNode.Uid: some
-            // frameworks emit several distinct results sharing the same UID
-            // (parameterized rows, theory data, in-process retries, framework
-            // misbehaviour). The engine surfaces all of them so no data is dropped.
-            CapturedTestResult? captured = TestResultCapture.TryCapture(update.TestNode);
-            if (captured is not null)
-            {
-                _tests.Add(captured);
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
-    {
-        testSessionContext.CancellationToken.ThrowIfCancellationRequested();
-        _testStartTime = _clock.UtcNow;
-        return Task.CompletedTask;
-    }
-
-    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
-    {
-        CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        cancellationToken.ThrowIfCancellationRequested();
-
-        ApplicationStateGuard.Ensure(_testStartTime is not null);
-
-        await _logger.LogTraceAsync($"Generating HTML report for {_tests.Count} test result(s).").ConfigureAwait(false);
-
-        int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
         var engine = new HtmlReportEngine(
             _fileSystem,
             _testApplicationModuleInfo,
@@ -135,23 +77,9 @@ internal sealed class HtmlReportGenerator :
             _configuration,
             _clock,
             _testFramework,
-            _testStartTime.Value,
+            testStartTime,
             exitCode,
             cancellationToken);
-
-        (string reportFileName, string? warning) = await engine.GenerateReportAsync([.. _tests]).ConfigureAwait(false);
-
-        if (warning is not null)
-        {
-            await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
-        }
-
-        await _messageBus.PublishAsync(
-            this,
-            new SessionFileArtifact(
-                testSessionContext.SessionUid,
-                new FileInfo(reportFileName),
-                ExtensionResources.HtmlReportArtifactDisplayName,
-                ExtensionResources.HtmlReportArtifactDescription)).ConfigureAwait(false);
+        return engine.GenerateReportAsync(tests);
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -53,6 +53,7 @@ This package extends Microsoft Testing Platform to produce self-contained HTML t
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -21,6 +21,8 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
     // so it matches the capped RawUid / ParentRawUid keys used everywhere else in capture
     // (see TestResultCapture.GetParentChainEntry / TryCapture). The engine uses this to
     // reconstruct the testpath of every test case in the report.
+    // MTP guarantees ConsumeAsync (and therefore OnTestNodeUpdate) is called sequentially
+    // for a given consumer instance, so Dictionary<TKey, TValue> is safe here without locking.
     private readonly Dictionary<string, TestResultCapture.ParentChainEntry> _parentChain = [];
 
     public JUnitReportGenerator(
@@ -93,13 +95,13 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
         CancellationToken cancellationToken)
     {
         var engine = new JUnitReportEngine(
-            _fileSystem,
-            _testApplicationModuleInfo,
-            _environment,
-            _commandLineOptions,
-            _configuration,
-            _clock,
-            _testFramework,
+            FileSystem,
+            TestApplicationModuleInfo,
+            Environment,
+            CommandLineOptions,
+            Configuration,
+            Clock,
+            TestFramework,
             testStartTime,
             exitCode,
             cancellationToken);

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -4,11 +4,8 @@
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
-using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
@@ -17,33 +14,13 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
-internal sealed class JUnitReportGenerator :
-    IDataConsumer,
-    ITestSessionLifetimeHandler,
-    IDataProducer,
-    IOutputDeviceDataProducer
+internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGenerator, CapturedTestResult>
 {
-    private readonly IConfiguration _configuration;
-    private readonly ICommandLineOptions _commandLineOptions;
-    private readonly IFileSystem _fileSystem;
-    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    private readonly IMessageBus _messageBus;
-    private readonly IClock _clock;
-    private readonly IEnvironment _environment;
-    private readonly IOutputDevice _outputDevice;
-    private readonly ITestFramework _testFramework;
-    private readonly ITestApplicationProcessExitCode _testApplicationProcessExitCode;
-    private readonly ILogger<JUnitReportGenerator> _logger;
-    private readonly List<CapturedTestResult> _tests = [];
-
     // Parent chain for ALL TestNodeUpdateMessages (including Discovered / InProgress).
     // Keyed by the raw, untruncated TestNodeUid value so that long UIDs do not break
     // chain lookups after capture-time truncation. The engine uses this to reconstruct
     // the testpath of every test case in the report.
     private readonly Dictionary<string, TestResultCapture.ParentChainEntry> _parentChain = [];
-    private readonly bool _isEnabled;
-
-    private DateTimeOffset? _testStartTime;
 
     public JUnitReportGenerator(
         IConfiguration configuration,
@@ -57,93 +34,63 @@ internal sealed class JUnitReportGenerator :
         ITestFramework testFramework,
         ITestApplicationProcessExitCode testApplicationProcessExitCode,
         ILogger<JUnitReportGenerator> logger)
+        : base(
+            configuration,
+            commandLineOptions,
+            fileSystem,
+            testApplicationModuleInfo,
+            messageBus,
+            clock,
+            environment,
+            outputDevice,
+            testFramework,
+            testApplicationProcessExitCode,
+            logger,
+            JUnitReportGeneratorCommandLine.JUnitReportOptionName)
     {
-        _configuration = configuration;
-        _commandLineOptions = commandLineOptions;
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
-        _messageBus = messageBus;
-        _clock = clock;
-        _environment = environment;
-        _outputDevice = outputDevice;
-        _testFramework = testFramework;
-        _testApplicationProcessExitCode = testApplicationProcessExitCode;
-        _logger = logger;
-        _isEnabled = commandLineOptions.IsOptionSet(JUnitReportGeneratorCommandLine.JUnitReportOptionName);
     }
 
-    public Type[] DataTypesConsumed { get; } =
-    [
-        typeof(TestNodeUpdateMessage),
-    ];
-
-    public Type[] DataTypesProduced { get; } = [typeof(SessionFileArtifact)];
+    /// <inheritdoc />
+    public override string Uid => nameof(JUnitReportGenerator);
 
     /// <inheritdoc />
-    public string Uid => nameof(JUnitReportGenerator);
+    public override string DisplayName { get; } = ExtensionResources.JUnitReportGeneratorDisplayName;
 
     /// <inheritdoc />
-    public string Version => ExtensionVersion.DefaultSemVer;
+    public override string Description { get; } = ExtensionResources.JUnitReportGeneratorDescription;
 
-    /// <inheritdoc />
-    public string DisplayName { get; } = ExtensionResources.JUnitReportGeneratorDisplayName;
+    protected override string ArtifactDisplayName => ExtensionResources.JUnitReportArtifactDisplayName;
 
-    /// <inheritdoc />
-    public string Description { get; } = ExtensionResources.JUnitReportGeneratorDescription;
+    protected override string ArtifactDescription => ExtensionResources.JUnitReportArtifactDescription;
 
-    /// <inheritdoc />
-    public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
+    protected override string GetGenerationLogMessage(int testResultCount)
+        => $"Generating JUnit XML report for {testResultCount} test result(s).";
 
-    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    protected override void OnTestNodeUpdate(TestNodeUpdateMessage update)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        // Record the parent chain entry for EVERY update so non-terminal parent
+        // nodes (Discovered / InProgress) are still available when reconstructing
+        // the path of a terminal child test. Later updates for the same UID just
+        // refresh the entry (frameworks may emit several updates per node).
+        // The raw UID is test-controlled and unbounded by the platform, so we
+        // truncate it to a fixed identity budget before using it as a dictionary
+        // key. Capture-side `RawUid`/`ParentRawUid` values are truncated to the
+        // same budget so cross-lookups remain consistent.
+        string rawUid = TestResultCapture.Truncate(update.TestNode.Uid.Value, TestResultCapture.MaxIdentityFieldLength)!;
+        _parentChain[rawUid] = TestResultCapture.GetParentChainEntry(update);
 
-        if (value is TestNodeUpdateMessage update)
-        {
-            // Record the parent chain entry for EVERY update so non-terminal parent
-            // nodes (Discovered / InProgress) are still available when reconstructing
-            // the path of a terminal child test. Later updates for the same UID just
-            // refresh the entry (frameworks may emit several updates per node).
-            // The raw UID is test-controlled and unbounded by the platform, so we
-            // truncate it to a fixed identity budget before using it as a dictionary
-            // key. Capture-side `RawUid`/`ParentRawUid` values are truncated to the
-            // same budget so cross-lookups remain consistent.
-            string rawUid = TestResultCapture.Truncate(update.TestNode.Uid.Value, TestResultCapture.MaxIdentityFieldLength)!;
-            _parentChain[rawUid] = TestResultCapture.GetParentChainEntry(update);
-
-            // Project to a capped DTO immediately so we don't retain the original
-            // TestNode (and its potentially huge stdout/stderr/stack trace strings)
-            // for the whole session. We never deduplicate on TestNode.Uid: some
-            // frameworks emit several distinct results sharing the same UID
-            // (parameterized rows, theory data, in-process retries, framework
-            // misbehaviour). The engine surfaces all of them so no data is dropped.
-            CapturedTestResult? captured = TestResultCapture.TryCapture(update);
-            if (captured is not null)
-            {
-                _tests.Add(captured);
-            }
-        }
-
-        return Task.CompletedTask;
+        base.OnTestNodeUpdate(update);
     }
 
-    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
+    protected override CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
+        => TestResultCapture.TryCapture(update);
+
+    protected override Task<(string FileName, string? Warning)> GenerateReportAsync(
+        CapturedTestResult[] tests,
+        DateTimeOffset testStartTime,
+        int exitCode,
+        CancellationToken cancellationToken)
     {
-        testSessionContext.CancellationToken.ThrowIfCancellationRequested();
-        _testStartTime = _clock.UtcNow;
-        return Task.CompletedTask;
-    }
-
-    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
-    {
-        CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        cancellationToken.ThrowIfCancellationRequested();
-
-        ApplicationStateGuard.Ensure(_testStartTime is not null);
-
-        await _logger.LogTraceAsync($"Generating JUnit XML report for {_tests.Count} test result(s).").ConfigureAwait(false);
-
-        int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
         var engine = new JUnitReportEngine(
             _fileSystem,
             _testApplicationModuleInfo,
@@ -152,23 +99,9 @@ internal sealed class JUnitReportGenerator :
             _configuration,
             _clock,
             _testFramework,
-            _testStartTime.Value,
+            testStartTime,
             exitCode,
             cancellationToken);
-
-        (string reportFileName, string? warning) = await engine.GenerateReportAsync([.. _tests], _parentChain).ConfigureAwait(false);
-
-        if (warning is not null)
-        {
-            await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
-        }
-
-        await _messageBus.PublishAsync(
-            this,
-            new SessionFileArtifact(
-                testSessionContext.SessionUid,
-                new FileInfo(reportFileName),
-                ExtensionResources.JUnitReportArtifactDisplayName,
-                ExtensionResources.JUnitReportArtifactDescription)).ConfigureAwait(false);
+        return engine.GenerateReportAsync(tests, _parentChain);
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Testing.Extensions.JUnitReport;
 internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGenerator, CapturedTestResult>
 {
     // Parent chain for ALL TestNodeUpdateMessages (including Discovered / InProgress).
-    // Keyed by the raw, untruncated TestNodeUid value so that long UIDs do not break
-    // chain lookups after capture-time truncation. The engine uses this to reconstruct
-    // the testpath of every test case in the report.
+    // Keyed by the TestNodeUid value after truncation to TestResultCapture.MaxIdentityFieldLength
+    // so it matches the capped RawUid / ParentRawUid keys used everywhere else in capture
+    // (see TestResultCapture.GetParentChainEntry / TryCapture). The engine uses this to
+    // reconstruct the testpath of every test case in the report.
     private readonly Dictionary<string, TestResultCapture.ParentChainEntry> _parentChain = [];
 
     public JUnitReportGenerator(

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -51,6 +51,7 @@ This package extends Microsoft Testing Platform to produce JUnit XML test report
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -123,8 +123,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         CancellationToken cancellationToken = testSessionContext.CancellationToken;
         cancellationToken.ThrowIfCancellationRequested();
 
-        ApplicationStateGuard.Ensure(_testStartTime is not null);
-        DateTimeOffset testStartTime = _testStartTime.Value;
+        DateTimeOffset testStartTime = _testStartTime ?? throw ApplicationStateGuard.Unreachable();
 
         await _logger.LogTraceAsync(GetGenerationLogMessage(_tests.Count)).ConfigureAwait(false);
 

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -24,21 +24,13 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
     where TCapturedTestResult : class
 {
-#pragma warning disable SA1401 // Fields should be private - derived report generators create report-specific engines from these services.
-    protected readonly IConfiguration _configuration;
-    protected readonly ICommandLineOptions _commandLineOptions;
-    protected readonly IFileSystem _fileSystem;
-    protected readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
-    protected readonly IClock _clock;
-    protected readonly IEnvironment _environment;
-    protected readonly ITestFramework _testFramework;
-#pragma warning restore SA1401
-
+    // MTP guarantees that ConsumeAsync is called sequentially (never concurrently)
+    // for a given consumer instance, so List<T> is safe here without locking.
+    private readonly List<TCapturedTestResult> _tests = [];
     private readonly IMessageBus _messageBus;
     private readonly IOutputDevice _outputDevice;
     private readonly ITestApplicationProcessExitCode _testApplicationProcessExitCode;
     private readonly ILogger<TGenerator> _logger;
-    private readonly List<TCapturedTestResult> _tests = [];
     private readonly bool _isEnabled;
 
     private DateTimeOffset? _testStartTime;
@@ -57,15 +49,15 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         ILogger<TGenerator> logger,
         string optionName)
     {
-        _configuration = configuration;
-        _commandLineOptions = commandLineOptions;
-        _fileSystem = fileSystem;
-        _testApplicationModuleInfo = testApplicationModuleInfo;
+        Configuration = configuration;
+        CommandLineOptions = commandLineOptions;
+        FileSystem = fileSystem;
+        TestApplicationModuleInfo = testApplicationModuleInfo;
         _messageBus = messageBus;
-        _clock = clock;
-        _environment = environment;
+        Clock = clock;
+        Environment = environment;
         _outputDevice = outputDevice;
-        _testFramework = testFramework;
+        TestFramework = testFramework;
         _testApplicationProcessExitCode = testApplicationProcessExitCode;
         _logger = logger;
         _isEnabled = commandLineOptions.IsOptionSet(optionName);
@@ -90,6 +82,20 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     /// <inheritdoc />
     public abstract string Description { get; }
 
+    protected IConfiguration Configuration { get; }
+
+    protected ICommandLineOptions CommandLineOptions { get; }
+
+    protected IFileSystem FileSystem { get; }
+
+    protected ITestApplicationModuleInfo TestApplicationModuleInfo { get; }
+
+    protected IClock Clock { get; }
+
+    protected IEnvironment Environment { get; }
+
+    protected ITestFramework TestFramework { get; }
+
     /// <inheritdoc />
     public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
 
@@ -108,7 +114,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
     {
         testSessionContext.CancellationToken.ThrowIfCancellationRequested();
-        _testStartTime = _clock.UtcNow;
+        _testStartTime = Clock.UtcNow;
         return Task.CompletedTask;
     }
 
@@ -118,11 +124,12 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         cancellationToken.ThrowIfCancellationRequested();
 
         ApplicationStateGuard.Ensure(_testStartTime is not null);
+        DateTimeOffset testStartTime = _testStartTime.Value;
 
         await _logger.LogTraceAsync(GetGenerationLogMessage(_tests.Count)).ConfigureAwait(false);
 
         int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
-        (string reportFileName, string? warning) = await GenerateReportAsync([.. _tests], _testStartTime.Value, exitCode, cancellationToken).ConfigureAwait(false);
+        (string reportFileName, string? warning) = await GenerateReportAsync([.. _tests], testStartTime, exitCode, cancellationToken).ConfigureAwait(false);
 
         if (warning is not null)
         {
@@ -138,6 +145,11 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
                 ArtifactDescription)).ConfigureAwait(false);
     }
 
+    // Capture every update unconditionally — no UID-based deduplication.
+    // CTRF relies on this to detect flaky tests (earlier attempts become retryAttempts[];
+    // see CtrfReportEngine.CollapseAttempts). HTML/JUnit rely on it to surface all results
+    // for tests that emit multiple updates per UID (parameterized rows, in-process retries,
+    // framework quirks). Engine-side logic handles any deduplication.
     protected virtual void OnTestNodeUpdate(TestNodeUpdateMessage update)
     {
         TCapturedTestResult? captured = TryCapture(update);

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Extensions;
+
+internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
+    IDataConsumer,
+    ITestSessionLifetimeHandler,
+    IDataProducer,
+    IOutputDeviceDataProducer
+    where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
+    where TCapturedTestResult : class
+{
+#pragma warning disable SA1401 // Fields should be private - derived report generators create report-specific engines from these services.
+    protected readonly IConfiguration _configuration;
+    protected readonly ICommandLineOptions _commandLineOptions;
+    protected readonly IFileSystem _fileSystem;
+    protected readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
+    protected readonly IClock _clock;
+    protected readonly IEnvironment _environment;
+    protected readonly ITestFramework _testFramework;
+#pragma warning restore SA1401
+
+    private readonly IMessageBus _messageBus;
+    private readonly IOutputDevice _outputDevice;
+    private readonly ITestApplicationProcessExitCode _testApplicationProcessExitCode;
+    private readonly ILogger<TGenerator> _logger;
+    private readonly List<TCapturedTestResult> _tests = [];
+    private readonly bool _isEnabled;
+
+    private DateTimeOffset? _testStartTime;
+
+    protected ReportGeneratorBase(
+        IConfiguration configuration,
+        ICommandLineOptions commandLineOptions,
+        IFileSystem fileSystem,
+        ITestApplicationModuleInfo testApplicationModuleInfo,
+        IMessageBus messageBus,
+        IClock clock,
+        IEnvironment environment,
+        IOutputDevice outputDevice,
+        ITestFramework testFramework,
+        ITestApplicationProcessExitCode testApplicationProcessExitCode,
+        ILogger<TGenerator> logger,
+        string optionName)
+    {
+        _configuration = configuration;
+        _commandLineOptions = commandLineOptions;
+        _fileSystem = fileSystem;
+        _testApplicationModuleInfo = testApplicationModuleInfo;
+        _messageBus = messageBus;
+        _clock = clock;
+        _environment = environment;
+        _outputDevice = outputDevice;
+        _testFramework = testFramework;
+        _testApplicationProcessExitCode = testApplicationProcessExitCode;
+        _logger = logger;
+        _isEnabled = commandLineOptions.IsOptionSet(optionName);
+    }
+
+    public Type[] DataTypesConsumed { get; } =
+    [
+        typeof(TestNodeUpdateMessage),
+    ];
+
+    public Type[] DataTypesProduced { get; } = [typeof(SessionFileArtifact)];
+
+    /// <inheritdoc />
+    public abstract string Uid { get; }
+
+    /// <inheritdoc />
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    /// <inheritdoc />
+    public abstract string DisplayName { get; }
+
+    /// <inheritdoc />
+    public abstract string Description { get; }
+
+    /// <inheritdoc />
+    public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (value is TestNodeUpdateMessage update)
+        {
+            OnTestNodeUpdate(update);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
+    {
+        testSessionContext.CancellationToken.ThrowIfCancellationRequested();
+        _testStartTime = _clock.UtcNow;
+        return Task.CompletedTask;
+    }
+
+    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
+    {
+        CancellationToken cancellationToken = testSessionContext.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ApplicationStateGuard.Ensure(_testStartTime is not null);
+
+        await _logger.LogTraceAsync(GetGenerationLogMessage(_tests.Count)).ConfigureAwait(false);
+
+        int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
+        (string reportFileName, string? warning) = await GenerateReportAsync([.. _tests], _testStartTime.Value, exitCode, cancellationToken).ConfigureAwait(false);
+
+        if (warning is not null)
+        {
+            await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
+        }
+
+        await _messageBus.PublishAsync(
+            this,
+            new SessionFileArtifact(
+                testSessionContext.SessionUid,
+                new FileInfo(reportFileName),
+                ArtifactDisplayName,
+                ArtifactDescription)).ConfigureAwait(false);
+    }
+
+    protected virtual void OnTestNodeUpdate(TestNodeUpdateMessage update)
+    {
+        TCapturedTestResult? captured = TryCapture(update);
+        if (captured is not null)
+        {
+            _tests.Add(captured);
+        }
+    }
+
+    protected abstract string ArtifactDisplayName { get; }
+
+    protected abstract string ArtifactDescription { get; }
+
+    protected abstract string GetGenerationLogMessage(int testResultCount);
+
+    protected abstract TCapturedTestResult? TryCapture(TestNodeUpdateMessage update);
+
+    protected abstract Task<(string FileName, string? Warning)> GenerateReportAsync(
+        TCapturedTestResult[] tests,
+        DateTimeOffset testStartTime,
+        int exitCode,
+        CancellationToken cancellationToken);
+}


### PR DESCRIPTION
Fixes #9098

Introduces a shared `ReportGeneratorBase` (in `SharedExtensionHelpers`) and migrates `CtrfReportGenerator`, `HtmlReportGenerator`, and `JUnitReportGenerator` onto it, eliminating ~180 duplicated lines of boilerplate (field declarations, constructor, `ConsumeAsync`, `OnTestSessionStartingAsync`, common `OnTestSessionFinishingAsync` flow) so future platform-service additions only have to be made once.