### PR TITLE
Fix duration regex flakiness in acceptance tests

### DIFF
--- a/.github/agents/expert-reviewer.agent.md
+++ b/.github/agents/expert-reviewer.agent.md
@@ -327,6 +327,7 @@ Tests that share state are the #1 cause of flaky test suites.
 3. Wall-clock time assertions with tight tolerances are flaky.
 4. File system race conditions from non-unique names or shared directories.
 5. Order-dependent assertions on unordered collections.
+6. Regex/string assertions on rendered test **durations** that hard-code `\(\d+ms\)` are flaky: the platform renders longer runs as `(1s 040ms)`, `(2m 03s 040ms)`, etc., so a `\d+ms`-only pattern fails when a normally-fast test occasionally crosses the one-second boundary (commonly on macOS, sometimes Windows). Acceptance tests MUST use the shared `AcceptanceAssert.DurationPattern` constant instead.
 
 **CHECK — Flag if:**
 - [ ] `Thread.Sleep` / `Task.Delay` for synchronization
@@ -334,6 +335,7 @@ Tests that share state are the #1 cause of flaky test suites.
 - [ ] `DateTime.Now` comparisons with tight tolerance
 - [ ] File system race conditions
 - [ ] Order-dependent assertions on unordered results
+- [ ] Duration assertions hard-coding `\(\d+ms\)` instead of `AcceptanceAssert.DurationPattern`
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,6 +93,7 @@ When making change to resource files, you MUST:
   - Most MTP unit-test projects (and `MSTest.Analyzers.UnitTests`, `MSTest.SelfRealExamples.UnitTests`) ban `AwesomeAssertions` and require MSTest `Assert`/`StringAssert`/`CollectionAssert`.
   - The adapter unit-test projects (`MSTestAdapter.UnitTests`, `MSTestAdapter.PlatformServices.UnitTests`) ban MSTest's `Assert` family and require `AwesomeAssertions` (FluentAssertions-style API).
 - Acceptance integration tests run with assembly-level method parallelization. Classes that share a single generated mutable test asset across multiple methods must be marked `[DoNotParallelize]` to avoid races on `bin/obj` outputs.
+- When asserting on test-host output that contains a rendered test **duration** (e.g. `failed MyTest (040ms)`), NEVER hard-code `\(\d+ms\)`. The duration format grows leading parts (`(1s 040ms)`, `(2m 03s 040ms)`, …) on slower machines (often macOS, sometimes Windows), so a `\d+ms`-only pattern is a classic source of timing flakiness. Use the shared `AcceptanceAssert.DurationPattern` constant (or, where a duration only ever applies to skipped tests, the deterministic `(0ms)`) instead.
 - When running acceptance tests, you must first run `./build.sh -pack` on Linux/macOS or `.\build.cmd -pack` on Windows.
 
 ## CLI options guidelines

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DynamicDataMethodTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DynamicDataMethodTests.cs
@@ -34,9 +34,9 @@ public sealed class DynamicDataMethodTests : AcceptanceTestBase<DynamicDataMetho
         //
         // failed TestMethodParamsNotSupported (0ms)
         //   Dynamic data method 'TestClass1.GetDataParams' should be static, non-generic, and cannot have 'params' parameter.
-        testHostResult.AssertOutputMatchesRegex(@"failed TestMethodSingleParameterIntCountMismatchSmaller \(\d+ms\)[\r\n]+\s+Parameter count mismatch.");
-        testHostResult.AssertOutputMatchesRegex(@"failed TestMethodSingleParameterIntCountMismatchLarger \(\d+ms\)[\r\n]+\s+Parameter count mismatch.");
-        testHostResult.AssertOutputMatchesRegex(@"failed TestMethodParamsNotSupported \(\d+ms\)[\r\n]+\s+Dynamic data method 'TestClass1.GetDataParams' should be static, non-generic, and cannot have 'params' parameter.");
+        testHostResult.AssertOutputMatchesRegex($@"failed TestMethodSingleParameterIntCountMismatchSmaller {AcceptanceAssert.DurationPattern}[\r\n]+\s+Parameter count mismatch.");
+        testHostResult.AssertOutputMatchesRegex($@"failed TestMethodSingleParameterIntCountMismatchLarger {AcceptanceAssert.DurationPattern}[\r\n]+\s+Parameter count mismatch.");
+        testHostResult.AssertOutputMatchesRegex($@"failed TestMethodParamsNotSupported {AcceptanceAssert.DurationPattern}[\r\n]+\s+Dynamic data method 'TestClass1.GetDataParams' should be static, non-generic, and cannot have 'params' parameter.");
 
         testHostResult.AssertOutputContains("TestMethodSingleParameterInt called with: 4");
         testHostResult.AssertOutputContains("TestMethodSingleParameterInt called with: 5");

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SoftAssertionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SoftAssertionTests.cs
@@ -28,7 +28,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
 
         testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
-            """failed ScopeWithSingleFailure \(\d+ms\)[\s\S]+Assertion failed\. Expected values to be equal\.[\s\S]+expected: 1[\s\S]+actual:\s+2[\s\S]+Assert\.AreEqual\(1, 2\)[\s\S]+at UnitTest1\.ScopeWithSingleFailure\(\)""");
+            $"""failed ScopeWithSingleFailure {AcceptanceAssert.DurationPattern}[\s\S]+Assertion failed\. Expected values to be equal\.[\s\S]+expected: 1[\s\S]+actual:\s+2[\s\S]+Assert\.AreEqual\(1, 2\)[\s\S]+at UnitTest1\.ScopeWithSingleFailure\(\)""");
     }
 
     [TestMethod]
