### PR TITLE
Upgrade MessagePack from 2.5.198 to 2.5.301 to fix vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,6 +90,8 @@
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <!-- This comes transitively via StreamJsonRpc, but we want to upgrade it to fix a security vulnerability -->
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
+    <!-- This comes transitively via StreamJsonRpc, but we want to upgrade it to fix a security vulnerability -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Management" Version="9.0.4" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="MSBuild.StructuredLogger" />
     <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
     <PackageReference Include="Nerdbank.MessagePack" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="MSBuild.StructuredLogger" />
     <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
     <PackageReference Include="Nerdbank.MessagePack" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Pins the transitive `MessagePack` dependency (brought in via `StreamJsonRpc`) from **2.5.198** to **2.5.301** to address a known security vulnerability.

## Changes

- `Directory.Packages.props` — added `<PackageVersion Include="MessagePack" Version="2.5.301" />` (CPM pin).
- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/*.csproj` — added `<PackageReference Include="MessagePack" />` to force the pin.
- `test/IntegrationTests/MSTest.Acceptance.IntegrationTests/*.csproj` — same.

This mirrors the existing `Nerdbank.MessagePack` pinning pattern already used for the same reason.

## Validation

`dotnet restore` succeeds and `project.assets.json` resolves `MessagePack/2.5.301`.