### PR TITLE
Suppress --no-progress deprecation warning in CI (fix broken main)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -200,7 +200,7 @@ An MTP terminal-reporter command-line option that controls whether animated prog
 | `on` | Same as `auto` (a dedicated heartbeat renderer for non-cursor modes is tracked separately) |
 | `off` | Suppress all progress output |
 
-Introduced in [PR #9145](https://github.com/microsoft/testfx/pull/9145) as a replacement for the former `--no-progress` flag. `--no-progress` continues to work as a deprecated alias that routes to `--progress off` and emits a one-per-process deprecation warning on stderr; `--progress` always wins when both are supplied.
+Introduced in [PR #9145](https://github.com/microsoft/testfx/pull/9145) as a replacement for the former `--no-progress` flag. `--no-progress` continues to work as a deprecated alias that routes to `--progress off`; outside of CI it emits a one-per-process deprecation warning on stderr. The warning is suppressed in CI environments, where it would be invisible noise and where build infrastructure (such as the Arcade SDK test runner) passes `--no-progress` unconditionally. `--progress` always wins when both are supplied.
 
 ### PropertyBag
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.Initialization.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.Initialization.cs
@@ -106,7 +106,12 @@ internal sealed partial class TerminalOutputDevice
         else if (_commandLineOptions.IsOptionSet(TerminalTestReporterCommandLineOptionsProvider.NoProgressOption))
         {
             noProgress = true;
-            if (Interlocked.Exchange(ref s_noProgressDeprecationWarningEmitted, 1) == 0)
+
+            // The deprecation warning is a nudge for interactive users to move to --progress off. We deliberately
+            // do not emit it in CI: it is invisible noise there, and build infrastructure (e.g. the Arcade SDK test
+            // runner) passes --no-progress unconditionally, so emitting to stderr would surface as a build error in
+            // logging setups that treat any stderr output as a failure.
+            if (!inCI && Interlocked.Exchange(ref s_noProgressDeprecationWarningEmitted, 1) == 0)
             {
                 await WriteToStandardErrorAsync(PlatformResources.TerminalNoProgressDeprecatedWarning).ConfigureAwait(false);
             }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/TerminalOutputDeviceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/TerminalOutputDeviceTests.cs
@@ -75,6 +75,21 @@ public sealed class TerminalOutputDeviceTests
     }
 
     [TestMethod]
+    public async Task InitializeAsync_NoProgressLegacyFlagInCI_DoesNotWriteDeprecationWarning()
+    {
+        // In CI the warning is invisible noise and build infrastructure (e.g. the Arcade SDK test runner) passes
+        // --no-progress unconditionally, so emitting it to stderr would surface as a build error.
+        string standardError = await InitializeAndCaptureStandardErrorAsync(
+            new Dictionary<string, string[]>
+            {
+                [TerminalTestReporterCommandLineOptionsProvider.NoProgressOption] = [],
+            },
+            isCIEnvironment: true);
+
+        Assert.IsFalse(standardError.Contains("--no-progress is deprecated", StringComparison.Ordinal), standardError);
+    }
+
+    [TestMethod]
     public async Task InitializeAsync_ProgressOff_DoesNotWriteDeprecationWarning()
     {
         string standardError = await InitializeAndCaptureStandardErrorAsync(new Dictionary<string, string[]>
@@ -82,7 +97,7 @@ public sealed class TerminalOutputDeviceTests
             [TerminalTestReporterCommandLineOptionsProvider.ProgressOption] = ["off"],
         });
 
-        Assert.IsFalse(standardError.Contains("deprecated", StringComparison.Ordinal), standardError);
+        Assert.IsFalse(standardError.Contains("--no-progress is deprecated", StringComparison.Ordinal), standardError);
     }
 
     [TestMethod]
@@ -95,10 +110,10 @@ public sealed class TerminalOutputDeviceTests
             [TerminalTestReporterCommandLineOptionsProvider.NoProgressOption] = [],
         });
 
