### PR TITLE
[test-improver] test: add edge case tests for MemberConditionShouldBeValidAnalyzer (MSTEST0070)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/MemberConditionShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/MemberConditionShouldBeValidAnalyzerTests.cs
@@ -576,4 +576,118 @@ public sealed class MemberConditionShouldBeValidAnalyzerTests
                 .WithLocation(0)
                 .WithArguments("int[]", "AnyName"));
     }
+
+    [TestMethod]
+    public async Task WhenMethodIsInstance_MemberNotStatic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Conditions
+            {
+                public bool InstanceMethod() => true;
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [{|#0:MemberCondition(typeof(Conditions), nameof(Conditions.InstanceMethod))|}]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(MemberConditionShouldBeValidAnalyzer.MemberNotStaticRule)
+                .WithLocation(0)
+                .WithArguments("Conditions", "InstanceMethod"));
+    }
+
+    [TestMethod]
+    public async Task WhenMethodIsInternalStatic_MemberNotPublic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public static class Conditions
+            {
+                internal static bool InternalMethod() => true;
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [{|#0:MemberCondition(typeof(Conditions), nameof(Conditions.InternalMethod))|}]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(MemberConditionShouldBeValidAnalyzer.MemberNotPublicRule)
+                .WithLocation(0)
+                .WithArguments("Conditions", "InternalMethod"));
+    }
+
+    [TestMethod]
+    public async Task WhenPropertyHasPrivateGetter_PropertyNotReadable()
+    {
+        // Property is public static but the getter is private — the runtime cannot invoke the getter.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public static class Conditions
+            {
+                public static bool PrivateGet { private get; set; }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [{|#0:MemberCondition(typeof(Conditions), nameof(Conditions.PrivateGet))|}]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(MemberConditionShouldBeValidAnalyzer.PropertyNotReadableRule)
+                .WithLocation(0)
+                .WithArguments("Conditions", "PrivateGet"));
+    }
+
+    [TestMethod]
+    public async Task WhenParamsArrayWithConditionMode_MultipleInvalidMembers_AllReported()
+    {
+        // Tests the 4-argument constructor overload: (ConditionMode, Type, string, params string[])
+        // All member names (the fixed name + each params element) must be validated.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public static class Conditions
+            {
+                public static bool IsTrue => true;
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [{|#0:MemberCondition(ConditionMode.Exclude, typeof(Conditions), "Missing1", "Missing2")|}]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(MemberConditionShouldBeValidAnalyzer.MemberNotFoundRule)
+                .WithLocation(0)
+                .WithArguments("Conditions", "Missing1"),
+            VerifyCS.Diagnostic(MemberConditionShouldBeValidAnalyzer.MemberNotFoundRule)
+                .WithLocation(0)
+                .WithArguments("Conditions", "Missing2"));
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`MemberConditionShouldBeValidAnalyzer` (MSTEST0070) validates `[MemberCondition]` attributes and has 7 diagnostic rules. The existing tests covered the main happy/error paths but left four code paths untested in `ValidateMethod` and `ValidateProperty`.

## Approach

Added 4 targeted edge-case tests:

| New test | Code path exercised | Rule |
|---|---|---|
| `WhenMethodIsInstance_MemberNotStatic` | `ValidateMethod` → `!method.IsStatic` | `MemberNotStaticRule` for methods |
| `WhenMethodIsInternalStatic_MemberNotPublic` | `ValidateMethod` → `DeclaredAccessibility != Public` | `MemberNotPublicRule` for methods |
| `WhenPropertyHasPrivateGetter_PropertyNotReadable` | `ValidateProperty` → `GetMethod.DeclaredAccessibility != Public` | `PropertyNotReadableRule` (private getter, not fully write-only) |
| `WhenParamsArrayWithConditionMode_MultipleInvalidMembers_AllReported` | 4-arg ctor `(ConditionMode, Type, string, params string[])` + both names invalid | `MemberNotFoundRule` ×2 |

Previously, `MemberNotStaticRule` and `MemberNotPublicRule` were only tested for **properties** and **fields**, not for **methods**. And `PropertyNotReadableRule` was only tested for a fully write-only property (no getter at all), not for a property with an existing-but-private getter.

## Trade-offs

- Tests are straightforward and low-maintenance.
- No new dependencies or test infrastructure.

## Reproducibility

```bash
DOTNET_INSTALL_DIR=/usr/share/dotnet ./build.sh --restore
.dotnet/dotnet run --project test/UnitTests/MSTest.Analyzers.UnitTests --launch-profile "" -f net8.0 --no-build -c Debug -- --filter "ClassName~MemberConditionShouldBeValid"
```

## Test Status

✅ 25 tests passed (21 existing + 4 new), 0 failed.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27583089678/agentic_workflow) workflow. · 1.6K AIC · ⌖ 23.4 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27583089678, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27583089678 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->