### PR TITLE
Deduplicate report capture DTOs/logic and SQL FixConnectionString (#9203, #9205, #9206)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/OdbcDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/OdbcDataConnection.cs
@@ -68,28 +68,14 @@ internal sealed class OdbcDataConnection : TestDataConnectionSql
         OdbcConnectionStringBuilder builder = [with(connectionString)];
 
         // only fix this for excel
-        if (!string.Equals(builder.Dsn, "Excel Files", StringComparison.Ordinal))
-        {
-            return connectionString;
-        }
-
-        string? fileName = builder["dbq"] as string;
-
-        if (StringEx.IsNullOrEmpty(fileName))
-        {
-            return connectionString;
-        }
-        else
-        {
-            // Fix-up magic file paths
-            string? fixedFilePath = FixPath(fileName, dataFolders);
-            if (fixedFilePath != null)
-            {
-                builder["dbq"] = fixedFilePath;
-            }
-
-            return builder.ConnectionString;
-        }
+        return !string.Equals(builder.Dsn, "Excel Files", StringComparison.Ordinal)
+            ? connectionString
+            : FixConnectionStringFilePath(
+                builder,
+                connectionString,
+                () => builder["dbq"] as string,
+                fixedFilePath => builder["dbq"] = fixedFilePath,
+                dataFolders);
     }
 }
 #endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/OleDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/OleDataConnection.cs
@@ -59,23 +59,12 @@ internal sealed class OleDataConnection : TestDataConnectionSql
     {
         OleDbConnectionStringBuilder oleDbBuilder = [with(connectionString)];
 
-        string fileName = oleDbBuilder.DataSource;
-
-        if (StringEx.IsNullOrEmpty(fileName))
-        {
-            return connectionString;
-        }
-        else
-        {
-            // Fix-up magic file paths
-            string? fixedFilePath = FixPath(fileName, dataFolders);
-            if (fixedFilePath != null)
-            {
-                oleDbBuilder.DataSource = fixedFilePath;
-            }
-
-            return oleDbBuilder.ConnectionString;
-        }
+        return FixConnectionStringFilePath(
+            oleDbBuilder,
+            connectionString,
+            () => oleDbBuilder.DataSource,
+            fixedFilePath => oleDbBuilder.DataSource = fixedFilePath,
+            dataFolders);
     }
 }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/SqlDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/SqlDataConnection.cs
@@ -51,23 +51,18 @@ internal sealed class SqlDataConnection : TestDataConnectionSql
             // No file, so no need to rewrite the connection string
             return connectionString;
         }
-        else
-        {
-            // Force pooling off for SQL when there is a file involved
-            // Without this, after the connection is closed, an exclusive lock persists
-            // for a long time, preventing us from moving files around
-            sqlBuilder.Pooling = false;
 
-            // Fix-up magic file paths
-            string? fixedFilePath = FixPath(attachedFile, dataFolders);
-            if (fixedFilePath != null)
-            {
-                sqlBuilder.AttachDBFilename = fixedFilePath;
-            }
+        // Force pooling off for SQL when there is a file involved
+        // Without this, after the connection is closed, an exclusive lock persists
+        // for a long time, preventing us from moving files around
+        sqlBuilder.Pooling = false;
 
-            // Return modified connection string
-            return sqlBuilder.ConnectionString;
-        }
+        return FixConnectionStringFilePath(
+            sqlBuilder,
+            connectionString,
+            () => attachedFile,
+            fixedFilePath => sqlBuilder.AttachDBFilename = fixedFilePath,
+            dataFolders);
     }
 }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnection.cs
@@ -139,6 +139,28 @@ internal abstract class TestDataConnection : IDisposable
         return Path.GetFullPath(Path.GetFileName(relPath));
     }
 
