### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -190,10 +190,6 @@ An MTP extension (`Microsoft.Testing.Extensions.OpenTelemetry`) that exports tes
 
 A sealed class (`Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest`, currently `[Experimental("MSTESTEXP")]`) that describes a test that has been discovered and passed the active filter for the current assembly, before execution begins. Exposes the test's `FullyQualifiedTestClassName`, `TestName`, `TestDisplayName`, `AssemblyPath`, `ManagedTypeName`, `ManagedMethodName`, source file location (`DeclaringFilePath`, `DeclaringLineNumber`), `TestCategories` (from `[TestCategory]`), and `TestProperties` (from `[TestProperty]`). Instances are accessed via `TestRun.Current.PlannedTests`. Data-driven tests whose rows are resolved only at execution time (non-serializable data, `TestDataSourceUnfoldingStrategy.Fold` set via `[TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Fold)]`, `[DataSource]`) appear as a single `PlannedTest` entry rather than one per row. See also [TestRun](#testrun) and RFC 014 (`docs/RFCs/014-TestRun-Current-PlannedTests.md`).
 
-### PropertyBag
-
-An MTP class (`Microsoft.Testing.Platform.Extensions.Messages.PropertyBag`) that holds a typed collection of `IProperty` instances attached to a [TestNode](#testnode). Extension authors populate a `PropertyBag` with properties such as `TimingProperty`, `TestFileLocationProperty`, and `TestMetadataProperty` to communicate rich metadata about a test to the platform and to other extensions. A `PropertyBag` enforces that at most one `TestNodeStateProperty` may be present at a time.
-
 ### --progress
 
 An MTP terminal-reporter command-line option that controls whether animated progress output is shown during a test run. Accepts three values:
@@ -205,6 +201,10 @@ An MTP terminal-reporter command-line option that controls whether animated prog
 | `off` | Suppress all progress output |
 
 Introduced in [PR #9145](https://github.com/microsoft/testfx/pull/9145) as a replacement for the former `--no-progress` flag. `--no-progress` continues to work as a deprecated alias that routes to `--progress off` and emits a one-per-process deprecation warning on stderr; `--progress` always wins when both are supplied.
+
+### PropertyBag
+
+An MTP class (`Microsoft.Testing.Platform.Extensions.Messages.PropertyBag`) that holds a typed collection of `IProperty` instances attached to a [TestNode](#testnode). Extension authors populate a `PropertyBag` with properties such as `TimingProperty`, `TestFileLocationProperty`, and `TestMetadataProperty` to communicate rich metadata about a test to the platform and to other extensions. A `PropertyBag` enforces that at most one `TestNodeStateProperty` may be present at a time.
 
 ## R
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -50,6 +50,10 @@ A public enum in `Microsoft.VisualStudio.TestTools.UnitTesting` used with [Condi
 
 An MTP extension (`Microsoft.Testing.Extensions.CrashDump`) that automatically captures a process memory dump when the test host crashes. Useful for diagnosing unexpected process termination during test runs.
 
+### CtrfReport
+
+An MTP extension (`Microsoft.Testing.Extensions.CtrfReport`) that generates a [CTRF](https://github.com/ctrf-io/ctrf) (Common Test Report Format) JSON report at the end of a test run. CTRF is a vendor-neutral open standard for structured test results, consumed by GitHub Actions test-summary tools, Slack/Teams notifiers, dashboards, and other CI tooling. Enable via `--report-ctrf`; override the output filename with `--report-ctrf-filename`. When using [MSTest.Sdk](#mstestsdk), opt in with `<EnableMicrosoftTestingExtensionsCtrfReport>true</EnableMicrosoftTestingExtensionsCtrfReport>`. Currently **experimental** — the CLI options and output format may change without notice.
+
 ## D
 
 ### DelayBackoffType
@@ -189,6 +193,18 @@ A sealed class (`Microsoft.VisualStudio.TestTools.UnitTesting.PlannedTest`, curr
 ### PropertyBag
 
 An MTP class (`Microsoft.Testing.Platform.Extensions.Messages.PropertyBag`) that holds a typed collection of `IProperty` instances attached to a [TestNode](#testnode). Extension authors populate a `PropertyBag` with properties such as `TimingProperty`, `TestFileLocationProperty`, and `TestMetadataProperty` to communicate rich metadata about a test to the platform and to other extensions. A `PropertyBag` enforces that at most one `TestNodeStateProperty` may be present at a time.
+
+### --progress
+
+An MTP terminal-reporter command-line option that controls whether animated progress output is shown during a test run. Accepts three values:
+
+| Value | Behavior |
+| --- | --- |
+| `auto` (default) | Show progress unless the terminal cannot update in place (non-ANSI/simple terminal), or the session is a test-host controller, `--list-tests`, or server mode |
+| `on` | Same as `auto` (a dedicated heartbeat renderer for non-cursor modes is tracked separately) |
+| `off` | Suppress all progress output |
+
+Introduced in [PR #9145](https://github.com/microsoft/testfx/pull/9145) as a replacement for the former `--no-progress` flag. `--no-progress` continues to work as a deprecated alias that routes to `--progress off` and emits a one-per-process deprecation warning on stderr; `--progress` always wins when both are supplied.
 
 ## R
 


### PR DESCRIPTION
### Glossary Updates

**Scan Type**: Full scan (weekly — Monday 2026-06-16, last 7 days)

**Terms Added**:
- **CtrfReport**: The `Microsoft.Testing.Extensions.CtrfReport` extension that generates a CTRF (Common Test Report Format) JSON report. Introduced by the `--report-ctrf` / `--report-ctrf-filename` CLI options and the `<EnableMicrosoftTestingExtensionsCtrfReport>` MSTest.Sdk property. Was already present in the codebase and actively referenced in recent commits but missing from the glossary.
- **--progress**: The new MTP terminal-reporter option (`--progress {auto|on|off}`) that replaces the former `--no-progress` flag. Documents the three modes and the deprecation behaviour of `--no-progress`.

**Terms Updated**: None

**Changes Analyzed**:
- Reviewed 30 commits from 2026-06-09 → 2026-06-16
- Analyzed 17 merged PRs
- Key PRs driving additions:
  - PR #9134: Reduce duplication in CTRF/JUnit/HTML report extensions — surface of CtrfReport
  - PR #9145: Add `--progress {auto|on|off}` and deprecate `--no-progress` in MTP terminal reporter




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Glossary Maintainer](https://github.com/microsoft/testfx/actions/runs/27598118367/agentic_workflow) workflow. · 725 AIC · ⌖ 23.6 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+glossary-maintainer%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/glossary-maintainer.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-18T06:29:04.057Z --> on Jun 18, 2026, 6:29 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27598118367, workflow_id: glossary-maintainer, run: https://github.com/microsoft/testfx/actions/runs/27598118367 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/glossary-maintainer -->