### PR TITLE
Reference System.Memory 4.6.3 in the .NETFramework adapter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,12 @@
          Tracking context: https://github.com/microsoft/testfx/issues/9091 (Task 5). -->
     <MicrosoftTestingInternalFrameworkVersion>1.5.0-preview.24577.4</MicrosoftTestingInternalFrameworkVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
+    <!-- System.Memory flows in transitively (via System.Reflection.Metadata / System.Collections.Immutable)
+         at 4.5.5, whose .NETFramework assembly version is 4.0.1.2. We pin it explicitly to 4.6.3
+         (assembly 4.0.5.0) so the .NETFramework adapter assemblies reference 4.0.5.0. Hosts that unify
+         System.Memory to 4.0.5.0 (e.g. Visual Studio) and run the adapter without applying a binding
+         redirect (the VSTest test host uses its own config) cannot otherwise load the 4.0.1.2 reference. -->
+    <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
   </PropertyGroup>
   <PropertyGroup Label="Test dependencies">
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.3-beta1.24423.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
@@ -69,6 +75,7 @@
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -80,6 +80,7 @@
     <NuspecProperty Include="Configuration=$(Configuration)" />
     <NuspecProperty Include="RepoRoot=$(RepoRoot)" />
     <NuspecProperty Include="SystemThreadingTasksExtensionsVersion=$(SystemThreadingTasksExtensionsVersion)" />
+    <NuspecProperty Include="SystemMemoryVersion=$(SystemMemoryVersion)" />
     <NuspecProperty Include="TestingPlatformVersion=$(Version.Replace('$(VersionPrefix)', '$(TestingPlatformVersionPrefix)'))" />
   </ItemGroup>
 

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.nuspec
@@ -8,10 +8,12 @@
         <dependency id="Microsoft.Testing.Platform.MSBuild" version="$TestingPlatformVersion$" />
         <dependency id="MSTest.TestFramework" version="$Version$" />
         <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
+        <dependency id="System.Memory" version="$SystemMemoryVersion$" />
       </group>
       <group targetFramework="uap10.0">
         <dependency id="MSTest.TestFramework" version="$Version$" />
         <dependency id="System.Threading.Tasks.Extensions" version="$SystemThreadingTasksExtensionsVersion$" />
+        <dependency id="System.Memory" version="$SystemMemoryVersion$" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="$TestingPlatformVersion$" />

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -38,6 +38,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
+    <!-- Span/MemoryMarshal used by the linked XxHash code below live in System.Memory on these TFMs.
+         Referenced explicitly so the compiled assembly binds System.Memory 4.6.3 (assembly 4.0.5.0)
+         instead of the transitive 4.5.5 (4.0.1.2). See SystemMemoryVersion in Directory.Packages.props. -->
+    <PackageReference Include="System.Memory" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -39,8 +39,8 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
     <!-- Span/MemoryMarshal used by the linked XxHash code below live in System.Memory on these TFMs.
-         Referenced explicitly so the compiled assembly binds System.Memory 4.6.3 (assembly 4.0.5.0)
-         instead of the transitive 4.5.5 (4.0.1.2). See SystemMemoryVersion in Directory.Packages.props. -->
+         Referenced explicitly so the compiled assembly binds the System.Memory assembly version 4.0.5.0
+         (see SystemMemoryVersion in Directory.Packages.props) instead of the transitive 4.5.5 (4.0.1.2). -->
     <PackageReference Include="System.Memory" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
   </ItemGroup>
 


### PR DESCRIPTION
On `net462`, `MSTestAdapter.PlatformServices` references `System.Memory` (the linked XxHash code uses `Span`/`MemoryMarshal`). That reference is currently `4.0.1.2`, pulled in transitively as `System.Memory 4.5.5` via `Microsoft.TestPlatform.ObjectModel` -> `System.Reflection.Metadata 8.0.0` -> `System.Collections.Immutable 8.0.0`.

Hosts that unify `System.Memory` to `4.0.5.0` (e.g. Visual Studio) and run the VSTest adapter under a test host that does not apply the test source's binding redirects (the VSTest test host loads its own config) cannot satisfy the `4.0.1.2` reference: the deployed `4.0.5.0` is rejected by exact-version assembly resolution and discovery fails with `FileNotFoundException` for `System.Memory 4.0.1.2`.

This pins `System.Memory` to `4.6.3` (assembly `4.0.5.0`) and references it explicitly so the `net462` adapter assemblies bind `4.0.5.0`, matching what those hosts deploy. The reference is conditioned on `net462`/`netstandard2.0`/`uwp`; modern .NET (net8.0+) uses the in-box `Span` and is unaffected.

Verified by rebuilding `net462`: `MSTestAdapter.PlatformServices.dll` now references `System.Memory 4.0.5.0` (was `4.0.1.2`).
