### PR TITLE
Draft 4.3.0 / 2.3.0 changelogs

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -35,7 +35,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 
 ### Fixed
 
-* Fix TreeNodeFilter OR-pattern diagnostics by @Evangelink in [#7415](https://github.com/microsoft/testfx/pull/7415)
+* Clarify TreeNodeFilter OR-pattern diagnostics for unsupported parenthesized full-path expressions by @Evangelink in [#7415](https://github.com/microsoft/testfx/pull/7415)
 * Fix TRX result attachment layout to include per-test relative results directory by @Copilot in [#8188](https://github.com/microsoft/testfx/pull/8188)
 * Prevent telemetry host termination on boolean MSTest setting payloads by @Copilot in [#8189](https://github.com/microsoft/testfx/pull/8189)
 * Avoid duplicate async cleanup for test host lifecycle callbacks by @Copilot in [#8254](https://github.com/microsoft/testfx/pull/8254)

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -4,11 +4,70 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased]
+## <a name="2.3.0" />[2.3.0] - UNRELEASED
+
+See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)
+
+### Added
+
+* Add --crash-report option to the CrashDump extension by @Copilot in [#8191](https://github.com/microsoft/testfx/pull/8191)
+* Support placeholders in --report-trx-filename by @Evangelink in [#8223](https://github.com/microsoft/testfx/pull/8223)
+* Stream TRX test results to disk and recover partial TRX on test host crash by @Evangelink in [#8263](https://github.com/microsoft/testfx/pull/8263)
+* Add --list-tests json for machine-readable test discovery output by @Evangelink in [#8280](https://github.com/microsoft/testfx/pull/8280)
+* Add Microsoft.Testing.Extensions.HtmlReport extension by @Evangelink in [#8283](https://github.com/microsoft/testfx/pull/8283)
+* Add live Azure DevOps test result publishing by @Evangelink in [#8297](https://github.com/microsoft/testfx/pull/8297)
+* Add Microsoft.Testing.Extensions.Logging bridge to Microsoft.Extensions.Logging by @Evangelink in [#8344](https://github.com/microsoft/testfx/pull/8344)
+* Add new diagnostic env var names matching renamed CLI options by @Evangelink in [#8388](https://github.com/microsoft/testfx/pull/8388)
+* Support environmentVariables section in testconfig.json by @Evangelink in [#8391](https://github.com/microsoft/testfx/pull/8391)
+* Allow paths in --report-trx-filename by @Evangelink in [#8406](https://github.com/microsoft/testfx/pull/8406)
+* Add --ansi &lt;auto|on|off&gt; CLI option for explicit ANSI control by @Evangelink in [#8493](https://github.com/microsoft/testfx/pull/8493)
+* Add --crash-sequence option to MTP CrashDump extension by @Evangelink in [#8526](https://github.com/microsoft/testfx/pull/8526)
+* Add two-stage Ctrl+C cancellation UX by @Evangelink in [#8581](https://github.com/microsoft/testfx/pull/8581)
+* Add TestInProgressMessages IPC for dotnet test active-test rendering by @Evangelink in [#8652](https://github.com/microsoft/testfx/pull/8652)
+* Read CLI options from testconfig.json via IConfiguration by @Evangelink in [#8664](https://github.com/microsoft/testfx/pull/8664)
+* Add --crash-report-if-supported and --hangdump-type-if-supported options by @Evangelink in [#8666](https://github.com/microsoft/testfx/pull/8666)
+* Suppress banner and default stdout/stderr to `failed` in LLM environments by @Evangelink in [#8771](https://github.com/microsoft/testfx/pull/8771)
+* Add AzDO summary, progress and stack-frame filter options (#5951 item 4) by @Evangelink in [#8778](https://github.com/microsoft/testfx/pull/8778)
+* Add Azure DevOps result-level attachments and run-level coverage upload by @Evangelink in [#8782](https://github.com/microsoft/testfx/pull/8782)
+* Add Microsoft.Testing.Extensions.JUnitReport extension by @Evangelink in [#8850](https://github.com/microsoft/testfx/pull/8850)
+* Add Microsoft.Testing.Extensions.CtrfReport extension (CTRF reporter) by @Evangelink in [#8903](https://github.com/microsoft/testfx/pull/8903)
+* \[MSTest.Sdk] Wire Microsoft.Testing.Extensions.JUnitReport into MSTest.Sdk (opt-in) by @Evangelink in [#8956](https://github.com/microsoft/testfx/pull/8956)
+* Add --progress {auto|on|off} and deprecate --no-progress in MTP terminal reporter by @Evangelink in [#9145](https://github.com/microsoft/testfx/pull/9145)
 
 ### Fixed
 
-* Clarify TreeNodeFilter OR-pattern diagnostics for unsupported parenthesized full-path expressions by @Evangelink in [#7415](https://github.com/microsoft/testfx/pull/7415)
+* (MISSING #7415)
+* Fix TRX result attachment layout to include per-test relative results directory by @Copilot in [#8188](https://github.com/microsoft/testfx/pull/8188)
+* Prevent telemetry host termination on boolean MSTest setting payloads by @Copilot in [#8189](https://github.com/microsoft/testfx/pull/8189)
+* Avoid duplicate async cleanup for test host lifecycle callbacks by @Copilot in [#8254](https://github.com/microsoft/testfx/pull/8254)
+* Include full command line in MTP validation errors by @Copilot in [#8255](https://github.com/microsoft/testfx/pull/8255)
+* Stop forcing verbose createdump diagnostics in CrashDump extension by @Evangelink in [#8350](https://github.com/microsoft/testfx/pull/8350)
+* Fix HangDump GetParentPidLinux mis-parsing /proc/&lt;pid&gt;/stat when comm contains spaces by @Evangelink in [#8381](https://github.com/microsoft/testfx/pull/8381)
+* Fix RetryOrchestrator leaking CancellationTokenSource and Process.Exited handler per attempt by @Evangelink in [#8382](https://github.com/microsoft/testfx/pull/8382)
+* Report unclosed quotes in response files by @Copilot in [#8448](https://github.com/microsoft/testfx/pull/8448)
+* Reject negative minimum expected test counts by @Copilot in [#8450](https://github.com/microsoft/testfx/pull/8450)
+* Preserve supplementary Unicode in TRX reports by @Copilot in [#8451](https://github.com/microsoft/testfx/pull/8451)
+* Validate retry option numeric ranges by @Copilot in [#8494](https://github.com/microsoft/testfx/pull/8494)
+* Reject negative timeout values during command-line validation by @Copilot in [#8496](https://github.com/microsoft/testfx/pull/8496)
+* Validate client port range during command-line parsing by @Copilot in [#8497](https://github.com/microsoft/testfx/pull/8497)
+* Fail on conflicting TestingPlatformBuilderHook IDs by @Copilot in [#8508](https://github.com/microsoft/testfx/pull/8508)
+* Fix HangDump artifact paths for Windows directories with spaces by @Copilot in [#8513](https://github.com/microsoft/testfx/pull/8513)
+* Fix AzureDevOpsReport suppressing failures without reporting stack frame by @Copilot in [#8525](https://github.com/microsoft/testfx/pull/8525)
+* Fix InvalidOperationException in BuildServerTestHostAsync when telemetry is enabled by @Evangelink in [#8553](https://github.com/microsoft/testfx/pull/8553)
+* Add \[UnsupportedOSPlatform("wasi")] to HangDump / Console / Process surface by @Evangelink in [#8564](https://github.com/microsoft/testfx/pull/8564)
+* Use args passed to CreateBuilderAsync in GetCurrentExecutableInfo by @Evangelink in [#8570](https://github.com/microsoft/testfx/pull/8570)
+* Improve diagnostic logging across MTP crash and IPC paths by @Evangelink in [#8584](https://github.com/microsoft/testfx/pull/8584)
+* IPC: handle disconnects and protocol corruption gracefully by @Evangelink in [#8602](https://github.com/microsoft/testfx/pull/8602)
+* Reject invalid runId in JSON-RPC requests with InvalidParams error by @Evangelink in [#8665](https://github.com/microsoft/testfx/pull/8665)
+* Make AOT-incompatible code paths a no-op at runtime in MTP/Native AOT mode by @Evangelink in [#8688](https://github.com/microsoft/testfx/pull/8688)
+* Strip --minimum-expected-tests on retry attempts in RetryOrchestrator by @Evangelink in [#8719](https://github.com/microsoft/testfx/pull/8719)
+* Honor NO_COLOR env var in TerminalOutputDevice by @Evangelink in [#8831](https://github.com/microsoft/testfx/pull/8831)
+* Auto-promote scalar JSON values for arg-bearing CLI options (fixes #8830) by @Evangelink in [#8836](https://github.com/microsoft/testfx/pull/8836)
+* Use deterministic `<asm>_<tfm>_<arch>` default for report and log file names by @Evangelink in [#8971](https://github.com/microsoft/testfx/pull/8971)
+* Remove non-conforming top-level 'code' from JSON-RPC error envelope by @Evangelink in [#9050](https://github.com/microsoft/testfx/pull/9050)
+* Flag bootstrap-only CLI options when set in testconfig.json by @Evangelink in [#9055](https://github.com/microsoft/testfx/pull/9055)
+* Fix report file-name collision between net8.0 and net8.0-windows builds by @Evangelink in [#9121](https://github.com/microsoft/testfx/pull/9121)
+* Harden report TFM resolution for custom/non-OS platforms (browserwasm) by @Evangelink in [#9137](https://github.com/microsoft/testfx/pull/9137)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -31,12 +31,11 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add Azure DevOps result-level attachments and run-level coverage upload by @Evangelink in [#8782](https://github.com/microsoft/testfx/pull/8782)
 * Add Microsoft.Testing.Extensions.JUnitReport extension by @Evangelink in [#8850](https://github.com/microsoft/testfx/pull/8850)
 * Add Microsoft.Testing.Extensions.CtrfReport extension (CTRF reporter) by @Evangelink in [#8903](https://github.com/microsoft/testfx/pull/8903)
-* \[MSTest.Sdk] Wire Microsoft.Testing.Extensions.JUnitReport into MSTest.Sdk (opt-in) by @Evangelink in [#8956](https://github.com/microsoft/testfx/pull/8956)
 * Add --progress {auto|on|off} and deprecate --no-progress in MTP terminal reporter by @Evangelink in [#9145](https://github.com/microsoft/testfx/pull/9145)
 
 ### Fixed
 
-* (MISSING #7415)
+* Fix TreeNodeFilter OR-pattern diagnostics by @Evangelink in [#7415](https://github.com/microsoft/testfx/pull/7415)
 * Fix TRX result attachment layout to include per-test relative results directory by @Copilot in [#8188](https://github.com/microsoft/testfx/pull/8188)
 * Prevent telemetry host termination on boolean MSTest setting payloads by @Copilot in [#8189](https://github.com/microsoft/testfx/pull/8189)
 * Avoid duplicate async cleanup for test host lifecycle callbacks by @Copilot in [#8254](https://github.com/microsoft/testfx/pull/8254)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## <a name="4.3.0" />[4.3.0] - UNRELEASED
+
+See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)
+
+### Added
+
+* Apply structured assertion messages to IsTrue, IsFalse, IsNull, IsNotNull by @Evangelink in [#8187](https://github.com/microsoft/testfx/pull/8187)
+* Add MSTestParallelizeScope/Workers MSBuild properties by @Evangelink in [#8233](https://github.com/microsoft/testfx/pull/8233)
+* Add Assert.ContainsAll and Assert.DoesNotContainAll with structured assertion messages by @Evangelink in [#8234](https://github.com/microsoft/testfx/pull/8234)
+* Add Assert.AreAllNotNull / AreAllDistinct / AreAllOfType by @Evangelink in [#8237](https://github.com/microsoft/testfx/pull/8237)
+* Add MSTEST0064 to prefer async assertions by @Copilot in [#8256](https://github.com/microsoft/testfx/pull/8256)
+* Add Assert.AreEquivalent for deep structural comparison by @Evangelink in [#8266](https://github.com/microsoft/testfx/pull/8266)
+* Add Assert.AreSequenceEqual / AreNotSequenceEqual with SequenceOrder option by @Evangelink in [#8334](https://github.com/microsoft/testfx/pull/8334)
+* Add MSTEST0065 analyzer: Avoid Assert.AreEqual on collection types by @Evangelink in [#8337](https://github.com/microsoft/testfx/pull/8337)
+* Flow TestContext.Properties through Assembly/Class lifecycle by @Evangelink in [#8386](https://github.com/microsoft/testfx/pull/8386)
+* RFC 014 + impl: experimental TestRun.Current / PlannedTests API by @Evangelink in [#8461](https://github.com/microsoft/testfx/pull/8461)
+* Support class-level \[Retry] attribute by @Evangelink in [#8566](https://github.com/microsoft/testfx/pull/8566)
+* Add MSTest reflection source generator (issue #1837) by @Evangelink in [#8586](https://github.com/microsoft/testfx/pull/8586)
+* Add MSTEST0067 analyzer to flag Thread.Sleep/Task.Wait/Task&lt;T&gt;.Result in tests by @Evangelink in [#8646](https://github.com/microsoft/testfx/pull/8646)
+* Add opt-in random test order to MSTest adapter by @Evangelink in [#8647](https://github.com/microsoft/testfx/pull/8647)
+* Add MSTEST0066: \[Ignore] should have a justification message by @Evangelink in [#8649](https://github.com/microsoft/testfx/pull/8649)
+* Add \[AssemblyFixtureProvider] for cross-assembly assembly fixtures by @Evangelink in [#8677](https://github.com/microsoft/testfx/pull/8677)
+* Add MSTEST0068 - CollectionAssert to Assert analyzer and code fix by @Evangelink in [#8768](https://github.com/microsoft/testfx/pull/8768)
+* Add \[MemberCondition] attribute for static-member-based test conditions by @Evangelink in [#9071](https://github.com/microsoft/testfx/pull/9071)
+* Add MSTEST0070 analyzer validating \[MemberCondition] member references by @Evangelink in [#9076](https://github.com/microsoft/testfx/pull/9076)
+
+### Fixed
+
+* Fix Assert.That: single-pass evaluation (#6690) and consistent method-call display by @Evangelink in [#8306](https://github.com/microsoft/testfx/pull/8306)
+* Apply \[StackTraceHidden] to Assert/CollectionAssert/StringAssert by @Evangelink in [#8393](https://github.com/microsoft/testfx/pull/8393)
+* Fix folded data-driven tests sharing TestContextImplementation across iterations by @Evangelink in [#8439](https://github.com/microsoft/testfx/pull/8439)
+* MSTEST0005: Stop reporting on fields of type TestContext by @Evangelink in [#8629](https://github.com/microsoft/testfx/pull/8629)
+* Fix MSTEST0066 false positive for \[Ignore(IgnoreMessage = "...")] by @Evangelink in [#8662](https://github.com/microsoft/testfx/pull/8662)
+* Add \[StackTraceHidden] to assertion API internals by @Evangelink in [#8853](https://github.com/microsoft/testfx/pull/8853)
+* Render BCL values with full precision in assertion failure messages by @Evangelink in [#8964](https://github.com/microsoft/testfx/pull/8964)
+* Apply DebuggerDisableUserUnhandledExceptionsAttribute to Assert.Throws helpers by @Evangelink in [#9041](https://github.com/microsoft/testfx/pull/9041)
+* Flag `Assert.AreEqual(x, x)` / `AreSame(x, x)` / `AreNotEqual(x, x)` / `AreNotSame(x, x)` by @Evangelink in [#9088](https://github.com/microsoft/testfx/pull/9088)
+
 ## <a name="4.2.3" />[4.2.3] - 2026-05-14
 
 See full log [of v4.2.2...v4.2.3](https://github.com/microsoft/testfx/compare/v4.2.2...v4.2.3)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -27,6 +27,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add MSTEST0066: \[Ignore] should have a justification message by @Evangelink in [#8649](https://github.com/microsoft/testfx/pull/8649)
 * Add \[AssemblyFixtureProvider] for cross-assembly assembly fixtures by @Evangelink in [#8677](https://github.com/microsoft/testfx/pull/8677)
 * Add MSTEST0068 - CollectionAssert to Assert analyzer and code fix by @Evangelink in [#8768](https://github.com/microsoft/testfx/pull/8768)
+* \[MSTest.Sdk] Wire Microsoft.Testing.Extensions.JUnitReport into MSTest.Sdk (opt-in) by @Evangelink in [#8956](https://github.com/microsoft/testfx/pull/8956)
 * Add \[MemberCondition] attribute for static-member-based test conditions by @Evangelink in [#9071](https://github.com/microsoft/testfx/pull/9071)
 * Add MSTEST0070 analyzer validating \[MemberCondition] member references by @Evangelink in [#9076](https://github.com/microsoft/testfx/pull/9076)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -22,6 +22,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * RFC 014 + impl: experimental TestRun.Current / PlannedTests API by @Evangelink in [#8461](https://github.com/microsoft/testfx/pull/8461)
 * Support class-level \[Retry] attribute by @Evangelink in [#8566](https://github.com/microsoft/testfx/pull/8566)
 * Add MSTest reflection source generator (issue #1837) by @Evangelink in [#8586](https://github.com/microsoft/testfx/pull/8586)
+* Add MSTEST0069: flag test classes relying on an inherited \[TestClass] attribute incompatible with MSTest source generation by @Evangelink in [#8586](https://github.com/microsoft/testfx/pull/8586)
 * Add MSTEST0067 analyzer to flag Thread.Sleep/Task.Wait/Task&lt;T&gt;.Result in tests by @Evangelink in [#8646](https://github.com/microsoft/testfx/pull/8646)
 * Add opt-in random test order to MSTest adapter by @Evangelink in [#8647](https://github.com/microsoft/testfx/pull/8647)
 * Add MSTEST0066: \[Ignore] should have a justification message by @Evangelink in [#8649](https://github.com/microsoft/testfx/pull/8649)


### PR DESCRIPTION
## Draft 4.3.0 / 2.3.0 changelogs

Drafts the next changelog sections for the **MSTest 4.3 / MTP 2.3** milestone (#75), covering user-facing changes merged to main since v4.2.3. Versions/dates are intentionally left as `UNRELEASED` to finalize at release time.

### `docs/Changelog.md` — `[4.3.0]`
- **Added** (19): RFC 012 structured assertion messages; new asserts (`ContainsAll`/`DoesNotContainAll`, `AreEquivalent`, `AreSequenceEqual`, `AreAll*`); analyzers MSTEST0064-0070; `[AssemblyFixtureProvider]`; class-level `[Retry]`; `[MemberCondition]`; opt-in random test order; MSTest reflection (AOT) source generator; `MSTestParallelizeScope/Workers` MSBuild props.
- **Fixed** (9): `Assert.That` single-pass evaluation; `[StackTraceHidden]` on assertions; folded data-driven `TestContext` sharing; MSTEST0005/0032/0066 corrections; full-precision BCL rendering.

### `docs/Changelog-Platform.md` — `[2.3.0]`
- **Added** (23): new `HtmlReport`, `JUnitReport`, `CtrfReport` and `Logging` extensions; live Azure DevOps publishing/attachments/summary; TRX streaming + filename placeholders; `--ansi`, `--progress`, `--crash-sequence`, `--list-tests json`; testconfig.json via `IConfiguration`; two-stage Ctrl+C; `dotnet test` active-test rendering.
- **Fixed** (32): NO_COLOR support; deterministic `<asm>_<tfm>_<arch>` report names; CLI option validation; JSON-RPC/IPC robustness; HangDump/Retry/telemetry fixes; wasi/Native AOT hardening.

### Notes
- Curated to the user-facing subset; automation/CI/refactor/dedup/test/docs/dependency-bump PRs excluded.
- markdownlint-cli2 clean; pure-additive diff (folds the prior platform `[Unreleased]` #7415 entry into 2.3.0).
- Companion milestone hygiene (assigning fixed issues + issue-less PRs to milestone #75, and 2 after-the-fact `Feature` tickets #9173/#9174) was applied directly on GitHub.