### PR TITLE
Share single EquatableArray<T> across source generators

### DIFF
--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Diagnostics/DiagnosticInfo.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Diagnostics/DiagnosticInfo.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis;
 
-using MSTest.AotReflection.SourceGeneration.Model;
+using MSTest.Analyzers.Shared;
 
 namespace MSTest.AotReflection.SourceGeneration.Diagnostics;
 

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MSTestReflectionMetadataGenerator.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MSTestReflectionMetadataGenerator.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
+using MSTest.Analyzers.Shared;
 using MSTest.AotReflection.SourceGeneration.Diagnostics;
 using MSTest.AotReflection.SourceGeneration.Helpers;
 using MSTest.AotReflection.SourceGeneration.Model;

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Helpers;
 
+using MSTest.Analyzers.Shared;
 using MSTest.AotReflection.SourceGeneration.Model;
 
 namespace MSTest.AotReflection.SourceGeneration.Generators;

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis;
 
+using MSTest.Analyzers.Shared;
 using MSTest.AotReflection.SourceGeneration.Diagnostics;
 using MSTest.AotReflection.SourceGeneration.Helpers;
 using MSTest.AotReflection.SourceGeneration.Model;

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\EquatableArray.cs" Link="Shared\EquatableArray.cs" />
     <Compile Include="..\MSTest.SourceGeneration\Helpers\Constants.cs" Link="Helpers\Constants.cs" />
     <Compile Include="..\MSTest.SourceGeneration\Helpers\IndentedStringBuilder.cs" Link="Helpers\IndentedStringBuilder.cs" />
 

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/Model/TestClassModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Immutable;
+using MSTest.Analyzers.Shared;
 
 namespace MSTest.AotReflection.SourceGeneration.Model;
 
@@ -86,75 +86,3 @@ internal sealed record TestClassModel(
     EquatableArray<TestPropertyModel> Properties,
     EquatableArray<AttributeApplicationModel> Attributes,
     EquatableArray<string> BaseTypeFullyQualifiedNames);
