### PR TITLE
Include full exception (stack trace + inner exceptions) in Assert.Throws* failure messages

### DIFF
--- a/docs/RFCs/012-Structured-Assertion-Messages.md
+++ b/docs/RFCs/012-Structured-Assertion-Messages.md
@@ -307,8 +307,9 @@ Assert.ThrowsExactly<ArgumentException>(() => Validate(input))
 Assertion failed. Expected exception of exact type ArgumentException but caught InvalidOperationException.
 
 expected type:    System.ArgumentException
-actual type:      System.InvalidOperationException
 actual exception: System.InvalidOperationException: Operation is not valid due to the current state of the object.
+                     at MyApp.Service.Validate(String input) in Service.cs:line 42
+                     at MyTests.ValidationTests.InvalidInput_ShouldThrow() in ValidationTests.cs:line 18
 
 Assert.ThrowsExactly<ArgumentException>(() => Validate(input))
    at MyTests.ValidationTests.InvalidInput_ShouldThrow() in ValidationTests.cs:line 18
@@ -679,8 +680,9 @@ Assertion failed. Expected exception of type ArgumentException (or derived) but 
 Assertion failed. Expected exception of type ArgumentException (or derived) but caught InvalidOperationException.
 
 expected type:    System.ArgumentException (or derived)
-actual type:      System.InvalidOperationException
 actual exception: System.InvalidOperationException: Operation is not valid due to the current state of the object.
+                     at MyApp.Service.Validate(String input) in Service.cs:line 42
+                     at MyTests.ValidationTests.InvalidInput_ShouldThrow() in ValidationTests.cs:line 18
 ```
 
 #### Assert.ThrowsExactly (no exception thrown)
@@ -695,8 +697,9 @@ Assertion failed. Expected exception of exact type ArgumentException but no exce
 Assertion failed. Expected exception of exact type ArgumentException but caught ArgumentNullException.
 
 expected type:    System.ArgumentException
-actual type:      System.ArgumentNullException
 actual exception: System.ArgumentNullException: Value cannot be null.
+                     at MyApp.Service.Validate(String input) in Service.cs:line 42
+                     at MyTests.ValidationTests.InvalidInput_ShouldThrow() in ValidationTests.cs:line 18
 ```
 
 #### Assert.ThrowsAsync / Assert.ThrowsExactlyAsync

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
@@ -181,9 +181,19 @@ public sealed partial class Assert
 
             // Render the full exception (type, message, inner-exception chain and stack trace) via ToString so the
             // unexpected exception can be diagnosed without re-running under a debugger. See issue #9190.
+            // Exception.ToString() prefixes the output with Type.ToString(), which uses CLR notation for generic
+            // types (e.g. "MyException`1[System.Int32]"). Replace that leading prefix with the friendly name so it
+            // stays consistent with the "expected type:" line; for non-generic types the two notations are identical.
+            string actualExceptionText = actualException.ToString();
+            string clrTypeName = actualType.ToString();
+            if (actualExceptionText.StartsWith(clrTypeName, StringComparison.Ordinal))
+            {
+                actualExceptionText = GetDisplayTypeName(actualType, includeNamespace: true) + actualExceptionText.Substring(clrTypeName.Length);
+            }
+
             EvidenceBlock evidence = EvidenceBlock.Create()
                 .AddLine("expected type:", expectedTypeLabel)
-                .AddLine("actual exception:", actualException.ToString());
+                .AddLine("actual exception:", actualExceptionText);
 
             message = new StructuredAssertionMessage(summary)
                 .WithUserMessage(userMessage)

--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
@@ -172,7 +172,6 @@ public sealed partial class Assert
             Exception actualException = state.ExceptionThrown!;
             Type actualType = actualException.GetType();
             string actualTypeName = GetDisplayTypeName(actualType, includeNamespace: false);
-            string actualTypeFullName = GetDisplayTypeName(actualType, includeNamespace: true);
 
             string summary = isStrictType
                 ? $"Expected exception of exact type {expectedTypeName} but caught {actualTypeName}."
@@ -180,11 +179,11 @@ public sealed partial class Assert
 
             string expectedTypeLabel = isStrictType ? expectedTypeFullName : $"{expectedTypeFullName} (or derived)";
 
-            // The "actual exception:" line is already prefixed with the exception type name, so we don't emit a
-            // separate "actual type:" line to avoid duplicating that information.
+            // Render the full exception (type, message, inner-exception chain and stack trace) via ToString so the
+            // unexpected exception can be diagnosed without re-running under a debugger. See issue #9190.
             EvidenceBlock evidence = EvidenceBlock.Create()
                 .AddLine("expected type:", expectedTypeLabel)
