### PR TITLE
Deduplicate test run summary logic between SimplifiedConsoleOutputDeviceBase and TerminalTestReporter

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -42,6 +42,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
 
     private bool _firstCallTo_OnSessionStartingAsync = true;
     private bool _bannerDisplayed;
+    private bool _wasCancelled;
 
     private int _passedTests;
     private int _failedTests;
@@ -84,6 +85,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
         => await _policiesService.RegisterOnAbortCallbackAsync(
             () =>
             {
+                _wasCancelled = true;
                 ConsoleLog(PlatformResources.CancellingTestSession);
                 ConsoleLog(PlatformResources.PressCtrlCAgainToForceExit);
                 return Task.CompletedTask;
@@ -210,16 +212,9 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
             }
 
             int total = _skippedTests + _passedTests + _failedTests;
-            // TODO: Duplicate the logic from TerminalTestReporter.AppendTestRunSummary, or refactor it
-            // so that it's easily shareable between the two implementations.
-            string text = $"""
-                    Total tests: {total}
-                    Failed tests: {_failedTests}
-                    Passed tests: {_passedTests}
-                    Skipped tests: {_skippedTests}
-                    """;
+            string text = TestRunSummaryHelper.FormatSummaryText(total, _failedTests, _passedTests, _skippedTests, _wasCancelled, minimumExpectedTests: 0);
 
-            if (_failedTests > 0)
+            if (TestRunSummaryHelper.IsRunFailed(total, _failedTests, _skippedTests, _wasCancelled, minimumExpectedTests: 0))
             {
                 ConsoleError(text);
             }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -42,7 +42,7 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
 
     private bool _firstCallTo_OnSessionStartingAsync = true;
     private bool _bannerDisplayed;
-    private bool _wasCancelled;
+    private volatile bool _wasCancelled;
 
     private int _passedTests;
     private int _failedTests;
@@ -212,6 +212,10 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
             }
 
             int total = _skippedTests + _passedTests + _failedTests;
+
+            // minimumExpectedTests is always 0 here because SimplifiedConsoleOutputDeviceBase does not
+            // receive ICommandLineOptions. The --minimum-expected-tests policy is still enforced via
+            // TestApplicationResult (exit code), but it is not surfaced in this summary.
             string text = TestRunSummaryHelper.FormatSummaryText(total, _failedTests, _passedTests, _skippedTests, _wasCancelled, minimumExpectedTests: 0);
 
             if (TestRunSummaryHelper.IsRunFailed(total, _failedTests, _skippedTests, _wasCancelled, minimumExpectedTests: 0))

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -213,12 +213,17 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
 
             int total = _skippedTests + _passedTests + _failedTests;
 
+            // The abort callback sets _wasCancelled, but it does not cover every cancellation path
+            // (e.g. cancellations that request the session token without going through the abort
+            // callback). Fold in the token state so the verdict and routing also reflect those.
+            bool wasCancelled = _wasCancelled || cancellationToken.IsCancellationRequested;
+
             // minimumExpectedTests is always 0 here because SimplifiedConsoleOutputDeviceBase does not
             // receive ICommandLineOptions. The --minimum-expected-tests policy is still enforced via
             // TestApplicationResult (exit code), but it is not surfaced in this summary.
-            string text = TestRunSummaryHelper.FormatSummaryText(total, _failedTests, _passedTests, _skippedTests, _wasCancelled, minimumExpectedTests: 0);
+            string text = TestRunSummaryHelper.FormatSummaryText(total, _failedTests, _passedTests, _skippedTests, wasCancelled, minimumExpectedTests: 0);
 
-            if (TestRunSummaryHelper.IsRunFailed(total, _failedTests, _skippedTests, _wasCancelled, minimumExpectedTests: 0))
+            if (TestRunSummaryHelper.IsRunFailed(total, _failedTests, _skippedTests, wasCancelled, minimumExpectedTests: 0))
             {
                 ConsoleError(text);
             }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -54,35 +54,12 @@ internal sealed partial class TerminalTestReporter
         // Two sibling sites mirror this decision and must stay in lockstep:
         //   - TestApplicationResult.ConsumeAsync (excludes skipped from `_totalRanTests` -> exit code 8)
         //   - Microsoft.Testing.Platform.MSBuild InvokeTestingPlatformTask (run-summary verdict)
-        bool notEnoughTests = totalTests < _options.MinimumExpectedTests;
-        bool allTestsWereSkipped = totalTests == 0 || totalTests == totalSkippedTests;
-        bool anyTestFailed = totalFailedTests > 0;
-        bool runFailed = anyTestFailed || notEnoughTests || allTestsWereSkipped || WasCancelled;
+        bool runFailed = TestRunSummaryHelper.IsRunFailed(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests);
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
 
         terminal.Append(PlatformResources.TestRunSummary);
         terminal.Append(' ');
