### PR TITLE
Extract shared AssertConditionAnalyzerHelper for Assert condition analyzers

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+using MSTest.Analyzers.RoslynAnalyzerHelpers;
+
+namespace MSTest.Analyzers.Helpers;
+
+internal static class AssertConditionAnalyzerHelper
+{
+    internal enum EqualityStatus
+    {
+        Unknown,
+        Equal,
+        NotEqual,
+    }
+
+    internal const string ExpectedParameterName = "expected";
+    internal const string NotExpectedParameterName = "notExpected";
+    internal const string ActualParameterName = "actual";
+    internal const string ConditionParameterName = "condition";
+    internal const string ValueParameterName = "value";
+
+    internal static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+        => GetRawArgumentValueWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
+        && GetRawArgumentValueWithName(operation, ActualParameterName) is { } actualArgument
+        && expectedArgument.IsEquivalentReferenceTo(actualArgument);
+
+    internal static IOperation? GetArgumentWithName(IInvocationOperation operation, string name)
+        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value.WalkDownConversion();
+
+    internal static IOperation? GetConditionArgument(IInvocationOperation operation)
+        => GetArgumentWithName(operation, ConditionParameterName);
+
+    internal static IOperation? GetValueArgument(IInvocationOperation operation)
+        => GetArgumentWithName(operation, ValueParameterName);
+
+    internal static EqualityStatus GetEqualityStatus(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+    {
+        if (GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedOrNotExpectedArgument &&
+            GetArgumentWithName(operation, ActualParameterName) is { } actualArgument &&
+            expectedOrNotExpectedArgument.ConstantValue.HasValue &&
+            actualArgument.ConstantValue.HasValue)
+        {
+            return Equals(expectedOrNotExpectedArgument.ConstantValue.Value, actualArgument.ConstantValue.Value) ? EqualityStatus.Equal : EqualityStatus.NotEqual;
+        }
+
+        // We are not sure about the equality status
+        return EqualityStatus.Unknown;
+    }
+
+    internal static bool IsNotNullableType(IOperation valueArgumentOperation)
+    {
+        ITypeSymbol? valueArgType = valueArgumentOperation.GetReferencedMemberOrLocalOrParameter().GetReferencedMemberOrLocalOrParameter();
+        return valueArgType is not null
+            && valueArgType.IsValueType
+            && valueArgType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
+    }
+
+    private static IOperation? GetRawArgumentValueWithName(IInvocationOperation operation, string name)
+        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value;
+}

--- a/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
 using MSTest.Analyzers.Helpers;
-using MSTest.Analyzers.RoslynAnalyzerHelpers;
 
 namespace MSTest.Analyzers;
 
@@ -20,18 +19,6 @@ namespace MSTest.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : DiagnosticAnalyzer
 {
-    private enum EqualityStatus
-    {
-        Unknown,
-        Equal,
-        NotEqual,
-    }
-
-    private const string ExpectedParameterName = "expected";
-    private const string NotExpectedParameterName = "notExpected";
-    private const string ActualParameterName = "actual";
-    private const string ConditionParameterName = "condition";
-    private const string ValueParameterName = "value";
     private const string MessageParameterName = "message";
 
     private static readonly LocalizableResourceString Title = new(nameof(Resources.PreferAssertFailOverAlwaysFalseConditionsTitle), Resources.ResourceManager, typeof(Resources));
@@ -89,53 +76,14 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : Diagnost
     private static bool IsAlwaysFalse(IInvocationOperation operation)
         => operation.TargetMethod.Name switch
         {
-            "IsTrue" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
-            "IsFalse" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
-            "AreEqual" => GetEqualityStatus(operation, ExpectedParameterName) == EqualityStatus.NotEqual,
-            "AreNotEqual" => GetEqualityStatus(operation, NotExpectedParameterName) == EqualityStatus.Equal
-                || HasIdenticalExpectedAndActual(operation, NotExpectedParameterName),
-            "AreNotSame" => HasIdenticalExpectedAndActual(operation, NotExpectedParameterName),
-            "IsNotNull" => GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
-            "IsNull" => GetValueArgument(operation) is { } valueArgumentOperation && IsNotNullableType(valueArgumentOperation),
+            "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
+            "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
+            "AreEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
+            "AreNotEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
+                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
+            "AreNotSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
+            "IsNotNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
+            "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { } valueArgumentOperation && AssertConditionAnalyzerHelper.IsNotNullableType(valueArgumentOperation),
             _ => false,
         };
-
-    private static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-        => GetRawArgumentValueWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
-        && GetRawArgumentValueWithName(operation, ActualParameterName) is { } actualArgument
-        && expectedArgument.IsEquivalentReferenceTo(actualArgument);
-
-    private static IOperation? GetRawArgumentValueWithName(IInvocationOperation operation, string name)
-        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value;
-
-    private static bool IsNotNullableType(IOperation valueArgumentOperation)
-    {
-        ITypeSymbol? valueArgType = valueArgumentOperation.GetReferencedMemberOrLocalOrParameter().GetReferencedMemberOrLocalOrParameter();
-        return valueArgType is not null
-            && valueArgType.IsValueType
-            && valueArgType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
-    }
-
-    private static IOperation? GetArgumentWithName(IInvocationOperation operation, string name)
-        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value.WalkDownConversion();
-
-    private static IOperation? GetConditionArgument(IInvocationOperation operation)
-        => GetArgumentWithName(operation, ConditionParameterName);
-
-    private static IOperation? GetValueArgument(IInvocationOperation operation)
-        => GetArgumentWithName(operation, ValueParameterName);
-
-    private static EqualityStatus GetEqualityStatus(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-    {
-        if (GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedOrNotExpectedArgument &&
-            GetArgumentWithName(operation, ActualParameterName) is { } actualArgument &&
-            expectedOrNotExpectedArgument.ConstantValue.HasValue &&
-            actualArgument.ConstantValue.HasValue)
-        {
-            return Equals(expectedOrNotExpectedArgument.ConstantValue.Value, actualArgument.ConstantValue.Value) ? EqualityStatus.Equal : EqualityStatus.NotEqual;
-        }
-
-        // We are not sure about the equality status
-        return EqualityStatus.Unknown;
-    }
 }

--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
 using MSTest.Analyzers.Helpers;
-using MSTest.Analyzers.RoslynAnalyzerHelpers;
 
 namespace MSTest.Analyzers;
 
@@ -20,19 +19,6 @@ namespace MSTest.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
 {
-    private enum EqualityStatus
-    {
-        Unknown,
-        Equal,
-        NotEqual,
-    }
-
-    private const string ExpectedParameterName = "expected";
-    private const string NotExpectedParameterName = "notExpected";
-    private const string ActualParameterName = "actual";
-    private const string ConditionParameterName = "condition";
-    private const string ValueParameterName = "value";
-
     private static readonly LocalizableResourceString Title = new(nameof(Resources.ReviewAlwaysTrueAssertConditionAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
     private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.ReviewAlwaysTrueAssertConditionAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
 
@@ -79,53 +65,14 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
     private static bool IsAlwaysTrue(IInvocationOperation operation)
         => operation.TargetMethod.Name switch
         {
-            "IsTrue" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
-            "IsFalse" => GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
-            "AreEqual" => GetEqualityStatus(operation, ExpectedParameterName) == EqualityStatus.Equal
-                || HasIdenticalExpectedAndActual(operation, ExpectedParameterName),
-            "AreNotEqual" => GetEqualityStatus(operation, NotExpectedParameterName) == EqualityStatus.NotEqual,
-            "AreSame" => HasIdenticalExpectedAndActual(operation, ExpectedParameterName),
-            "IsNull" => GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
-            "IsNotNull" => GetValueArgument(operation) is { } valueArgumentOperation && IsNotNullableType(valueArgumentOperation),
+            "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
+            "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
+            "AreEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
+                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
+            "AreNotEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
+            "AreSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
+            "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
+            "IsNotNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { } valueArgumentOperation && AssertConditionAnalyzerHelper.IsNotNullableType(valueArgumentOperation),
             _ => false,
         };
-
-    private static bool HasIdenticalExpectedAndActual(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-        => GetRawArgumentValueWithName(operation, expectedOrNotExpectedParameterName) is { } expectedArgument
-        && GetRawArgumentValueWithName(operation, ActualParameterName) is { } actualArgument
-        && expectedArgument.IsEquivalentReferenceTo(actualArgument);
-
-    private static IOperation? GetRawArgumentValueWithName(IInvocationOperation operation, string name)
-        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value;
-
-    private static bool IsNotNullableType(IOperation valueArgumentOperation)
-    {
-        ITypeSymbol? valueArgType = valueArgumentOperation.GetReferencedMemberOrLocalOrParameter().GetReferencedMemberOrLocalOrParameter();
-        return valueArgType is not null
-            && valueArgType.IsValueType
-            && valueArgType.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T;
-    }
-
-    private static IOperation? GetArgumentWithName(IInvocationOperation operation, string name)
-        => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value.WalkDownConversion();
-
-    private static IOperation? GetConditionArgument(IInvocationOperation operation)
-        => GetArgumentWithName(operation, ConditionParameterName);
-
-    private static IOperation? GetValueArgument(IInvocationOperation operation)
-        => GetArgumentWithName(operation, ValueParameterName);
-
-    private static EqualityStatus GetEqualityStatus(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-    {
-        if (GetArgumentWithName(operation, expectedOrNotExpectedParameterName) is { } expectedOrNotExpectedArgument &&
-            GetArgumentWithName(operation, ActualParameterName) is { } actualArgument &&
-            expectedOrNotExpectedArgument.ConstantValue.HasValue &&
-            actualArgument.ConstantValue.HasValue)
-        {
-            return Equals(expectedOrNotExpectedArgument.ConstantValue.Value, actualArgument.ConstantValue.Value) ? EqualityStatus.Equal : EqualityStatus.NotEqual;
-        }
-
-        // We are not sure about the equality status
-        return EqualityStatus.Unknown;
-    }
 }


### PR DESCRIPTION
Fixes #9099

Extracted the duplicated Assert condition analysis helpers into an internal shared AssertConditionAnalyzerHelper and updated the always-false/always-true Assert analyzers to use it while keeping their analyzer-specific switch logic local.