### PR TITLE
Fix report file-name collision between net8.0 and net8.0-windows builds

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileNaming.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileNaming.cs
@@ -33,9 +33,7 @@ internal sealed partial class CtrfReportEngine
     }
 
     private static string GetTargetFrameworkMoniker()
-        => TargetFrameworkParser.GetShortTargetFramework(
-            Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
-            ?? TargetFrameworkParser.GetShortTargetFramework(RuntimeInformation.FrameworkDescription)
+        => TargetFrameworkParser.GetShortTargetFrameworkIncludingPlatform(Assembly.GetEntryAssembly())
             ?? "unknown";
 
     // CTRF `osPlatform` is the short Node-style platform identifier (e.g. "win32",

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TargetFrameworkParser.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TargetFrameworkParser.cs
@@ -73,4 +73,61 @@ internal static class TargetFrameworkParser
 
         return frameworkDescription;
     }
+
+    /// <summary>
+    /// Resolves the short target framework moniker of <paramref name="entryAssembly"/>, including the
+    /// OS-platform component (e.g. <c>net8.0-windows10.0.18362.0</c>) when the assembly was built for an
+    /// OS-specific TFM.
+    /// </summary>
+    /// <remarks>
+    /// A plain <c>net8.0</c> build and a <c>net8.0-windows10.0.18362.0</c> build carry the exact same
+    /// <see cref="TargetFrameworkAttribute"/> (<c>.NETCoreApp,Version=v8.0</c>) and produce the same
+    /// <see cref="RuntimeInformation.FrameworkDescription"/>, so the short TFM alone cannot tell them apart.
+    /// The only runtime-visible signal is <c>System.Runtime.Versioning.TargetPlatformAttribute</c>, which the
+    /// SDK emits for OS-specific TFMs only. Appending it here keeps report file names unique per build so two
+    /// modules of the same assembly no longer overwrite each other's report.
+    /// </remarks>
+    public static string? GetShortTargetFrameworkIncludingPlatform(Assembly? entryAssembly)
+    {
+        string? shortTargetFramework = GetShortTargetFramework(entryAssembly?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
+            ?? GetShortTargetFramework(RuntimeInformation.FrameworkDescription);
+
+        return BuildTargetFrameworkMoniker(shortTargetFramework, GetTargetPlatformName(entryAssembly));
+    }
+
+    /// <summary>
+    /// Combines a short target framework (e.g. <c>net8.0</c>) with an optional OS-platform name
+    /// (e.g. <c>Windows10.0.18362.0</c>) into a full moniker (e.g. <c>net8.0-windows10.0.18362.0</c>).
+    /// </summary>
+    internal static string? BuildTargetFrameworkMoniker(string? shortTargetFramework, string? targetPlatformName)
+        => shortTargetFramework is null || RoslynString.IsNullOrEmpty(targetPlatformName)
+            ? shortTargetFramework
+            : $"{shortTargetFramework}-{targetPlatformName!.ToLowerInvariant()}";
+
+    /// <summary>
+    /// Reads the OS-platform name from <c>System.Runtime.Versioning.TargetPlatformAttribute</c> on
+    /// <paramref name="entryAssembly"/>, or <see langword="null"/> when the assembly targets no specific OS.
+    /// </summary>
+    internal static string? GetTargetPlatformName(Assembly? entryAssembly)
+    {
+        if (entryAssembly is null)
+        {
+            return null;
+        }
+
+        // TargetPlatformAttribute only exists in the .NET 5+ BCL, so read it by full type name through
+        // CustomAttributeData to keep this method compiling for netstandard2.0 / net462 consumers.
+        foreach (CustomAttributeData attribute in entryAssembly.GetCustomAttributesData())
+        {
+            if (string.Equals(attribute.AttributeType.FullName, "System.Runtime.Versioning.TargetPlatformAttribute", StringComparison.Ordinal)
+                && attribute.ConstructorArguments.Count == 1
+                && attribute.ConstructorArguments[0].Value is string platformName
+                && platformName.Length > 0)
+            {
+                return platformName;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingHelper.cs
@@ -38,8 +38,7 @@ internal static partial class ArtifactNamingHelper
         string? asmName = Assembly.GetEntryAssembly()?.GetName().Name;
         replacements["asm"] = asmName ?? "unknown";
 
-        string? tfm = TargetFrameworkParser.GetShortTargetFramework(Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
-            ?? TargetFrameworkParser.GetShortTargetFramework(RuntimeInformation.FrameworkDescription);
+        string? tfm = TargetFrameworkParser.GetShortTargetFrameworkIncludingPlatform(Assembly.GetEntryAssembly());
         replacements["tfm"] = tfm ?? "unknown";
 
         return replacements;

--- a/src/Platform/SharedExtensionHelpers/TargetFrameworkMonikerHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/TargetFrameworkMonikerHelper.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Testing.Extensions;
 internal static class TargetFrameworkMonikerHelper
 {
     public static string GetTargetFrameworkMoniker()
-        => TargetFrameworkParser.GetShortTargetFramework(Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkDisplayName)
-            ?? TargetFrameworkParser.GetShortTargetFramework(RuntimeInformation.FrameworkDescription)
+        => TargetFrameworkParser.GetShortTargetFrameworkIncludingPlatform(Assembly.GetEntryAssembly())
             ?? "unknown";
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TargetFrameworkParserTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TargetFrameworkParserTests.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NET
+using System.Reflection.Emit;
+#endif
+
 using Microsoft.Testing.Platform.OutputDevice;
 
 namespace Microsoft.Testing.Platform.UnitTests;
@@ -56,4 +60,68 @@ public sealed class TargetFrameworkParserTests
     [TestMethod]
     public void GetTargetPlatformName_WithNullAssembly_ReturnsNull()
         => Assert.IsNull(TargetFrameworkParser.GetTargetPlatformName(null));
+
+#if NET
+    [TestMethod]
+    public void GetTargetPlatformName_WithTargetPlatformAttribute_ReturnsPlatformName()
+    {
+        Assembly dynamicAssembly = CreateAssemblyWithTargetPlatform("Windows10.0.18362.0");
+        Assert.AreEqual("Windows10.0.18362.0", TargetFrameworkParser.GetTargetPlatformName(dynamicAssembly));
+    }
+
+    [TestMethod]
+    public void GetTargetPlatformName_WithoutTargetPlatformAttribute_ReturnsNull()
+    {
+        Assembly dynamicAssembly = CreateAssemblyWithoutTargetPlatform();
+        Assert.IsNull(TargetFrameworkParser.GetTargetPlatformName(dynamicAssembly));
+    }
+
+    [TestMethod]
+    public void GetTargetPlatformName_WithEmptyPlatformValue_ReturnsNull()
+    {
+        Assembly dynamicAssembly = CreateAssemblyWithTargetPlatform(string.Empty);
+        Assert.IsNull(TargetFrameworkParser.GetTargetPlatformName(dynamicAssembly));
+    }
+
+    [TestMethod]
+    public void GetShortTargetFrameworkIncludingPlatform_WithTargetPlatformAttribute_AppendsLowercasedPlatform()
+    {
+        Assembly dynamicAssembly = CreateAssemblyWithTargetPlatform("Windows10.0.18362.0");
+
+        // The dynamic assembly carries no TargetFrameworkAttribute, so the parser falls back to
+        // RuntimeInformation.FrameworkDescription. The point of this test is to verify the platform
+        // discriminator gets appended (and lowercased) on top of whatever the .NET runtime reports.
+        string? result = TargetFrameworkParser.GetShortTargetFrameworkIncludingPlatform(dynamicAssembly);
+
+        Assert.IsNotNull(result);
+        Assert.EndsWith("-windows10.0.18362.0", result);
+    }
+
+    [TestMethod]
+    public void GetShortTargetFrameworkIncludingPlatform_WithoutTargetPlatformAttribute_ReturnsShortTargetFrameworkOnly()
+    {
+        Assembly dynamicAssembly = CreateAssemblyWithoutTargetPlatform();
+
+        string? result = TargetFrameworkParser.GetShortTargetFrameworkIncludingPlatform(dynamicAssembly);
+
+        Assert.IsNotNull(result);
+        Assert.DoesNotContain("-", result);
+    }
+
+    private static Assembly CreateAssemblyWithTargetPlatform(string platformName)
+    {
+        var name = new AssemblyName($"TestAssembly_{Guid.NewGuid():N}");
+        var builder = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndCollect);
+
+        ConstructorInfo ctor = typeof(System.Runtime.Versioning.TargetPlatformAttribute).GetConstructor([typeof(string)])!;
+        builder.SetCustomAttribute(new CustomAttributeBuilder(ctor, [platformName]));
+        return builder;
+    }
+
+    private static Assembly CreateAssemblyWithoutTargetPlatform()
+    {
+        var name = new AssemblyName($"TestAssembly_{Guid.NewGuid():N}");
+        return AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndCollect);
+    }
+#endif
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TargetFrameworkParserTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TargetFrameworkParserTests.cs
@@ -36,4 +36,24 @@ public sealed class TargetFrameworkParserTests
     [TestMethod]
     public void ParseNET(string longName, string expectedShortName)
         => Assert.AreEqual(expectedShortName, TargetFrameworkParser.GetShortTargetFramework(longName));
+
+    [TestMethod]
+    public void BuildTargetFrameworkMoniker_WithoutPlatform_ReturnsShortTargetFramework()
+        => Assert.AreEqual("net8.0", TargetFrameworkParser.BuildTargetFrameworkMoniker("net8.0", null));
+
+    [TestMethod]
+    public void BuildTargetFrameworkMoniker_WithEmptyPlatform_ReturnsShortTargetFramework()
+        => Assert.AreEqual("net8.0", TargetFrameworkParser.BuildTargetFrameworkMoniker("net8.0", string.Empty));
+
+    [TestMethod]
+    public void BuildTargetFrameworkMoniker_WithPlatform_AppendsLowercasedPlatform()
+        => Assert.AreEqual("net8.0-windows10.0.18362.0", TargetFrameworkParser.BuildTargetFrameworkMoniker("net8.0", "Windows10.0.18362.0"));
+
+    [TestMethod]
+    public void BuildTargetFrameworkMoniker_WithNullShortTargetFramework_ReturnsNull()
+        => Assert.IsNull(TargetFrameworkParser.BuildTargetFrameworkMoniker(null, "Windows10.0.18362.0"));
+
+    [TestMethod]
+    public void GetTargetPlatformName_WithNullAssembly_ReturnsNull()
+        => Assert.IsNull(TargetFrameworkParser.GetTargetPlatformName(null));
 }


### PR DESCRIPTION
## Problem

The internal pipeline emits warnings like:

> The JUnit report file `...\Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests_net8.0_x64.xml` already exists and will be overwritten.

This is **not** a duplicate test run. The three affected projects (`TestFramework.UnitTests`, `MSTestAdapter.UnitTests`, `MSTestAdapter.PlatformServices.UnitTests`) are exactly the three that, on Windows, multi-target an extra OS-specific TFM `$(WinUiMinimum)` = `net8.0-windows10.0.18362.0` alongside `net8.0`. Both modules genuinely run, but the report file name uses the **short** TFM, which collapses `net8.0-windows10.0.18362.0` down to `net8.0`. Both therefore resolve to the identical `<asm>_net8.0_x64.xml`, so the second run overwrites the first — silently losing one platform build report (TRX/CTRF collide the same way, just without a warning).

## Root cause

A plain `net8.0` build and a `net8.0-windows10.0.18362.0` build carry the **same** `TargetFrameworkAttribute(".NETCoreApp,Version=v8.0")` and the same `RuntimeInformation.FrameworkDescription`, so the short TFM cannot tell them apart. The only runtime-visible discriminator is `System.Runtime.Versioning.TargetPlatformAttribute("Windows10.0.18362.0")`, which the SDK emits for OS-specific TFMs only.

## Fix

- Add `TargetFrameworkParser.GetShortTargetFrameworkIncludingPlatform(Assembly?)` which appends the OS platform (read by full type name via `CustomAttributeData` so it still compiles for `netstandard2.0`/`net462`) when present, yielding e.g. `net8.0-windows10.0.18362.0`.
- Route the report-naming helpers through it: `TargetFrameworkMonikerHelper` (JUnit/HTML/TRX/CTRF default `{asm}_{tfm}_{arch}` names + AzDO labels), `ArtifactNamingHelper` `{tfm}` placeholder (`--report-*-filename` templates + HangDump), and `CtrfReportEngine`.
- Terminal/console display TFM is intentionally left as the short form to avoid help/info acceptance-test churn.

Result: the two Windows modules now write distinct `..._net8.0_x64.xml` and `..._net8.0-windows10.0.18362.0_x64.xml` — no collision, no overwrite warning, no lost report.

## Testing

- Builds clean across `net8.0`/`net9.0`/`netstandard2.0`/`net462` for all consumers.
- 5 new unit tests in `TargetFrameworkParserTests` (17/17 pass); `ArtifactNamingHelper` 18/18.
- `Microsoft.Testing.Extensions.UnitTests` report/naming suite: 231 passed, 4 skipped, 0 failed.
- Empirically confirmed `TargetPlatformAttribute` is present on the real built `net8.0-windows10.0.18362.0` assembly and absent on `net8.0`.
