### PR TITLE
Add black-box baseline tests for dotnet-test pipe protocol (#51615 prep)

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
@@ -33,7 +33,7 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
             testHost, cancellationToken: TestContext.CancellationToken);
 
         Assert.IsNotNull(result.ReceivedHandshake, "Test app never sent a handshake message.");
-        Assert.IsNotNull(result.SentHandshakeReply);
+        Assert.IsNotNull(result.SentHandshakeReply, "Fake SDK never sent a handshake reply — check that the handshake frame was received and decoded.");
 
         Assert.IsTrue(
             result.ReceivedHandshake.TryGetValue(DotnetTestPipeProtocol.HandshakeProperties.SupportedProtocolVersions, out string? appVersions),
@@ -92,7 +92,7 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
             testHost, cancellationToken: TestContext.CancellationToken);
 
         Assert.DoesNotMatchRegex(
-            BannerRegex.ToString(),
+            BannerRegex,
             result.TestHostResult.StandardOutput,
             $"BASELINE: under --server dotnettestcli the test app already silences its banner. " +
             $"If this fails, something started re-emitting the banner under pipe mode.{Environment.NewLine}" +

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// Baseline tests for the <c>--server dotnettestcli</c> pipe protocol that lock down today's
+/// behavior so subsequent phases (quiet output device under pipe mode, protocol 1.0.1, live log
+/// and stream forwarding) can be reviewed as targeted diffs against these assertions.
+/// <para>
+/// Tracks <a href="https://github.com/dotnet/sdk/issues/51615">dotnet/sdk#51615</a> and the
+/// related <a href="https://github.com/microsoft/testfx/issues/7161">microsoft/testfx#7161</a>.
+/// </para>
+/// </summary>
+[TestClass]
+public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBaselineTests.TestAssetFixture>
+{
+    private const string AssetName = "DotnetTestPipeBaselineTest";
+
+    private static readonly Regex BannerRegex = new(@"Microsoft\.Testing\.Platform v.+ \[.+\]", RegexOptions.Compiled);
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task DotnetTestPipe_TestAppAdvertisesAndNegotiatesProtocolV100_Today()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost, cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsNotNull(result.ReceivedHandshake, "Test app never sent a handshake message.");
+        Assert.IsNotNull(result.SentHandshakeReply);
+
+        Assert.IsTrue(
+            result.ReceivedHandshake.TryGetValue(DotnetTestPipeProtocol.HandshakeProperties.SupportedProtocolVersions, out string? appVersions),
+            "Handshake from test app is missing SupportedProtocolVersions.");
+        Assert.AreEqual(
+            FakeDotnetTestSdk.DefaultSupportedProtocolVersions,
+            appVersions,
+            "BASELINE: today the test app advertises only protocol 1.0.0. When this assertion " +
+            "starts failing, it means the testfx side has been bumped to 1.0.1+ and the version " +
+            "negotiation tests should take over (Phase 2 of dotnet/sdk#51615).");
+
+        Assert.AreEqual(
+            FakeDotnetTestSdk.DefaultSupportedProtocolVersions,
+            result.NegotiatedProtocolVersion,
+            "Fake SDK should have selected '1.0.0' from the test app's advertised list.");
+    }
+
+    [TestMethod]
+    public async Task DotnetTestPipe_EmitsTestSessionStartAndEnd()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost, cancellationToken: TestContext.CancellationToken);
+
+        byte[] sessionEventTypes =
+        [
+            .. result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.TestSessionEvent)
+                .Select(m => DotnetTestPipeProtocol.DecodeTestSessionEventBody(m.Body).SessionType)
+                .Where(t => t.HasValue)
+                .Select(t => t!.Value)
+        ];
+
+        Assert.HasCount(2, sessionEventTypes, $"Expected exactly two session events; got [{string.Join(", ", sessionEventTypes)}].");
+        Assert.AreEqual(DotnetTestPipeProtocol.SessionEventTypes.TestSessionStart, sessionEventTypes[0]);
+        Assert.AreEqual(DotnetTestPipeProtocol.SessionEventTypes.TestSessionEnd, sessionEventTypes[1]);
+    }
+
+    /// <summary>
+    /// BASELINE: under <c>--server dotnettestcli</c> the test app today emits nothing to stdout/stderr
+    /// for a passing run (the MTP banner is already silenced via <c>_isServerMode</c> in
+    /// <c>TerminalOutputDevice</c>, and our <c>DummyTestFramework</c> writes nothing of its own).
+    /// This test pins that contract so future changes can't accidentally start leaking output that
+    /// would compete with what the SDK is also rendering (the original symptom behind
+    /// dotnet/sdk#51615 and microsoft/testfx#7161). When this test fails, evaluate whether the
+    /// added stdout/stderr writes should instead flow through the pipe as structured messages.
+    /// </summary>
+    [TestMethod]
+    public async Task DotnetTestPipe_ChildEmitsNoStdoutOrStderrForPassingRun_Baseline()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost, cancellationToken: TestContext.CancellationToken);
+
+        Assert.DoesNotMatchRegex(
+            BannerRegex.ToString(),
+            result.TestHostResult.StandardOutput,
+            $"BASELINE: under --server dotnettestcli the test app already silences its banner. " +
+            $"If this fails, something started re-emitting the banner under pipe mode.{Environment.NewLine}" +
+            $"Captured stdout:{Environment.NewLine}{result.TestHostResult.StandardOutput}");
+
+        Assert.AreEqual(
+            string.Empty,
+            result.TestHostResult.StandardOutput.Trim(),
+            $"BASELINE: today the test app emits nothing to stdout under pipe mode for a no-op " +
+            $"DummyTestFramework run. New text leaking here likely belongs in a pipe message " +
+            $"(Phase 2 of dotnet/sdk#51615 adds a LogMessage channel for this).{Environment.NewLine}" +
+            $"Captured stdout:{Environment.NewLine}{result.TestHostResult.StandardOutput}");
+
+        Assert.AreEqual(
+            string.Empty,
+            result.TestHostResult.StandardError.Trim(),
+            $"BASELINE: today the test app emits nothing to stderr under pipe mode for a passing run.{Environment.NewLine}" +
+            $"Captured stderr:{Environment.NewLine}{result.TestHostResult.StandardError}");
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string AssetCode = """
+#file DotnetTestPipeBaselineTest.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <UseAppHost>true</UseAppHost>
+        <LangVersion>preview</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+    </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestFramework());
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public class DummyTestFramework : ITestFramework
+{
+    public string Uid => nameof(DummyTestFramework);
+    public string Version => "2.0.0";
+    public string DisplayName => nameof(DummyTestFramework);
+    public string Description => nameof(DummyTestFramework);
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+    public Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        context.Complete();
+        return Task.CompletedTask;
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            AssetCode
+                .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -1,0 +1,293 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.IO.Pipes;
+using System.Text;
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// Black-box reader/writer for the <c>--server dotnettestcli --dotnet-test-pipe</c> wire
+/// protocol. Implements the framing and the serializer IDs / field IDs documented in
+/// <c>src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs</c>
+/// without referencing any of the testfx internal types (which are <c>[Embedded]</c> and
+/// therefore invisible to this assembly).
+/// <para>
+/// Treating this as a contract reader makes the resulting tests true black-box assertions on the
+/// wire format: any silent change to the message shape on the testfx side will be caught here.
+/// </para>
+/// </summary>
+internal static class DotnetTestPipeProtocol
+{
+    /// <summary>
+    /// Frame layout (matches <c>NamedPipeBase</c>):
+    /// <code>
+    ///   int32  totalPayloadLength    // = sizeof(serializerId) + bodyLength
+    ///   int32  serializerId
+    ///   byte[] body
+    /// </code>
+    /// </summary>
+    public static class SerializerIds
+    {
+        public const int VoidResponse = 0;
+        public const int TestHostCompletedRequest = 1;
+        public const int TestHostProcessPIDRequest = 2;
+        public const int CommandLineOptionMessages = 3;
+        public const int DiscoveredTestMessages = 5;
+        public const int TestResultMessages = 6;
+        public const int FileArtifactMessages = 7;
+        public const int TestSessionEvent = 8;
+        public const int HandshakeMessage = 9;
+        public const int TestInProgressMessages = 10;
+    }
+
+    public static class HandshakeProperties
+    {
+        public const byte PID = 0;
+        public const byte Architecture = 1;
+        public const byte Framework = 2;
+        public const byte OS = 3;
+        public const byte SupportedProtocolVersions = 4;
+        public const byte HostType = 5;
+        public const byte ModulePath = 6;
+        public const byte ExecutionId = 7;
+        public const byte InstanceId = 8;
+        public const byte IsIDE = 9;
+        public const byte ExecutionMode = 10;
+    }
+
+    public static class SessionEventTypes
+    {
+        public const byte TestSessionStart = 0;
+        public const byte TestSessionEnd = 1;
+    }
+
+    public static class TestSessionEventFields
+    {
+        public const ushort SessionType = 1;
+        public const ushort SessionUid = 2;
+        public const ushort ExecutionId = 3;
+    }
+
+    /// <summary>
+    /// Computes the OS-level named pipe name from a friendly identifier. Mirrors
+    /// <c>NamedPipeServer.GetPipeName</c> in testfx.
+    /// </summary>
+    public static string GetPipeName(string name)
+    {
+        bool isUnix = Path.DirectorySeparatorChar == '/';
+        return isUnix
+            ? Path.Combine("/tmp", name)
+            : $"testingplatform.pipe.{name.Replace('\\', '.')}";
+    }
+
+    /// <summary>
+    /// Reads exactly one framed message from the pipe. Returns <see langword="null"/> on EOF
+    /// (peer disconnected cleanly).
+    /// </summary>
+    public static async Task<RawMessage?> ReadFrameAsync(PipeStream stream, CancellationToken cancellationToken)
+    {
+        byte[] header = ArrayPool<byte>.Shared.Rent(sizeof(int));
+        try
+        {
+            if (!await TryReadExactlyAsync(stream, header.AsMemory(0, sizeof(int)), cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            int totalPayloadLength = BitConverter.ToInt32(header, 0);
+
+            byte[] payload = new byte[totalPayloadLength];
+            if (!await TryReadExactlyAsync(stream, payload, cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            int serializerId = BitConverter.ToInt32(payload, 0);
+            byte[] body = new byte[totalPayloadLength - sizeof(int)];
+            Array.Copy(payload, sizeof(int), body, 0, body.Length);
+
+            return new RawMessage(serializerId, body);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(header);
+        }
+    }
+
+    /// <summary>
+    /// Writes one framed message to the pipe.
+    /// </summary>
+    public static async Task WriteFrameAsync(PipeStream stream, int serializerId, byte[] body, CancellationToken cancellationToken)
+    {
+        int totalPayloadLength = sizeof(int) + body.Length;
+        byte[] header = BitConverter.GetBytes(totalPayloadLength);
+        byte[] id = BitConverter.GetBytes(serializerId);
+
+        await stream.WriteAsync(header.AsMemory(0, sizeof(int)), cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(id.AsMemory(0, sizeof(int)), cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(body.AsMemory(0, body.Length), cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        if (OperatingSystem.IsWindows() && stream is NamedPipeServerStream serverStream)
+        {
+            serverStream.WaitForPipeDrain();
+        }
+    }
+
+    /// <summary>
+    /// Decodes the body of a <see cref="SerializerIds.HandshakeMessage"/> frame into its property
+    /// dictionary. Format: <c>ushort fieldCount; (byte key, length-prefixed UTF-8 value) * fieldCount</c>.
+    /// </summary>
+    public static Dictionary<byte, string> DecodeHandshakeBody(byte[] body)
+    {
+        Dictionary<byte, string> result = [];
+        using MemoryStream stream = new(body, writable: false);
+
+        ushort count = ReadUShort(stream);
+        for (int i = 0; i < count; i++)
+        {
+            byte key = (byte)stream.ReadByte();
+            string value = ReadLengthPrefixedString(stream);
+            result.Add(key, value);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Encodes the body of a <see cref="SerializerIds.HandshakeMessage"/> frame from a property
+    /// dictionary.
+    /// </summary>
+    public static byte[] EncodeHandshakeBody(Dictionary<byte, string> properties)
+    {
+        using MemoryStream stream = new();
+        WriteUShort(stream, (ushort)properties.Count);
+        foreach (KeyValuePair<byte, string> kvp in properties)
+        {
+            stream.WriteByte(kvp.Key);
+            WriteLengthPrefixedString(stream, kvp.Value);
+        }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Decodes the body of a <see cref="SerializerIds.TestSessionEvent"/> frame.
+    /// Format: <c>ushort fieldCount; (ushort fieldId, int fieldSize, payload)*fieldCount</c>
+    /// where payload shape is determined by fieldId. Returns <c>null</c> for fields that are absent.
+    /// </summary>
+    public static (byte? SessionType, string? SessionUid, string? ExecutionId) DecodeTestSessionEventBody(byte[] body)
+    {
+        byte? sessionType = null;
+        string? sessionUid = null;
+        string? executionId = null;
+
+        using MemoryStream stream = new(body, writable: false);
+        ushort fieldCount = ReadUShort(stream);
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case TestSessionEventFields.SessionType:
+                    sessionType = (byte)stream.ReadByte();
+                    break;
+                case TestSessionEventFields.SessionUid:
+                    sessionUid = ReadFixedSizeString(stream, fieldSize);
+                    break;
+                case TestSessionEventFields.ExecutionId:
+                    executionId = ReadFixedSizeString(stream, fieldSize);
+                    break;
+                default:
+                    // Unknown field id: skip forward.
+                    stream.Seek(fieldSize, SeekOrigin.Current);
+                    break;
+            }
+        }
+
+        return (sessionType, sessionUid, executionId);
+    }
+
+    private static async Task<bool> TryReadExactlyAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            int read = await stream.ReadAsync(buffer.Slice(totalRead), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                return false;
+            }
+
+            totalRead += read;
+        }
+
+        return true;
+    }
+
+    private static ushort ReadUShort(Stream stream)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+        stream.ReadExactly(bytes);
+        return BitConverter.ToUInt16(bytes);
+    }
+
+    private static int ReadInt(Stream stream)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        stream.ReadExactly(bytes);
+        return BitConverter.ToInt32(bytes);
+    }
+
+    private static void WriteUShort(Stream stream, ushort value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+        BitConverter.TryWriteBytes(bytes, value);
+        stream.Write(bytes);
+    }
+
+    private static string ReadLengthPrefixedString(Stream stream)
+    {
+        int length = ReadInt(stream);
+        return ReadFixedSizeString(stream, length);
+    }
+
+    private static string ReadFixedSizeString(Stream stream, int length)
+    {
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
+        try
+        {
+            stream.ReadExactly(buffer, 0, length);
+            return Encoding.UTF8.GetString(buffer, 0, length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static void WriteLengthPrefixedString(Stream stream, string value)
+    {
+        int byteCount = Encoding.UTF8.GetByteCount(value);
+        byte[] header = BitConverter.GetBytes(byteCount);
+        stream.Write(header, 0, header.Length);
+
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(value, buffer);
+            stream.Write(buffer, 0, written);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}
+
+/// <summary>A raw decoded pipe frame (serializer id + body bytes, no further decoding).</summary>
+internal sealed record RawMessage(int SerializerId, byte[] Body);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -195,6 +195,14 @@ internal static class DotnetTestPipeProtocol
             {
                 case TestSessionEventFields.SessionType:
                     sessionType = (byte)stream.ReadByte();
+
+                    // SessionType is a single byte today, but advance past any extra bytes the
+                    // wire format may carry so subsequent fields stay aligned.
+                    if (fieldSize > 1)
+                    {
+                        stream.Seek(fieldSize - 1, SeekOrigin.Current);
+                    }
+
                     break;
                 case TestSessionEventFields.SessionUid:
                     sessionUid = ReadFixedSizeString(stream, fieldSize);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
@@ -40,7 +40,8 @@ internal static class FakeDotnetTestSdk
         string pipeId = Guid.NewGuid().ToString("N");
         string osPipeName = DotnetTestPipeProtocol.GetPipeName(pipeId);
 
-        // CurrentUserOnly only exists on .NET Core; on .NET Framework we omit it.
+        // CurrentUserOnly hardens the pipe ACL so only the current user can connect. It is
+        // available here because this harness only targets .NET (Core) ($(NetCurrent)).
         PipeOptions options = PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly;
 
         // .NET Framework's NamedPipeServerStream takes the pipe name without leading \\.\pipe\
@@ -53,14 +54,9 @@ internal static class FakeDotnetTestSdk
         Dictionary<byte, string>? sentHandshakeReply = null;
         string? negotiatedVersion = null;
 
-        Task<TestHostResult> hostRun = Task.Run(
-            async () =>
-            {
-                string pipeArgs = $"--server dotnettestcli --dotnet-test-pipe {osPipeName}";
-                string finalArgs = extraArguments is null ? pipeArgs : $"{pipeArgs} {extraArguments}";
-                return await testHost.ExecuteAsync(finalArgs, environmentVariables, cancellationToken: cancellationToken).ConfigureAwait(false);
-            },
-            cancellationToken);
+        string pipeArgs = $"--server dotnettestcli --dotnet-test-pipe {osPipeName}";
+        string finalArgs = extraArguments is null ? pipeArgs : $"{pipeArgs} {extraArguments}";
+        Task<TestHostResult> hostRun = testHost.ExecuteAsync(finalArgs, environmentVariables, cancellationToken: cancellationToken);
 
         // Wait for the test app to connect.
         await stream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -108,7 +104,7 @@ internal static class FakeDotnetTestSdk
     /// also in <paramref name="sdkSupportedVersions"/>. Returns <see cref="string.Empty"/> if none
     /// match.
     /// </summary>
-    public static string SelectHighestMutuallySupportedVersion(Dictionary<byte, string> handshakeProperties, string sdkSupportedVersions)
+    private static string SelectHighestMutuallySupportedVersion(Dictionary<byte, string> handshakeProperties, string sdkSupportedVersions)
     {
         if (!handshakeProperties.TryGetValue(DotnetTestPipeProtocol.HandshakeProperties.SupportedProtocolVersions, out string? appVersions)
             || string.IsNullOrWhiteSpace(appVersions))
@@ -116,13 +112,14 @@ internal static class FakeDotnetTestSdk
             return string.Empty;
         }
 
-        HashSet<string> sdkSet = new(sdkSupportedVersions.Split(';', StringSplitOptions.RemoveEmptyEntries), StringComparer.Ordinal);
+        HashSet<string> sdkSet = new(
+            sdkSupportedVersions.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(static raw => raw.Trim()),
+            StringComparer.Ordinal);
 
         string? best = null;
         Version? bestParsed = null;
-        foreach (string raw in appVersions.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        foreach (string candidate in appVersions.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(static raw => raw.Trim()))
         {
-            string candidate = raw.Trim();
             if (!sdkSet.Contains(candidate))
             {
                 continue;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// In-process stand-in for the <c>dotnet test</c> SDK side of the
+/// <c>--server dotnettestcli --dotnet-test-pipe</c> protocol. Listens on a named pipe, performs
+/// the same handshake negotiation the real SDK uses today, captures every message the test app
+/// sends, and returns a <see cref="FakeDotnetTestSdkResult"/>.
+/// <para>
+/// Built on a hand-rolled wire reader (<see cref="DotnetTestPipeProtocol"/>) so that this harness
+/// is independent of testfx internal types and exercises the wire format itself.
+/// </para>
+/// </summary>
+internal static class FakeDotnetTestSdk
+{
+    /// <summary>Default fake-SDK advertised protocol version. Mirrors today's
+    /// <c>ProtocolConstants.SupportedVersions</c> on the SDK side.</summary>
+    public const string DefaultSupportedProtocolVersions = "1.0.0";
+
+    /// <summary>
+    /// Spins up a fake SDK pipe server, runs <paramref name="testHost"/> against it, and returns
+    /// everything observed during the run.
+    /// </summary>
+    public static async Task<FakeDotnetTestSdkResult> RunAsync(
+        global::Microsoft.Testing.TestInfrastructure.TestHost testHost,
+        string? extraArguments = null,
+        Dictionary<string, string?>? environmentVariables = null,
+        string supportedProtocolVersions = DefaultSupportedProtocolVersions,
+        bool isIde = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(testHost);
+
+        string pipeId = Guid.NewGuid().ToString("N");
+        string osPipeName = DotnetTestPipeProtocol.GetPipeName(pipeId);
+
+        // CurrentUserOnly only exists on .NET Core; on .NET Framework we omit it.
+        PipeOptions options = PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly;
+
+        // .NET Framework's NamedPipeServerStream takes the pipe name without leading \\.\pipe\
+        // — Windows adds it automatically. On Unix, .NET 6+ uses Unix domain sockets at the given
+        // path (matching what NamedPipeServer.GetPipeName produces with Path.Combine("/tmp", name)).
+        using NamedPipeServerStream stream = new(osPipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, options);
+
+        List<RawMessage> received = [];
+        Dictionary<byte, string>? receivedHandshake = null;
+        Dictionary<byte, string>? sentHandshakeReply = null;
+        string? negotiatedVersion = null;
+
+        Task<TestHostResult> hostRun = Task.Run(
+            async () =>
+            {
+                string pipeArgs = $"--server dotnettestcli --dotnet-test-pipe {osPipeName}";
+                string finalArgs = extraArguments is null ? pipeArgs : $"{pipeArgs} {extraArguments}";
+                return await testHost.ExecuteAsync(finalArgs, environmentVariables, cancellationToken: cancellationToken).ConfigureAwait(false);
+            },
+            cancellationToken);
+
+        // Wait for the test app to connect.
+        await stream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        // Read frames until the peer disconnects.
+        while (true)
+        {
+            RawMessage? frame = await DotnetTestPipeProtocol.ReadFrameAsync(stream, cancellationToken).ConfigureAwait(false);
+            if (frame is null)
+            {
+                break;
+            }
+
+            received.Add(frame);
+
+            if (frame.SerializerId == DotnetTestPipeProtocol.SerializerIds.HandshakeMessage)
+            {
+                receivedHandshake = DotnetTestPipeProtocol.DecodeHandshakeBody(frame.Body);
+                string selected = SelectHighestMutuallySupportedVersion(receivedHandshake, supportedProtocolVersions);
+                negotiatedVersion = selected;
+                sentHandshakeReply = BuildSdkHandshakeReply(selected, isIde);
+                byte[] replyBody = DotnetTestPipeProtocol.EncodeHandshakeBody(sentHandshakeReply);
+                await DotnetTestPipeProtocol.WriteFrameAsync(stream, DotnetTestPipeProtocol.SerializerIds.HandshakeMessage, replyBody, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                // For every other request the SDK replies with a VoidResponse (empty body).
+                await DotnetTestPipeProtocol.WriteFrameAsync(stream, DotnetTestPipeProtocol.SerializerIds.VoidResponse, body: [], cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        TestHostResult hostResult = await hostRun.ConfigureAwait(false);
+
+        return new FakeDotnetTestSdkResult(
+            hostResult,
+            received,
+            receivedHandshake,
+            sentHandshakeReply,
+            negotiatedVersion);
+    }
+
+    /// <summary>
+    /// Mirrors <c>TestApplication.GetSupportedProtocolVersion</c> on the SDK side: takes the
+    /// semicolon-separated list the test app advertised and returns the highest version that is
+    /// also in <paramref name="sdkSupportedVersions"/>. Returns <see cref="string.Empty"/> if none
+    /// match.
+    /// </summary>
+    public static string SelectHighestMutuallySupportedVersion(Dictionary<byte, string> handshakeProperties, string sdkSupportedVersions)
+    {
+        if (!handshakeProperties.TryGetValue(DotnetTestPipeProtocol.HandshakeProperties.SupportedProtocolVersions, out string? appVersions)
+            || string.IsNullOrWhiteSpace(appVersions))
+        {
+            return string.Empty;
+        }
+
+        HashSet<string> sdkSet = new(sdkSupportedVersions.Split(';', StringSplitOptions.RemoveEmptyEntries), StringComparer.Ordinal);
+
+        string? best = null;
+        Version? bestParsed = null;
+        foreach (string raw in appVersions.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string candidate = raw.Trim();
+            if (!sdkSet.Contains(candidate))
+            {
+                continue;
+            }
+
+            if (!Version.TryParse(candidate, out Version? parsed))
+            {
+                best ??= candidate;
+                continue;
+            }
+
+            if (bestParsed is null || parsed > bestParsed)
+            {
+                best = candidate;
+                bestParsed = parsed;
+            }
+        }
+
+        return best ?? string.Empty;
+    }
+
+    private static Dictionary<byte, string> BuildSdkHandshakeReply(string selectedVersion, bool isIde)
+    {
+        Dictionary<byte, string> properties = new(capacity: 6)
+        {
+            { DotnetTestPipeProtocol.HandshakeProperties.PID, Environment.ProcessId.ToString(CultureInfo.InvariantCulture) },
+            { DotnetTestPipeProtocol.HandshakeProperties.Architecture, RuntimeInformation.ProcessArchitecture.ToString() },
+            { DotnetTestPipeProtocol.HandshakeProperties.Framework, RuntimeInformation.FrameworkDescription },
+            { DotnetTestPipeProtocol.HandshakeProperties.OS, RuntimeInformation.OSDescription },
+            { DotnetTestPipeProtocol.HandshakeProperties.SupportedProtocolVersions, selectedVersion },
+        };
+
+        if (isIde)
+        {
+            properties.Add(DotnetTestPipeProtocol.HandshakeProperties.IsIDE, bool.TrueString);
+        }
+
+        return properties;
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdkResult.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdkResult.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// Captures everything the fake SDK observed during a single test-app run driven through the
+/// <c>--server dotnettestcli --dotnet-test-pipe</c> protocol: the raw frames received on the
+/// named pipe, the SDK-selected handshake reply, and the process-level <see cref="TestHostResult"/>.
+/// Used by baseline tests to assert current behavior before any source change.
+/// </summary>
+internal sealed class FakeDotnetTestSdkResult
+{
+    public FakeDotnetTestSdkResult(
+        TestHostResult testHostResult,
+        IReadOnlyList<RawMessage> receivedMessages,
+        Dictionary<byte, string>? receivedHandshake,
+        Dictionary<byte, string>? sentHandshakeReply,
+        string? negotiatedProtocolVersion)
+    {
+        TestHostResult = testHostResult;
+        ReceivedMessages = receivedMessages;
+        ReceivedHandshake = receivedHandshake;
+        SentHandshakeReply = sentHandshakeReply;
+        NegotiatedProtocolVersion = negotiatedProtocolVersion;
+    }
+
+    /// <summary>The process-level result: exit code, captured stdout, captured stderr.</summary>
+    public TestHostResult TestHostResult { get; }
+
+    /// <summary>All raw frames the test app sent over the pipe, in arrival order.</summary>
+    public IReadOnlyList<RawMessage> ReceivedMessages { get; }
+
+    /// <summary>The decoded handshake properties the test app sent (advertising its supported
+    /// protocol versions, PID, architecture, framework, OS, etc.).</summary>
+    public Dictionary<byte, string>? ReceivedHandshake { get; }
+
+    /// <summary>The handshake the fake SDK replied with (carrying the selected protocol version).</summary>
+    public Dictionary<byte, string>? SentHandshakeReply { get; }
+
+    /// <summary>The version the fake SDK selected from the test app's advertised list, or null/empty if none.</summary>
+    public string? NegotiatedProtocolVersion { get; }
+
+    /// <summary>Returns all frames whose serializer ID matches <paramref name="serializerId"/>.</summary>
+    public IEnumerable<RawMessage> MessagesWithSerializerId(int serializerId)
+        => ReceivedMessages.Where(m => m.SerializerId == serializerId);
+}


### PR DESCRIPTION
Prep PR for dotnet/sdk#51615 ("Improve stdout/stderr handling of MTP test apps under `dotnet test`").

This PR is intentionally **product-code-free**. It introduces a black-box
acceptance harness and three baseline tests that pin today's wire-format
behavior of `Microsoft.Testing.Platform` running under
`--server dotnettestcli`, so that the upcoming behavior changes (live
stdout/stderr forwarding, `IOutputDevice` routing through the pipe,
protocol bump to `1.0.1`) can be reviewed against an explicit before/after.

## Why a black-box harness?

The production IPC types under `src/Platform/Microsoft.Testing.Platform/IPC/*`
(`NamedPipeServer`, `IRequest`, `IResponse`, `NamedPipeBase`, all base
serializers) carry `[Microsoft.CodeAnalysis.Embedded]`, which means they
are emitted as private copies per assembly and cannot be referenced from
the acceptance test project even with `InternalsVisibleTo`.

Rather than copy-link ~30 files into the test project (and silently
diverge from product over time), the harness re-implements the wire
format on top of `System.IO.Pipes.NamedPipeServerStream`. As a side
benefit, it now also doubles as a **contract test for the wire format**.

## What's in the PR

```
test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/
├── DotnetTestPipeProtocol.cs     ← framing + handshake/event encode/decode (BCL only)
├── FakeDotnetTestSdk.cs          ← `FakeDotnetTestSdk.RunAsync(testHost, ...)` harness
├── FakeDotnetTestSdkResult.cs    ← DTO returned by harness
└── DotnetTestPipeBaselineTests.cs ← 3 baseline `[TestMethod]`s with inline asset
```

### Baseline tests

1. **`DotnetTestPipe_TestAppAdvertisesAndNegotiatesProtocolV100_Today`**
   pins that the test app advertises `1.0.0` and that a fake SDK
   advertising `1.0.0` negotiates `1.0.0`.

2. **`DotnetTestPipe_EmitsTestSessionStartAndEnd`** pins that a single
   no-op session produces exactly one `TestSessionEvent` with
   `SessionType=TestSessionStart` and one with `TestSessionEnd`.

3. **`DotnetTestPipe_ChildEmitsNoStdoutOrStderrForPassingRun_Baseline`**
   pins that today the test app emits nothing to stdout/stderr under
   pipe mode for a passing no-op run (the banner is already silenced
   via the existing `_isServerMode` check in `TerminalOutputDevice`).

### Test results

```
total: 3
failed: 0
succeeded: 3
duration: 3s 736ms
```

No product code changes. No public API changes.

## Follow-ups (separate PRs)

- **#51615 Phase 1** — testfx: route warnings/errors/text through pipe
  under `--server dotnettestcli` instead of writing to local `IConsole`
  (closes microsoft/testfx#7161 too). Adds new `LogMessage` message.
- **#51615 Phase 2** — protocol bump to `1.0.1` (both sides advertise
  `1.0.1;1.0.0`) plus new `StandardStreamChunk` message for live
  stdout/stderr forwarding (opt-in via handshake flag).
- **#51615 Phase 3** — SDK side: consume new messages and add CLI
  surface (`--live-output` or equivalent).

Once Phase 1 lands, these baseline tests will need to be adjusted to
match the new contracts; today they intentionally describe the *current*
behavior so the diff is reviewable.