### PR TITLE
Scope CI runs by changed paths (product vs samples)

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -12,6 +12,11 @@ trigger:
       - .github/**
       - .gitignore
       - azure-pipelines-codeql.yml
+      # The official pipeline ships product packages. The samples/** folder is not part of the
+      # shipping product (it is built by the PR pipeline via eng/build-samples.ps1). Skip the
+      # official pipeline for samples-only changes.
+      - samples/**
+      - eng/build-samples.ps1
 
 parameters:
 - name: isRTM

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,9 @@ stages:
         set -euo pipefail
 
         target="${SYSTEM_PULLREQUEST_TARGETBRANCH:-}"
+        # ADO exposes the target branch as a full ref (e.g. "refs/heads/main"); strip the
+        # "refs/heads/" prefix so it can be combined with the "origin/" remote-tracking prefix.
+        target="${target#refs/heads/}"
         if [[ -z "${target}" ]]; then
           echo "Not a PR build (SYSTEM_PULLREQUEST_TARGETBRANCH is empty); running all jobs."
           hasProduct=true
@@ -88,13 +91,16 @@ stages:
             hasProduct=true
             hasSamples=true
           else
-            # Anything outside samples/** counts as a product change.
-            if echo "${files}" | grep -qv '^samples/'; then
+            # A file is a "samples-affecting" change if it lives under samples/** or it is
+            # one of the eng/ scripts that drives the samples build (build-samples.ps1).
+            # Everything else is treated as a product change.
+            samples_pattern='^(samples/|eng/build-samples\.ps1$)'
+            if echo "${files}" | grep -Eqv "${samples_pattern}"; then
               hasProduct=true
             else
               hasProduct=false
             fi
-            if echo "${files}" | grep -q '^samples/'; then
+            if echo "${files}" | grep -Eq "${samples_pattern}"; then
               hasSamples=true
             else
               hasSamples=false
@@ -123,7 +129,7 @@ stages:
       jobs:
       - job: Windows
         dependsOn: DetectChanges
-        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
+        condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         timeoutInMinutes: 90
         pool:
           name: NetCore-Public
@@ -254,7 +260,7 @@ stages:
 
       - job: Linux
         dependsOn: DetectChanges
-        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
+        condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         timeoutInMinutes: 90
         pool:
           name: NetCore-Public
@@ -284,7 +290,7 @@ stages:
 
       - job: MacOS
         dependsOn: DetectChanges
-        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
+        condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         timeoutInMinutes: 90
         pool:
           name: Azure Pipelines
@@ -325,7 +331,7 @@ stages:
       jobs:
       - job: WindowsSamples
         dependsOn: DetectChanges
-        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasSamplesChanges'], 'false'))
+        condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasSamplesChanges'], 'false'))
         timeoutInMinutes: 30
         pool:
           name: NetCore-Public

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,71 @@ stages:
   displayName: Build
   jobs:
 
+  # Lightweight job that classifies the PR diff into two scopes (product vs samples)
+  # and exposes them as output variables. Downstream jobs use them to skip work that
+  # the diff does not touch (so e.g. a samples-only Dependabot PR does not spin up
+  # the full Windows/Linux/macOS product matrix, and a product-only PR does not run
+  # the samples build).
+  #
+  # Fail-safe behaviour:
+  #   - Non-PR triggers (manual queue, scheduled, etc.) leave SYSTEM_PULLREQUEST_TARGETBRANCH
+  #     empty, so we emit "true" for both flags and run everything.
+  #   - If the diff is empty (e.g. force-push to the same SHA), we also run everything.
+  #   - Downstream conditions use `ne(..., 'false')` rather than `eq(..., 'true')`
+  #     so a missing/empty output (e.g. detect step failed) still runs the job.
+  - job: DetectChanges
+    displayName: Detect changed paths
+    pool:
+      name: NetCore-Public
+      demands: ImageOverride -equals build.ubuntu.2204.amd64.open
+    steps:
+    - checkout: self
+      fetchDepth: 0
+      clean: false
+    - bash: |
+        set -euo pipefail
+
+        target="${SYSTEM_PULLREQUEST_TARGETBRANCH:-}"
+        if [[ -z "${target}" ]]; then
+          echo "Not a PR build (SYSTEM_PULLREQUEST_TARGETBRANCH is empty); running all jobs."
+          hasProduct=true
+          hasSamples=true
+        else
+          echo "PR target branch: ${target}"
+          git fetch --no-tags --depth=200 origin "${target}" 2>/dev/null \
+            || git fetch --no-tags origin "${target}"
+          base="$(git merge-base "origin/${target}" HEAD)"
+          echo "Diff range: ${base}..HEAD"
+          files="$(git diff --name-only "${base}" HEAD)"
+          echo "Changed files:"
+          echo "${files}"
+
+          if [[ -z "${files}" ]]; then
+            echo "No files changed in diff; running all jobs."
+            hasProduct=true
+            hasSamples=true
+          else
+            # Anything outside samples/** counts as a product change.
+            if echo "${files}" | grep -qv '^samples/'; then
+              hasProduct=true
+            else
+              hasProduct=false
+            fi
+            if echo "${files}" | grep -q '^samples/'; then
+              hasSamples=true
+            else
+              hasSamples=false
+            fi
+          fi
+        fi
+
+        echo "hasProductChanges=${hasProduct}"
+        echo "hasSamplesChanges=${hasSamples}"
+        echo "##vso[task.setvariable variable=hasProductChanges;isOutput=true]${hasProduct}"
+        echo "##vso[task.setvariable variable=hasSamplesChanges;isOutput=true]${hasSamples}"
+      name: detect
+      displayName: Classify changed files
+
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
@@ -57,6 +122,8 @@ stages:
       enableTelemetry: true
       jobs:
       - job: Windows
+        dependsOn: DetectChanges
+        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         timeoutInMinutes: 90
         pool:
           name: NetCore-Public
@@ -186,6 +253,8 @@ stages:
             condition: failed()
 
       - job: Linux
+        dependsOn: DetectChanges
+        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         timeoutInMinutes: 90
         pool:
           name: NetCore-Public
@@ -214,6 +283,8 @@ stages:
               osName: Linux
 
       - job: MacOS
+        dependsOn: DetectChanges
+        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         timeoutInMinutes: 90
         pool:
           name: Azure Pipelines
@@ -253,6 +324,8 @@ stages:
       enableTelemetry: true
       jobs:
       - job: WindowsSamples
+        dependsOn: DetectChanges
+        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasSamplesChanges'], 'false'))
         timeoutInMinutes: 30
         pool:
           name: NetCore-Public


### PR DESCRIPTION
## What

Scope CI to only run the work a PR actually touches:

* PR pipeline (`azure-pipelines.yml`) — add a lightweight `DetectChanges` job that classifies the PR diff into `hasProductChanges` and `hasSamplesChanges` output variables. Existing jobs gate on those:
  * `Windows` / `Linux` / `MacOS` skip when only `samples/**` changed.
  * `WindowsSamples` skips when `samples/**` was not touched.
* Official pipeline (`azure-pipelines-official.yml`) — add `samples/**` and `eng/build-samples.ps1` to `paths.exclude` so the shipping pipeline does not trigger on samples-only changes.

## Why

Today a Dependabot bump like #9122 (only touches `samples/public/global.json`) spins up the full Windows/Linux/macOS product matrix even though none of that work is exercised by the change. Conversely every product PR rebuilds all samples even when they cannot have been affected. Both legs are wasted compute and add 5–25 min to the PR turnaround.

## Fail-safe behaviour

* The classifier is intentionally permissive — downstream jobs use `ne(..., 'false')` rather than `eq(..., 'true')`, so:
  * a missing/empty output (e.g. detect step failed) still runs the job, and
  * non-PR triggers (manual queue, scheduled, etc.) leave `SYSTEM_PULLREQUEST_TARGETBRANCH` empty and the script emits `true` for both flags → nothing is skipped.
* An empty diff also runs everything.

## Verification

Tested the classification bash locally against six representative input sets (samples-only, product-only, mixed, empty, single file, nested samples) — all pass. Also re-ran the script against PR #9122's actual diff via `git diff` and got `hasProductChanges=false`, `hasSamplesChanges=true` as expected.

## Branch-protection note for reviewers

When a job is skipped by `condition: false`, AzDO reports the corresponding GitHub status check as `Skipped` (neutral). If any of `microsoft.testfx (Build Windows/Linux/MacOS/WindowsSamples *)` is configured as a *required* status check in branch protection, please confirm the rule treats `Skipped` as passing (default behaviour for AzDO GitHub status checks). If not, the required-checks list should be relaxed or moved up to just `microsoft.testfx` (the pipeline-level rollup), which already reports success when all non-skipped jobs pass.

Closes nothing on its own but unblocks more responsive CI feedback for samples-only Dependabot PRs.