### PR TITLE
Extract duplicate banner logic into OutputDeviceBannerHelper

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceBannerHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceBannerHelper.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+internal static class OutputDeviceBannerHelper
+{
+#pragma warning disable SA1310 // Field names should not contain underscore
+    internal const string TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER = nameof(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER);
+#pragma warning restore SA1310 // Field names should not contain underscore
+
+    internal static string BuildBannerText(IPlatformInformation platformInformation, IRuntimeFeature runtimeFeature, string? longArchitecture, string? runtimeFramework)
+    {
+        StringBuilder stringBuilder = new();
+        stringBuilder.Append(platformInformation.Name);
+
+        if (platformInformation.Version is { } version)
+        {
+            stringBuilder.Append(CultureInfo.InvariantCulture, $" v{version}");
+            if (platformInformation.CommitHash is { } commitHash)
+            {
+                stringBuilder.Append(CultureInfo.InvariantCulture, $"+{commitHash[..10]}");
+            }
+        }
+
+        if (platformInformation.BuildDate is { } buildDate)
+        {
+            stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime:d})");
+        }
+
+        if (runtimeFeature.IsDynamicCodeSupported)
+        {
+            stringBuilder.Append(" [");
+            stringBuilder.Append(longArchitecture);
+            stringBuilder.Append(" - ");
+            stringBuilder.Append(runtimeFramework);
+            stringBuilder.Append(']');
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceBannerHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceBannerHelper.cs
@@ -22,7 +22,7 @@ internal static class OutputDeviceBannerHelper
             stringBuilder.Append(CultureInfo.InvariantCulture, $" v{version}");
             if (platformInformation.CommitHash is { } commitHash)
             {
-                stringBuilder.Append(CultureInfo.InvariantCulture, $"+{commitHash[..10]}");
+                stringBuilder.Append(CultureInfo.InvariantCulture, $"+{(commitHash.Length >= 10 ? commitHash[..10] : commitHash)}");
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -21,10 +21,6 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
     ITestSessionLifetimeHandler,
     IAsyncInitializableExtension
 {
-#pragma warning disable SA1310 // Field names should not contain underscore
-    private const string TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER = nameof(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER);
-#pragma warning restore SA1310 // Field names should not contain underscore
-
     private readonly IConsole _console;
     private readonly IAsyncMonitor _asyncMonitor;
     private readonly IRuntimeFeature _runtimeFeature;
@@ -74,7 +70,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
 
         _assemblyName = testApplicationModuleInfo.GetDisplayName();
 
-        if (environment.GetEnvironmentVariable(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER) is not null)
+        if (environment.GetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER) is not null)
         {
             _bannerDisplayed = true;
         }
@@ -127,7 +123,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
             }
 
             // skip the banner for the children processes
-            _environment.SetEnvironmentVariable(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
+            _environment.SetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
 
             _bannerDisplayed = true;
 
@@ -137,33 +133,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
                 return;
             }
 
-            StringBuilder stringBuilder = new();
-            stringBuilder.Append(_platformInformation.Name);
-
-            if (_platformInformation.Version is { } version)
-            {
-                stringBuilder.Append(CultureInfo.InvariantCulture, $" v{version}");
-                if (_platformInformation.CommitHash is { } commitHash)
-                {
-                    stringBuilder.Append(CultureInfo.InvariantCulture, $"+{commitHash[..10]}");
-                }
-            }
-
-            if (_platformInformation.BuildDate is { } buildDate)
-            {
-                stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime:d})");
-            }
-
-            if (_runtimeFeature.IsDynamicCodeSupported)
-            {
-                stringBuilder.Append(" [");
-                stringBuilder.Append(_longArchitecture);
-                stringBuilder.Append(" - ");
-                stringBuilder.Append(_runtimeFramework);
-                stringBuilder.Append(']');
-            }
-
-            ConsoleLog(stringBuilder.ToString());
+            ConsoleLog(OutputDeviceBannerHelper.BuildBannerText(_platformInformation, _runtimeFeature, _longArchitecture, _runtimeFramework));
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -25,8 +25,6 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
     IAsyncInitializableExtension
 {
 #pragma warning disable SA1310 // Field names should not contain underscore
-    private const string TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER = nameof(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER);
-
     // Opt-in knobs (env vars only) for the silence-driven heartbeat renderer used in non-cursor modes.
     private const string MTP_PROGRESS_SILENCE_SECONDS = nameof(MTP_PROGRESS_SILENCE_SECONDS);
     private const string MTP_PROGRESS_SLOW_TEST_SECONDS = nameof(MTP_PROGRESS_SLOW_TEST_SECONDS);
@@ -110,7 +108,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
         _assemblyName = testApplicationModuleInfo.GetDisplayName();
 
-        if (environment.GetEnvironmentVariable(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER) is not null)
+        if (environment.GetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER) is not null)
         {
             _bannerDisplayed = true;
         }
