### PR TITLE
Dependency health: address Tasks 3, 4, 5 from #9091

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
       - dependency-name: Moq
     commit-message:
       prefix: '[main] '
+  - package-ecosystem: nuget
+    directory: "/samples/public"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      # handled by Darc/Maestro flows
+      - dependency-name: "Microsoft.DotNet.Arcade.Sdk"
+      - dependency-name: Moq
+    commit-message:
+      prefix: '[main] '
   - package-ecosystem: dotnet-sdk
     directory: /
     schedule:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,10 @@
     <MicrosoftCodeAnalysisVersion>3.11.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionForTests>4.10.0</MicrosoftCodeAnalysisVersionForTests>
     <MicrosoftCodeAnalysisVersionForSourceGen>4.8.0</MicrosoftCodeAnalysisVersionForSourceGen>
-    <!-- Pinned to a daily build for PublicApi analyzer support until the next stable package. -->
+    <!-- Microsoft.CodeAnalysis.PublicApiAnalyzers / .BannedApiAnalyzers pinned to a daily build (5.5.x).
+         The last stable release (3.3.4, 2022) lacks newer RS0017/RS0026/RS0036 fixes that testfx's
+         public-API surface tracking depends on. Promote back to the next stable 5.x once one ships.
+         Tracking context: https://github.com/microsoft/testfx/issues/9091 (Task 5). -->
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>5.5.0-2.26224.1</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- UWP and WinUI dependencies -->
@@ -26,7 +29,10 @@
     <MicrosoftNETTestSdkVersion>18.4.0</MicrosoftNETTestSdkVersion>
     <MicrosoftPlaywrightVersion>1.58.0</MicrosoftPlaywrightVersion>
     <MicrosoftTestingExtensionsFakesVersion>18.1.1</MicrosoftTestingExtensionsFakesVersion>
-    <!-- Pinned to a preview build for internal test framework features until the next stable package. -->
+    <!-- Microsoft.Testing.Internal.Framework is an internal-only NuGet (consumed by tests that
+         opt into UseInternalTestFramework via TestFramework.ForTestingMSTest); there is no public
+         stable release on nuget.org. Promote when the internal feed ships a non-preview version.
+         Tracking context: https://github.com/microsoft/testfx/issues/9091 (Task 5). -->
     <MicrosoftTestingInternalFrameworkVersion>1.5.0-preview.24577.4</MicrosoftTestingInternalFrameworkVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <MicrosoftCodeAnalysisVersion>3.11.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionForTests>4.10.0</MicrosoftCodeAnalysisVersionForTests>
     <MicrosoftCodeAnalysisVersionForSourceGen>4.8.0</MicrosoftCodeAnalysisVersionForSourceGen>
+    <!-- Pinned to a daily build for PublicApi analyzer support until the next stable package. -->
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>5.5.0-2.26224.1</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- UWP and WinUI dependencies -->
@@ -25,6 +26,7 @@
     <MicrosoftNETTestSdkVersion>18.4.0</MicrosoftNETTestSdkVersion>
     <MicrosoftPlaywrightVersion>1.58.0</MicrosoftPlaywrightVersion>
     <MicrosoftTestingExtensionsFakesVersion>18.1.1</MicrosoftTestingExtensionsFakesVersion>
+    <!-- Pinned to a preview build for internal test framework features until the next stable package. -->
     <MicrosoftTestingInternalFrameworkVersion>1.5.0-preview.24577.4</MicrosoftTestingInternalFrameworkVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
   </PropertyGroup>
@@ -93,6 +95,7 @@
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Management" Version="9.0.4" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <!--
     Declare below packages that we will be referenced through MSTest.Sdk but don't have direct reference.

--- a/samples/CtrfPlayground/XunitMtp/XunitMtp.csproj
+++ b/samples/CtrfPlayground/XunitMtp/XunitMtp.csproj
@@ -19,6 +19,6 @@
 
   <ItemGroup>
     <!-- xunit.v3 ships its own CTRF reporter, enabled via the `-ctrf <file>` switch (see README.md). -->
-    <PackageReference Include="xunit.v3.mtp-v2" VersionOverride="3.2.2" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Partially addresses #9091.

- Task 3: Added a NuGet Dependabot entry for `/samples/public`, mirroring the root NuGet entry's style and ignore/commit-message settings.
- Task 4: Registered `xunit.v3.mtp-v2` in root `Directory.Packages.props` and removed the matching `VersionOverride` from `samples/CtrfPlayground/XunitMtp/XunitMtp.csproj`. `OpenTelemetry.Exporter.Console` was left unchanged because `samples/public/Directory.Packages.props` disables Central Package Management, so that sample is outside the root CPM scope.
- Task 5: Added brief comments documenting the preview/daily analyzer and internal test framework pins.

Tasks 1 (System.CommandLine upgrade) and 2 (WindowsAppSDK sync) are deliberately deferred because they need more careful migration work.