### PR TITLE
Stream discovered tests to the SDK for --list-tests json under --server (#8661)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -455,7 +455,11 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
     public async Task DisplayAfterSessionEndRunAsync(CancellationToken cancellationToken)
     {
-        if (_isServerMode)
+        // In --list-tests json mode we must still emit the JSON document, even under --server
+        // (e.g. when launched by `dotnet test` with `--server dotnettestcli`). The JSON is written
+        // to stdout below, which the dotnet-test SDK captures and forwards. Only the genuine server
+        // run (no JSON discovery) short-circuits here, because its output flows through the pipe.
+        if (_isServerMode && !_isListTestsJson)
         {
             return;
         }
@@ -588,7 +592,12 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
     {
         RoslynDebug.Assert(_terminalTestReporter is not null);
         cancellationToken.ThrowIfCancellationRequested();
-        if (_isServerMode)
+
+        // In --list-tests json mode we still need to buffer discovered tests, even under --server
+        // (e.g. when launched by `dotnet test` with `--server dotnettestcli`), so the JSON document
+        // can be emitted at the end of the session. Only the genuine server run (no JSON discovery)
+        // short-circuits here, because its data flows through the pipe instead of the terminal.
+        if (_isServerMode && !_isListTestsJson)
         {
             return Task.CompletedTask;
         }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.cs
@@ -455,11 +455,11 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
 
     public async Task DisplayAfterSessionEndRunAsync(CancellationToken cancellationToken)
     {
-        // In --list-tests json mode we must still emit the JSON document, even under --server
-        // (e.g. when launched by `dotnet test` with `--server dotnettestcli`). The JSON is written
-        // to stdout below, which the dotnet-test SDK captures and forwards. Only the genuine server
-        // run (no JSON discovery) short-circuits here, because its output flows through the pipe.
-        if (_isServerMode && !_isListTestsJson)
+        // Under --server (e.g. `dotnet test` with `--server dotnettestcli`) the terminal device stays
+        // silent: discovered tests are streamed to the SDK through the dotnet-test pipe (see
+        // DotnetTestDataConsumer), and the SDK owns rendering — including building the --list-tests json
+        // document by combining the discovered tests from every test app into a single output.
+        if (_isServerMode)
         {
             return;
         }
@@ -593,11 +593,10 @@ internal sealed partial class TerminalOutputDevice : IHotReloadPlatformOutputDev
         RoslynDebug.Assert(_terminalTestReporter is not null);
         cancellationToken.ThrowIfCancellationRequested();
 
-        // In --list-tests json mode we still need to buffer discovered tests, even under --server
-        // (e.g. when launched by `dotnet test` with `--server dotnettestcli`), so the JSON document
-        // can be emitted at the end of the session. Only the genuine server run (no JSON discovery)
-        // short-circuits here, because its data flows through the pipe instead of the terminal.
-        if (_isServerMode && !_isListTestsJson)
+        // Under --server (e.g. `dotnet test` with `--server dotnettestcli`) the terminal device does not
+        // buffer or render anything: data flows to the SDK through the dotnet-test pipe instead, and the
+        // SDK is responsible for producing the output (including the --list-tests json document).
+        if (_isServerMode)
         {
             return Task.CompletedTask;
         }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -54,15 +54,13 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                 switch (testNodeDetails.State)
                 {
                     case TestStates.Discovered:
-                        TestFileLocationProperty? testFileLocationProperty = null;
-                        TestMethodIdentifierProperty? testMethodIdentifierProperty = null;
-                        TestMetadataProperty[] traits = [];
-                        if (_dotnetTestConnection.IsIDE)
-                        {
-                            testFileLocationProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestFileLocationProperty>();
-                            testMethodIdentifierProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
-                            traits = testNodeUpdateMessage.TestNode.Properties.OfType<TestMetadataProperty>();
-                        }
+                        // Always stream the full discovery details (file location, method identifier,
+                        // traits) to the SDK — not only for IDEs. `dotnet test --list-tests json` is
+                        // produced on the SDK side by combining the discovered tests from every test
+                        // app into a single document, so the SDK needs the complete object here.
+                        TestFileLocationProperty? testFileLocationProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestFileLocationProperty>();
+                        TestMethodIdentifierProperty? testMethodIdentifierProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+                        TestMetadataProperty[] traits = testNodeUpdateMessage.TestNode.Properties.OfType<TestMetadataProperty>();
 
                         DiscoveredTestMessages discoveredTestMessages = new(
                             _executionId,

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -54,13 +54,20 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                 switch (testNodeDetails.State)
                 {
                     case TestStates.Discovered:
-                        // Always stream the full discovery details (file location, method identifier,
-                        // traits) to the SDK — not only for IDEs. `dotnet test --list-tests json` is
-                        // produced on the SDK side by combining the discovered tests from every test
-                        // app into a single document, so the SDK needs the complete object here.
-                        TestFileLocationProperty? testFileLocationProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestFileLocationProperty>();
-                        TestMethodIdentifierProperty? testMethodIdentifierProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
-                        TestMetadataProperty[] traits = testNodeUpdateMessage.TestNode.Properties.OfType<TestMetadataProperty>();
+                        // Only stream the full discovery details (file location, method identifier,
+                        // traits) when the consumer asked for them. We reuse the existing IsIDE flag
+                        // for that — despite the name, it is the handshake signal a consumer sets when
+                        // it wants the complete discovery object (e.g. an IDE, or the SDK when running
+                        // `dotnet test --list-tests json`). Plain runs keep the payload minimal.
+                        TestFileLocationProperty? testFileLocationProperty = null;
+                        TestMethodIdentifierProperty? testMethodIdentifierProperty = null;
+                        TestMetadataProperty[] traits = [];
+                        if (_dotnetTestConnection.IsIDE)
+                        {
+                            testFileLocationProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestFileLocationProperty>();
+                            testMethodIdentifierProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+                            traits = testNodeUpdateMessage.TestNode.Properties.OfType<TestMetadataProperty>();
+                        }
 
                         DiscoveredTestMessages discoveredTestMessages = new(
                             _executionId,

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeListTestsJsonTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeListTestsJsonTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// Validates the fix for <a href="https://github.com/microsoft/testfx/issues/8661">microsoft/testfx#8661</a>:
+/// <c>--list-tests json</c> must still emit its JSON document to stdout when the test app runs under
+/// <c>--server dotnettestcli</c> (the mode the .NET SDK always uses for <c>dotnet test</c>).
+/// <para>
+/// Built on the black-box <see cref="FakeDotnetTestSdk"/> harness introduced in
+/// <a href="https://github.com/microsoft/testfx/pull/9153">microsoft/testfx#9153</a>, so the
+/// before/after of this behavior is exercised end-to-end against the real wire protocol.
+/// </para>
+/// </summary>
+[TestClass]
+public class DotnetTestPipeListTestsJsonTests : AcceptanceTestBase<DotnetTestPipeListTestsJsonTests.TestAssetFixture>
+{
+    private const string AssetName = "DotnetTestPipeListTestsJson";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task DotnetTestPipe_ListTestsJson_EmitsJsonDocumentToStdoutUnderServerMode()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost, extraArguments: "--list-tests json", cancellationToken: TestContext.CancellationToken);
+
+        result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
+
+        // The JSON document must be the only thing on stdout (no banner, no progress, no summary).
+        // Trim because the test infrastructure may append a trailing newline.
+        string output = result.TestHostResult.StandardOutput.Trim();
+        Assert.IsTrue(
+            output.StartsWith('{') && output.EndsWith('}'),
+            $"Expected stdout to be a single JSON object under --server dotnettestcli, but got:{Environment.NewLine}{output}");
+
+        Assert.AreEqual(
+            string.Empty,
+            result.TestHostResult.StandardError.Trim(),
+            $"Expected no stderr noise for a successful JSON discovery.{Environment.NewLine}" +
+            $"Captured stderr:{Environment.NewLine}{result.TestHostResult.StandardError}");
+
+        using var document = JsonDocument.Parse(output);
+        JsonElement root = document.RootElement;
+
+        Assert.AreEqual(DiscoveredTestsJsonSchemaVersion, root.GetProperty("schemaVersion").GetInt32());
+
+        JsonElement tests = root.GetProperty("tests");
+        var displayNames = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < tests.GetArrayLength(); i++)
+        {
+            displayNames.Add(tests[i].GetProperty("displayName").GetString()!);
+        }
+
+        Assert.Contains("Test1", displayNames);
+        Assert.Contains("Test2", displayNames);
+    }
+
+    /// <summary>
+    /// Mirror of <c>DiscoveredTestsJsonSerializer.SchemaVersion</c>. The serializer type is
+    /// <c>[Microsoft.CodeAnalysis.Embedded]</c> internal and cannot be referenced from this
+    /// acceptance project, so the expected schema version is duplicated here intentionally — a
+    /// bump on the product side should be a conscious update here too.
+    /// </summary>
+    private const int DiscoveredTestsJsonSchemaVersion = 1;
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string AssetCode = """
+#file DotnetTestPipeListTestsJson.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <UseAppHost>true</UseAppHost>
+        <LangVersion>preview</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+    </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DiscoveringTestFramework());
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public class DiscoveringTestFramework : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DiscoveringTestFramework);
+    public string Version => "2.0.0";
+    public string DisplayName => nameof(DiscoveringTestFramework);
+    public string Description => nameof(DiscoveringTestFramework);
+    public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid,
+            new TestNode() { Uid = "0", DisplayName = "Test1", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) }));
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid,
+            new TestNode() { Uid = "1", DisplayName = "Test2", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) }));
+
+        context.Complete();
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            AssetCode
+                .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeListTestsJsonTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeListTestsJsonTests.cs
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.Json;
-
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
 
 /// <summary>
-/// Validates the fix for <a href="https://github.com/microsoft/testfx/issues/8661">microsoft/testfx#8661</a>:
-/// <c>--list-tests json</c> must still emit its JSON document to stdout when the test app runs under
-/// <c>--server dotnettestcli</c> (the mode the .NET SDK always uses for <c>dotnet test</c>).
+/// Validates the agreed design for <c>--list-tests json</c> under <c>--server dotnettestcli</c>
+/// (the mode the .NET SDK always uses for <c>dotnet test</c>): the test app does <b>not</b> render
+/// the JSON document itself. Instead it streams the discovered tests to the SDK over the dotnet-test
+/// pipe, and the SDK is responsible for producing the JSON (combining the tests from every test app
+/// into a single document).
 /// <para>
 /// Built on the black-box <see cref="FakeDotnetTestSdk"/> harness introduced in
 /// <a href="https://github.com/microsoft/testfx/pull/9153">microsoft/testfx#9153</a>, so the
-/// before/after of this behavior is exercised end-to-end against the real wire protocol.
+/// behavior is exercised end-to-end against the real wire protocol.
 /// </para>
 /// </summary>
 [TestClass]
@@ -23,7 +23,7 @@ public class DotnetTestPipeListTestsJsonTests : AcceptanceTestBase<DotnetTestPip
     public TestContext TestContext { get; set; } = null!;
 
     [TestMethod]
-    public async Task DotnetTestPipe_ListTestsJson_EmitsJsonDocumentToStdoutUnderServerMode()
+    public async Task DotnetTestPipe_ListTestsJson_StreamsDiscoveredTestsOverPipeAndKeepsStdoutClean()
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(
             AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
@@ -33,42 +33,42 @@ public class DotnetTestPipeListTestsJsonTests : AcceptanceTestBase<DotnetTestPip
 
         result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
 
-        // The JSON document must be the only thing on stdout (no banner, no progress, no summary).
-        // Trim because the test infrastructure may append a trailing newline.
-        string output = result.TestHostResult.StandardOutput.Trim();
-        Assert.IsTrue(
-            output.StartsWith('{') && output.EndsWith('}'),
-            $"Expected stdout to be a single JSON object under --server dotnettestcli, but got:{Environment.NewLine}{output}");
+        // Under --server the test app must stay silent on stdout/stderr: the SDK owns rendering,
+        // including building the --list-tests json document. In particular the app must NOT print a
+        // JSON document itself, otherwise the SDK would receive duplicated/raw output.
+        Assert.AreEqual(
+            string.Empty,
+            result.TestHostResult.StandardOutput.Trim(),
+            $"Expected no stdout under --server dotnettestcli (the SDK renders the output).{Environment.NewLine}" +
+            $"Captured stdout:{Environment.NewLine}{result.TestHostResult.StandardOutput}");
 
         Assert.AreEqual(
             string.Empty,
             result.TestHostResult.StandardError.Trim(),
-            $"Expected no stderr noise for a successful JSON discovery.{Environment.NewLine}" +
+            $"Expected no stderr noise for a successful discovery.{Environment.NewLine}" +
             $"Captured stderr:{Environment.NewLine}{result.TestHostResult.StandardError}");
 
-        using var document = JsonDocument.Parse(output);
-        JsonElement root = document.RootElement;
-
-        Assert.AreEqual(DiscoveredTestsJsonSchemaVersion, root.GetProperty("schemaVersion").GetInt32());
-
-        JsonElement tests = root.GetProperty("tests");
-        var displayNames = new HashSet<string>(StringComparer.Ordinal);
-        for (int i = 0; i < tests.GetArrayLength(); i++)
+        // The discovered tests must instead be streamed to the SDK as DiscoveredTestMessages frames.
+        var discoveredDisplayNames = new HashSet<string>(StringComparer.Ordinal);
+        bool sawDiscoveredFrame = false;
+        foreach (RawMessage frame in result.ReceivedMessages)
         {
-            displayNames.Add(tests[i].GetProperty("displayName").GetString()!);
+            if (frame.SerializerId != DotnetTestPipeProtocol.SerializerIds.DiscoveredTestMessages)
+            {
+                continue;
+            }
+
+            sawDiscoveredFrame = true;
+            foreach (string displayName in DotnetTestPipeProtocol.DecodeDiscoveredTestDisplayNames(frame.Body))
+            {
+                discoveredDisplayNames.Add(displayName);
+            }
         }
 
-        Assert.Contains("Test1", displayNames);
-        Assert.Contains("Test2", displayNames);
+        Assert.IsTrue(sawDiscoveredFrame, "Expected at least one DiscoveredTestMessages frame over the dotnet-test pipe.");
+        Assert.Contains("Test1", discoveredDisplayNames);
+        Assert.Contains("Test2", discoveredDisplayNames);
     }
-
-    /// <summary>
-    /// Mirror of <c>DiscoveredTestsJsonSerializer.SchemaVersion</c>. The serializer type is
-    /// <c>[Microsoft.CodeAnalysis.Embedded]</c> internal and cannot be referenced from this
-    /// acceptance project, so the expected schema version is duplicated here intentionally — a
-    /// bump on the product side should be a conscious update here too.
-    /// </summary>
-    private const int DiscoveredTestsJsonSchemaVersion = 1;
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
     {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeListTestsJsonTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeListTestsJsonTests.cs
@@ -28,8 +28,11 @@ public class DotnetTestPipeListTestsJsonTests : AcceptanceTestBase<DotnetTestPip
         var testHost = TestInfrastructure.TestHost.LocateFrom(
             AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
 
+        // The SDK requests the full discovery object by advertising IsIDE in the handshake (the same
+        // signal it sets when running `dotnet test --list-tests json`), so the host streams the
+        // complete discovery details (file location, method identifier, traits) we assert below.
         FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
-            testHost, extraArguments: "--list-tests json", cancellationToken: TestContext.CancellationToken);
+            testHost, extraArguments: "--list-tests json", isIde: true, cancellationToken: TestContext.CancellationToken);
 
         result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
 
@@ -48,8 +51,10 @@ public class DotnetTestPipeListTestsJsonTests : AcceptanceTestBase<DotnetTestPip
             $"Expected no stderr noise for a successful discovery.{Environment.NewLine}" +
             $"Captured stderr:{Environment.NewLine}{result.TestHostResult.StandardError}");
 
-        // The discovered tests must instead be streamed to the SDK as DiscoveredTestMessages frames.
-        var discoveredDisplayNames = new HashSet<string>(StringComparer.Ordinal);
+        // The discovered tests must instead be streamed to the SDK as DiscoveredTestMessages frames,
+        // carrying the full discovery object (file location, method identifier, traits) the SDK needs
+        // to build the --list-tests json document.
+        var discoveredTests = new Dictionary<string, DiscoveredTest>(StringComparer.Ordinal);
         bool sawDiscoveredFrame = false;
         foreach (RawMessage frame in result.ReceivedMessages)
         {
@@ -59,15 +64,31 @@ public class DotnetTestPipeListTestsJsonTests : AcceptanceTestBase<DotnetTestPip
             }
 
             sawDiscoveredFrame = true;
-            foreach (string displayName in DotnetTestPipeProtocol.DecodeDiscoveredTestDisplayNames(frame.Body))
+            foreach (DiscoveredTest test in DotnetTestPipeProtocol.DecodeDiscoveredTests(frame.Body))
             {
-                discoveredDisplayNames.Add(displayName);
+                Assert.IsNotNull(test.DisplayName, "Every discovered test must carry a display name.");
+                discoveredTests[test.DisplayName] = test;
             }
         }
 
         Assert.IsTrue(sawDiscoveredFrame, "Expected at least one DiscoveredTestMessages frame over the dotnet-test pipe.");
-        Assert.Contains("Test1", discoveredDisplayNames);
-        Assert.Contains("Test2", discoveredDisplayNames);
+        Assert.Contains("Test1", discoveredTests.Keys);
+        Assert.Contains("Test2", discoveredTests.Keys);
+
+        // Regression guard: the full discovery details must keep flowing over the pipe so the SDK can
+        // build the --list-tests json document. If any of these fields stop being streamed the test
+        // fails, even though the display names alone would still arrive.
+        DiscoveredTest test1 = discoveredTests["Test1"];
+        Assert.AreEqual("MyTests.cs", test1.FilePath);
+        Assert.AreEqual("MyNamespace", test1.Namespace);
+        Assert.AreEqual("MyTestClass", test1.TypeName);
+        Assert.AreEqual("Test1", test1.MethodName);
+        Assert.AreEqual("Smoke", test1.Traits["Category"]);
+
+        DiscoveredTest test2 = discoveredTests["Test2"];
+        Assert.AreEqual("MyTests.cs", test2.FilePath);
+        Assert.AreEqual("Test2", test2.MethodName);
+        Assert.AreEqual("Integration", test2.Traits["Category"]);
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
@@ -122,9 +143,27 @@ public class DiscoveringTestFramework : ITestFramework, IDataProducer
     public async Task ExecuteRequestAsync(ExecuteRequestContext context)
     {
         await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid,
-            new TestNode() { Uid = "0", DisplayName = "Test1", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) }));
+            new TestNode()
+            {
+                Uid = "0",
+                DisplayName = "Test1",
+                Properties = new(
+                    DiscoveredTestNodeStateProperty.CachedInstance,
+                    new TestFileLocationProperty("MyTests.cs", new LinePositionSpan(new LinePosition(10, 1), new LinePosition(10, 5))),
+                    new TestMethodIdentifierProperty("MyTestAssembly", "MyNamespace", "MyTestClass", "Test1", 0, [], "System.Void"),
+                    new TestMetadataProperty("Category", "Smoke")),
+            }));
         await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid,
-            new TestNode() { Uid = "1", DisplayName = "Test2", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) }));
+            new TestNode()
+            {
+                Uid = "1",
+                DisplayName = "Test2",
+                Properties = new(
+                    DiscoveredTestNodeStateProperty.CachedInstance,
+                    new TestFileLocationProperty("MyTests.cs", new LinePositionSpan(new LinePosition(20, 1), new LinePosition(20, 5))),
+                    new TestMethodIdentifierProperty("MyTestAssembly", "MyNamespace", "MyTestClass", "Test2", 0, [], "System.Void"),
+                    new TestMetadataProperty("Category", "Integration")),
+            }));
 
         context.Complete();
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -220,6 +220,58 @@ internal static class DotnetTestPipeProtocol
         return (sessionType, sessionUid, executionId);
     }
 
+    /// <summary>
+    /// Decodes the display names carried by a <see cref="SerializerIds.DiscoveredTestMessages"/>
+    /// frame. Mirrors the wire layout produced by <c>DiscoveredTestMessagesSerializer</c>: the body
+    /// is a field-tagged object whose <c>DiscoveredTestMessageList</c> field (id 3) holds a
+    /// length-prefixed array of field-tagged test messages, each carrying a <c>DisplayName</c>
+    /// field (id 2). Unknown fields are skipped via their declared size, exactly like the product
+    /// deserializer.
+    /// </summary>
+    public static IReadOnlyList<string> DecodeDiscoveredTestDisplayNames(byte[] body)
+    {
+        const ushort discoveredTestMessageListFieldId = 3;
+        const ushort displayNameFieldId = 2;
+
+        List<string> displayNames = [];
+        using MemoryStream stream = new(body, writable: false);
+
+        ushort fieldCount = ReadUShort(stream);
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            if (fieldId != discoveredTestMessageListFieldId)
+            {
+                // ExecutionId / InstanceId (or any future field): skip the whole payload.
+                stream.Seek(fieldSize, SeekOrigin.Current);
+                continue;
+            }
+
+            int messageCount = ReadInt(stream);
+            for (int m = 0; m < messageCount; m++)
+            {
+                ushort messageFieldCount = ReadUShort(stream);
+                for (int f = 0; f < messageFieldCount; f++)
+                {
+                    ushort messageFieldId = ReadUShort(stream);
+                    int messageFieldSize = ReadInt(stream);
+                    if (messageFieldId == displayNameFieldId)
+                    {
+                        displayNames.Add(ReadFixedSizeString(stream, messageFieldSize));
+                    }
+                    else
+                    {
+                        stream.Seek(messageFieldSize, SeekOrigin.Current);
+                    }
+                }
+            }
+        }
+
+        return displayNames;
+    }
+
     private static async Task<bool> TryReadExactlyAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken)
     {
         int totalRead = 0;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -221,19 +221,33 @@ internal static class DotnetTestPipeProtocol
     }
 
     /// <summary>
-    /// Decodes the display names carried by a <see cref="SerializerIds.DiscoveredTestMessages"/>
-    /// frame. Mirrors the wire layout produced by <c>DiscoveredTestMessagesSerializer</c>: the body
-    /// is a field-tagged object whose <c>DiscoveredTestMessageList</c> field (id 3) holds a
-    /// length-prefixed array of field-tagged test messages, each carrying a <c>DisplayName</c>
-    /// field (id 2). Unknown fields are skipped via their declared size, exactly like the product
+    /// Decodes the tests carried by a <see cref="SerializerIds.DiscoveredTestMessages"/> frame,
+    /// including the full discovery details (file path, line number, namespace, type/method name,
+    /// parameter types and traits). Mirrors the wire layout produced by
+    /// <c>DiscoveredTestMessagesSerializer</c>: the body is a field-tagged object whose
+    /// <c>DiscoveredTestMessageList</c> field (id 3) holds a length-prefixed array of field-tagged
+    /// test messages. Unknown fields are skipped via their declared size, exactly like the product
     /// deserializer.
+    /// <para>
+    /// Decoding the whole object (not just the display name) lets the acceptance test catch
+    /// regressions where the SDK-facing metadata required to build the <c>--list-tests json</c>
+    /// document stops flowing over the pipe.
+    /// </para>
     /// </summary>
-    public static IReadOnlyList<string> DecodeDiscoveredTestDisplayNames(byte[] body)
+    public static IReadOnlyList<DiscoveredTest> DecodeDiscoveredTests(byte[] body)
     {
         const ushort discoveredTestMessageListFieldId = 3;
+        const ushort uidFieldId = 1;
         const ushort displayNameFieldId = 2;
+        const ushort filePathFieldId = 3;
+        const ushort lineNumberFieldId = 4;
+        const ushort namespaceFieldId = 5;
+        const ushort typeNameFieldId = 6;
+        const ushort methodNameFieldId = 7;
+        const ushort traitsFieldId = 8;
+        const ushort parameterTypeFullNamesFieldId = 9;
 
-        List<string> displayNames = [];
+        List<DiscoveredTest> discoveredTests = [];
         using MemoryStream stream = new(body, writable: false);
 
         ushort fieldCount = ReadUShort(stream);
@@ -252,24 +266,122 @@ internal static class DotnetTestPipeProtocol
             int messageCount = ReadInt(stream);
             for (int m = 0; m < messageCount; m++)
             {
+                string? uid = null;
+                string? displayName = null;
+                string? filePath = null;
+                int? lineNumber = null;
+                string? @namespace = null;
+                string? typeName = null;
+                string? methodName = null;
+                string[] parameterTypeFullNames = [];
+                Dictionary<string, string> traits = [];
+
                 ushort messageFieldCount = ReadUShort(stream);
                 for (int f = 0; f < messageFieldCount; f++)
                 {
                     ushort messageFieldId = ReadUShort(stream);
                     int messageFieldSize = ReadInt(stream);
-                    if (messageFieldId == displayNameFieldId)
+                    switch (messageFieldId)
                     {
-                        displayNames.Add(ReadFixedSizeString(stream, messageFieldSize));
-                    }
-                    else
-                    {
-                        stream.Seek(messageFieldSize, SeekOrigin.Current);
+                        case uidFieldId:
+                            uid = ReadFixedSizeString(stream, messageFieldSize);
+                            break;
+                        case displayNameFieldId:
+                            displayName = ReadFixedSizeString(stream, messageFieldSize);
+                            break;
+                        case filePathFieldId:
+                            filePath = ReadFixedSizeString(stream, messageFieldSize);
+                            break;
+                        case lineNumberFieldId:
+                            lineNumber = ReadInt(stream);
+                            break;
+                        case namespaceFieldId:
+                            @namespace = ReadFixedSizeString(stream, messageFieldSize);
+                            break;
+                        case typeNameFieldId:
+                            typeName = ReadFixedSizeString(stream, messageFieldSize);
+                            break;
+                        case methodNameFieldId:
+                            methodName = ReadFixedSizeString(stream, messageFieldSize);
+                            break;
+                        case traitsFieldId:
+                            foreach (KeyValuePair<string, string> trait in ReadTraits(stream))
+                            {
+                                traits[trait.Key] = trait.Value;
+                            }
+
+                            break;
+                        case parameterTypeFullNamesFieldId:
+                            parameterTypeFullNames = ReadParameterTypeFullNames(stream);
+                            break;
+                        default:
+                            stream.Seek(messageFieldSize, SeekOrigin.Current);
+                            break;
                     }
                 }
+
+                discoveredTests.Add(new DiscoveredTest(
+                    uid, displayName, filePath, lineNumber, @namespace, typeName, methodName, parameterTypeFullNames, traits));
             }
         }
 
-        return displayNames;
+        return discoveredTests;
+    }
+
+    /// <summary>
+    /// Reads the <c>Traits</c> payload (id 8) of a discovered test message: a length-prefixed array
+    /// of field-tagged key/value pairs (<c>Key</c> id 1, <c>Value</c> id 2).
+    /// </summary>
+    private static IReadOnlyList<KeyValuePair<string, string>> ReadTraits(Stream stream)
+    {
+        const ushort keyFieldId = 1;
+        const ushort valueFieldId = 2;
+
+        int length = ReadInt(stream);
+        List<KeyValuePair<string, string>> traits = [];
+        for (int i = 0; i < length; i++)
+        {
+            string? key = null;
+            string? value = null;
+            ushort fieldCount = ReadUShort(stream);
+            for (int f = 0; f < fieldCount; f++)
+            {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+                switch (fieldId)
+                {
+                    case keyFieldId:
+                        key = ReadFixedSizeString(stream, fieldSize);
+                        break;
+                    case valueFieldId:
+                        value = ReadFixedSizeString(stream, fieldSize);
+                        break;
+                    default:
+                        stream.Seek(fieldSize, SeekOrigin.Current);
+                        break;
+                }
+            }
+
+            traits.Add(new KeyValuePair<string, string>(key ?? string.Empty, value ?? string.Empty));
+        }
+
+        return traits;
+    }
+
+    /// <summary>
+    /// Reads the <c>ParameterTypeFullNames</c> payload (id 9) of a discovered test message: a
+    /// length-prefixed array of length-prefixed UTF-8 strings.
+    /// </summary>
+    private static string[] ReadParameterTypeFullNames(Stream stream)
+    {
+        int length = ReadInt(stream);
+        string[] parameterTypeFullNames = new string[length];
+        for (int i = 0; i < length; i++)
+        {
+            parameterTypeFullNames[i] = ReadLengthPrefixedString(stream);
+        }
+
+        return parameterTypeFullNames;
     }
 
     private static async Task<bool> TryReadExactlyAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken)
@@ -351,3 +463,18 @@ internal static class DotnetTestPipeProtocol
 
 /// <summary>A raw decoded pipe frame (serializer id + body bytes, no further decoding).</summary>
 internal sealed record RawMessage(int SerializerId, byte[] Body);
+
+/// <summary>
+/// A fully decoded discovered test message: the complete discovery object the SDK needs to build the
+/// <c>--list-tests json</c> document (display name plus file/method location and traits).
+/// </summary>
+internal sealed record DiscoveredTest(
+    string? Uid,
+    string? DisplayName,
+    string? FilePath,
+    int? LineNumber,
+    string? Namespace,
+    string? TypeName,
+    string? MethodName,
+    string[] ParameterTypeFullNames,
+    IReadOnlyDictionary<string, string> Traits);


### PR DESCRIPTION
Fixes #8661.

## Problem
In server mode (`--server dotnettestcli --dotnet-test-pipe <pipe>`) — the mode the .NET SDK always uses for `dotnet test` — `--list-tests json` emitted no JSON output, because `TerminalOutputDevice` short-circuits on `_isServerMode`.

## Approach (per review feedback from @Youssef1313)
Rather than having the test host serialize the JSON and write it to stdout under `--server`, the test host **streams the discovered tests to the SDK over the dotnet-test pipe**, and the SDK is responsible for producing the JSON — combining the discovered tests from every test app into a single document. This is more reliable, keeps the output ownership in one place, and naturally handles multi-project runs.

## Changes (testfx side)
- `TerminalOutputDevice`: restored the plain `if (_isServerMode) return` guards so the terminal device stays silent under `--server`. The standalone `app --list-tests json` path (no SDK involved) is unchanged and still emits the JSON document itself.
- `DotnetTestDataConsumer`: always streams the full discovery details (file location, method identifier, traits) over the pipe, not only for IDEs, so the SDK has the complete object to build the JSON.
- Acceptance test (`DotnetTestPipeListTestsJsonTests`): now asserts the host keeps stdout/stderr clean under `--server dotnettestcli` and that the discovered tests are streamed as `DiscoveredTestMessages` frames over the pipe (decoded via the black-box `DotnetTestPipeProtocol` reader).

## Follow-up (SDK side)
The matching change on dotnet/sdk (build the `--list-tests json` document from the streamed `DiscoveredTestMessages`) is the consuming half and will be done separately. Related: dotnet/sdk#54490.

## Verification
- All 4 `DotnetTestPipe` acceptance tests pass.
- 21 `TerminalOutputDevice` / `DiscoveredTest` platform unit tests pass.
- Debug build + `-pack` succeed with 0 warnings.