### PR TITLE
Pin MessagePack in sample projects (missed in #9120 / #9124)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,9 +96,18 @@
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
-    <!-- This comes transitively via StreamJsonRpc, but we want to upgrade it to fix a security vulnerability -->
+    <!--
+      Nerdbank.MessagePack and MessagePack both come transitively via StreamJsonRpc, but we pin them
+      here to pick up versions that fix security vulnerabilities in the transitive versions shipped
+      by StreamJsonRpc.
+
+      IMPORTANT: Central Package Management only pins the version when a project actually declares a
+      <PackageReference> for the package. Any project that references StreamJsonRpc (directly or via
+      a ProjectReference chain) must ALSO add explicit <PackageReference Include="Nerdbank.MessagePack" />
+      AND <PackageReference Include="MessagePack" /> entries, otherwise the transitive (vulnerable)
+      versions get restored. See PR #9120 / #9124 for context.
+    -->
     <PackageVersion Include="Nerdbank.MessagePack" Version="1.2.4" />
-    <!-- This comes transitively via StreamJsonRpc, but we want to upgrade it to fix a security vulnerability -->
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="StrongNamer" Version="0.2.5" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/samples/FSharpPlayground/FSharpPlayground.fsproj
+++ b/samples/FSharpPlayground/FSharpPlayground.fsproj
@@ -25,6 +25,8 @@
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
     <PackageReference Include="Nerdbank.MessagePack" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
   </ItemGroup>

--- a/samples/Playground/Playground.csproj
+++ b/samples/Playground/Playground.csproj
@@ -26,7 +26,10 @@
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers.CodeFixes\MSTest.Analyzers.CodeFixes.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
     <ProjectReference Include="$(RepoRoot)src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
     <PackageReference Include="Nerdbank.MessagePack" />
+    <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
+    <PackageReference Include="MessagePack" />
     <PackageReference Include="StreamJsonRpc" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Telemetry\Microsoft.Testing.Extensions.Telemetry.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.TrxReport\Microsoft.Testing.Extensions.TrxReport.csproj" />


### PR DESCRIPTION
PR #9120 / #9124 pinned `MessagePack` via `Directory.Packages.props` and added explicit `<PackageReference Include="MessagePack" />` to the acceptance test projects, but missed the two sample projects (`samples/Playground` and `samples/FSharpPlayground`) that also pull `StreamJsonRpc` transitively.

Central Package Management only enforces the pinned version on projects that declare an explicit `PackageReference`, so those samples were still restoring the vulnerable transitive `MessagePack 2.5.x`.

## Changes

- Add explicit `<PackageReference Include="MessagePack" />` (with the same security-pinning comment used in the acceptance test projects) to both sample project files.
- Expand the comment above the `Nerdbank.MessagePack` / `MessagePack` `PackageVersion` entries in `Directory.Packages.props` with an **IMPORTANT** note explaining the CPM gotcha and instructing future contributors to add explicit `PackageReference`s for **both** `Nerdbank.MessagePack` and `MessagePack` on every `StreamJsonRpc` consumer.

## Verification

Restored both samples; `artifacts/obj/{Playground,FSharpPlayground}/project.assets.json` now contain `MessagePack/3.1.7` (well above the requested 2.5.301).

Closes the gap reported in this user request:

> Upgrade MessagePack from 2.5.198 to 2.5.301 to fix the vulnerability.
> Location: /samples/FSharpPlayground/FSharpPlayground.fsproj, /samples/Playground/Playground.csproj