-                .AddLine("actual exception:", $"{actualTypeFullName}: {actualException.Message}");
+                .AddLine("actual exception:", actualException.ToString());
 
             message = new StructuredAssertionMessage(summary)
                 .WithUserMessage(userMessage)

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
@@ -150,7 +150,7 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*MyParamNameHere*
 
                 Assert.Throws<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
                 """);
@@ -212,7 +212,7 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*MyParamNameHere*
 
                 Assert.ThrowsExactly<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
                 """);
@@ -274,7 +274,7 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*MyParamNameHere*
 
                 Assert.ThrowsAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
                 """);
@@ -336,7 +336,7 @@ public partial class AssertTests
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*MyParamNameHere*
 
                 Assert.ThrowsExactlyAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
                 """);

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.ThrowsExceptionTests.cs
@@ -70,12 +70,12 @@ public partial class AssertTests
         Action action = t.Wait;
         action.Should().Throw<AggregateException>()
             .WithInnerException<AssertFailedException>()
-            .Which.Message.Should().Be(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of type ArgumentException (or derived) but caught Exception.
 
                 expected type:    System.ArgumentException (or derived)
-                actual exception: System.Exception: Exception of type 'System.Exception' was thrown.
+                actual exception: System.Exception: Exception of type 'System.Exception' was thrown.*
 
                 Assert.ThrowsAsync<ArgumentException>(() => throw new Exception())
                 """);
@@ -87,12 +87,12 @@ public partial class AssertTests
         Action action = t.Wait;
         action.Should().Throw<AggregateException>()
             .WithInnerException<AssertFailedException>()
-            .Which.Message.Should().Be(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of exact type ArgumentException but caught ArgumentNullException.
 
                 expected type:    System.ArgumentException
-                actual exception: System.ArgumentNullException: Value cannot be null.
+                actual exception: System.ArgumentNullException: Value cannot be null.*
 
                 Assert.ThrowsExactlyAsync<ArgumentException>(() => throw new ArgumentNullException())
                 """);
@@ -144,23 +144,13 @@ public partial class AssertTests
             return "message constructed via builder.";
         });
         action.Should().Throw<AssertFailedException>()
-            .Which.Message.Should().BeOneOf(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of type ArgumentNullException (or derived) but caught ArgumentOutOfRangeException.
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
-
-                Assert.Throws<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
-                """,
-                """
-                Assertion failed. Expected exception of type ArgumentNullException (or derived) but caught ArgumentOutOfRangeException.
-                message constructed via builder.
-
-                expected type:    System.ArgumentNullException (or derived)
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
-                                  Parameter name: MyParamNameHere
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
 
                 Assert.Throws<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
                 """);
@@ -216,23 +206,13 @@ public partial class AssertTests
             return "message constructed via builder.";
         });
         action.Should().Throw<AssertFailedException>()
-            .Which.Message.Should().BeOneOf(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of exact type ArgumentNullException but caught ArgumentOutOfRangeException.
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
-
-                Assert.ThrowsExactly<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
-                """,
-                """
-                Assertion failed. Expected exception of exact type ArgumentNullException but caught ArgumentOutOfRangeException.
-                message constructed via builder.
-
-                expected type:    System.ArgumentNullException
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
-                                  Parameter name: MyParamNameHere
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
 
                 Assert.ThrowsExactly<ArgumentNullException>(() => throw new ArgumentOutOfRangeException("MyParamNameHere"))
                 """);
@@ -288,23 +268,13 @@ public partial class AssertTests
             return "message constructed via builder.";
         });
         (await action.Should().ThrowAsync<AssertFailedException>())
-            .Which.Message.Should().BeOneOf(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of type ArgumentNullException (or derived) but caught ArgumentOutOfRangeException.
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException (or derived)
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
-
-                Assert.ThrowsAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
-                """,
-                """
-                Assertion failed. Expected exception of type ArgumentNullException (or derived) but caught ArgumentOutOfRangeException.
-                message constructed via builder.
-
-                expected type:    System.ArgumentNullException (or derived)
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
-                                  Parameter name: MyParamNameHere
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
 
                 Assert.ThrowsAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
                 """);
@@ -360,23 +330,13 @@ public partial class AssertTests
             return "message constructed via builder.";
         });
         (await action.Should().ThrowAsync<AssertFailedException>())
-            .Which.Message.Should().BeOneOf(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of exact type ArgumentNullException but caught ArgumentOutOfRangeException.
                 message constructed via builder.
 
                 expected type:    System.ArgumentNullException
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'MyParamNameHere')
-
-                Assert.ThrowsExactlyAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
-                """,
-                """
-                Assertion failed. Expected exception of exact type ArgumentNullException but caught ArgumentOutOfRangeException.
-                message constructed via builder.
-
-                expected type:    System.ArgumentNullException
-                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
-                                  Parameter name: MyParamNameHere
+                actual exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.*
 
                 Assert.ThrowsExactlyAsync<ArgumentNullException>(() => Task.FromException(new ArgumentOutOfRangeException("MyParamNameHere")))
                 """);