+    protected static string FixConnectionStringFilePath(
+        DbConnectionStringBuilder builder,
+        string originalConnectionString,
+        Func<string?> getFilePath,
+        Action<string> setFilePath,
+        List<string> dataFolders)
+    {
+        string? filePath = getFilePath();
+        if (StringEx.IsNullOrEmpty(filePath))
+        {
+            return originalConnectionString;
+        }
+
+        string? fixedFilePath = FixPath(filePath, dataFolders);
+        if (fixedFilePath is not null)
+        {
+            setFilePath(fixedFilePath);
+        }
+
+        return builder.ConnectionString;
+    }
+
     [Conditional("DEBUG")]
     protected internal static void WriteDiagnostics(string formatString, params object?[] parameters)
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnection.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Data/TestDataConnection.cs
@@ -146,6 +146,10 @@ internal abstract class TestDataConnection : IDisposable
         Action<string> setFilePath,
         List<string> dataFolders)
     {
+        // Precondition: any builder mutations that must be preserved in the returned string
+        // (e.g. Pooling = false) must be applied before calling this helper, AND
+        // getFilePath() must not return null/empty at that point — otherwise those
+        // mutations are discarded and originalConnectionString is returned unchanged.
         string? filePath = getFilePath();
         if (StringEx.IsNullOrEmpty(filePath))
         {

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CapturedTestResult.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CapturedTestResult.cs
@@ -3,17 +3,8 @@
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
-// Minimal capped-size projection of a TestNodeUpdateMessage. The consumer projects
-// each message into this DTO immediately so that we don't retain entire test nodes
-// (and their potentially huge stdout/stderr/stack trace strings) in memory for the
-// whole session. All variable-length text fields are already truncated at this point
-// so the engine doesn't need to truncate again.
-internal sealed class CapturedTestResult
+internal sealed class CapturedTestResult : CapturedTestResultBase
 {
-    public required string Uid { get; init; }
-
-    public required string DisplayName { get; init; }
-
     // CTRF status (passed/failed/skipped/pending/other) — already normalized.
     public required string Status { get; init; }
 
@@ -21,31 +12,9 @@ internal sealed class CapturedTestResult
     // (e.g. "timedOut", "errored", "cancelled"). Surfaced via CTRF `rawStatus`.
     public string? RawStatus { get; init; }
 
-    public required TimeSpan Duration { get; init; }
-
-    public DateTimeOffset? StartTime { get; init; }
-
-    public DateTimeOffset? EndTime { get; init; }
-
     public string? Namespace { get; init; }
-
-    public string? ClassName { get; init; }
-
-    public string? MethodName { get; init; }
-
-    public string? ErrorMessage { get; init; }
-
-    public string? ExceptionType { get; init; }
-
-    public string? StackTrace { get; init; }
-
-    public string? StandardOutput { get; init; }
-
-    public string? StandardError { get; init; }
 
     public string? FilePath { get; init; }
 
     public int? Line { get; init; }
-
-    public IReadOnlyList<KeyValuePair<string, string>>? Traits { get; init; }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -59,6 +59,7 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\CapturedTestResultBase.cs" Link="Helpers\CapturedTestResultBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
@@ -27,70 +27,11 @@ internal static class TestResultCapture
             return null;
         }
 
-        // Keep the O(1) state lookup above as a fast path for non-terminal messages. Terminal
-        // results collect all remaining required properties in one pass — replacing
-        // 5 × SingleOrDefault<T>() + 1 × foreach/GetEnumerator() with one zero-allocation
-        // GetStructEnumerator() pass. Singleton-typed properties use the local GetSingleOrDefaultValue
-        // helper to preserve the throw-on-duplicate invariant that SingleOrDefault<T>() provided;
-        // TestMetadataProperty is intentionally multi-valued and accumulates into a list.
-        TimingProperty? timing = null;
-        TestMethodIdentifierProperty? identifier = null;
-        StandardOutputProperty? standardOutput = null;
-        StandardErrorProperty? standardError = null;
-        TestFileLocationProperty? location = null;
-        List<KeyValuePair<string, string>>? traits = null;
-
-        PropertyBag.PropertyBagEnumerator enumerator = node.Properties.GetStructEnumerator();
-        while (enumerator.MoveNext())
-        {
-            switch (enumerator.Current)
-            {
-                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
-                case TestMethodIdentifierProperty m: identifier = GetSingleOrDefaultValue(identifier, m); break;
-                case StandardOutputProperty so: standardOutput = GetSingleOrDefaultValue(standardOutput, so); break;
-                case StandardErrorProperty se: standardError = GetSingleOrDefaultValue(standardError, se); break;
-                case TestFileLocationProperty loc: location = GetSingleOrDefaultValue(location, loc); break;
-                case TestMetadataProperty meta:
-                    // Trait keys and values are test-controlled so we truncate them to
-                    // bound the size of the in-memory result list and generated report.
-                    traits ??= [];
-                    traits.Add(new KeyValuePair<string, string>(
-                        Truncate(meta.Key, MaxTraitFieldLength)!,
-                        Truncate(meta.Value, MaxTraitFieldLength)!));
-                    break;
-            }
-        }
-
-        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
-            where TProperty : class, IProperty
-            => existingProperty is not null
-                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
-                : property;
-
+        CapturedTestResultProperties properties = TestResultCaptureHelper.ExtractProperties(node.Properties, includeLocation: true);
         (string status, string? rawStatus) = ClassifyStatus(state);
-        TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-        (string? ns, string? className, string? methodName) = GetClassAndMethodName(identifier);
-
-        string? errorMessage = state.Explanation;
-        string? stackTrace = null;
-        string? exceptionType = null;
-        Exception? exception = state switch
-        {
-            FailedTestNodeStateProperty f => f.Exception,
-            ErrorTestNodeStateProperty e => e.Exception,
-            TimeoutTestNodeStateProperty t => t.Exception,
-#pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
-            CancelledTestNodeStateProperty c => c.Exception,
-#pragma warning restore CS0618, MTP0001
-            _ => null,
-        };
-
-        if (exception is not null)
-        {
-            errorMessage ??= exception.Message;
-            stackTrace = exception.StackTrace;
-            exceptionType = exception.GetType().FullName;
-        }
+        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
+        (string? ns, string? className, string? methodName) = GetClassAndMethodName(properties.Identifier);
+        CapturedExceptionDetails exceptionDetails = TestResultCaptureHelper.ExtractExceptionDetails(state);
 
         return new CapturedTestResult
         {
@@ -102,19 +43,19 @@ internal static class TestResultCapture
             Status = status,
             RawStatus = rawStatus,
             Duration = duration,
-            StartTime = timing?.GlobalTiming.StartTime,
-            EndTime = timing?.GlobalTiming.EndTime,
+            StartTime = properties.Timing?.GlobalTiming.StartTime,
+            EndTime = properties.Timing?.GlobalTiming.EndTime,
             Namespace = Truncate(ns, MaxIdentityFieldLength),
             ClassName = Truncate(className, MaxIdentityFieldLength),
             MethodName = Truncate(methodName, MaxIdentityFieldLength),
-            ErrorMessage = Truncate(errorMessage, MaxMessageLength),
-            ExceptionType = exceptionType,
-            StackTrace = Truncate(stackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(standardOutput?.StandardOutput, MaxStandardStreamLength),
-            StandardError = Truncate(standardError?.StandardError, MaxStandardStreamLength),
-            FilePath = Truncate(location?.FilePath, MaxIdentityFieldLength),
-            Line = location?.LineSpan.Start.Line,
-            Traits = traits,
+            ErrorMessage = Truncate(exceptionDetails.ErrorMessage, MaxMessageLength),
+            ExceptionType = exceptionDetails.ExceptionType,
+            StackTrace = Truncate(exceptionDetails.StackTrace, MaxStackTraceLength),
+            StandardOutput = Truncate(properties.StandardOutput?.StandardOutput, MaxStandardStreamLength),
+            StandardError = Truncate(properties.StandardError?.StandardError, MaxStandardStreamLength),
+            FilePath = Truncate(properties.Location?.FilePath, MaxIdentityFieldLength),
+            Line = properties.Location?.LineSpan.Start.Line,
+            Traits = properties.Traits,
         };
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/CapturedTestResult.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/CapturedTestResult.cs
@@ -3,38 +3,7 @@
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
-// Minimal capped-size projection of a TestNodeUpdateMessage. The consumer projects
-// each message into this DTO immediately so that we don't retain entire test nodes
-// (and their potentially huge stdout/stderr/stack trace strings) in memory for the
-// whole session. All variable-length text fields are already truncated at this point
-// so the engine doesn't need to truncate again.
-internal sealed class CapturedTestResult
+internal sealed class CapturedTestResult : CapturedTestResultBase
 {
-    public required string Uid { get; init; }
-
-    public required string DisplayName { get; init; }
-
     public required string Outcome { get; init; }
-
-    public required TimeSpan Duration { get; init; }
-
-    public DateTimeOffset? StartTime { get; init; }
-
-    public DateTimeOffset? EndTime { get; init; }
-
-    public string? ClassName { get; init; }
-
-    public string? MethodName { get; init; }
-
-    public string? ErrorMessage { get; init; }
-
-    public string? ExceptionType { get; init; }
-
-    public string? StackTrace { get; init; }
-
-    public string? StandardOutput { get; init; }
-
-    public string? StandardError { get; init; }
-
-    public IReadOnlyList<KeyValuePair<string, string>>? Traits { get; init; }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -46,6 +46,7 @@ This package extends Microsoft Testing Platform to produce self-contained HTML t
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameHelper.cs" Link="Helpers\ReportFileNameHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\CapturedTestResultBase.cs" Link="Helpers\CapturedTestResultBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -24,68 +24,11 @@ internal static class TestResultCapture
             return null;
         }
 
-        // Keep the O(1) state lookup above as a fast path for non-terminal messages. Terminal
-        // results collect all remaining required properties in one pass — replacing
-        // 4 × SingleOrDefault<T>() + 1 × foreach/GetEnumerator() with one zero-allocation
-        // GetStructEnumerator() pass. Singleton-typed properties use the local GetSingleOrDefaultValue
-        // helper to preserve the throw-on-duplicate invariant that SingleOrDefault<T>() provided;
-        // TestMetadataProperty is intentionally multi-valued and accumulates into a list.
-        TimingProperty? timing = null;
-        TestMethodIdentifierProperty? identifier = null;
-        StandardOutputProperty? standardOutput = null;
-        StandardErrorProperty? standardError = null;
-        List<KeyValuePair<string, string>>? traits = null;
-
-        PropertyBag.PropertyBagEnumerator enumerator = node.Properties.GetStructEnumerator();
-        while (enumerator.MoveNext())
-        {
-            switch (enumerator.Current)
-            {
-                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
-                case TestMethodIdentifierProperty m: identifier = GetSingleOrDefaultValue(identifier, m); break;
-                case StandardOutputProperty so: standardOutput = GetSingleOrDefaultValue(standardOutput, so); break;
-                case StandardErrorProperty se: standardError = GetSingleOrDefaultValue(standardError, se); break;
-                case TestMetadataProperty meta:
-                    // Trait keys and values are test-controlled so we truncate them to
-                    // bound the size of the in-memory result list and generated HTML.
-                    traits ??= [];
-                    traits.Add(new KeyValuePair<string, string>(
-                        Truncate(meta.Key, MaxTraitFieldLength)!,
-                        Truncate(meta.Value, MaxTraitFieldLength)!));
-                    break;
-            }
-        }
-
-        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
-            where TProperty : class, IProperty
-            => existingProperty is not null
-                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
-                : property;
-
+        CapturedTestResultProperties properties = TestResultCaptureHelper.ExtractProperties(node.Properties);
         string outcome = ClassifyOutcome(state);
-        TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-        (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(identifier);
-
-        string? errorMessage = state.Explanation;
-        string? stackTrace = null;
-        string? exceptionType = null;
-        Exception? exception = state switch
-        {
-            FailedTestNodeStateProperty f => f.Exception,
-            ErrorTestNodeStateProperty e => e.Exception,
-            TimeoutTestNodeStateProperty t => t.Exception,
-#pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
-            CancelledTestNodeStateProperty c => c.Exception,
-#pragma warning restore CS0618, MTP0001
-            _ => null,
-        };
-
-        if (exception is not null)
-        {
-            errorMessage ??= exception.Message;
-            stackTrace = exception.StackTrace;
-            exceptionType = exception.GetType().FullName;
-        }
+        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
+        (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(properties.Identifier);
+        CapturedExceptionDetails exceptionDetails = TestResultCaptureHelper.ExtractExceptionDetails(state);
 
         return new CapturedTestResult
         {
@@ -96,16 +39,16 @@ internal static class TestResultCapture
             DisplayName = Truncate(node.DisplayName, MaxIdentityFieldLength)!,
             Outcome = outcome,
             Duration = duration,
-            StartTime = timing?.GlobalTiming.StartTime,
-            EndTime = timing?.GlobalTiming.EndTime,
+            StartTime = properties.Timing?.GlobalTiming.StartTime,
+            EndTime = properties.Timing?.GlobalTiming.EndTime,
             ClassName = Truncate(className, MaxIdentityFieldLength),
             MethodName = Truncate(methodName, MaxIdentityFieldLength),
-            ErrorMessage = Truncate(errorMessage, MaxMessageLength),
-            ExceptionType = exceptionType,
-            StackTrace = Truncate(stackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(standardOutput?.StandardOutput, MaxStandardStreamLength),
-            StandardError = Truncate(standardError?.StandardError, MaxStandardStreamLength),
-            Traits = traits,
+            ErrorMessage = Truncate(exceptionDetails.ErrorMessage, MaxMessageLength),
+            ExceptionType = exceptionDetails.ExceptionType,
+            StackTrace = Truncate(exceptionDetails.StackTrace, MaxStackTraceLength),
+            StandardOutput = Truncate(properties.StandardOutput?.StandardOutput, MaxStandardStreamLength),
+            StandardError = Truncate(properties.StandardError?.StandardError, MaxStandardStreamLength),
+            Traits = properties.Traits,
         };
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/CapturedTestResult.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/CapturedTestResult.cs
@@ -5,11 +5,13 @@ namespace Microsoft.Testing.Extensions.JUnitReport;
 
 internal sealed class CapturedTestResult : CapturedTestResultBase
 {
-    // Raw, untruncated UID. Used internally to look up parents in the parent-chain
-    // dictionary so that truncation of a long UID does not break the chain lookup.
+    // Raw UID used internally as the key to look up parents in the parent-chain
+    // dictionary. It is capped with MaxIdentityFieldLength (same budget as Uid) so that
+    // both sides of a lookup are truncated consistently and the chain lookup still matches.
     public required string RawUid { get; init; }
 
-    // Raw, untruncated parent UID for the same reason.
+    // Raw parent UID (edge into the parent-chain dictionary) for the same reason; also
+    // capped with MaxIdentityFieldLength so it matches the corresponding RawUid key.
     public string? ParentRawUid { get; init; }
 
     public required string Outcome { get; init; }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/CapturedTestResult.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/CapturedTestResult.cs
@@ -3,16 +3,8 @@
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
-// Minimal capped-size projection of a TestNodeUpdateMessage. The consumer projects
-// each message into this DTO immediately so that we don't retain entire test nodes
-// (and their potentially huge stdout/stderr/stack trace strings) in memory for the
-// whole session. All variable-length text fields are already truncated at this point
-// so the engine doesn't need to truncate again.
-internal sealed class CapturedTestResult
+internal sealed class CapturedTestResult : CapturedTestResultBase
 {
-    // Truncated UID (kept as the public-facing identity in the report).
-    public required string Uid { get; init; }
-
     // Raw, untruncated UID. Used internally to look up parents in the parent-chain
     // dictionary so that truncation of a long UID does not break the chain lookup.
     public required string RawUid { get; init; }
@@ -20,29 +12,5 @@ internal sealed class CapturedTestResult
     // Raw, untruncated parent UID for the same reason.
     public string? ParentRawUid { get; init; }
 
-    public required string DisplayName { get; init; }
-
     public required string Outcome { get; init; }
-
-    public required TimeSpan Duration { get; init; }
-
-    public DateTimeOffset? StartTime { get; init; }
-
-    public DateTimeOffset? EndTime { get; init; }
-
-    public string? ClassName { get; init; }
-
-    public string? MethodName { get; init; }
-
-    public string? ErrorMessage { get; init; }
-
-    public string? ExceptionType { get; init; }
-
-    public string? StackTrace { get; init; }
-
-    public string? StandardOutput { get; init; }
-
-    public string? StandardError { get; init; }
-
-    public IReadOnlyList<KeyValuePair<string, string>>? Traits { get; init; }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -49,6 +49,7 @@ This package extends Microsoft Testing Platform to produce JUnit XML test report
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameHelper.cs" Link="Helpers\ReportFileNameHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\CapturedTestResultBase.cs" Link="Helpers\CapturedTestResultBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/TestResultCapture.cs
@@ -41,68 +41,11 @@ internal static class TestResultCapture
             return null;
         }
 
-        // Keep the O(1) state lookup above as a fast path for non-terminal messages. Terminal
-        // results collect all remaining required properties in one pass — replacing
-        // 4 × SingleOrDefault<T>() + 1 × foreach/GetEnumerator() with one zero-allocation
-        // GetStructEnumerator() pass. Singleton-typed properties use the local GetSingleOrDefaultValue
-        // helper to preserve the throw-on-duplicate invariant that SingleOrDefault<T>() provided;
-        // TestMetadataProperty is intentionally multi-valued and accumulates into a list.
-        TimingProperty? timing = null;
-        TestMethodIdentifierProperty? identifier = null;
-        StandardOutputProperty? standardOutput = null;
-        StandardErrorProperty? standardError = null;
-        List<KeyValuePair<string, string>>? traits = null;
-
-        PropertyBag.PropertyBagEnumerator enumerator = node.Properties.GetStructEnumerator();
-        while (enumerator.MoveNext())
-        {
-            switch (enumerator.Current)
-            {
-                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
-                case TestMethodIdentifierProperty m: identifier = GetSingleOrDefaultValue(identifier, m); break;
-                case StandardOutputProperty so: standardOutput = GetSingleOrDefaultValue(standardOutput, so); break;
-                case StandardErrorProperty se: standardError = GetSingleOrDefaultValue(standardError, se); break;
-                case TestMetadataProperty meta:
-                    // Trait keys and values are test-controlled so we truncate them to
-                    // bound the size of the in-memory result list and generated XML.
-                    traits ??= [];
-                    traits.Add(new KeyValuePair<string, string>(
-                        Truncate(meta.Key, MaxTraitFieldLength)!,
-                        Truncate(meta.Value, MaxTraitFieldLength)!));
-                    break;
-            }
-        }
-
-        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
-            where TProperty : class, IProperty
-            => existingProperty is not null
-                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
-                : property;
-
+        CapturedTestResultProperties properties = TestResultCaptureHelper.ExtractProperties(node.Properties);
         string outcome = ClassifyOutcome(state);
-        TimeSpan duration = timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-        (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(identifier);
-
-        string? errorMessage = state.Explanation;
-        string? stackTrace = null;
-        string? exceptionType = null;
-        Exception? exception = state switch
-        {
-            FailedTestNodeStateProperty f => f.Exception,
-            ErrorTestNodeStateProperty e => e.Exception,
-            TimeoutTestNodeStateProperty t => t.Exception,
-#pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
-            CancelledTestNodeStateProperty c => c.Exception,
-#pragma warning restore CS0618, MTP0001
-            _ => null,
-        };
-
-        if (exception is not null)
-        {
-            errorMessage ??= exception.Message;
-            stackTrace = exception.StackTrace;
-            exceptionType = exception.GetType().FullName;
-        }
+        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
+        (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(properties.Identifier);
+        CapturedExceptionDetails exceptionDetails = TestResultCaptureHelper.ExtractExceptionDetails(state);
 
         return new CapturedTestResult
         {
@@ -118,16 +61,16 @@ internal static class TestResultCapture
             DisplayName = Truncate(node.DisplayName, MaxIdentityFieldLength)!,
             Outcome = outcome,
             Duration = duration,
-            StartTime = timing?.GlobalTiming.StartTime,
-            EndTime = timing?.GlobalTiming.EndTime,
+            StartTime = properties.Timing?.GlobalTiming.StartTime,
+            EndTime = properties.Timing?.GlobalTiming.EndTime,
             ClassName = Truncate(className, MaxIdentityFieldLength),
             MethodName = Truncate(methodName, MaxIdentityFieldLength),
-            ErrorMessage = Truncate(errorMessage, MaxMessageLength),
-            ExceptionType = exceptionType,
-            StackTrace = Truncate(stackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(standardOutput?.StandardOutput, MaxStandardStreamLength),
-            StandardError = Truncate(standardError?.StandardError, MaxStandardStreamLength),
-            Traits = traits,
+            ErrorMessage = Truncate(exceptionDetails.ErrorMessage, MaxMessageLength),
+            ExceptionType = exceptionDetails.ExceptionType,
+            StackTrace = Truncate(exceptionDetails.StackTrace, MaxStackTraceLength),
+            StandardOutput = Truncate(properties.StandardOutput?.StandardOutput, MaxStandardStreamLength),
+            StandardError = Truncate(properties.StandardError?.StandardError, MaxStandardStreamLength),
+            Traits = properties.Traits,
         };
     }
 

--- a/src/Platform/SharedExtensionHelpers/CapturedTestResultBase.cs
+++ b/src/Platform/SharedExtensionHelpers/CapturedTestResultBase.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions;
+
+// Minimal capped-size projection of a TestNodeUpdateMessage. The consumer projects
+// each message into this DTO immediately so that we don't retain entire test nodes
+// (and their potentially huge stdout/stderr/stack trace strings) in memory for the
+// whole session. All variable-length text fields are already truncated at this point
+// so the engine doesn't need to truncate again.
+internal abstract class CapturedTestResultBase
+{
+    public required string Uid { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public required TimeSpan Duration { get; init; }
+
+    public DateTimeOffset? StartTime { get; init; }
+
+    public DateTimeOffset? EndTime { get; init; }
+
+    public string? ClassName { get; init; }
+
+    public string? MethodName { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public string? ExceptionType { get; init; }
+
+    public string? StackTrace { get; init; }
+
+    public string? StandardOutput { get; init; }
+
+    public string? StandardError { get; init; }
+
+    public IReadOnlyList<KeyValuePair<string, string>>? Traits { get; init; }
+}

--- a/src/Platform/SharedExtensionHelpers/CapturedTestResultBase.cs
+++ b/src/Platform/SharedExtensionHelpers/CapturedTestResultBase.cs
@@ -3,11 +3,13 @@
 
 namespace Microsoft.Testing.Extensions;
 
-// Minimal capped-size projection of a TestNodeUpdateMessage. The consumer projects
-// each message into this DTO immediately so that we don't retain entire test nodes
-// (and their potentially huge stdout/stderr/stack trace strings) in memory for the
-// whole session. All variable-length text fields are already truncated at this point
-// so the engine doesn't need to truncate again.
+// Minimal projection of a terminal test result, shared by the HtmlReport, JUnitReport and
+// CtrfReport consumers (which capture from either a TestNode or a TestNodeUpdateMessage).
+// The consumer projects each result into this DTO immediately so that we don't retain
+// entire test nodes (and their potentially huge stdout/stderr/stack trace strings) in
+// memory for the whole session. The variable-length text fields declared here are
+// truncated by the capturing code before construction; derived DTOs may add further
+// fields that follow their own truncation rules, so do not assume every field is capped.
 internal abstract class CapturedTestResultBase
 {
     public required string Uid { get; init; }

--- a/src/Platform/SharedExtensionHelpers/TestResultCaptureHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/TestResultCaptureHelper.cs
@@ -16,6 +16,69 @@ internal static class TestResultCaptureHelper
     internal const int MaxIdentityFieldLength = 4 * 1024;
     internal const int MaxTraitFieldLength = 1024;
 
+    internal static CapturedTestResultProperties ExtractProperties(PropertyBag propertyBag, bool includeLocation = false)
+    {
+        TimingProperty? timing = null;
+        TestMethodIdentifierProperty? identifier = null;
+        StandardOutputProperty? standardOutput = null;
+        StandardErrorProperty? standardError = null;
+        TestFileLocationProperty? location = null;
+        List<KeyValuePair<string, string>>? traits = null;
+
+        PropertyBag.PropertyBagEnumerator enumerator = propertyBag.GetStructEnumerator();
+        while (enumerator.MoveNext())
+        {
+            switch (enumerator.Current)
+            {
+                case TimingProperty t: timing = GetSingleOrDefaultValue(timing, t); break;
+                case TestMethodIdentifierProperty m: identifier = GetSingleOrDefaultValue(identifier, m); break;
+                case StandardOutputProperty so: standardOutput = GetSingleOrDefaultValue(standardOutput, so); break;
+                case StandardErrorProperty se: standardError = GetSingleOrDefaultValue(standardError, se); break;
+                case TestFileLocationProperty loc when includeLocation: location = GetSingleOrDefaultValue(location, loc); break;
+                case TestMetadataProperty meta:
+                    traits ??= [];
+                    traits.Add(new KeyValuePair<string, string>(
+                        Truncate(meta.Key, MaxTraitFieldLength)!,
+                        Truncate(meta.Value, MaxTraitFieldLength)!));
+                    break;
+            }
+        }
+
+        return new CapturedTestResultProperties(timing, identifier, standardOutput, standardError, location, traits);
+
+        static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
+            where TProperty : class, IProperty
+            => existingProperty is not null
+                ? throw new InvalidOperationException($"Found multiple properties of type '{typeof(TProperty)}'.")
+                : property;
+    }
+
+    internal static CapturedExceptionDetails ExtractExceptionDetails(TestNodeStateProperty state)
+    {
+        string? errorMessage = state.Explanation;
+        string? stackTrace = null;
+        string? exceptionType = null;
+        Exception? exception = state switch
+        {
+            FailedTestNodeStateProperty f => f.Exception,
+            ErrorTestNodeStateProperty e => e.Exception,
+            TimeoutTestNodeStateProperty t => t.Exception,
+#pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
+            CancelledTestNodeStateProperty c => c.Exception,
+#pragma warning restore CS0618, MTP0001
+            _ => null,
+        };
+
+        if (exception is not null)
+        {
+            errorMessage ??= exception.Message;
+            stackTrace = exception.StackTrace;
+            exceptionType = exception.GetType().FullName;
+        }
+
+        return new CapturedExceptionDetails(errorMessage, stackTrace, exceptionType);
+    }
+
     internal static string ClassifyOutcome(TestNodeStateProperty state)
         => state switch
         {
@@ -64,3 +127,16 @@ internal static class TestResultCaptureHelper
             + $"\n…[truncated, original length: {value.Length.ToString(CultureInfo.InvariantCulture)}]";
     }
 }
+
+internal readonly record struct CapturedTestResultProperties(
+    TimingProperty? Timing,
+    TestMethodIdentifierProperty? Identifier,
+    StandardOutputProperty? StandardOutput,
+    StandardErrorProperty? StandardError,
+    TestFileLocationProperty? Location,
+    IReadOnlyList<KeyValuePair<string, string>>? Traits);
+
+internal readonly record struct CapturedExceptionDetails(
+    string? ErrorMessage,
+    string? StackTrace,
+    string? ExceptionType);


### PR DESCRIPTION
Deduplicates three sets of structurally-identical code flagged by the Duplicate Code Detector.

### #9206 — `FixConnectionString` duplication
Added `protected static FixConnectionStringFilePath` to `TestDataConnection` (centralizes read path → `FixPath` → write-back → return `ConnectionString`). `OdbcDataConnection`/`OleDataConnection`/`SqlDataConnection` delegate to it. The ODBC `Excel Files` DSN guard and the SQL `Pooling = false` side-effect (and its ordering) are preserved.

### #9205 — `CapturedTestResult` DTO duplication
Introduced `internal abstract class CapturedTestResultBase` in `SharedExtensionHelpers` holding the 13 shared properties. The Html/JUnit/Ctrf `CapturedTestResult` types now inherit it and add only their format-specific fields (JUnit: `RawUid`/`ParentRawUid`; Ctrf: `Status`/`RawStatus`/`Namespace`/`FilePath`/`Line`).

### #9203 — `TestResultCapture.TryCapture` duplication
Extracted `ExtractProperties` (property-bag enumeration + throw-on-duplicate invariant) and `ExtractExceptionDetails` into `TestResultCaptureHelper`. Html/JUnit/Ctrf `TryCapture` now call the shared helpers and map to their own DTO. CTRF location capture (`includeLocation`) and JUnit raw-uid handling kept report-specific.

### Verification
- `dotnet build` HtmlReport / JUnitReport / CtrfReport: 0 warnings, 0 errors each
- `dotnet build` MSTestAdapter.PlatformServices `-f net462`: succeeded
- `Microsoft.Testing.Extensions.UnitTests` (net8.0): 534 passed / 4 skipped

Fixes #9203
Fixes #9205
Fixes #9206