-
-        if (WasCancelled)
-        {
-            terminal.Append(PlatformResources.Aborted);
-        }
-        else if (notEnoughTests)
-        {
-            terminal.Append(string.Format(CultureInfo.CurrentCulture, PlatformResources.MinimumExpectedTestsPolicyViolation, totalTests, _options.MinimumExpectedTests));
-        }
-        else if (allTestsWereSkipped)
-        {
-            terminal.Append(PlatformResources.ZeroTestsRan);
-        }
-        else if (anyTestFailed)
-        {
-            terminal.Append($"{PlatformResources.Failed}!");
-        }
-        else
-        {
-            terminal.Append($"{PlatformResources.Passed}!");
-        }
+        terminal.Append(TestRunSummaryHelper.GetVerdictText(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests));
 
         terminal.SetColor(TerminalColor.DarkGray);
         terminal.Append(" - ");

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
@@ -27,21 +27,30 @@ internal static class TestRunSummaryHelper
     /// <summary>
     /// Computes the verdict string for the test run.
     /// </summary>
-    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests) =>
-        wasCancelled
-            ? PlatformResources.Aborted
-            : totalTests < minimumExpectedTests
-                ? string.Format(CultureInfo.CurrentCulture, PlatformResources.MinimumExpectedTestsPolicyViolation, totalTests, minimumExpectedTests)
-                : totalTests == 0 || totalTests == skippedTests
-                    ? PlatformResources.ZeroTestsRan
-                    : failedTests > 0
-                        ? $"{PlatformResources.Failed}!"
-                        : $"{PlatformResources.Passed}!";
+    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests)
+    {
+        if (wasCancelled)
+        {
+            return PlatformResources.Aborted;
+        }
+
+        if (totalTests < minimumExpectedTests)
+        {
+            return string.Format(CultureInfo.CurrentCulture, PlatformResources.MinimumExpectedTestsPolicyViolation, totalTests, minimumExpectedTests);
+        }
+
+        if (totalTests == 0 || totalTests == skippedTests)
+        {
+            return PlatformResources.ZeroTestsRan;
+        }
+
+        return failedTests > 0 ? $"{PlatformResources.Failed}!" : $"{PlatformResources.Passed}!";
+    }
 
     /// <summary>
-    /// Formats a plain-text test run summary suitable for console output (no ANSI escape codes).
-    /// Produces the same logical content as <see cref="Terminal.TerminalTestReporter.AppendTestRunSummary"/>
-    /// but as a simple multi-line string.
+    /// Formats a plain-text test run summary with verdict and counts, suitable for console output
+    /// (no ANSI escape codes). Unlike <see cref="Terminal.TerminalTestReporter.AppendTestRunSummary"/>,
+    /// this does not include artifacts, duration, or assembly/TFM/architecture context.
     /// </summary>
     internal static string FormatSummaryText(int totalTests, int failedTests, int passedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests)
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
@@ -28,24 +28,14 @@ internal static class TestRunSummaryHelper
     /// Computes the verdict string for the test run.
     /// </summary>
     internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests)