@@ -371,7 +369,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
             // The env var propagates to any child test host the controller spawns so they also
             // stay quiet — important because the JSON document must be the sole stdout content.
             _bannerDisplayed = true;
-            _environment.SetEnvironmentVariable(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
+            _environment.SetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
             return;
         }
 
@@ -380,7 +378,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
             if (!_bannerDisplayed && !_isServerMode)
             {
                 // skip the banner for the children processes
-                _environment.SetEnvironmentVariable(TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
+                _environment.SetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
 
                 _bannerDisplayed = true;
 
@@ -390,33 +388,7 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
                 }
                 else
                 {
-                    StringBuilder stringBuilder = new();
-                    stringBuilder.Append(_platformInformation.Name);
-
-                    if (_platformInformation.Version is { } version)
-                    {
-                        stringBuilder.Append(CultureInfo.InvariantCulture, $" v{version}");
-                        if (_platformInformation.CommitHash is { } commitHash)
-                        {
-                            stringBuilder.Append(CultureInfo.InvariantCulture, $"+{commitHash[..10]}");
-                        }
-                    }
-
-                    if (_platformInformation.BuildDate is { } buildDate)
-                    {
-                        stringBuilder.Append(CultureInfo.InvariantCulture, $" (UTC {buildDate.UtcDateTime:d})");
-                    }
-
-                    if (_runtimeFeature.IsDynamicCodeSupported)
-                    {
-                        stringBuilder.Append(" [");
-                        stringBuilder.Append(_longArchitecture);
-                        stringBuilder.Append(" - ");
-                        stringBuilder.Append(_runtimeFramework);
-                        stringBuilder.Append(']');
-                    }
-
-                    _terminalTestReporter.WriteMessage(stringBuilder.ToString());
+                    _terminalTestReporter.WriteMessage(OutputDeviceBannerHelper.BuildBannerText(_platformInformation, _runtimeFeature, _longArchitecture, _runtimeFramework));
                 }
             }
 


### PR DESCRIPTION
## Summary

Both `TerminalOutputDevice` and `SimplifiedConsoleOutputDeviceBase` independently defined the same `TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER` constant and implemented nearly identical `DisplayBannerAsync` logic (~30 lines of duplicated `StringBuilder`-based banner construction).

## Changes

- **New file** `OutputDeviceBannerHelper.cs` — a static helper class containing:
  - The shared `TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER` constant
  - `BuildBannerText(IPlatformInformation, IRuntimeFeature, string?, string?)` that constructs the platform information banner string
- **Updated** `SimplifiedConsoleOutputDeviceBase.cs` — removed the private constant and inline banner construction; now calls the shared helper
- **Updated** `TerminalOutputDevice.cs` — same treatment

## Validation

- Build succeeded with 0 warnings, 0 errors across all TFMs (net8.0, net9.0, netstandard2.0)
- No public API changes (all types are internal)

Fixes #9170