@@ -41,7 +41,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         // Validate the output includes the aggregate message and that inner exception stack traces
         // point to the test method (assertion call site).
         testHostResult.AssertOutputMatchesRegex(
-            """failed ScopeWithMultipleFailures \(\d+ms\)[\s\S]+2 assertion\(s\) failed within the assert scope\.[\s\S]+at UnitTest1\.ScopeWithMultipleFailures\(\)""");
+            $"""failed ScopeWithMultipleFailures {AcceptanceAssert.DurationPattern}[\s\S]+2 assertion\(s\) failed within the assert scope\.[\s\S]+at UnitTest1\.ScopeWithMultipleFailures\(\)""");
     }
 
     [TestMethod]
@@ -54,7 +54,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         // Assert.Fail is a hard assertion — it throws immediately, even within a scope.
         // The second Assert.Fail should not be reached.
         testHostResult.AssertOutputMatchesRegex(
-            """failed AssertFailIsHardFailure \(\d+ms\)[\s\S]+Assertion failed\.[\r\n]+\s+hard failure""");
+            $"""failed AssertFailIsHardFailure {AcceptanceAssert.DurationPattern}[\s\S]+Assertion failed\.[\r\n]+\s+hard failure""");
         testHostResult.AssertOutputDoesNotContain("second failure");
     }
 
@@ -66,7 +66,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
 
         testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
-            """failed SoftFailureFollowedByException \(\d+ms\)[\s\S]+at UnitTest1\.SoftFailureFollowedByException\(\)""");
+            $"""failed SoftFailureFollowedByException {AcceptanceAssert.DurationPattern}[\s\S]+at UnitTest1\.SoftFailureFollowedByException\(\)""");
     }
 
     [TestMethod]
@@ -77,7 +77,7 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
 
         testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
-            """failed ScopeWithIsNotNullSoftFailure \(\d+ms\)[\s\S]+Assertion failed\. Expected value to not be null\.[\s\S]+at UnitTest1\.ScopeWithIsNotNullSoftFailure\(\)""");
+            $"""failed ScopeWithIsNotNullSoftFailure {AcceptanceAssert.DurationPattern}[\s\S]+Assertion failed\. Expected value to not be null\.[\s\S]+at UnitTest1\.ScopeWithIsNotNullSoftFailure\(\)""");
     }
 
     [TestMethod]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
@@ -7,6 +7,20 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 
 internal static class AcceptanceAssert
 {
+    /// <summary>
+    /// Regex fragment (including the surrounding parentheses) that matches a test duration as rendered in the
+    /// platform output, e.g. <c>(040ms)</c>, <c>(1s 040ms)</c>, <c>(2m 03s 040ms)</c> or <c>(1h 02m 03s 040ms)</c>.
+    /// </summary>
+    /// <remarks>
+    /// The duration format (see <c>HumanReadableDurationFormatter</c> in Microsoft.Testing.Platform) grows additional
+    /// leading parts (seconds, minutes, hours, days) as the elapsed time increases. A naive <c>\(\d+ms\)</c> pattern
+    /// only matches sub-second durations and is a frequent source of timing flakiness on slower machines (often macOS,
+    /// sometimes Windows) where a test that usually runs in a few hundred milliseconds occasionally takes over a second
+    /// and is rendered as <c>(1s 040ms)</c>. Always use this constant when asserting on output that contains a duration
+    /// instead of hard-coding <c>\(\d+ms\)</c>.
+    /// </remarks>
+    public const string DurationPattern = @"\((?:\d+d )?(?:\d+h )?(?:\d+m )?(?:\d+s )?\d+ms\)";
+
     public static void AssertExitCodeIs(this TestHostResult testHostResult, int exitCode, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.AreEqual(exitCode, testHostResult.ExitCode, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 


### PR DESCRIPTION
## Problem

Acceptance tests asserting on a rendered test **duration** hard-coded `\(\d+ms\)`, which only matches sub-second runs. The platform's `HumanReadableDurationFormatter` renders longer runs as `(1s 040ms)`, `(2m 03s 040ms)`, etc. When a normally-fast test occasionally crosses the one-second boundary (commonly on macOS, sometimes Windows), the `\d+ms`-only pattern fails to match and the assertion flakes — even though the product behaved correctly.

Reported failure: `SoftAssertionTests.ScopeWithMultipleFailures_TestFailsWithAggregatedMessage`, where the output `failed ScopeWithMultipleFailures (1s 040ms)` failed to match `failed ScopeWithMultipleFailures \(\d+ms\)`.

## Changes

- **New shared helper** — `AcceptanceAssert.DurationPattern` constant: `\((?:\d+d )?(?:\d+h )?(?:\d+m )?(?:\d+s )?\d+ms\)`, covering every duration format the platform emits (`(040ms)` → `(1d 02h 03m 04s 040ms)`).
- **Audited the codebase** for the `\d+ms` anti-pattern and fixed the at-risk (executed-test) call sites:
  - `SoftAssertionTests.cs` (5 spots)
  - `DynamicDataMethodTests.cs` (3 spots)
  - `GenericTestMethodTests.cs` already used the robust `(\d+s )?\d+ms` form — left as-is.
  - `ParameterizedTestTests.cs` only matches `skipped …` lines, which deterministically report `(0ms)` — left as-is.
- **Documentation / review guardrails:**
  - `.github/copilot-instructions.md` → Testing Guidelines: never hard-code `\(\d+ms\)`; use `AcceptanceAssert.DurationPattern`.
  - `.github/agents/expert-reviewer.agent.md` → Flakiness Patterns (dimension 12): added a rule + CHECK item so reviews flag this.

## Verification

- Validated `DurationPattern` matches all duration forms.
- `MSTest.Acceptance.IntegrationTests` builds with 0 warnings / 0 errors.