-        Assert.IsFalse(standardError.Contains("deprecated", StringComparison.Ordinal), standardError);
+        Assert.IsFalse(standardError.Contains("--no-progress is deprecated", StringComparison.Ordinal), standardError);
     }
 
-    private static async Task<string> InitializeAndCaptureStandardErrorAsync(Dictionary<string, string[]> options)
+    private static async Task<string> InitializeAndCaptureStandardErrorAsync(Dictionary<string, string[]> options, bool isCIEnvironment = false)
     {
         await ConsoleErrorSemaphore.WaitAsync();
         TextWriter originalError = Console.Error;
@@ -108,7 +123,7 @@ public sealed class TerminalOutputDeviceTests
 
         try
         {
-            using TerminalOutputDevice outputDevice = CreateOutputDevice(options);
+            using TerminalOutputDevice outputDevice = CreateOutputDevice(options, isCIEnvironment);
             await outputDevice.InitializeAsync();
 
             return errorWriter.ToString();
@@ -126,13 +141,14 @@ public sealed class TerminalOutputDeviceTests
             .GetField("s_noProgressDeprecationWarningEmitted", BindingFlags.NonPublic | BindingFlags.Static)!
             .SetValue(null, 0);
 
-    private static TerminalOutputDevice CreateOutputDevice(Dictionary<string, string[]> options)
+    private static TerminalOutputDevice CreateOutputDevice(Dictionary<string, string[]> options, bool isCIEnvironment = false)
     {
         var testApplicationModuleInfo = new Mock<ITestApplicationModuleInfo>();
         testApplicationModuleInfo.Setup(x => x.GetDisplayName()).Returns("testhost");
 
         var environment = new Mock<IEnvironment>();
-        environment.Setup(x => x.GetEnvironmentVariable(It.IsAny<string>())).Returns((string?)null);
+        environment.Setup(x => x.GetEnvironmentVariable(It.IsAny<string>()))
+            .Returns<string>(name => isCIEnvironment && name == "TF_BUILD" ? "true" : null);
 
         var stopPoliciesService = new Mock<IStopPoliciesService>();
         stopPoliciesService.Setup(x => x.RegisterOnAbortCallbackAsync(It.IsAny<Func<Task>>()))


### PR DESCRIPTION
## Problem

Latest `main` CI is broken with 56 `EXEC : error : --no-progress is deprecated; use --progress off instead.` errors across every unit-test project.

### Root cause

A collision between two changes:

1. **PR #9145** made `--no-progress` a deprecated alias for `--progress off` and emits a one-per-process deprecation warning to **stderr**.
2. The bumped **Arcade SDK** runs MTP tests via its `Microsoft.Testing.Platform.targets`, whose `_TestRunnerArgs` **hardcodes `--no-progress`**.

Because testfx CI sets `TestCaptureOutput=false` (`test/Directory.Build.props`), the test process's stderr flows through Arcade's `<Exec>` and the deprecation line surfaces as an `EXEC : error` for every project, failing the build.

## Fix

Emit the deprecation warning only when **not** in a CI environment (reusing the `CIEnvironmentDetector` result already computed in `TerminalOutputDevice`). `--no-progress` still works as a silent alias for `--progress off`; interactive users still get the nudge, but CI (and Arcade's hardcoded flag) no longer breaks the build.

## Changes

- `TerminalOutputDevice.cs`: gate the stderr warning behind `!inCI`.
- `TerminalOutputDeviceTests.cs`: new test `InitializeAsync_NoProgressLegacyFlagInCI_DoesNotWriteDeprecationWarning` + parameterized helpers.
- `docs/glossary.md`: document the CI suppression.

## Verification

- Built `Microsoft.Testing.Platform` (0 warnings/errors).
- `TerminalOutputDeviceTests`: 6/6 pass.
- Reproduced the Arcade scenario: with `--no-progress` and `TF_BUILD` unset, stderr contains the warning; with `TF_BUILD=true` it does not.