-    {
-        if (wasCancelled)
+        => true switch
         {
-            return PlatformResources.Aborted;
-        }
-
-        if (totalTests < minimumExpectedTests)
-        {
-            return string.Format(CultureInfo.CurrentCulture, PlatformResources.MinimumExpectedTestsPolicyViolation, totalTests, minimumExpectedTests);
-        }
-
-        if (totalTests == 0 || totalTests == skippedTests)
-        {
-            return PlatformResources.ZeroTestsRan;
-        }
-
-        return failedTests > 0 ? $"{PlatformResources.Failed}!" : $"{PlatformResources.Passed}!";
-    }
+            _ when wasCancelled => PlatformResources.Aborted,
+            _ when totalTests < minimumExpectedTests => string.Format(CultureInfo.CurrentCulture, PlatformResources.MinimumExpectedTestsPolicyViolation, totalTests, minimumExpectedTests),
+            _ when totalTests == 0 || totalTests == skippedTests => PlatformResources.ZeroTestsRan,
+            _ when failedTests > 0 => $"{PlatformResources.Failed}!",
+            _ => $"{PlatformResources.Passed}!",
+        };
 
     /// <summary>
     /// Formats a plain-text test run summary with verdict and counts, suitable for console output

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Resources;
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+/// <summary>
+/// Shared helper for computing test run verdicts and formatting plain-text summaries.
+/// Used by both <see cref="Terminal.TerminalTestReporter"/> (verdict logic) and
+/// <see cref="SimplifiedConsoleOutputDeviceBase"/> (full plain-text summary).
+/// </summary>
+internal static class TestRunSummaryHelper
+{
+    /// <summary>
+    /// Determines whether the test run should be considered failed based on the given outcome counters and state.
+    /// </summary>
+    internal static bool IsRunFailed(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests)
+    {
+        bool notEnoughTests = totalTests < minimumExpectedTests;
+        bool allTestsWereSkipped = totalTests == 0 || totalTests == skippedTests;
+        bool anyTestFailed = failedTests > 0;
+
+        return anyTestFailed || notEnoughTests || allTestsWereSkipped || wasCancelled;
+    }
+
+    /// <summary>
+    /// Computes the verdict string for the test run.
+    /// </summary>
+    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests) =>
+        wasCancelled
+            ? PlatformResources.Aborted
+            : totalTests < minimumExpectedTests
+                ? string.Format(CultureInfo.CurrentCulture, PlatformResources.MinimumExpectedTestsPolicyViolation, totalTests, minimumExpectedTests)
+                : totalTests == 0 || totalTests == skippedTests
+                    ? PlatformResources.ZeroTestsRan
+                    : failedTests > 0
+                        ? $"{PlatformResources.Failed}!"
+                        : $"{PlatformResources.Passed}!";
+
+    /// <summary>
+    /// Formats a plain-text test run summary suitable for console output (no ANSI escape codes).
+    /// Produces the same logical content as <see cref="Terminal.TerminalTestReporter.AppendTestRunSummary"/>
+    /// but as a simple multi-line string.
+    /// </summary>
+    internal static string FormatSummaryText(int totalTests, int failedTests, int passedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests)
+    {
+        string verdict = GetVerdictText(totalTests, failedTests, skippedTests, wasCancelled, minimumExpectedTests);
+
+        return $"""
+            {PlatformResources.TestRunSummary} {verdict}
+              {PlatformResources.TotalLowercase}: {totalTests}
+              {PlatformResources.FailedLowercase}: {failedTests}
+              {PlatformResources.SucceededLowercase}: {passedTests}
+              {PlatformResources.SkippedLowercase}: {skippedTests}
+            """;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
@@ -60,6 +60,22 @@ internal static partial class PlatformResources
     internal static string @PlatformCommandLinePortOptionSingleArgument => GetResourceString("PlatformCommandLinePortOptionSingleArgument");
 
     internal static string @PlatformCommandLineTimeoutArgumentErrorMessage => GetResourceString("PlatformCommandLineTimeoutArgumentErrorMessage");
+
+    internal static string @Aborted => GetResourceString("Aborted");
+
+    internal static string @ZeroTestsRan => GetResourceString("ZeroTestsRan");
+
+    internal static string @Failed => GetResourceString("Failed");
+
+    internal static string @Passed => GetResourceString("Passed");
+
+    internal static string @TotalLowercase => GetResourceString("TotalLowercase");
+
+    internal static string @FailedLowercase => GetResourceString("FailedLowercase");
+
+    internal static string @SucceededLowercase => GetResourceString("SucceededLowercase");
+
+    internal static string @SkippedLowercase => GetResourceString("SkippedLowercase");
 #endif
 
 #endif

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/TestRunSummaryHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/TestRunSummaryHelperTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Resources;
+
+namespace Microsoft.Testing.Platform.UnitTests.OutputDevice;
+
+[TestClass]
+public sealed class TestRunSummaryHelperTests
+{
+    [TestMethod]
+    public void IsRunFailed_WhenTestsFailed_ReturnsTrue()
+        => Assert.IsTrue(TestRunSummaryHelper.IsRunFailed(totalTests: 10, failedTests: 2, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void IsRunFailed_WhenBelowMinimumExpectedTests_ReturnsTrue()
+        => Assert.IsTrue(TestRunSummaryHelper.IsRunFailed(totalTests: 3, failedTests: 0, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 10));
+
+    [TestMethod]
+    public void IsRunFailed_WhenZeroTests_ReturnsTrue()
+        => Assert.IsTrue(TestRunSummaryHelper.IsRunFailed(totalTests: 0, failedTests: 0, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void IsRunFailed_WhenAllTestsSkipped_ReturnsTrue()
+        => Assert.IsTrue(TestRunSummaryHelper.IsRunFailed(totalTests: 5, failedTests: 0, skippedTests: 5, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void IsRunFailed_WhenCancelled_ReturnsTrue()
+        => Assert.IsTrue(TestRunSummaryHelper.IsRunFailed(totalTests: 10, failedTests: 0, skippedTests: 0, wasCancelled: true, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void IsRunFailed_WhenAllPassed_ReturnsFalse()
+        => Assert.IsFalse(TestRunSummaryHelper.IsRunFailed(totalTests: 10, failedTests: 0, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void GetVerdictText_WhenCancelled_ReturnsAborted()
+        => Assert.AreEqual(PlatformResources.Aborted, TestRunSummaryHelper.GetVerdictText(totalTests: 10, failedTests: 5, skippedTests: 0, wasCancelled: true, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void GetVerdictText_WhenBelowMinimumExpectedTests_ReturnsPolicyViolation()
+    {
+        string result = TestRunSummaryHelper.GetVerdictText(totalTests: 3, failedTests: 0, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 10);
+
+        Assert.Contains("3", result, StringComparison.Ordinal);
+        Assert.Contains("10", result, StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void GetVerdictText_WhenAllTestsSkipped_ReturnsZeroTestsRan()
+        => Assert.AreEqual(PlatformResources.ZeroTestsRan, TestRunSummaryHelper.GetVerdictText(totalTests: 5, failedTests: 0, skippedTests: 5, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void GetVerdictText_WhenZeroTests_ReturnsZeroTestsRan()
+        => Assert.AreEqual(PlatformResources.ZeroTestsRan, TestRunSummaryHelper.GetVerdictText(totalTests: 0, failedTests: 0, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void GetVerdictText_WhenTestsFailed_ReturnsFailed()
+        => Assert.AreEqual($"{PlatformResources.Failed}!", TestRunSummaryHelper.GetVerdictText(totalTests: 10, failedTests: 2, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void GetVerdictText_WhenAllPassed_ReturnsPassed()
+        => Assert.AreEqual($"{PlatformResources.Passed}!", TestRunSummaryHelper.GetVerdictText(totalTests: 10, failedTests: 0, skippedTests: 0, wasCancelled: false, minimumExpectedTests: 0));
+
+    [TestMethod]
+    public void FormatSummaryText_ContainsVerdictAndAllCounts()
+    {
+        string result = TestRunSummaryHelper.FormatSummaryText(totalTests: 10, failedTests: 2, passedTests: 7, skippedTests: 1, wasCancelled: false, minimumExpectedTests: 0);
+
+        Assert.Contains($"{PlatformResources.Failed}!", result, StringComparison.Ordinal);
+        Assert.Contains($"{PlatformResources.TotalLowercase}: 10", result, StringComparison.Ordinal);
+        Assert.Contains($"{PlatformResources.FailedLowercase}: 2", result, StringComparison.Ordinal);
+        Assert.Contains($"{PlatformResources.SucceededLowercase}: 7", result, StringComparison.Ordinal);
+        Assert.Contains($"{PlatformResources.SkippedLowercase}: 1", result, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts a shared `TestRunSummaryHelper` class to eliminate duplicate test run summary logic between `SimplifiedConsoleOutputDeviceBase` (browser/WASI output) and `TerminalTestReporter` (terminal output).

## Changes

### New file: `TestRunSummaryHelper.cs`
- `IsRunFailed`: determines whether the test run should be considered failed (checks failed tests, all-skipped, minimum-expected-tests policy, cancellation)
- `GetVerdictText`: produces the localized verdict string (Aborted / ZeroTestsRan / Failed! / Passed! / MinimumExpectedTests policy violation)
- `FormatSummaryText`: formats a complete plain-text summary with verdict + counts using localized resource strings

### Updated: `SimplifiedConsoleOutputDeviceBase.cs`
- Replaced inline hardcoded summary (`Total tests: {total}` etc.) with call to `TestRunSummaryHelper.FormatSummaryText`
- Added `_wasCancelled` field set in the abort callback, so the simplified output now correctly reports aborted runs
- Uses `IsRunFailed` for the error vs. log routing (previously only checked `_failedTests > 0`, missing all-skipped/cancellation cases)
- Removed the `TODO` comment

### Updated: `TerminalTestReporter.Summary.cs`
- Replaced inline verdict boolean computation + if-else chain with calls to `TestRunSummaryHelper.IsRunFailed` and `GetVerdictText`
- Retained terminal-specific colorization and formatting

## Behavioral improvements for browser/WASI users
- Summary now uses localized resource strings (consistent with terminal)
- Cancelled runs are reported as "Aborted" (previously shown as passed)
- Zero-test / all-skipped runs route to `ConsoleError` (previously only failed tests did)

Fixes #9171