### PR TITLE
Extract shared report-provider registration helper (#9131)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
@@ -24,7 +24,7 @@ public static class CtrfReportExtensions
         => ReportProviderRegistration.AddReportProvider(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
-            new CtrfReportGeneratorCommandLine(),
+            () => new CtrfReportGeneratorCommandLine(),
             serviceProvider =>
                 new CtrfReportGenerator(
                     serviceProvider.GetConfiguration(),

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Testing.Extensions.CtrfReport;
 using Microsoft.Testing.Extensions.CtrfReport.Resources;
 using Microsoft.Testing.Platform.Builder;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
@@ -22,16 +21,11 @@ public static class CtrfReportExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddCtrfReportProvider(this ITestApplicationBuilder builder)
-    {
-        if (builder is not TestApplicationBuilder)
-        {
-            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
-        }
-
-        var commandLine = new CtrfReportGeneratorCommandLine();
-
-        var compositeCtrfReportGenerator =
-            new CompositeExtensionFactory<CtrfReportGenerator>(serviceProvider =>
+        => ReportProviderRegistration.AddReportProvider(
+            builder,
+            ExtensionResources.InvalidTestApplicationBuilderType,
+            new CtrfReportGeneratorCommandLine(),
+            serviceProvider =>
                 new CtrfReportGenerator(
                     serviceProvider.GetConfiguration(),
                     serviceProvider.GetCommandLineOptions(),
@@ -44,10 +38,4 @@ public static class CtrfReportExtensions
                     serviceProvider.GetTestFramework(),
                     serviceProvider.GetTestApplicationProcessExitCode(),
                     serviceProvider.GetLoggerFactory().CreateLogger<CtrfReportGenerator>()));
-
-        builder.TestHost.AddDataConsumer(compositeCtrfReportGenerator);
-        builder.TestHost.AddTestSessionLifetimeHandler(compositeCtrfReportGenerator);
-
-        builder.CommandLine.AddProvider(() => commandLine);
-    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -56,6 +56,7 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Testing.Extensions.HtmlReport;
 using Microsoft.Testing.Extensions.HtmlReport.Resources;
 using Microsoft.Testing.Platform.Builder;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
@@ -22,16 +21,11 @@ public static class HtmlReportExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddHtmlReportProvider(this ITestApplicationBuilder builder)
-    {
-        if (builder is not TestApplicationBuilder)
-        {
-            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
-        }
-
-        var commandLine = new HtmlReportGeneratorCommandLine();
-
-        var compositeHtmlReportGenerator =
-            new CompositeExtensionFactory<HtmlReportGenerator>(serviceProvider =>
+        => ReportProviderRegistration.AddReportProvider(
+            builder,
+            ExtensionResources.InvalidTestApplicationBuilderType,
+            new HtmlReportGeneratorCommandLine(),
+            serviceProvider =>
                 new HtmlReportGenerator(
                     serviceProvider.GetConfiguration(),
                     serviceProvider.GetCommandLineOptions(),
@@ -44,10 +38,4 @@ public static class HtmlReportExtensions
                     serviceProvider.GetTestFramework(),
                     serviceProvider.GetTestApplicationProcessExitCode(),
                     serviceProvider.GetLoggerFactory().CreateLogger<HtmlReportGenerator>()));
-
-        builder.TestHost.AddDataConsumer(compositeHtmlReportGenerator);
-        builder.TestHost.AddTestSessionLifetimeHandler(compositeHtmlReportGenerator);
-
-        builder.CommandLine.AddProvider(() => commandLine);
-    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
@@ -24,7 +24,7 @@ public static class HtmlReportExtensions
         => ReportProviderRegistration.AddReportProvider(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
-            new HtmlReportGeneratorCommandLine(),
+            () => new HtmlReportGeneratorCommandLine(),
             serviceProvider =>
                 new HtmlReportGenerator(
                     serviceProvider.GetConfiguration(),

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -54,6 +54,7 @@ This package extends Microsoft Testing Platform to produce self-contained HTML t
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
@@ -24,7 +24,7 @@ public static class JUnitReportExtensions
         => ReportProviderRegistration.AddReportProvider(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
-            new JUnitReportGeneratorCommandLine(),
+            () => new JUnitReportGeneratorCommandLine(),
             serviceProvider =>
                 new JUnitReportGenerator(
                     serviceProvider.GetConfiguration(),

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Testing.Extensions.JUnitReport;
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
 using Microsoft.Testing.Platform.Builder;
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Services;
@@ -22,16 +21,11 @@ public static class JUnitReportExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddJUnitReportProvider(this ITestApplicationBuilder builder)
-    {
-        if (builder is not TestApplicationBuilder)
-        {
-            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
-        }
-
-        var commandLine = new JUnitReportGeneratorCommandLine();
-
-        var compositeJUnitReportGenerator =
-            new CompositeExtensionFactory<JUnitReportGenerator>(serviceProvider =>
+        => ReportProviderRegistration.AddReportProvider(
+            builder,
+            ExtensionResources.InvalidTestApplicationBuilderType,
+            new JUnitReportGeneratorCommandLine(),
+            serviceProvider =>
                 new JUnitReportGenerator(
                     serviceProvider.GetConfiguration(),
                     serviceProvider.GetCommandLineOptions(),
@@ -44,10 +38,4 @@ public static class JUnitReportExtensions
                     serviceProvider.GetTestFramework(),
                     serviceProvider.GetTestApplicationProcessExitCode(),
                     serviceProvider.GetLoggerFactory().CreateLogger<JUnitReportGenerator>()));
-
-        builder.TestHost.AddDataConsumer(compositeJUnitReportGenerator);
-        builder.TestHost.AddTestSessionLifetimeHandler(compositeJUnitReportGenerator);
-
-        builder.CommandLine.AddProvider(() => commandLine);
-    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -52,6 +52,7 @@ This package extends Microsoft Testing Platform to produce JUnit XML test report
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />

--- a/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
@@ -12,19 +12,19 @@ internal static class ReportProviderRegistration
 {
     /// <summary>
     /// Registers a report generator as both a data consumer and a test session lifetime handler, along with its
-    /// command-line options provider, applying the shared <see cref="TestApplicationBuilder"/> guard.
+    /// command-line options provider, applying the shared <c>TestApplicationBuilder</c> implementation guard.
     /// </summary>
     /// <typeparam name="TGenerator">The report generator type.</typeparam>
     /// <param name="builder">The test application builder.</param>
     /// <param name="invalidBuilderTypeErrorMessage">
-    /// The error message used when <paramref name="builder"/> is not a <see cref="TestApplicationBuilder"/>.
+    /// The error message used when <paramref name="builder"/> is not a <c>TestApplicationBuilder</c>.
     /// </param>
-    /// <param name="commandLine">The command-line options provider associated with the report.</param>
+    /// <param name="commandLineFactory">The factory that creates the command-line options provider associated with the report.</param>
     /// <param name="generatorFactory">The factory that creates the report generator from the service provider.</param>
     public static void AddReportProvider<TGenerator>(
         ITestApplicationBuilder builder,
         string invalidBuilderTypeErrorMessage,
-        ICommandLineOptionsProvider commandLine,
+        Func<ICommandLineOptionsProvider> commandLineFactory,
         Func<IServiceProvider, TGenerator> generatorFactory)
         where TGenerator : class, IDataConsumer, ITestSessionLifetimeHandler
     {
@@ -38,6 +38,7 @@ internal static class ReportProviderRegistration
         builder.TestHost.AddDataConsumer(compositeReportGenerator);
         builder.TestHost.AddTestSessionLifetimeHandler(compositeReportGenerator);
 
+        ICommandLineOptionsProvider commandLine = commandLineFactory();
         builder.CommandLine.AddProvider(() => commandLine);
     }
 }

--- a/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+
+namespace Microsoft.Testing.Extensions;
+
+internal static class ReportProviderRegistration
+{
+    /// <summary>
+    /// Registers a report generator as both a data consumer and a test session lifetime handler, along with its
+    /// command-line options provider, applying the shared <see cref="TestApplicationBuilder"/> guard.
+    /// </summary>
+    /// <typeparam name="TGenerator">The report generator type.</typeparam>
+    /// <param name="builder">The test application builder.</param>
+    /// <param name="invalidBuilderTypeErrorMessage">
+    /// The error message used when <paramref name="builder"/> is not a <see cref="TestApplicationBuilder"/>.
+    /// </param>
+    /// <param name="commandLine">The command-line options provider associated with the report.</param>
+    /// <param name="generatorFactory">The factory that creates the report generator from the service provider.</param>
+    public static void AddReportProvider<TGenerator>(
+        ITestApplicationBuilder builder,
+        string invalidBuilderTypeErrorMessage,
+        ICommandLineOptionsProvider commandLine,
+        Func<IServiceProvider, TGenerator> generatorFactory)
+        where TGenerator : class, IDataConsumer, ITestSessionLifetimeHandler
+    {
+        if (builder is not TestApplicationBuilder)
+        {
+            throw new InvalidOperationException(invalidBuilderTypeErrorMessage);
+        }
+
+        var compositeReportGenerator = new CompositeExtensionFactory<TGenerator>(generatorFactory);
+
+        builder.TestHost.AddDataConsumer(compositeReportGenerator);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeReportGenerator);
+
+        builder.CommandLine.AddProvider(() => commandLine);
+    }
+}


### PR DESCRIPTION
Fixes #9131.

Follow-up to #9134, which fixed the missing `TestApplicationBuilder` guard in `CtrfReportExtensions` but left the structural duplication (recommendation #2) unaddressed.

This extracts the repeated `CompositeExtensionFactory` construction, the `TestApplicationBuilder` guard, and the data-consumer / test-session-lifetime / command-line registration block — shared by the CTRF, JUnit, and HTML report extensions — into a new `ReportProviderRegistration.AddReportProvider` helper in `SharedExtensionHelpers`.

Each `Add*ReportProvider` method is now a single expression-bodied call that supplies only the generator factory and the per-extension resource strings. Behavior is unchanged (same guard, same registration order).

## Validation
- `dotnet build` of all three report extension projects: 0 warnings, 0 errors
- `Microsoft.Testing.Extensions.UnitTests` (net8.0): all passed