### PR TITLE
Remove redundant 'actual type:' line from Assert.Throws* failure message

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
@@ -180,9 +180,10 @@ public sealed partial class Assert
 
             string expectedTypeLabel = isStrictType ? expectedTypeFullName : $"{expectedTypeFullName} (or derived)";
 
+            // The "actual exception:" line is already prefixed with the exception type name, so we don't emit a
+            // separate "actual type:" line to avoid duplicating that information.
             EvidenceBlock evidence = EvidenceBlock.Create()
                 .AddLine("expected type:", expectedTypeLabel)
-                .AddLine("actual type:", actualTypeFullName)
                 .AddLine("actual exception:", $"{actualTypeFullName}: {actualException.Message}");
 
             message = new StructuredAssertionMessage(summary)

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
@@ -75,7 +75,6 @@ public partial class AssertTests
                 Assertion failed. Expected exception of type ArgumentException (or derived) but caught Exception.
 
                 expected type:    System.ArgumentException (or derived)
-                actual type:      System.Exception
                 actual exception: System.Exception: Exception of type 'System.Exception' was thrown.
 
                 Assert.ThrowsAsync<ArgumentException>(() => throw new Exception())
@@ -93,7 +92,6 @@ public partial class AssertTests
                 Assertion failed. Expected exception of exact type ArgumentException but caught ArgumentNullException.
 
                 expected type:    System.ArgumentException
-                actual type:      System.ArgumentNullException
                 actual exception: System.ArgumentNullException: Value cannot be null.
 
                 Assert.ThrowsExactlyAsync<ArgumentException>(() => throw new ArgumentNullException())
@@ -152,7 +150,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
 
                 Assert.Throws<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
@@ -162,7 +159,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
                                   Parameter name: MyParamNameHere
 
@@ -226,7 +222,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
 
                 Assert.ThrowsExactly<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
@@ -236,7 +231,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
                                   Parameter name: MyParamNameHere
 
@@ -300,7 +294,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
 
                 Assert.ThrowsAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
@@ -310,7 +303,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
                                   Parameter name: MyParamNameHere
 
@@ -374,7 +366,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
 
                 Assert.ThrowsExactlyAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
@@ -384,7 +375,6 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual type:      System.ArgumentOutOfRangeException
                 actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
                                   Parameter name: MyParamNameHere
 
@@ -436,7 +426,6 @@ public partial class AssertTests
                 Assertion failed. Expected exception of type ArgumentException (or derived) but caught InvalidOperationException.
 
                 expected type:    System.ArgumentException (or derived)
-                actual type:      System.InvalidOperationException
                 actual exception: System.InvalidOperationException: line1
                                   line2
 
@@ -461,7 +450,6 @@ public partial class AssertTests
                 Assertion failed. Expected exception of type ArgumentException (or derived) but caught InvalidOperationException.
 
                 expected type:    System.ArgumentException (or derived)
-                actual type:      System.InvalidOperationException
                 actual exception: System.InvalidOperationException: oops
 
                 Assert.Throws<ArgumentException>(<action>)
@@ -481,7 +469,6 @@ public partial class AssertTests
                 Assertion failed. Expected exception of type ThrowsTestGenericException<Int32> (or derived) but caught InvalidOperationException.
 
                 expected type:    Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.ThrowsTestGenericException<System.Int32> (or derived)
-                actual type:      System.InvalidOperationException
                 actual exception: System.InvalidOperationException: oops
 
                 Assert.Throws<ThrowsTestGenericException<Int32>>(() => throw new InvalidOperationException("oops"))


### PR DESCRIPTION
## Summary

Addresses the duplicate-information concern raised in #9190.

When an `Assert.Throws*` method fails, the failure message rendered both an `actual type:` line and an `actual exception:` line. The `actual exception:` line is already built as `{ExceptionTypeFullName}: {Message}`, so it is **always** prefixed with the exception type name — making the separate `actual type:` line redundant.

### Before
```
Assertion failed. Expected exception of exact type NotSupportedException but caught InvalidOperationException.

expected type:    System.NotSupportedException
actual type:      System.InvalidOperationException
actual exception: System.InvalidOperationException: C
```

### After
```
Assertion failed. Expected exception of exact type NotSupportedException but caught InvalidOperationException.

expected type:    System.NotSupportedException
actual exception: System.InvalidOperationException: C
```

## Changes
- `Assert.ThrowsException.Core.cs` — drop the `actual type:` evidence line; the type is already present on the `actual exception:` line.
- `AssertTests.ThrowsExceptionTests.cs` — remove the now-redundant `actual type:` expectation lines. Label padding is unchanged because `actual exception:` remains the longest label.

## Notes
#9190 also requests appending the actual exception's full stack trace / `Exception.ToString()`. That is a larger, separate behavioral change (and harder to assert deterministically in unit tests), so it is intentionally **not** included here — this PR only removes the duplicated type information.

## Validation
Built and ran `TestFramework.UnitTests` across net48 / net8.0 / net9.0 / net8.0-windows — all pass, 0 warnings.
