### PR TITLE
Add Assert.AddValueFormatter for customizing assertion failure rendering

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.AddValueFormatter.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AddValueFormatter.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// A collection of helper classes to test various conditions within
+/// unit tests. If the condition being tested is not met, an exception
+/// is thrown.
+/// </summary>
+public sealed partial class Assert
+{
+    /// <summary>
+    /// Registers a custom formatter that controls how values of <typeparamref name="T"/> are rendered
+    /// inside structured assertion failure messages. The registration is scoped to the current asynchronous
+    /// flow (backed by <see cref="AsyncLocal{T}"/>) and is removed when the returned <see cref="IDisposable"/>
+    /// is disposed.
+    /// </summary>
+    /// <typeparam name="T">The type whose rendered representation should be customized.</typeparam>
+    /// <param name="formatter">
+    /// A function that returns the string representation to use, or <see langword="null"/> to fall through to
+    /// the next registered formatter (or the built-in renderer when no other formatter handles the value).
+    /// </param>
+    /// <returns>An <see cref="IDisposable"/> whose disposal removes the registration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="formatter"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// <para>
+    /// Formatters affect only how values are rendered in failure messages. They do not change equality
+    /// comparisons performed by assertions such as <c>Assert.AreEqual</c>. To customize equality, use the
+    /// existing <see cref="IEqualityComparer{T}"/> overloads.
+    /// </para>
+    /// <para>
+    /// Registrations stack newest-first: the most recently registered formatter is consulted first.
+    /// A formatter returning <see langword="null"/> defers to the next formatter, and ultimately to the
+    /// built-in renderer. <see langword="null"/> values are always rendered as <c>"null"</c> by the
+    /// built-in renderer and are never passed to user formatters.
+    /// </para>
+    /// <para>
+    /// Common registration sites and their effective scope:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>Inside a <c>[TestMethod]</c>: that test method (and its async continuations).</description></item>
+    /// <item><description><c>[TestInitialize]</c>: each test in the containing class.</description></item>
+    /// <item><description><c>[ClassInitialize]</c>: all tests in the containing class.</description></item>
+    /// <item><description><c>[AssemblyInitialize]</c>: all tests in the containing assembly.</description></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    /// [TestMethod]
+    /// public void DateTimeFailureShowsKind()
+    /// {
+    ///     using var _ = Assert.AddValueFormatter&lt;DateTime&gt;(dt =&gt; $"{dt:O} [{dt.Kind}]");
+    ///     Assert.AreEqual(DateTime.UtcNow, DateTime.Now);
+    /// }
+    /// </code>
+    /// </example>
+    [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+    public static IDisposable AddValueFormatter<T>(Func<T, string?> formatter)
+    {
+        _ = formatter ?? throw new ArgumentNullException(nameof(formatter));
+
+        return AssertionValueFormatterRegistry.Add(next => value =>
+        {
+            if (value is T typed)
+            {
+                string? result = formatter(typed);
+                if (result is not null)
+                {
+                    return result;
+                }
+            }
+
+            return next(value);
+        });
+    }
+
+    /// <summary>
+    /// Registers a chain-of-responsibility value-formatter factory. The factory receives the <c>next</c>
+    /// formatter in the chain and returns a new formatter; the returned formatter should either produce a
+    /// string for the values it handles or delegate to <c>next</c> for the values it does not handle.
+    /// The registration is scoped to the current asynchronous flow and is removed when the returned
+    /// <see cref="IDisposable"/> is disposed.
+    /// </summary>
+    /// <param name="factory">
+    /// A function that receives the next formatter in the chain and returns a formatter to install ahead of it.
+    /// </param>
+    /// <returns>An <see cref="IDisposable"/> whose disposal removes the registration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="factory"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Use this overload when you need to inspect more than a single type (for example to render any object
+    /// that implements a marker interface) or when you need explicit control over delegation to <c>next</c>.
+    /// For the common "format a specific type" case prefer <see cref="AddValueFormatter{T}(Func{T, string?})"/>.
+    /// </remarks>
+    [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
+    public static IDisposable AddValueFormatter(Func<Func<object?, string>, Func<object?, string>> factory)
+    {
+        _ = factory ?? throw new ArgumentNullException(nameof(factory));
+
+        return AssertionValueFormatterRegistry.Add(factory);
+    }
+}

--- a/src/TestFramework/TestFramework/Assertions/Assert.AddValueFormatter.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AddValueFormatter.cs
@@ -91,6 +91,13 @@ public sealed partial class Assert
     /// Use this overload when you need to inspect more than a single type (for example to render any object
     /// that implements a marker interface) or when you need explicit control over delegation to <c>next</c>.
     /// For the common "format a specific type" case prefer <see cref="AddValueFormatter{T}(Func{T, string?})"/>.
+    /// <para>
+    /// <paramref name="factory"/> is the chain builder, not the formatter itself: it is invoked every time a
+    /// value is rendered while the registration is active (the chain is rebuilt per render so that out-of-order
+    /// disposal of other registrations is honored), not just once at registration time. Keep it cheap and
+    /// side-effect free; perform any expensive setup outside the factory and have it return a formatter that
+    /// closes over the precomputed state.
+    /// </para>
     /// </remarks>
     [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
     public static IDisposable AddValueFormatter(Func<Func<object?, string>, Func<object?, string>> factory)

--- a/src/TestFramework/TestFramework/Assertions/AssertionValueFormatterRegistry.cs
+++ b/src/TestFramework/TestFramework/Assertions/AssertionValueFormatterRegistry.cs
@@ -31,10 +31,10 @@ internal static class AssertionValueFormatterRegistry
     private static readonly AsyncLocal<Node?> CurrentStack = new();
 
     /// <summary>
-    /// Gets a value indicating whether any formatter node is present in the current async flow.
+    /// Gets a value indicating whether any active formatter node is present in the current async flow.
     /// The fast-path check; the renderer still needs <see cref="Render"/> to skip removed nodes.
     /// </summary>
-    internal static bool HasFormatters => CurrentStack.Value is not null;
+    internal static bool HasFormatters => GetActiveHead() is not null;
 
     /// <summary>
     /// Registers a chain-of-responsibility factory and returns an <see cref="IDisposable"/> whose
@@ -59,7 +59,7 @@ internal static class AssertionValueFormatterRegistry
     /// </remarks>
     internal static string Render(object? value, Func<object?, string> builtIn)
     {
-        Node? head = CurrentStack.Value;
+        Node? head = GetActiveHead();
         if (head is null)
         {
             return builtIn(value);
@@ -73,6 +73,28 @@ internal static class AssertionValueFormatterRegistry
         {
             return $"{builtIn(value)} (value formatter threw {ex.GetType().Name})";
         }
+    }
+
+    // Returns the newest active node for the current async flow, pruning any leading removed nodes and
+    // updating the AsyncLocal head so the zero-allocation fast-path is restored once every registration
+    // in the flow has been disposed. Without this, CurrentStack.Value would keep pointing at a removed
+    // node, leaving HasFormatters permanently true and forcing every subsequent render to walk (and skip)
+    // removed nodes for the remainder of the flow.
+    private static Node? GetActiveHead()
+    {
+        Node? head = CurrentStack.Value;
+        Node? active = head;
+        while (active is not null && active.IsRemoved)
+        {
+            active = active.Next;
+        }
+
+        if (!ReferenceEquals(active, head))
+        {
+            CurrentStack.Value = active;
+        }
+
+        return active;
     }
 
     private static Func<object?, string> BuildChain(Node? node, Func<object?, string> terminal)

--- a/src/TestFramework/TestFramework/Assertions/AssertionValueFormatterRegistry.cs
+++ b/src/TestFramework/TestFramework/Assertions/AssertionValueFormatterRegistry.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Holds the per-async-flow stack of user-registered value formatters consulted by
+/// <see cref="AssertionValueRenderer.RenderValue(object?)"/> when rendering values inside structured
+/// assertion failure messages.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Formatters are chained "newest-first": when rendering a value the most recently registered formatter
+/// runs first and may either return a string (handling the value) or delegate to the supplied
+/// <c>next</c> formatter (falling through to the formatter that was registered before it). The terminal
+/// <c>next</c> is the built-in renderer captured in <see cref="AssertionValueRenderer"/>.
+/// </para>
+/// <para>
+/// Disposing a registration marks its node as removed; the renderer skips removed nodes when assembling
+/// the chain. This keeps node identity stable so out-of-order disposal of multiple registrations works
+/// correctly regardless of stack position.
+/// </para>
+/// </remarks>
+[StackTraceHidden]
+internal static class AssertionValueFormatterRegistry
+{
+    // Singly-linked list of factories. Head is the newest registration so it ends up wrapping the
+    // chain last (and therefore runs first). Nodes are append-only and reused across async flows that
+    // captured a chain head at registration time; Dispose marks them inactive instead of rewriting
+    // the list to keep identity stable for out-of-order disposal.
+    private static readonly AsyncLocal<Node?> CurrentStack = new();
+
+    /// <summary>
+    /// Gets a value indicating whether any formatter node is present in the current async flow.
+    /// The fast-path check; the renderer still needs <see cref="Render"/> to skip removed nodes.
+    /// </summary>
+    internal static bool HasFormatters => CurrentStack.Value is not null;
+
+    /// <summary>
+    /// Registers a chain-of-responsibility factory and returns an <see cref="IDisposable"/> whose
+    /// <see cref="IDisposable.Dispose"/> removes the registration. Disposing is safe to call multiple times
+    /// and from a different async flow than the registration.
+    /// </summary>
+    internal static IDisposable Add(Func<Func<object?, string>, Func<object?, string>> factory)
+    {
+        Node node = new(factory, CurrentStack.Value);
+        CurrentStack.Value = node;
+        return new Registration(node);
+    }
+
+    /// <summary>
+    /// Invokes the user formatter chain (if any) for <paramref name="value"/>, falling back to
+    /// <paramref name="builtIn"/> when no formatter handles the value.
+    /// </summary>
+    /// <remarks>
+    /// If a user formatter throws, the built-in renderer's output is returned with a trailing
+    /// annotation so the original assertion failure is not lost behind a formatter bug.
+    /// </remarks>
+    internal static string Render(object? value, Func<object?, string> builtIn)
+    {
+        Node? head = CurrentStack.Value;
+        if (head is null)
+        {
+            return builtIn(value);
+        }
+
+        Func<object?, string> chain = BuildChain(head, builtIn);
+        try
+        {
+            return chain(value);
+        }
+        catch (Exception ex)
+        {
+            return $"{builtIn(value)} (value formatter threw {ex.GetType().Name})";
+        }
+    }
+
+    private static Func<object?, string> BuildChain(Node? node, Func<object?, string> terminal)
+    {
+        if (node is null)
+        {
+            return terminal;
+        }
+
+        Func<object?, string> inner = BuildChain(node.Next, terminal);
+
+        // Skip removed nodes — their factory is not invoked and the chain behaves as if they were
+        // never registered.
+        return node.IsRemoved ? inner : node.Factory(inner);
+    }
+
+    private sealed class Node
+    {
+        internal Node(Func<Func<object?, string>, Func<object?, string>> factory, Node? next)
+        {
+            Factory = factory;
+            Next = next;
+        }
+
+        internal Func<Func<object?, string>, Func<object?, string>> Factory { get; }
+
+        internal Node? Next { get; }
+
+        // Mutated by Registration.Dispose. Volatile is unnecessary here because reads/writes to a
+        // bool field are atomic on every CLR-supported platform and we only need eventual visibility
+        // across async continuations, which AsyncLocal already provides.
+        internal bool IsRemoved { get; set; }
+    }
+
+    private sealed class Registration : IDisposable
+    {
+        private readonly Node _node;
+
+        internal Registration(Node node) => _node = node;
+
+        public void Dispose() => _node.IsRemoved = true;
+    }
+}

--- a/src/TestFramework/TestFramework/Assertions/AssertionValueFormatterRegistry.cs
+++ b/src/TestFramework/TestFramework/Assertions/AssertionValueFormatterRegistry.cs
@@ -53,8 +53,9 @@ internal static class AssertionValueFormatterRegistry
     /// <paramref name="builtIn"/> when no formatter handles the value.
     /// </summary>
     /// <remarks>
-    /// If a user formatter throws, the built-in renderer's output is returned with a trailing
-    /// annotation so the original assertion failure is not lost behind a formatter bug.
+    /// If a user formatter throws — either while building the chain (the factory delegate) or while
+    /// rendering the value — the built-in renderer's output is returned with a trailing annotation so the
+    /// original assertion failure is not lost behind a formatter bug.
     /// </remarks>
     internal static string Render(object? value, Func<object?, string> builtIn)
     {
@@ -64,10 +65,9 @@ internal static class AssertionValueFormatterRegistry
             return builtIn(value);
         }
 
-        Func<object?, string> chain = BuildChain(head, builtIn);
         try
         {
-            return chain(value);
+            return BuildChain(head, builtIn)(value);
         }
         catch (Exception ex)
         {
@@ -101,10 +101,17 @@ internal static class AssertionValueFormatterRegistry
 
         internal Node? Next { get; }
 
-        // Mutated by Registration.Dispose. Volatile is unnecessary here because reads/writes to a
-        // bool field are atomic on every CLR-supported platform and we only need eventual visibility
-        // across async continuations, which AsyncLocal already provides.
-        internal bool IsRemoved { get; set; }
+        // Mutated by Registration.Dispose, potentially from a different async flow/thread than the one
+        // rendering. Marked volatile so the renderer reliably observes the removal across threads — a
+        // plain bool read/write is atomic but carries no memory barrier, so visibility would otherwise
+        // not be guaranteed for out-of-flow disposal.
+        private volatile bool _isRemoved;
+
+        internal bool IsRemoved
+        {
+            get => _isRemoved;
+            set => _isRemoved = value;
+        }
     }
 
     private sealed class Registration : IDisposable

--- a/src/TestFramework/TestFramework/Assertions/AssertionValueRenderer.cs
+++ b/src/TestFramework/TestFramework/Assertions/AssertionValueRenderer.cs
@@ -9,10 +9,27 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 [StackTraceHidden]
 internal static class AssertionValueRenderer
 {
+    // Cache the built-in renderer as a delegate so passing it to the formatter registry doesn't allocate
+    // on every RenderValue call.
+    private static readonly Func<object?, string> BuiltInRenderer = RenderBuiltIn;
+
     /// <summary>
     /// Renders a value as a string suitable for display in the evidence block.
     /// </summary>
+    /// <remarks>
+    /// User-registered formatters (see <see cref="Assert.AddValueFormatter{T}(Func{T, string?})"/>) are consulted
+    /// first for non-<see langword="null"/> values. <see langword="null"/> is always rendered as <c>"null"</c>
+    /// and is not exposed to user formatters, to avoid surprising <see cref="NullReferenceException"/>s
+    /// inside user code.
+    /// </remarks>
     internal static string RenderValue(object? value)
+        => value is null
+            ? "null"
+            : AssertionValueFormatterRegistry.HasFormatters
+                ? AssertionValueFormatterRegistry.Render(value, BuiltInRenderer)
+                : RenderBuiltIn(value);
+
+    private static string RenderBuiltIn(object? value)
         => value switch
         {
             null => "null",

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+[MSTESTEXP]static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AddValueFormatter(System.Func<System.Func<object?, string!>!, System.Func<object?, string!>!>! factory) -> System.IDisposable!
+[MSTESTEXP]static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AddValueFormatter<T>(System.Func<T, string?>! formatter) -> System.IDisposable!
 [MSTESTEXP]static Microsoft.VisualStudio.TestTools.UnitTesting.Assert.Scope() -> System.IDisposable!
 Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyFixtureProviderAttribute
 Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyFixtureProviderAttribute.AssemblyFixtureProviderAttribute(System.Type! fixtureType) -> void

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ValueFormatterFlowTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ValueFormatterFlowTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Acceptance tests for <c>Assert.AddValueFormatter</c> scope flow-down across the
+/// AssemblyInitialize / ClassInitialize / TestMethod lifecycle. The registry is backed by
+/// <c>AsyncLocal&lt;T&gt;</c>, so these tests run a real MSTest process to prove that a formatter
+/// registered in an outer scope (assembly / class) is visible in the inner scopes (class / test),
+/// that inner registrations layer on top of outer ones, and that a test-local registration is
+/// isolated to the test that created it. See https://github.com/microsoft/testfx/issues/9089.
+/// </summary>
+[TestClass]
+public sealed class ValueFormatterFlowTests : AcceptanceTestBase<ValueFormatterFlowTests.TestAssetFixture>
+{
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ValueFormatterScopesFlowDownCorrectly(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+
+        // The custom test assets assert the flow-down behavior themselves; a non-zero exit code or a
+        // failing test surfaces the violated expectation (the rendered failure messages are echoed to
+        // stdout to aid diagnosis).
+        testHostResult.AssertExitCodeIs(0);
+
+        // AssemblyScopeTests: 1, ClassScopeTests: 1, TestLocalScopeTests: 2 => 4 passing tests.
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 4, skipped: 0);
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        public const string ProjectName = "ValueFormatterFlow";
+
+        public string ProjectPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file ValueFormatterFlow.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+    <EnableMicrosoftTestingPlatform>true</EnableMicrosoftTestingPlatform>
+    <!-- Assert.AddValueFormatter is an experimental API. -->
+    <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+</Project>
+
+#file UnitTest1.cs
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+// A type whose default rendering ("DEFAULT:<name>") is distinct from any registered formatter so the
+// rendered failure message reveals exactly which formatter (if any) handled the value.
+public sealed class Marker
+{
+    public Marker(string name) => Name = name;
+
+    public string Name { get; }
+
+    public override string ToString() => "DEFAULT:" + Name;
+}
+
+internal static class FormatterProbe
+{
+    // Forces an Assert.AreEqual failure between two distinct Markers and returns the rendered message
+    // (which routes both values through AssertionValueRenderer.RenderValue and therefore the registry).
+    public static string CaptureFailureMessage(string expected, string actual)
+    {
+        try
+        {
+            Assert.AreEqual(new Marker(expected), new Marker(actual));
+        }
+        catch (AssertFailedException ex)
+        {
+            return ex.Message;
+        }
+
+        throw new InvalidOperationException("Assert.AreEqual unexpectedly passed for two distinct Markers.");
+    }
+}
+
+// Registers an assembly-scoped formatter and verifies it flows down to a test in a class that has no
+// ClassInitialize formatter of its own.
+[TestClass]
+public sealed class AssemblyScopeTests
+{
+    [AssemblyInitialize]
+    public static void AssemblyInit(TestContext context)
+        => Assert.AddValueFormatter<Marker>(m => "asm:" + m.Name);
+
+    [TestMethod]
+    public void AssemblyFormatterFlowsToTest()
+    {
+        string message = FormatterProbe.CaptureFailureMessage("x", "y");
+        Console.WriteLine("[AssemblyFormatterFlowsToTest] " + message);
+
+        Assert.Contains("asm:x", message);
+        Assert.Contains("asm:y", message);
+    }
+}
+
+// Registers a class-scoped formatter and verifies it both wins over and layers on top of the
+// assembly-scoped formatter.
+[TestClass]
+public sealed class ClassScopeTests
+{
+    [ClassInitialize]
+    public static void ClassInit(TestContext context)
+        // Handles every Marker except "fall", which it defers (returns null) so the underlying
+        // assembly formatter handles it -- proving the chain layers class-over-assembly.
+        => Assert.AddValueFormatter<Marker>(m => m.Name == "fall" ? null : "class:" + m.Name);
+
+    [TestMethod]
+    public void ClassFormatterWinsAndLayersOnAssemblyFormatter()
+    {
+        string message = FormatterProbe.CaptureFailureMessage("a", "fall");
+        Console.WriteLine("[ClassFormatterWinsAndLayersOnAssemblyFormatter] " + message);
+
+        // The class formatter wins for "a"...
+        Assert.Contains("class:a", message);
+        // ...and defers "fall" to the assembly formatter underneath it.
+        Assert.Contains("asm:fall", message);
+    }
+}
+
+// Verifies a test-local registration applies within its test and does not leak into a sibling test.
+[TestClass]
+public sealed class TestLocalScopeTests
+{
+    [TestMethod]
+    public void LocalFormatterAppliesWithinTest()
+    {
+        using (Assert.AddValueFormatter<Marker>(m => "local:" + m.Name))
+        {
+            string message = FormatterProbe.CaptureFailureMessage("p", "q");
+            Console.WriteLine("[LocalFormatterAppliesWithinTest] " + message);
+
+            Assert.Contains("local:p", message);
+            Assert.Contains("local:q", message);
+        }
+    }
+
+    [TestMethod]
+    public void LocalFormatterDoesNotLeakIntoSiblingTest()
+    {
+        // No local formatter registered here; the local formatter from the sibling test must not be
+        // visible. The assembly formatter still applies (assembly scope), so values render as "asm:".
+        string message = FormatterProbe.CaptureFailureMessage("p", "q");
+        Console.WriteLine("[LocalFormatterDoesNotLeakIntoSiblingTest] " + message);
+
+        Assert.DoesNotContain("local:", message);
+        Assert.Contains("asm:p", message);
+    }
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+}

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AddValueFormatter.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AddValueFormatter.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+using AwesomeAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestFramework.ForTestingMSTest;
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
+
+public partial class AssertTests : TestContainer
+{
+    public void AddValueFormatter_Typed_NullFormatter_ThrowsArgumentNullException()
+    {
+        Action act = () => Assert.AddValueFormatter<int>(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("formatter");
+    }
+
+    public void AddValueFormatter_Factory_NullFactory_ThrowsArgumentNullException()
+    {
+        Action act = () => Assert.AddValueFormatter(null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("factory");
+    }
+
+    public void AddValueFormatter_Typed_CustomizesFailureMessage()
+    {
+        using (Assert.AddValueFormatter<DateTime>(dt =>
+            $"{dt.ToString("O", CultureInfo.InvariantCulture)} [{dt.Kind}]"))
+        {
+            // Use different ticks so AreEqual actually fails, while still exercising Kind in the rendering.
+            var expected = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var actual = new DateTime(2024, 1, 1, 12, 0, 1, DateTimeKind.Local);
+
+            Action act = () => Assert.AreEqual(expected, actual);
+            AssertFailedException ex = act.Should().Throw<AssertFailedException>().Which;
+            ex.Message.Should().Contain("[Utc]");
+            ex.Message.Should().Contain("[Local]");
+        }
+    }
+
+    public void AddValueFormatter_Typed_FormatterRemovedAfterDispose()
+    {
+        var dt = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Inside the scope the custom rendering is used.
+        using (Assert.AddValueFormatter<DateTime>(d => "CUSTOM"))
+        {
+            AssertionValueRenderer.RenderValue(dt).Should().Be("CUSTOM");
+        }
+
+        // After dispose the built-in renderer takes over again.
+        AssertionValueRenderer.RenderValue(dt).Should().Be(dt.ToString("O", CultureInfo.InvariantCulture));
+    }
+
+    public void AddValueFormatter_Typed_ReturningNullFallsThroughToBuiltIn()
+    {
+        // The typed formatter returns null for non-utc DateTimes so the built-in rendering applies.
+        using (Assert.AddValueFormatter<DateTime>(dt =>
+            dt.Kind == DateTimeKind.Utc ? "UTC!" : null))
+        {
+            var utc = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+            var local = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Local);
+
+            AssertionValueRenderer.RenderValue(utc).Should().Be("UTC!");
+            AssertionValueRenderer.RenderValue(local).Should().Be(local.ToString("O", CultureInfo.InvariantCulture));
+        }
+    }
+
+    public void AddValueFormatter_Typed_DoesNotMatchUnrelatedTypes()
+    {
+        using (Assert.AddValueFormatter<DateTime>(_ => "CUSTOM"))
+        {
+            // Int is not DateTime, so the int still uses the built-in renderer.
+            AssertionValueRenderer.RenderValue(42).Should().Be("42");
+        }
+    }
+
+    public void AddValueFormatter_NullValuesAlwaysRenderedAsNullLiteral()
+    {
+        // Even with a registered formatter, nulls always render as "null" (built-in fast-path).
+        using (Assert.AddValueFormatter<object>(_ => "FORMATTER-RAN"))
+        {
+            AssertionValueRenderer.RenderValue(null).Should().Be("null");
+        }
+    }
+
+    public void AddValueFormatter_StacksNewestFirst()
+    {
+        using (Assert.AddValueFormatter<int>(i => $"outer:{i}"))
+        using (Assert.AddValueFormatter<int>(i => $"inner:{i}"))
+        {
+            // The most recently registered formatter wins.
+            AssertionValueRenderer.RenderValue(7).Should().Be("inner:7");
+        }
+    }
+
+    public void AddValueFormatter_StacksFallThroughInOrder()
+    {
+        using (Assert.AddValueFormatter<int>(i => $"outer:{i}"))
+        using (Assert.AddValueFormatter<int>(i => i > 100 ? $"inner:{i}" : null))
+        {
+            // Inner returns null for small ints so the outer formatter handles it.
+            AssertionValueRenderer.RenderValue(7).Should().Be("outer:7");
+
+            // Large ints are handled by the inner formatter directly.
+            AssertionValueRenderer.RenderValue(500).Should().Be("inner:500");
+        }
+    }
+
+    public void AddValueFormatter_DisposeRemovesOnlyThatRegistration()
+    {
+        IDisposable outer = Assert.AddValueFormatter<int>(i => $"outer:{i}");
+        IDisposable inner = Assert.AddValueFormatter<int>(i => $"inner:{i}");
+
+        try
+        {
+            // Disposing the outer registration (not the top of the stack) keeps inner active.
+            outer.Dispose();
+            AssertionValueRenderer.RenderValue(7).Should().Be("inner:7");
+
+            // Disposing the inner registration falls back to the built-in renderer.
+            inner.Dispose();
+            AssertionValueRenderer.RenderValue(7).Should().Be("7");
+        }
+        finally
+        {
+            outer.Dispose();
+            inner.Dispose();
+        }
+    }
+
+    public void AddValueFormatter_DisposeIsIdempotent()
+    {
+        IDisposable d = Assert.AddValueFormatter<int>(i => $"x:{i}");
+        d.Dispose();
+
+        // A second dispose call is a no-op.
+        Action act = () => d.Dispose();
+        act.Should().NotThrow();
+
+        AssertionValueRenderer.RenderValue(7).Should().Be("7");
+    }
+
+    public void AddValueFormatter_AppliesToCollectionItems()
+    {
+        using (Assert.AddValueFormatter<int>(i => $"#{i}"))
+        {
+            AssertionValueRenderer.RenderValue(new[] { 1, 2, 3 }).Should().Be("[#1, #2, #3]");
+        }
+    }
+
+    public void AddValueFormatter_FactoryOverload_ReceivesNextDelegate()
+    {
+        using (Assert.AddValueFormatter(next => value =>
+            value is int i ? $"int={i}" : next(value)))
+        {
+            AssertionValueRenderer.RenderValue(42).Should().Be("int=42");
+
+            // Non-int still goes to the built-in renderer via the `next` delegate.
+            AssertionValueRenderer.RenderValue("hello").Should().Be("\"hello\"");
+        }
+    }
+
+    public void AddValueFormatter_FactoryOverload_ChainsWithTypedOverload()
+    {
+        using (Assert.AddValueFormatter<int>(i => $"typed:{i}"))
+        using (Assert.AddValueFormatter(next => value =>
+            value is int i && i < 0 ? $"factory-negative:{i}" : next(value)))
+        {
+            // Factory is newest so it runs first; for negative ints it handles, otherwise falls through.
+            AssertionValueRenderer.RenderValue(-5).Should().Be("factory-negative:-5");
+            AssertionValueRenderer.RenderValue(5).Should().Be("typed:5");
+        }
+    }
+
+    public void AddValueFormatter_ThrowingFormatterDoesNotDerailRendering()
+    {
+        using (Assert.AddValueFormatter<int>(_ => throw new InvalidOperationException("boom")))
+        {
+            // The renderer must not propagate the exception; it falls back to the built-in renderer
+            // with a marker so the assertion failure remains useful.
+            string rendered = AssertionValueRenderer.RenderValue(42);
+            rendered.Should().Contain("42");
+            rendered.Should().Contain("InvalidOperationException");
+        }
+    }
+}

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AddValueFormatter.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AddValueFormatter.cs
@@ -144,6 +144,24 @@ public partial class AssertTests : TestContainer
         AssertionValueRenderer.RenderValue(7).Should().Be("7");
     }
 
+    public void AddValueFormatter_DisposingAllRegistrationsRestoresFastPath()
+    {
+        AssertionValueFormatterRegistry.HasFormatters.Should().BeFalse();
+
+        IDisposable outer = Assert.AddValueFormatter<int>(i => $"outer:{i}");
+        IDisposable inner = Assert.AddValueFormatter<int>(i => $"inner:{i}");
+        AssertionValueFormatterRegistry.HasFormatters.Should().BeTrue();
+
+        // Disposing the leading (newest) registration leaves the older one active.
+        inner.Dispose();
+        AssertionValueFormatterRegistry.HasFormatters.Should().BeTrue();
+
+        // Once every registration in the flow is disposed the zero-allocation fast-path is restored
+        // instead of leaving HasFormatters permanently true on a removed node.
+        outer.Dispose();
+        AssertionValueFormatterRegistry.HasFormatters.Should().BeFalse();
+    }
+
     public void AddValueFormatter_AppliesToCollectionItems()
     {
         using (Assert.AddValueFormatter<int>(i => $"#{i}"))


### PR DESCRIPTION
Fixes #9089

Adds two public `Assert.AddValueFormatter` overloads that let users register custom formatters used by the structured assertion failure message renderer introduced by RFC-012 (#8964):

* `AddValueFormatter<T>(Func<T, string?>)` — typed sugar. Return `null` to fall through to the next formatter / built-in renderer.
* `AddValueFormatter(Func<Func<object?, string>, Func<object?, string>>)` — chain-of-responsibility factory that receives the `next` formatter.

Both overloads return an `IDisposable` whose disposal removes the registration. Registrations are anchored on `AsyncLocal<T>`, so the scope follows the test context (per-test, per-class, per-assembly), and they stack newest-first so the most recently registered formatter wins.

### Example

```csharp
[TestMethod]
public void DateTimeFailureShowsKind()
{
    using var _ = Assert.AddValueFormatter<DateTime>(dt => $""{dt:O} [{dt.Kind}]"");
    Assert.AreEqual(d1, d2); // failure message now annotates DateTime.Kind
}
```

### Implementation

* New `AssertionValueFormatterRegistry` (internal, `AsyncLocal`-backed) holds the chain. Nodes are append-only with a mutable `IsRemoved` flag so `Dispose` works for any position in the stack (including out-of-order disposal).
* `AssertionValueRenderer.RenderValue` consults the registry ahead of the built-in switch, and only when at least one formatter is registered (zero-allocation fast-path for the common no-formatter case).
* `null` is always rendered as `""null""` and is never exposed to user formatters, to avoid spurious `NullReferenceException`s inside user code.
* User-formatter exceptions are caught and annotated so the underlying assertion failure remains useful.
* New API is marked `[Experimental(""MSTESTEXP"")]` consistent with `Assert.Scope()`.

### Tests

15 new `AssertTests.AddValueFormatter` tests cover:
* `ArgumentNullException` on both overloads
* End-to-end assertion failure-message customization
* Disposal removes the registration (including out-of-order disposal)
* Idempotent `Dispose`
* Newest-first stacking + fall-through ordering
* Null values bypass the registry
* Non-matching types bypass the typed overload
* Collection items get per-item formatting
* The factory overload composes with the typed overload
* Throwing formatters do not derail rendering

Verified passing on net9.0, net8.0, and net48.

### Out of scope (per the issue)

* No discovery via attributes/interfaces (deferred).
* No built-in defaults changed.
* No equality customization (existing `IEqualityComparer<T>` overloads cover that).