### PR TITLE
Quote MSBuild function results in == conditions (B-2) (#9023)

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Sdk.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Sdk.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- If the project targets .NET Standard, it's not supposed to be a test application. So, we default to false. -->
-    <IsTestApplication Condition=" '$(IsTestApplication)' == '' AND $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETStandard' ">false</IsTestApplication>
+    <IsTestApplication Condition=" '$(IsTestApplication)' == '' AND '$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETStandard' ">false</IsTestApplication>
     <IsTestApplication Condition=" '$(IsTestApplication)' == '' ">true</IsTestApplication>
   </PropertyGroup>
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -13,7 +13,7 @@
     <MSTestAnalysisMode>Recommended</MSTestAnalysisMode>
 
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --diagnostic --diagnostic-output-directory $(RepoRoot)artifacts/log/$(Configuration) --diagnostic-file-prefix $(ModuleName) --diagnostic-verbosity trace</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments Condition=" $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-ctrf --report-ctrf-filename $(MSBuildProjectName)_$(TargetFramework).ctrf.json</TestingPlatformCommandLineArguments>


### PR DESCRIPTION
Addresses the MSBuild file quality findings in #9023 (Rule B-2: quote both operands of `==` in MSBuild conditions).

## Changes
- `src/Package/MSTest.Sdk/Sdk/Sdk.targets` — quote the `GetTargetFrameworkIdentifier` result in the `IsTestApplication` condition.
- `test/Directory.Build.targets` — quote the `GetTargetFrameworkIdentifier` result in the `--crashdump` condition.

The third finding (`Common.targets` `TestingExtensionsProfile`) was already fixed on `main`.

## Note on the suggested fix
The report suggested keeping the inner argument quotes, e.g. `'$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)'))'`. That form fails with **MSB4092** (`unexpected token`) because of the nested single quotes. This PR instead removes the inner argument quotes and wraps the whole function call: `'$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))'`. Verified that this evaluates correctly for `net8.0` and for an empty `TargetFramework` (returns empty, no error).

Closes #9023