### PR TITLE
[efficiency-improver] perf: single-pass PropertyBag walk in DiscoveredTestsJsonSerializer

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/DiscoveredTestsJsonSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/DiscoveredTestsJsonSerializer.cs
@@ -70,7 +70,7 @@ internal static class DiscoveredTestsJsonSerializer
         List<TestMetadataProperty>? traits = null;
         List<SerializableKeyValuePairStringProperty>? kvps = null;
 
-        PropertyBag.PropertyBagEnumerator enumerator = test.Properties.GetStructEnumerator();
+        using PropertyBag.PropertyBagEnumerator enumerator = test.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
         {
             switch (enumerator.Current)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/DiscoveredTestsJsonSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/DiscoveredTestsJsonSerializer.cs
@@ -62,7 +62,32 @@ internal static class DiscoveredTestsJsonSerializer
         writer.WriteString("uid", test.Uid.Value);
         writer.WriteString("displayName", test.DisplayName);
 
-        TestMethodIdentifierProperty? methodIdentifier = test.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        // Collect all required properties in a single linked-list pass — replacing
+        // 4 × PropertyBag traversals (2 × SingleOrDefault + 2 × OfType) with one
+        // zero-allocation GetStructEnumerator() pass per discovered test.
+        TestMethodIdentifierProperty? methodIdentifier = null;
+        TestFileLocationProperty? fileLocation = null;
+        List<TestMetadataProperty>? traits = null;
+        List<SerializableKeyValuePairStringProperty>? kvps = null;
+
+        PropertyBag.PropertyBagEnumerator enumerator = test.Properties.GetStructEnumerator();
+        while (enumerator.MoveNext())
+        {
+            switch (enumerator.Current)
+            {
+                case TestMethodIdentifierProperty m: methodIdentifier = GetSingleOrDefaultValue(methodIdentifier, m); break;
+                case TestFileLocationProperty l: fileLocation = GetSingleOrDefaultValue(fileLocation, l); break;
+                case TestMetadataProperty meta: (traits ??= []).Add(meta); break;
+                case SerializableKeyValuePairStringProperty kvp: (kvps ??= []).Add(kvp); break;
+            }
+        }
+
+        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+            where TProperty : class, IProperty
+            => existingProperty is not null
+                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                : property;
+
         if (methodIdentifier is not null)
         {
             writer.WriteStartObject("type");
@@ -86,7 +111,6 @@ internal static class DiscoveredTestsJsonSerializer
             writer.WriteEndObject();
         }
 
-        TestFileLocationProperty? fileLocation = test.Properties.SingleOrDefault<TestFileLocationProperty>();
         if (fileLocation is not null)
         {
             writer.WriteStartObject("location");
@@ -96,14 +120,12 @@ internal static class DiscoveredTestsJsonSerializer
             writer.WriteEndObject();
         }
 
-        TestMetadataProperty[] traits = test.Properties.OfType<TestMetadataProperty>();
-        if (traits.Length > 0)
+        if (traits is not null)
         {
-            // PropertyBag stores properties as a linked list and prepends on Add, so OfType walks
-            // them in reverse insertion order. Reverse here so the JSON reflects the order in
-            // which the adapter recorded the traits, which is what consumers will reasonably
-            // expect and what makes diffs stable across runs.
-            Array.Reverse(traits);
+            // PropertyBag prepends on Add, so GetStructEnumerator yields in reverse insertion order.
+            // Reverse here so the JSON reflects the order in which the adapter recorded the traits,
+            // which is what consumers will reasonably expect and what makes diffs stable across runs.
+            traits.Reverse();
             writer.WriteStartArray("traits");
             foreach (TestMetadataProperty trait in traits)
             {
@@ -116,13 +138,12 @@ internal static class DiscoveredTestsJsonSerializer
             writer.WriteEndArray();
         }
 
-        SerializableKeyValuePairStringProperty[] kvps = test.Properties.OfType<SerializableKeyValuePairStringProperty>();
-        if (kvps.Length > 0)
+        if (kvps is not null)
         {
             // Same rationale as traits above: reverse so the JSON reflects insertion order.
             // Emit as an array of {key, value} (mirroring traits) so duplicate keys — which
             // PropertyBag allows — survive serialization. A JSON object would silently collapse them.
-            Array.Reverse(kvps);
+            kvps.Reverse();
             writer.WriteStartArray("properties");
             foreach (SerializableKeyValuePairStringProperty kvp in kvps)
             {


### PR DESCRIPTION
## Goal

Reduce energy consumption in the `--list-tests json` test-discovery path by eliminating redundant `PropertyBag` traversals in `DiscoveredTestsJsonSerializer.WriteTestNode()`.

## Focus Area

**Code-Level Efficiency** — algorithmic redundancy (repeated data-structure traversal).

## Approach

### Before

`WriteTestNode()` walked the `PropertyBag` linked list four times independently:

```csharp
var methodId = test.Properties.SingleOrDefault<TestMethodIdentifierProperty>();  // walk 1
var fileLoc  = test.Properties.SingleOrDefault<TestFileLocationProperty>();       // walk 2
var traits   = test.Properties.OfType<TestMetadataProperty>();                    // walk 3 + T[] alloc
var kvps     = test.Properties.OfType<SerializableKeyValuePairStringProperty>();  // walk 4 + T[] alloc
```

`OfType<T>()` allocates a `TProperty[]` for every test regardless of whether it has traits or key-value properties.

### After

One `GetStructEnumerator()` pass (a zero-allocation struct enumerator internal to the platform assembly) collects all four categories simultaneously. `List<T>?` locals start `null`, eliminating any allocation for tests that carry no traits or key-value properties:

```csharp
PropertyBag.PropertyBagEnumerator enumerator = test.Properties.GetStructEnumerator();
while (enumerator.MoveNext())
{
    switch (enumerator.Current)
    {
        case TestMethodIdentifierProperty m:             methodIdentifier = GetSingleOrDefaultValue(methodIdentifier, m); break;
        case TestFileLocationProperty l:                 fileLocation     = GetSingleOrDefaultValue(fileLocation, l);     break;
        case TestMetadataProperty meta:                  (traits ??= []).Add(meta); break;
        case SerializableKeyValuePairStringProperty kvp: (kvps ??= []).Add(kvp);   break;
    }
}
```

`GetSingleOrDefaultValue` preserves the duplicate-detection semantics of `SingleOrDefault<T>()`.

## Energy Efficiency Evidence

**Proxy metric**: CPU cycles / linked-list node visits — maps directly to memory reads and therefore DRAM energy and CPU cache pressure.

| Metric | Before | After | Saving |
|--------|--------|-------|--------|
| PropertyBag walks per test | 4 | 1 | −75 % |
| Heap allocs for tests **without** traits/kvps | 2 (`T[]` from `OfType`) | 0 (`List<T>?` stays null) | −100 % |
| Heap allocs for tests **with** traits/kvps | 2 (`T[]`) | 1–2 (`List<T>`) | similar |

For a run listing 1 000 tests (typical IDE test-discovery scan):
- **~3 000 extra linked-list traversals eliminated**
- **~2 000 small heap allocations eliminated** for trait-free tests

## Green Software Foundation Context

**Hardware Efficiency** — `GetStructEnumerator()` is a value-type enumerator allocated on the stack, not the heap. The single pass touches each `PropertyBag` node once rather than four times, making better use of CPU cache lines.

**Software Carbon Intensity (SCI)** — Fewer DRAM reads per test listed → lower energy per functional unit (test discovered). In CI pipelines listing thousands of tests across many daily runs, the aggregate saving in CPU energy compounds.

## Trade-offs

- The `switch` + `List<T>?` pattern is marginally more code than four one-liner calls. Comments explain the `Reverse()` calls (needed because `PropertyBag.Add()` prepends, so `GetStructEnumerator` yields in reverse insertion order).
- Output is byte-for-byte identical: verified by 12 existing `DiscoveredTestsJsonSerializerTests` including insertion-order tests.

## Reproducibility

```bash
DOTNET_INSTALL_DIR=/usr/share/dotnet ./build.sh
artifacts/bin/Microsoft.Testing.Platform.UnitTests/Debug/net8.0/Microsoft.Testing.Platform.UnitTests
# Expected: all 1163 tests pass, 0 failures
```

## Test Status

✅ 1 163 unit tests pass, 0 failures.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27580449841/agentic_workflow) workflow. · 2K AIC · ⌖ 38 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27580449841, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27580449841 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->