### PR TITLE
Reduce duplication in CTRF/JUnit/HTML report extensions (#9129, #9131, #9132)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.CtrfReport;
+using Microsoft.Testing.Extensions.CtrfReport.Resources;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Helpers;
@@ -22,6 +23,11 @@ public static class CtrfReportExtensions
     /// <param name="builder">The test application builder.</param>
     public static void AddCtrfReportProvider(this ITestApplicationBuilder builder)
     {
+        if (builder is not TestApplicationBuilder)
+        {
+            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
+        }
+
         var commandLine = new CtrfReportGeneratorCommandLine();
 
         var compositeCtrfReportGenerator =

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGeneratorCommandLine.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.CtrfReport.Resources;
-using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Extensions;
-using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
-internal sealed class CtrfReportGeneratorCommandLine : CommandLineOptionsProviderBase
+internal sealed class CtrfReportGeneratorCommandLine : ReportGeneratorCommandLineBase
 {
     public const string CtrfReportOptionName = "report-ctrf";
     public const string CtrfReportFileNameOptionName = "report-ctrf-filename";
@@ -16,32 +13,18 @@ internal sealed class CtrfReportGeneratorCommandLine : CommandLineOptionsProvide
     public CtrfReportGeneratorCommandLine()
         : base(
             nameof(CtrfReportGeneratorCommandLine),
-            ExtensionVersion.DefaultSemVer,
             ExtensionResources.CtrfReportGeneratorDisplayName,
             ExtensionResources.CtrfReportGeneratorDescription,
-            [
-                new(CtrfReportOptionName, ExtensionResources.CtrfReportOptionDescription, ArgumentArity.Zero, false),
-                new(CtrfReportFileNameOptionName, ExtensionResources.CtrfReportFileNameOptionDescription, ArgumentArity.ExactlyOne, false),
-            ])
-    {
-    }
-
-    public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
-        => commandOption.Name == CtrfReportFileNameOptionName
-            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
-                arguments,
-                ".json",
-                ExtensionResources.CtrfReportFileNameMustNotBeEmpty,
-                ExtensionResources.CtrfReportFileNameExtensionIsNotJson,
-                ExtensionResources.CtrfReportFileNameRelativePathMustStayUnderResultsDirectory)
-            : ValidationResult.ValidTask;
-
-    public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
-            commandLineOptions,
             CtrfReportOptionName,
             CtrfReportFileNameOptionName,
+            ExtensionResources.CtrfReportOptionDescription,
+            ExtensionResources.CtrfReportFileNameOptionDescription,
+            ".json",
+            ExtensionResources.CtrfReportFileNameMustNotBeEmpty,
+            ExtensionResources.CtrfReportFileNameExtensionIsNotJson,
+            ExtensionResources.CtrfReportFileNameRelativePathMustStayUnderResultsDirectory,
             ExtensionResources.CtrfReportFileNameRequiresCtrfReport,
-            ExtensionResources.CtrfReportIsNotValidForDiscovery,
-            PlatformCommandLineProvider.DiscoverTestsOptionKey);
+            ExtensionResources.CtrfReportIsNotValidForDiscovery)
+    {
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -56,7 +56,9 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/ExtensionResources.resx
@@ -108,4 +108,8 @@ Example: MyReport_{tfm}.ctrf.json</value>
     <value>Enable generating a CTRF (Common Test Report Format) JSON report</value>
     <comment>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</comment>
   </data>
+  <data name="InvalidTestApplicationBuilderType" xml:space="preserve">
+    <value>Invalid test application builder type. Expected 'TestApplicationBuilder'.</value>
+    <comment>Do not localize {Locked="TestApplicationBuilder"}.</comment>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -66,6 +66,11 @@ Příklad: MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Povolit generování sestavy JSON CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.de.xlf
@@ -66,6 +66,11 @@ Beispiel: MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Generierung eines CTRF-JSON-Berichts (Common Test Report Format) aktivieren</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.es.xlf
@@ -66,6 +66,11 @@ Ejemplo: MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Habilitación de la generación de un informe JSON de CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -66,6 +66,11 @@ Exemple : MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Activer la génération d’un rapport JSON CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.it.xlf
@@ -66,6 +66,11 @@ Esempio: MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Abilita la generazione di un report JSON CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -66,6 +66,11 @@ Example: MyReport_{tfm}.ctrf.json</source>
         <target state="translated">CTRF (Common Test Report Format) JSON レポートの生成を有効にする</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -66,6 +66,11 @@ Example: MyReport_{tfm}.ctrf.json</source>
         <target state="translated">CTRF(Common Test Report Format) JSON 보고서 생성 사용</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -66,6 +66,11 @@ Przykład: MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Włącz generowanie raportu JSON CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -66,6 +66,11 @@ Exemplo: MyReport_{tfm}.ctrf.json</target>
         <target state="translated">Habilitar a geração de um relatório JSON CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -66,6 +66,11 @@ Example: MyReport_{tfm}.ctrf.json</source>
         <target state="translated">Включить создание JSON-отчета в формате CTRF (Common Test Report Format)</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -66,6 +66,11 @@ Example: MyReport_{tfm}.ctrf.json</source>
         <target state="translated">CTRF (Common Test Report Format) JSON raporu oluşturmayı etkinleştir</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -66,6 +66,11 @@ Example: MyReport_{tfm}.ctrf.json</source>
         <target state="translated">启用生成 CTRF (Common Test Report Format) JSON 报表</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -66,6 +66,11 @@ Example: MyReport_{tfm}.ctrf.json</source>
         <target state="translated">能夠產生 CTRF (Common Test Report Format) JSON 報告</target>
         <note>Do not localize option name {Locked="--report-ctrf"} or format names {Locked="CTRF"}{Locked="Common Test Report Format"}{Locked="JSON"}.</note>
       </trans-unit>
+      <trans-unit id="InvalidTestApplicationBuilderType">
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
+        <target state="new">Invalid test application builder type. Expected 'TestApplicationBuilder'.</target>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 // stdout/stderr/stack traces) in memory for the whole session.
 internal static class TestResultCapture
 {
-    internal const int MaxStandardStreamLength = 32 * 1024;
-    internal const int MaxStackTraceLength = 32 * 1024;
-    internal const int MaxMessageLength = 16 * 1024;
-    internal const int MaxIdentityFieldLength = 4 * 1024;
-    internal const int MaxTraitFieldLength = 1024;
+    internal const int MaxStandardStreamLength = TestResultCaptureHelper.MaxStandardStreamLength;
+    internal const int MaxStackTraceLength = TestResultCaptureHelper.MaxStackTraceLength;
+    internal const int MaxMessageLength = TestResultCaptureHelper.MaxMessageLength;
+    internal const int MaxIdentityFieldLength = TestResultCaptureHelper.MaxIdentityFieldLength;
+    internal const int MaxTraitFieldLength = TestResultCaptureHelper.MaxTraitFieldLength;
 
     public static CapturedTestResult? TryCapture(TestNode node)
     {
@@ -149,8 +149,5 @@ internal static class TestResultCapture
     }
 
     internal static string? Truncate(string? value, int maxLength)
-        => value is null || value.Length <= maxLength
-            ? value
-            : value.Substring(0, maxLength)
-                + $"\n…[truncated, original length: {value.Length.ToString(CultureInfo.InvariantCulture)}]";
+        => TestResultCaptureHelper.Truncate(value, maxLength);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.HtmlReport.Resources;
-using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Extensions;
-using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
-internal sealed class HtmlReportGeneratorCommandLine : CommandLineOptionsProviderBase
+internal sealed class HtmlReportGeneratorCommandLine : ReportGeneratorCommandLineBase
 {
     public const string HtmlReportOptionName = "report-html";
     public const string HtmlReportFileNameOptionName = "report-html-filename";
@@ -16,32 +13,18 @@ internal sealed class HtmlReportGeneratorCommandLine : CommandLineOptionsProvide
     public HtmlReportGeneratorCommandLine()
         : base(
             nameof(HtmlReportGeneratorCommandLine),
-            ExtensionVersion.DefaultSemVer,
             ExtensionResources.HtmlReportGeneratorDisplayName,
             ExtensionResources.HtmlReportGeneratorDescription,
-            [
-                new(HtmlReportOptionName, ExtensionResources.HtmlReportOptionDescription, ArgumentArity.Zero, false),
-                new(HtmlReportFileNameOptionName, ExtensionResources.HtmlReportFileNameOptionDescription, ArgumentArity.ExactlyOne, false),
-            ])
-    {
-    }
-
-    public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
-        => commandOption.Name == HtmlReportFileNameOptionName
-            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
-                arguments,
-                ".html",
-                ExtensionResources.HtmlReportFileNameMustNotBeEmpty,
-                ExtensionResources.HtmlReportFileNameExtensionIsNotHtml,
-                ExtensionResources.HtmlReportFileNameRelativePathMustStayUnderResultsDirectory)
-            : ValidationResult.ValidTask;
-
-    public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
-            commandLineOptions,
             HtmlReportOptionName,
             HtmlReportFileNameOptionName,
+            ExtensionResources.HtmlReportOptionDescription,
+            ExtensionResources.HtmlReportFileNameOptionDescription,
+            ".html",
+            ExtensionResources.HtmlReportFileNameMustNotBeEmpty,
+            ExtensionResources.HtmlReportFileNameExtensionIsNotHtml,
+            ExtensionResources.HtmlReportFileNameRelativePathMustStayUnderResultsDirectory,
             ExtensionResources.HtmlReportFileNameRequiresHtmlReport,
-            ExtensionResources.HtmlReportIsNotValidForDiscovery,
-            PlatformCommandLineProvider.DiscoverTestsOptionKey);
+            ExtensionResources.HtmlReportIsNotValidForDiscovery)
+    {
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -54,6 +54,7 @@ This package extends Microsoft Testing Platform to produce self-contained HTML t
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
-using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Extensions;
-using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
-internal sealed class JUnitReportGeneratorCommandLine : CommandLineOptionsProviderBase
+internal sealed class JUnitReportGeneratorCommandLine : ReportGeneratorCommandLineBase
 {
     public const string JUnitReportOptionName = "report-junit";
     public const string JUnitReportFileNameOptionName = "report-junit-filename";
@@ -16,32 +13,18 @@ internal sealed class JUnitReportGeneratorCommandLine : CommandLineOptionsProvid
     public JUnitReportGeneratorCommandLine()
         : base(
             nameof(JUnitReportGeneratorCommandLine),
-            ExtensionVersion.DefaultSemVer,
             ExtensionResources.JUnitReportGeneratorDisplayName,
             ExtensionResources.JUnitReportGeneratorDescription,
-            [
-                new(JUnitReportOptionName, ExtensionResources.JUnitReportOptionDescription, ArgumentArity.Zero, false),
-                new(JUnitReportFileNameOptionName, ExtensionResources.JUnitReportFileNameOptionDescription, ArgumentArity.ExactlyOne, false),
-            ])
-    {
-    }
-
-    public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
-        => commandOption.Name == JUnitReportFileNameOptionName
-            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
-                arguments,
-                ".xml",
-                ExtensionResources.JUnitReportFileNameMustNotBeEmpty,
-                ExtensionResources.JUnitReportFileNameExtensionIsNotXml,
-                ExtensionResources.JUnitReportFileNameRelativePathMustStayUnderResultsDirectory)
-            : ValidationResult.ValidTask;
-
-    public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
-        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
-            commandLineOptions,
             JUnitReportOptionName,
             JUnitReportFileNameOptionName,
+            ExtensionResources.JUnitReportOptionDescription,
+            ExtensionResources.JUnitReportFileNameOptionDescription,
+            ".xml",
+            ExtensionResources.JUnitReportFileNameMustNotBeEmpty,
+            ExtensionResources.JUnitReportFileNameExtensionIsNotXml,
+            ExtensionResources.JUnitReportFileNameRelativePathMustStayUnderResultsDirectory,
             ExtensionResources.JUnitReportFileNameRequiresJUnitReport,
-            ExtensionResources.JUnitReportIsNotValidForDiscovery,
-            PlatformCommandLineProvider.DiscoverTestsOptionKey);
+            ExtensionResources.JUnitReportIsNotValidForDiscovery)
+    {
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -52,6 +52,7 @@ This package extends Microsoft Testing Platform to produce JUnit XML test report
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorCommandLineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorCommandLineBase.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+
+namespace Microsoft.Testing.Extensions;
+
+internal abstract class ReportGeneratorCommandLineBase : CommandLineOptionsProviderBase
+{
+    private readonly string _reportOptionName;
+    private readonly string _reportFileNameOptionName;
+    private readonly string _fileExtension;
+    private readonly string _fileNameMustNotBeEmpty;
+    private readonly string _fileNameExtensionIsNotExpected;
+    private readonly string _relativePathMustStayUnderResultsDirectory;
+    private readonly string _fileNameRequiresReport;
+    private readonly string _reportIsNotValidForDiscovery;
+
+    protected ReportGeneratorCommandLineBase(
+        string providerName,
+        string displayName,
+        string description,
+        string reportOptionName,
+        string reportFileNameOptionName,
+        string reportOptionDescription,
+        string reportFileNameOptionDescription,
+        string fileExtension,
+        string fileNameMustNotBeEmpty,
+        string fileNameExtensionIsNotExpected,
+        string relativePathMustStayUnderResultsDirectory,
+        string fileNameRequiresReport,
+        string reportIsNotValidForDiscovery)
+        : base(
+            providerName,
+            ExtensionVersion.DefaultSemVer,
+            displayName,
+            description,
+            [
+                new(reportOptionName, reportOptionDescription, ArgumentArity.Zero, false),
+                new(reportFileNameOptionName, reportFileNameOptionDescription, ArgumentArity.ExactlyOne, false),
+            ])
+    {
+        _reportOptionName = reportOptionName;
+        _reportFileNameOptionName = reportFileNameOptionName;
+        _fileExtension = fileExtension;
+        _fileNameMustNotBeEmpty = fileNameMustNotBeEmpty;
+        _fileNameExtensionIsNotExpected = fileNameExtensionIsNotExpected;
+        _relativePathMustStayUnderResultsDirectory = relativePathMustStayUnderResultsDirectory;
+        _fileNameRequiresReport = fileNameRequiresReport;
+        _reportIsNotValidForDiscovery = reportIsNotValidForDiscovery;
+    }
+
+    public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
+        => commandOption.Name == _reportFileNameOptionName
+            ? ReportFileNameValidator.ValidateReportFileNameArgumentAsync(
+                arguments,
+                _fileExtension,
+                _fileNameMustNotBeEmpty,
+                _fileNameExtensionIsNotExpected,
+                _relativePathMustStayUnderResultsDirectory)
+            : ValidationResult.ValidTask;
+
+    public override Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
+        => ReportFileNameValidator.ValidateReportCommandLineOptionsAsync(
+            commandLineOptions,
+            _reportOptionName,
+            _reportFileNameOptionName,
+            _fileNameRequiresReport,
+            _reportIsNotValidForDiscovery,
+            PlatformCommandLineProvider.DiscoverTestsOptionKey);
+}


### PR DESCRIPTION
Fixes #9129, #9131, #9132 (sub-issues of the #9130 Duplicate Code Detector group).

All three are duplicate-code findings across the CTRF / JUnit / HTML report extensions. The changes touch disjoint files and were validated together.

### #9129 — CTRF `TestResultCapture` duplicated constants + divergent `Truncate`
- `CtrfReport/TestResultCapture.cs` now delegates the 5 size constants and `Truncate` to the canonical `TestResultCaptureHelper` (matching JUnit/HTML).
- This also fixes a latent bug: the old CTRF `Truncate` could split a UTF-16 surrogate pair, producing an invalid string; the shared helper guards against that.
- Linked `TestResultCaptureHelper.cs` into the CtrfReport project (it was not previously linked).

### #9131 — Missing `TestApplicationBuilder` guard in `CtrfReportExtensions`
- Added the `if (builder is not TestApplicationBuilder) throw ...` guard to `AddCtrfReportProvider` so CTRF fails fast like JUnit/HTML instead of silently succeeding against unsupported custom builders.
- Added the `InvalidTestApplicationBuilderType` resource string and regenerated all 13 `.xlf` files via `/t:UpdateXlf`.

### #9132 — Identical `*ReportGeneratorCommandLine` structure
- Extracted `ReportGeneratorCommandLineBase` into `SharedExtensionHelpers`, holding the two validation overrides once.
- Ctrf/JUnit/Html providers now derive from it as small constants + constructor declarations.
- **Pure refactor**: provider names (uids), option names, descriptions, arity, and validation are byte-for-byte unchanged, so `--help`/`--info` output is unaffected.

### Validation
- All three extension projects build clean (0 warnings, 0 errors) across net8.0/net9.0/netstandard2.0.
- `Microsoft.Testing.Extensions.UnitTests` (net9.0): 507 passed, 0 failed, 4 skipped (unrelated Windows crash-report tests).