@@ -421,13 +381,13 @@ public partial class AssertTests
 
         // "actual exception:" is the longest label (17 chars) + 1 space = 18 chars indent for the continuation line.
         action.Should().Throw<AssertFailedException>()
-            .Which.Message.Should().Be(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of type ArgumentException (or derived) but caught InvalidOperationException.
 
                 expected type:    System.ArgumentException (or derived)
                 actual exception: System.InvalidOperationException: line1
-                                  line2
+                                  line2*
 
                 Assert.Throws<ArgumentException>(() => throw new InvalidOperationException("line1\nline2"))
                 """);
@@ -445,12 +405,12 @@ public partial class AssertTests
         Action action = Action;
 
         action.Should().Throw<AssertFailedException>()
-            .Which.Message.Should().Be(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of type ArgumentException (or derived) but caught InvalidOperationException.
 
                 expected type:    System.ArgumentException (or derived)
-                actual exception: System.InvalidOperationException: oops
+                actual exception: System.InvalidOperationException: oops*
 
                 Assert.Throws<ArgumentException>(<action>)
                 """);
@@ -464,12 +424,12 @@ public partial class AssertTests
         Action action = Action;
 
         action.Should().Throw<AssertFailedException>()
-            .Which.Message.Should().Be(
+            .Which.Message.Should().Match(
                 """
                 Assertion failed. Expected exception of type ThrowsTestGenericException<Int32> (or derived) but caught InvalidOperationException.
 
                 expected type:    Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests.ThrowsTestGenericException<System.Int32> (or derived)
-                actual exception: System.InvalidOperationException: oops
+                actual exception: System.InvalidOperationException: oops*
 
                 Assert.Throws<ThrowsTestGenericException<Int32>>(() => throw new InvalidOperationException("oops"))
                 """);


### PR DESCRIPTION
Fixes #9190.

## What

When `Assert.Throws*` / `Assert.ThrowsExactly*` (and their async variants) fail because the *wrong* exception type was caught, the failure message now renders the caught exception's full `Exception.ToString()` — type, message, **inner-exception chain**, and **stack trace** — on the `actual exception:` evidence line, instead of just `{type}: {message}`.

This lets you diagnose an unexpected exception (which inner exception, which line) directly from the failure message, without re-running under a debugger.

### Before
```text
Assertion failed. Expected exception of exact type NotSupportedException but caught InvalidOperationException.

expected type:    System.NotSupportedException
actual exception: System.InvalidOperationException: C

Assert.ThrowsExactly<NotSupportedException>(Do)
```

### After
```text
Assertion failed. Expected exception of exact type NotSupportedException but caught InvalidOperationException.

expected type:    System.NotSupportedException
actual exception: System.InvalidOperationException: C
                   ---> System.ArgumentException: B
                   ---> System.NullReferenceException: Object reference not set to an instance of an object.
                     at DogFood.ThrowTest.Do() in ThrowTest.cs:line 6
                     --- End of inner exception stack trace ---
                     ...
                     at DogFood.ThrowTest.Do() in ThrowTest.cs:line 9

Assert.ThrowsExactly<NotSupportedException>(Do)
```

## How

- `Assert.ThrowsException.Core.cs`: `actual exception:` now uses `actualException.ToString()`. The existing `EvidenceBlock` already re-indents multi-line values, so the trace renders cleanly under the label. (Builds on #9195, which removed the now-redundant `actual type:` line.)
- Tests: the wrong-type failure-message assertions move from exact `.Be()` / `.BeOneOf()` to wildcard `.Match()` — the deterministic prefix + call-site is anchored, `*` absorbs the environment-dependent stack trace. The `ArgumentOutOfRangeException` cross-runtime `BeOneOf` cases collapse to a single pattern. "No exception thrown" cases are unchanged.
- Updated the `Assert.Throws*` examples in `docs/RFCs/012-Structured-Assertion-Messages.md` (also syncing them with the `actual type:` removal from #9195).

## Validation

`.\build.cmd -test -projects test\UnitTests\TestFramework.UnitTests` — all tests pass on net48, net8.0, net9.0, net8.0-windows; 0 warnings, 0 errors. Confirmed the rendered output against the issue's exact repro.