-
-/// <summary>
-/// Value-equatable wrapper around <see cref="ImmutableArray{T}"/> so incremental generation
-/// can cache results between runs. Kept minimal — we don't need indexing in this PoC.
-/// </summary>
-/// <typeparam name="T">Element type stored in the underlying <see cref="ImmutableArray{T}"/>.</typeparam>
-internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>
-    where T : IEquatable<T>
-{
-    public static readonly EquatableArray<T> Empty = new(ImmutableArray<T>.Empty);
-
-    private readonly ImmutableArray<T> _array;
-
-    public EquatableArray(ImmutableArray<T> array)
-        => _array = array;
-
-    public int Length => _array.IsDefault ? 0 : _array.Length;
-
-    public T this[int index] => _array[index];
-
-    public ImmutableArray<T> AsImmutableArray()
-        => _array.IsDefault ? ImmutableArray<T>.Empty : _array;
-
-    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)AsImmutableArray()).GetEnumerator();
-
-    public bool Equals(EquatableArray<T> other)
-    {
-        if (Length != other.Length)
-        {
-            return false;
-        }
-
-        ImmutableArray<T> left = AsImmutableArray();
-        ImmutableArray<T> right = other.AsImmutableArray();
-        for (int i = 0; i < left.Length; i++)
-        {
-            if (!EqualityComparer<T>.Default.Equals(left[i], right[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
-
-    public override int GetHashCode()
-    {
-        // Combine element hashes (using the same fold .NET uses for HashCode.Combine of ints).
-        int hash = 17;
-        foreach (T item in AsImmutableArray())
-        {
-            hash = unchecked((hash * 31) + (item?.GetHashCode() ?? 0));
-        }
-
-        return hash;
-    }
-}
-
-internal static class EquatableArrayExtensions
-{
-    private static readonly Func<object?, bool> NotNullTest = x => x is not null;
-
-    public static EquatableArray<T> ToEquatableArray<T>(this IEnumerable<T> source)
-        where T : IEquatable<T>
-        => new(source.ToImmutableArray());
-
-    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
-        where T : class
-        => source.Where((Func<T?, bool>)NotNullTest)!;
-}

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/ReflectionMetadataGenerator.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/ReflectionMetadataGenerator.cs
@@ -9,6 +9,8 @@ using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceG
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Models;
 
+using MSTest.Analyzers.Shared;
+
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Generators;
 
 /// <summary>

--- a/src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.SourceGeneration/MSTest.SourceGeneration.csproj
@@ -42,6 +42,7 @@ This package provides the C# source generators that emit reflection metadata so 
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src/Polyfills/**/*.cs" Link="Polyfills\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\Shared\EquatableArray.cs" Link="Shared\EquatableArray.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Analyzers/MSTest.SourceGeneration/Models/TestAssemblyMetadata.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Models/TestAssemblyMetadata.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Immutable;
+using MSTest.Analyzers.Shared;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Models;
 
@@ -27,56 +27,3 @@ internal sealed record TestMethodMetadata(string Name, EquatableArray<string> Pa
 internal sealed record TestAssemblyMetadata(
     string AssemblyName,
     EquatableArray<TestClassMetadata> Classes);
-
-/// <summary>
-/// Minimal value-equatable wrapper around an <see cref="ImmutableArray{T}"/>. Source generators
-/// need value equality on collections; <see cref="ImmutableArray{T}"/> only has reference equality
-/// out of the box, which would cause cache misses on every compilation tick.
-/// </summary>
-/// <typeparam name="T">The element type stored in the underlying <see cref="ImmutableArray{T}"/>.</typeparam>
-internal readonly record struct EquatableArray<T>(ImmutableArray<T> Items)
-    where T : IEquatable<T>
-{
-    public int Count => Items.IsDefault ? 0 : Items.Length;
-
-    // Return ImmutableArray<T>.Enumerator (a struct) by value so that 'foreach' uses the duck-typed
-    // enumerator and avoids boxing on the source-generator hot path. Returning IEnumerator<T> here
-    // would force an interface dispatch and allocate on every iteration.
-    public ImmutableArray<T>.Enumerator GetEnumerator() => (Items.IsDefault ? ImmutableArray<T>.Empty : Items).GetEnumerator();
-
-    public bool Equals(EquatableArray<T> other)
-    {
-        ImmutableArray<T> a = Items.IsDefault ? ImmutableArray<T>.Empty : Items;
-        ImmutableArray<T> b = other.Items.IsDefault ? ImmutableArray<T>.Empty : other.Items;
-        if (a.Length != b.Length)
-        {
-            return false;
-        }
-
-        for (int i = 0; i < a.Length; i++)
-        {
-            if (!EqualityComparer<T>.Default.Equals(a[i], b[i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    public override int GetHashCode()
-    {
-        if (Items.IsDefault)
-        {
-            return 0;
-        }
-
-        int hash = 17;
-        foreach (T item in Items)
-        {
-            hash = unchecked((hash * 31) + (item?.GetHashCode() ?? 0));
-        }
-
-        return hash;
-    }
-}

--- a/src/Analyzers/Shared/EquatableArray.cs
+++ b/src/Analyzers/Shared/EquatableArray.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace MSTest.Analyzers.Shared;
+
+/// <summary>
+/// Value-equatable wrapper around <see cref="ImmutableArray{T}"/> so incremental generation
+/// can cache results between runs.
+/// </summary>
+/// <typeparam name="T">Element type stored in the underlying <see cref="ImmutableArray{T}"/>.</typeparam>
+internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>
+    where T : IEquatable<T>
+{
+    public static readonly EquatableArray<T> Empty = new(ImmutableArray<T>.Empty);
+
+    private readonly ImmutableArray<T> _array;
+
+    public EquatableArray(ImmutableArray<T> array)
+        => _array = array;
+
+    public ImmutableArray<T> Items => AsImmutableArray();
+
+    public int Count => Length;
+
+    public int Length => _array.IsDefault ? 0 : _array.Length;
+
+    public T this[int index] => AsImmutableArray()[index];
+
+    public ImmutableArray<T> AsImmutableArray()
+        => _array.IsDefault ? ImmutableArray<T>.Empty : _array;
+
+    public ImmutableArray<T>.Enumerator GetEnumerator() => AsImmutableArray().GetEnumerator();
+
+    public bool Equals(EquatableArray<T> other)
+    {
+        if (Length != other.Length)
+        {
+            return false;
+        }
+
+        ImmutableArray<T> left = AsImmutableArray();
+        ImmutableArray<T> right = other.AsImmutableArray();
+        for (int i = 0; i < left.Length; i++)
+        {
+            if (!EqualityComparer<T>.Default.Equals(left[i], right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        int hash = 17;
+        foreach (T item in AsImmutableArray())
+        {
+            hash = unchecked((hash * 31) + (item?.GetHashCode() ?? 0));
+        }
+
+        return hash;
+    }
+}
+
+internal static class EquatableArrayExtensions
+{
+    private static readonly Func<object?, bool> NotNullTest = x => x is not null;
+
+    public static EquatableArray<T> ToEquatableArray<T>(this IEnumerable<T> source)
+        where T : IEquatable<T>
+        => new(source.ToImmutableArray());
+
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
+        where T : class
+        => source.Where((Func<T?, bool>)NotNullTest)!;
+}


### PR DESCRIPTION
Fixes #9105

Adds a shared EquatableArray<T> implementation under src/Analyzers/Shared and links it into both source-generator projects. Removes the duplicate local implementations and updates generator code to use the shared namespace.