### PR TITLE
docs: add missing 4.3.0/2.3.0 changelog entries for `#9147`, `#9148`, `#9176`, `#9177`

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -32,8 +32,8 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add Microsoft.Testing.Extensions.JUnitReport extension by @Evangelink in [#8850](https://github.com/microsoft/testfx/pull/8850)
 * Add Microsoft.Testing.Extensions.CtrfReport extension (CTRF reporter) by @Evangelink in [#8903](https://github.com/microsoft/testfx/pull/8903)
 * Add --progress {auto|on|off} and deprecate --no-progress in MTP terminal reporter by @Evangelink in [#9145](https://github.com/microsoft/testfx/pull/9145)
-* Add Azure DevOps per-assembly log groups by @Evangelink in [#9177](https://github.com/microsoft/testfx/pull/9177)
 * Add silence-driven progress heartbeat for SimpleAnsi/NoAnsi output modes by @Evangelink in [#9147](https://github.com/microsoft/testfx/pull/9147)
+* Add Azure DevOps per-assembly log groups by @Evangelink in [#9177](https://github.com/microsoft/testfx/pull/9177)
 
 ### Fixed
 

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -32,6 +32,8 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add Microsoft.Testing.Extensions.JUnitReport extension by @Evangelink in [#8850](https://github.com/microsoft/testfx/pull/8850)
 * Add Microsoft.Testing.Extensions.CtrfReport extension (CTRF reporter) by @Evangelink in [#8903](https://github.com/microsoft/testfx/pull/8903)
 * Add --progress {auto|on|off} and deprecate --no-progress in MTP terminal reporter by @Evangelink in [#9145](https://github.com/microsoft/testfx/pull/9145)
+* Add Azure DevOps per-assembly log groups by @Evangelink in [#9177](https://github.com/microsoft/testfx/pull/9177)
+* Add silence-driven progress heartbeat for SimpleAnsi/NoAnsi output modes by @Evangelink in [#9147](https://github.com/microsoft/testfx/pull/9147)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -31,6 +31,8 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * \[MSTest.Sdk] Wire Microsoft.Testing.Extensions.JUnitReport into MSTest.Sdk (opt-in) by @Evangelink in [#8956](https://github.com/microsoft/testfx/pull/8956)
 * Add \[MemberCondition] attribute for static-member-based test conditions by @Evangelink in [#9071](https://github.com/microsoft/testfx/pull/9071)
 * Add MSTEST0070 analyzer validating \[MemberCondition] member references by @Evangelink in [#9076](https://github.com/microsoft/testfx/pull/9076)
+* Add Assert.AddValueFormatter for customizing assertion failure rendering by @Evangelink in [#9148](https://github.com/microsoft/testfx/pull/9148)
+* Add Span\<T> and Memory\<T> overloads to Assert.HasCount and extend MSTEST0037 coverage by @Evangelink in [#9176](https://github.com/microsoft/testfx/pull/9176)
 
 ### Fixed
 


### PR DESCRIPTION
Four features merged on 2026-06-16 (same day as the changelog draft PR `#9175`) were not included in the UNRELEASED sections.

### MSTest `Changelog.md` (4.3.0)

- **Assert.AddValueFormatter** (`#9148`) — new API for customising assertion failure rendering
- **Assert.HasCount Span\(T)/Memory\(T) overloads + MSTEST0037 extension** (`#9176`)

### MTP `Changelog-Platform.md` (2.3.0)

- **Azure DevOps per-assembly log groups** (`#9177`)
- **Silence-driven progress heartbeat for SimpleAnsi/NoAnsi modes** (`#9147`)

No code changes — documentation only.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/27672839374/agentic_workflow) workflow. · 749.1 AIC · ⌖ 24 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27672839374, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/27672839374 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->