### PR TITLE
Fix MSTEST0032 in CommandLineParseResult reflexivity test

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineParseResultTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineParseResultTests.cs
@@ -204,7 +204,7 @@ public sealed class CommandLineParseResultTests
     {
         var a = new CommandLineParseResult("tool", [], []);
 
-        Assert.AreEqual(a, a);
+        Assert.IsTrue(a.Equals(a));
     }
 
     [TestMethod]


### PR DESCRIPTION
Unblocks darc-main PR #9128.

## Investigation

PR #9128 (darc-main dependency bump of MSTest analyzers from `4.3.0-preview.26312.9` to `4.3.0-preview.26314.12`) brings in [MSTest PR #9087](https://github.com/microsoft/testfx/pull/9087) — `Flag Assert.AreEqual(x, x) / AreSame(x, x) / AreNotEqual(x, x) / AreNotSame(x, x)`. With the new analyzer rule, `CommandLineParseResultTests.Equals_ReturnsTrueForSameReference` now fails with:

```
CommandLineParseResultTests.cs(207,9): error MSTEST0032: Review or remove the assertion as its condition is known to be always true
```

### Is this a true error?

**Yes.** The analyzer is correct, on two fronts:

1. **Structural diagnostic** — `Assert.AreEqual(a, a)` has syntactically identical `expected` and `actual` operands, so it is a tautology at compile time. Any regression in `Equals` would not be detected: `EqualityComparer<T>.Default.Equals(a, a)` short-circuits via `ReferenceEquals` before ever calling the overridden `Equals(object?)`.
2. **Intent mismatch** — the test name is `Equals_ReturnsTrueForSameReference`. To exercise the `IEquatable` reflexivity contract the test must invoke `Equals` directly. `Assert.IsTrue(a.Equals(a))` does that and is also clearer about intent.

The MSTest rule does **not** need to be relaxed: the canonical way to assert reflexivity is to call `Equals` explicitly. No other production test in the repo is affected (the matches in `test/UnitTests/TestFramework.UnitTests` and `test/IntegrationTests/TestAssets/*` either test `Assert` itself via the internal `TestContainer` framework or are pre-built test assets, neither of which run MSTest analyzers).

## Fix

Replace `Assert.AreEqual(a, a)` with `Assert.IsTrue(a.Equals(a))` in `Equals_ReturnsTrueForSameReference`.

Verified locally:
- `build.cmd -projects test/UnitTests/Microsoft.Testing.Platform.UnitTests/...` — 0 warnings, 0 errors
- `dotnet run ... -f net8.0 -- --filter "FullyQualifiedName~CommandLineParseResultTests"` — 22/22 passed
