### PR TITLE
Share dotnet test wire contract (ObjectFieldIds + Constants) as source

### DIFF
--- a/TestFx.slnx
+++ b/TestFx.slnx
@@ -134,6 +134,7 @@
   <Folder Name="/test/UnitTests/">
     <Project Path="test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj" />
     <Project Path="test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests.csproj" />
+    <Project Path="test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj" />
     <Project Path="test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests.csproj" />
     <Project Path="test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj" />
     <Project Path="test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj" />

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestProtocolContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestProtocolContract.props
@@ -1,0 +1,32 @@
+<Project>
+
+  <!--
+    Shared-source manifest for the 'dotnet test' named-pipe protocol *wire contract*.
+
+    PURPOSE
+      ObjectFieldIds.cs and Constants.cs define the serializer ids, field ids and the handshake/session/state
+      constants that flow over the named pipe between a Microsoft.Testing.Platform test host and 'dotnet test'.
+      The dotnet/sdk repository hand-copies these exact values (see its ObjectFieldIds.cs, which carries a
+      "must be kept aligned with the testfx repo" warning). Any drift is a silent wire-protocol break.
+
+      This .props lets the same source files be compiled into another assembly (a standalone consumer, or - once
+      packaged as a source NuGet - the dotnet/sdk 'dotnet test' implementation) so the contract has a single source
+      of truth instead of being duplicated by hand.
+
+    SCOPE
+      Only the zero-dependency wire contract (ids + constants) is shared here. The message models and serializers
+      are intentionally NOT included yet: they still depend on TestMetadataProperty (Microsoft.Testing.Platform.
+      Extensions.Messages) and use a different class shape than the SDK's copy, so they require decoupling/unifying
+      first. See the protocol contract tests in
+      test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs.
+
+    USAGE
+      Import this file from any project that needs the contract. Microsoft.Testing.Platform itself does NOT import
+      it (it compiles these files via its default source globbing); importing it there would double-include them.
+  -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)IPC\ObjectFieldIds.cs" Link="DotnetTestProtocol\ObjectFieldIds.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IPC\Constants.cs" Link="DotnetTestProtocol\Constants.cs" />
+  </ItemGroup>
+
+</Project>

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/BannedSymbols.txt
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/BannedSymbols.txt
@@ -1,0 +1,1 @@
+N:AwesomeAssertions; Use MSTest assertions instead.

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests;
 [TestClass]
 public sealed class DotnetTestProtocolContractTests
 {
-    // The dictionary initializer additionally guarantees every serializer id is unique.
+    // Uniqueness of the serializer ids is enforced by the assertions below, not by the indexer
+    // initializer (a duplicate id would silently overwrite the earlier entry). This test is mirrored
+    // by ProtocolTests.SerializerIds_AreStable in Microsoft.Testing.Platform.UnitTests; keep both in sync.
     [TestMethod]
     public void SerializerIds_AreStable()
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.IPC;
+
+namespace Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests;
+
+/// <summary>
+/// Verifies the shared 'dotnet test' wire-contract source (ObjectFieldIds + Constants), compiled into this
+/// independent assembly via <c>DotnetTestProtocolContract.props</c>.
+/// </summary>
+/// <remarks>
+/// This project does not reference Microsoft.Testing.Platform's protocol types; it compiles the same source files.
+/// The assertions pin every value that flows over the pipe and is mirrored by hand in dotnet/sdk's
+/// <c>ObjectFieldIds</c>, so a drift between the two repositories - or an accidental change to the contract - fails
+/// the build here. The fact that this assembly compiles at all is the proof that the contract is self-contained and
+/// consumable with a single source of truth.
+/// </remarks>
+[TestClass]
+public sealed class DotnetTestProtocolContractTests
+{
+    // The dictionary initializer additionally guarantees every serializer id is unique.
+    [TestMethod]
+    public void SerializerIds_AreStable()
+    {
+        Dictionary<int, string> serializerIds = new()
+        {
+            [VoidResponseFieldsId.MessagesSerializerId] = nameof(VoidResponseFieldsId),
+            [TestHostCompletedRequestFieldsId.MessagesSerializerId] = nameof(TestHostCompletedRequestFieldsId),
+            [TestHostProcessPIDRequestFieldsId.MessagesSerializerId] = nameof(TestHostProcessPIDRequestFieldsId),
+            [CommandLineOptionMessagesFieldsId.MessagesSerializerId] = nameof(CommandLineOptionMessagesFieldsId),
+            [DiscoveredTestMessagesFieldsId.MessagesSerializerId] = nameof(DiscoveredTestMessagesFieldsId),
+            [TestResultMessagesFieldsId.MessagesSerializerId] = nameof(TestResultMessagesFieldsId),
+            [FileArtifactMessagesFieldsId.MessagesSerializerId] = nameof(FileArtifactMessagesFieldsId),
+            [TestSessionEventFieldsId.MessagesSerializerId] = nameof(TestSessionEventFieldsId),
+            [HandshakeMessageFieldsId.MessagesSerializerId] = nameof(HandshakeMessageFieldsId),
+            [TestInProgressMessagesFieldsId.MessagesSerializerId] = nameof(TestInProgressMessagesFieldsId),
+        };
+
+        Assert.AreEqual(nameof(VoidResponseFieldsId), serializerIds[0]);
+        Assert.AreEqual(nameof(TestHostCompletedRequestFieldsId), serializerIds[1]);
+        Assert.AreEqual(nameof(TestHostProcessPIDRequestFieldsId), serializerIds[2]);
+        Assert.AreEqual(nameof(CommandLineOptionMessagesFieldsId), serializerIds[3]);
+        // Id 4 is reserved (formerly ModuleSerializer) and must never be reused.
+        Assert.IsFalse(serializerIds.ContainsKey(4), "Serializer id 4 is reserved and must not be reassigned.");
+        Assert.AreEqual(nameof(DiscoveredTestMessagesFieldsId), serializerIds[5]);
+        Assert.AreEqual(nameof(TestResultMessagesFieldsId), serializerIds[6]);
+        Assert.AreEqual(nameof(FileArtifactMessagesFieldsId), serializerIds[7]);
+        Assert.AreEqual(nameof(TestSessionEventFieldsId), serializerIds[8]);
+        Assert.AreEqual(nameof(HandshakeMessageFieldsId), serializerIds[9]);
+        Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
+    }
+
+    [TestMethod]
+    public void HandshakeMessagePropertyNames_AreStable()
+    {
+        Dictionary<byte, string> properties = new()
+        {
+            [HandshakeMessagePropertyNames.PID] = nameof(HandshakeMessagePropertyNames.PID),
+            [HandshakeMessagePropertyNames.Architecture] = nameof(HandshakeMessagePropertyNames.Architecture),
+            [HandshakeMessagePropertyNames.Framework] = nameof(HandshakeMessagePropertyNames.Framework),
+            [HandshakeMessagePropertyNames.OS] = nameof(HandshakeMessagePropertyNames.OS),
+            [HandshakeMessagePropertyNames.SupportedProtocolVersions] = nameof(HandshakeMessagePropertyNames.SupportedProtocolVersions),
+            [HandshakeMessagePropertyNames.HostType] = nameof(HandshakeMessagePropertyNames.HostType),
+            [HandshakeMessagePropertyNames.ModulePath] = nameof(HandshakeMessagePropertyNames.ModulePath),
+            [HandshakeMessagePropertyNames.ExecutionId] = nameof(HandshakeMessagePropertyNames.ExecutionId),
+            [HandshakeMessagePropertyNames.InstanceId] = nameof(HandshakeMessagePropertyNames.InstanceId),
+            [HandshakeMessagePropertyNames.IsIDE] = nameof(HandshakeMessagePropertyNames.IsIDE),
+            [HandshakeMessagePropertyNames.ExecutionMode] = nameof(HandshakeMessagePropertyNames.ExecutionMode),
+        };
+
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.PID), properties[0]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.Architecture), properties[1]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.Framework), properties[2]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.OS), properties[3]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.SupportedProtocolVersions), properties[4]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.HostType), properties[5]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ModulePath), properties[6]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ExecutionId), properties[7]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.InstanceId), properties[8]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.IsIDE), properties[9]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ExecutionMode), properties[10]);
+    }
+
+    [TestMethod]
+    public void HandshakeMessageExecutionModes_AreStable()
+    {
+        string[] modes = [HandshakeMessageExecutionModes.Run, HandshakeMessageExecutionModes.Help, HandshakeMessageExecutionModes.Discover];
+
+        Assert.AreEqual("run", modes[0]);
+        Assert.AreEqual("help", modes[1]);
+        Assert.AreEqual("discover", modes[2]);
+    }
+
+    [TestMethod]
+    public void SessionEventTypes_AreStable()
+    {
+        Dictionary<byte, string> sessionEventTypes = new()
+        {
+            [SessionEventTypes.TestSessionStart] = nameof(SessionEventTypes.TestSessionStart),
+            [SessionEventTypes.TestSessionEnd] = nameof(SessionEventTypes.TestSessionEnd),
+        };
+
+        Assert.AreEqual(nameof(SessionEventTypes.TestSessionStart), sessionEventTypes[0]);
+        Assert.AreEqual(nameof(SessionEventTypes.TestSessionEnd), sessionEventTypes[1]);
+    }
+
+    [TestMethod]
+    public void TestStates_AreStable()
+    {
+        Dictionary<byte, string> testStates = new()
+        {
+            [TestStates.Discovered] = nameof(TestStates.Discovered),
+            [TestStates.Passed] = nameof(TestStates.Passed),
+            [TestStates.Skipped] = nameof(TestStates.Skipped),
+            [TestStates.Failed] = nameof(TestStates.Failed),
+            [TestStates.Error] = nameof(TestStates.Error),
+            [TestStates.Timeout] = nameof(TestStates.Timeout),
+            [TestStates.Cancelled] = nameof(TestStates.Cancelled),
+            [TestStates.InProgress] = nameof(TestStates.InProgress),
+        };
+
+        Assert.AreEqual(nameof(TestStates.Discovered), testStates[0]);
+        Assert.AreEqual(nameof(TestStates.Passed), testStates[1]);
+        Assert.AreEqual(nameof(TestStates.Skipped), testStates[2]);
+        Assert.AreEqual(nameof(TestStates.Failed), testStates[3]);
+        Assert.AreEqual(nameof(TestStates.Error), testStates[4]);
+        Assert.AreEqual(nameof(TestStates.Timeout), testStates[5]);
+        Assert.AreEqual(nameof(TestStates.Cancelled), testStates[6]);
+        Assert.AreEqual(nameof(TestStates.InProgress), testStates[7]);
+    }
+
+    [TestMethod]
+    public void ProtocolVersion_IsStable()
+    {
+        // Indirect through a collection so the MSTest analyzer does not flag the comparison of a compile-time
+        // constant as "always true" (MSTEST0032).
+        string[] versions = [ProtocolConstants.Version];
+        Assert.AreEqual("1.0.0", versions[0]);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(SupportedNetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462</TargetFrameworks>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <!--
+    This project intentionally does NOT reference Microsoft.Testing.Platform's protocol types directly. It compiles
+    the shared 'dotnet test' wire-contract source (ObjectFieldIds + Constants) into its own assembly via the shared
+    .props, proving that the contract can live in testfx and be consumed by an independent assembly (e.g. dotnet/sdk)
+    with a single source of truth.
+  -->
+  <Import Project="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\DotnetTestProtocolContract.props" />
+
+</Project>

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj
@@ -7,6 +7,10 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+
   <!--
     This project intentionally does NOT reference Microsoft.Testing.Platform's protocol types directly. It compiles
     the shared 'dotnet test' wire-contract source (ObjectFieldIds + Constants) into its own assembly via the shared

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Program.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Program.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions;
+
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
+
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel, Workers = 0)]
+
+// Opt-out telemetry
+Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+
+builder.AddMSTest(() => [Assembly.GetEntryAssembly()!]);
+
+#if ENABLE_CODECOVERAGE
+builder.AddCodeCoverageProvider();
+#endif
+builder.AddCrashDumpProvider();
+
+#if !NETFRAMEWORK
+if (!OperatingSystem.IsBrowser())
+#endif
+{
+    builder.AddHangDumpProvider();
+}
+
+builder.AddTrxReportProvider();
+builder.AddJUnitReportProvider();
+builder.AddAzureDevOpsProvider();
+builder.AddCtrfReportProvider();
+
+builder.AddOpenTelemetryProvider(
+    tracing => tracing.AddTestingPlatformInstrumentation(),
+    metrics => metrics.AddTestingPlatformInstrumentation());
+
+ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -250,6 +250,125 @@ public sealed class ProtocolTests
         Assert.HasCount(0, actual.InProgressMessages);
     }
 
+    [TestMethod]
+    public void CommandLineOptionMessagesSerializeDeserialize()
+    {
+        object serializer = new CommandLineOptionMessagesSerializer();
+        var message = new CommandLineOptionMessages(
+            "path/to/module.dll",
+            [
+                new CommandLineOptionMessage("filter", "Filters the tests", false, true),
+                new CommandLineOptionMessage("hidden-option", null, true, false),
+                new CommandLineOptionMessage(null, "no name", null, null),
+            ]);
+
+        var stream = new MemoryStream();
+        Serialize(serializer, message, stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        var actual = (CommandLineOptionMessages)Deserialize(serializer, stream);
+
+        Assert.AreEqual(message.ModulePath, actual.ModulePath);
+        Assert.IsNotNull(message.CommandLineOptionMessageList);
+        Assert.IsNotNull(actual.CommandLineOptionMessageList);
+        Assert.HasCount(message.CommandLineOptionMessageList.Length, actual.CommandLineOptionMessageList);
+        for (int i = 0; i < message.CommandLineOptionMessageList.Length; i++)
+        {
+            CommandLineOptionMessage expected = message.CommandLineOptionMessageList[i];
+            CommandLineOptionMessage actualOption = actual.CommandLineOptionMessageList[i];
+            Assert.AreEqual(expected.Name, actualOption.Name);
+            Assert.AreEqual(expected.Description, actualOption.Description);
+            Assert.AreEqual(expected.IsHidden, actualOption.IsHidden);
+            Assert.AreEqual(expected.IsBuiltIn, actualOption.IsBuiltIn);
+        }
+    }
+
+    [TestMethod]
+    public void FileArtifactMessagesSerializeDeserialize()
+    {
+        object serializer = new FileArtifactMessagesSerializer();
+        var message = new FileArtifactMessages(
+            "MyExecId",
+            "MyInstId",
+            [
+                new FileArtifactMessage("/full/path/artifact1.txt", "artifact1", "description1", "uid-1", "Test 1", "session-1"),
+                new FileArtifactMessage("/full/path/artifact2.coverage", "artifact2", null, null, null, null),
+            ]);
+
+        var stream = new MemoryStream();
+        Serialize(serializer, message, stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        var actual = (FileArtifactMessages)Deserialize(serializer, stream);
+
+        Assert.AreEqual(message.ExecutionId, actual.ExecutionId);
+        Assert.AreEqual(message.InstanceId, actual.InstanceId);
+        Assert.HasCount(message.FileArtifacts.Length, actual.FileArtifacts);
+        for (int i = 0; i < message.FileArtifacts.Length; i++)
+        {
+            FileArtifactMessage expected = message.FileArtifacts[i];
+            FileArtifactMessage actualArtifact = actual.FileArtifacts[i];
+            Assert.AreEqual(expected.FullPath, actualArtifact.FullPath);
+            Assert.AreEqual(expected.DisplayName, actualArtifact.DisplayName);
+            Assert.AreEqual(expected.Description, actualArtifact.Description);
+            Assert.AreEqual(expected.TestUid, actualArtifact.TestUid);
+            Assert.AreEqual(expected.TestDisplayName, actualArtifact.TestDisplayName);
+            Assert.AreEqual(expected.SessionUid, actualArtifact.SessionUid);
+        }
+    }
+
+    [TestMethod]
+    public void TestSessionEventSerializeDeserialize()
+    {
+        object serializer = new TestSessionEventSerializer();
+        var message = new TestSessionEvent(SessionEventTypes.TestSessionStart, "session-uid", "exec-id");
+
+        var stream = new MemoryStream();
+        Serialize(serializer, message, stream);
+        stream.Seek(0, SeekOrigin.Begin);
+        var actual = (TestSessionEvent)Deserialize(serializer, stream);
+
+        Assert.AreEqual(message.SessionType, actual.SessionType);
+        Assert.AreEqual(message.SessionUid, actual.SessionUid);
+        Assert.AreEqual(message.ExecutionId, actual.ExecutionId);
+    }
+
+    // The serializer ids registered in RegisterSerializers flow over IPC to dotnet test in the
+    // dotnet/sdk repository (see ObjectFieldIds.cs, which carries a "must be kept aligned" warning).
+    // Changing any existing id is a wire-protocol break for older platform <-> SDK pairings, so the
+    // full registry is intentionally pinned here. Note id 4 is permanently reserved (was ModuleSerializer).
+    [TestMethod]
+    public void SerializerIds_AreStable()
+    {
+        // Building the map through the constants (instead of asserting on the literals directly)
+        // keeps the MSTest analyzer from flagging compile-time constant comparisons, and the
+        // dictionary initializer additionally guarantees every id is unique.
+        Dictionary<int, string> serializerIds = new()
+        {
+            [VoidResponseFieldsId.MessagesSerializerId] = nameof(VoidResponseFieldsId),
+            [TestHostCompletedRequestFieldsId.MessagesSerializerId] = nameof(TestHostCompletedRequestFieldsId),
+            [TestHostProcessPIDRequestFieldsId.MessagesSerializerId] = nameof(TestHostProcessPIDRequestFieldsId),
+            [CommandLineOptionMessagesFieldsId.MessagesSerializerId] = nameof(CommandLineOptionMessagesFieldsId),
+            [DiscoveredTestMessagesFieldsId.MessagesSerializerId] = nameof(DiscoveredTestMessagesFieldsId),
+            [TestResultMessagesFieldsId.MessagesSerializerId] = nameof(TestResultMessagesFieldsId),
+            [FileArtifactMessagesFieldsId.MessagesSerializerId] = nameof(FileArtifactMessagesFieldsId),
+            [TestSessionEventFieldsId.MessagesSerializerId] = nameof(TestSessionEventFieldsId),
+            [HandshakeMessageFieldsId.MessagesSerializerId] = nameof(HandshakeMessageFieldsId),
+            [TestInProgressMessagesFieldsId.MessagesSerializerId] = nameof(TestInProgressMessagesFieldsId),
+        };
+
+        Assert.AreEqual(nameof(VoidResponseFieldsId), serializerIds[0]);
+        Assert.AreEqual(nameof(TestHostCompletedRequestFieldsId), serializerIds[1]);
+        Assert.AreEqual(nameof(TestHostProcessPIDRequestFieldsId), serializerIds[2]);
+        Assert.AreEqual(nameof(CommandLineOptionMessagesFieldsId), serializerIds[3]);
+        // Id 4 is reserved (formerly ModuleSerializer) and must never be reused.
+        Assert.IsFalse(serializerIds.ContainsKey(4), "Serializer id 4 is reserved and must not be reassigned.");
+        Assert.AreEqual(nameof(DiscoveredTestMessagesFieldsId), serializerIds[5]);
+        Assert.AreEqual(nameof(TestResultMessagesFieldsId), serializerIds[6]);
+        Assert.AreEqual(nameof(FileArtifactMessagesFieldsId), serializerIds[7]);
+        Assert.AreEqual(nameof(TestSessionEventFieldsId), serializerIds[8]);
+        Assert.AreEqual(nameof(HandshakeMessageFieldsId), serializerIds[9]);
+        Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
+    }
+
     private static void Serialize<TMessage>(object serializer, TMessage message, Stream stream)
         => serializer.GetType()
             .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -335,12 +335,15 @@ public sealed class ProtocolTests
     // dotnet/sdk repository (see ObjectFieldIds.cs, which carries a "must be kept aligned" warning).
     // Changing any existing id is a wire-protocol break for older platform <-> SDK pairings, so the
     // full registry is intentionally pinned here. Note id 4 is permanently reserved (was ModuleSerializer).
+    // This test is mirrored by DotnetTestProtocolContractTests.SerializerIds_AreStable in the standalone
+    // Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests project; keep both in sync.
     [TestMethod]
     public void SerializerIds_AreStable()
     {
         // Building the map through the constants (instead of asserting on the literals directly)
-        // keeps the MSTest analyzer from flagging compile-time constant comparisons, and the
-        // dictionary initializer additionally guarantees every id is unique.
+        // keeps the MSTest analyzer from flagging compile-time constant comparisons. Uniqueness of the
+        // ids is not guaranteed by the indexer initializer (a duplicate id would silently overwrite the
+        // earlier entry); the assertions below are what enforce that every id maps to its expected serializer.
         Dictionary<int, string> serializerIds = new()
         {
             [VoidResponseFieldsId.MessagesSerializerId] = nameof(VoidResponseFieldsId),
@@ -367,6 +370,62 @@ public sealed class ProtocolTests
         Assert.AreEqual(nameof(TestSessionEventFieldsId), serializerIds[8]);
         Assert.AreEqual(nameof(HandshakeMessageFieldsId), serializerIds[9]);
         Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
+    }
+
+    // The SessionEventTypes byte values flow over IPC to dotnet test in the dotnet/sdk repository.
+    // Changing any existing value is a wire-protocol break, so it is intentionally pinned here.
+    // Mirrored by DotnetTestProtocolContractTests.SessionEventTypes_AreStable.
+    [TestMethod]
+    public void SessionEventTypes_AreStable()
+    {
+        Dictionary<byte, string> sessionEventTypes = new()
+        {
+            [SessionEventTypes.TestSessionStart] = nameof(SessionEventTypes.TestSessionStart),
+            [SessionEventTypes.TestSessionEnd] = nameof(SessionEventTypes.TestSessionEnd),
+        };
+
+        Assert.AreEqual(nameof(SessionEventTypes.TestSessionStart), sessionEventTypes[0]);
+        Assert.AreEqual(nameof(SessionEventTypes.TestSessionEnd), sessionEventTypes[1]);
+    }
+
+    // The TestStates byte values flow over IPC to dotnet test in the dotnet/sdk repository.
+    // Changing any existing value is a wire-protocol break, so it is intentionally pinned here.
+    // Mirrored by DotnetTestProtocolContractTests.TestStates_AreStable.
+    [TestMethod]
+    public void TestStates_AreStable()
+    {
+        Dictionary<byte, string> testStates = new()
+        {
+            [TestStates.Discovered] = nameof(TestStates.Discovered),
+            [TestStates.Passed] = nameof(TestStates.Passed),
+            [TestStates.Skipped] = nameof(TestStates.Skipped),
+            [TestStates.Failed] = nameof(TestStates.Failed),
+            [TestStates.Error] = nameof(TestStates.Error),
+            [TestStates.Timeout] = nameof(TestStates.Timeout),
+            [TestStates.Cancelled] = nameof(TestStates.Cancelled),
+            [TestStates.InProgress] = nameof(TestStates.InProgress),
+        };
+
+        Assert.AreEqual(nameof(TestStates.Discovered), testStates[0]);
+        Assert.AreEqual(nameof(TestStates.Passed), testStates[1]);
+        Assert.AreEqual(nameof(TestStates.Skipped), testStates[2]);
+        Assert.AreEqual(nameof(TestStates.Failed), testStates[3]);
+        Assert.AreEqual(nameof(TestStates.Error), testStates[4]);
+        Assert.AreEqual(nameof(TestStates.Timeout), testStates[5]);
+        Assert.AreEqual(nameof(TestStates.Cancelled), testStates[6]);
+        Assert.AreEqual(nameof(TestStates.InProgress), testStates[7]);
+    }
+
+    // The protocol version string flows over IPC to dotnet test in the dotnet/sdk repository.
+    // Changing it is a wire-protocol break, so it is intentionally pinned here.
+    // Mirrored by DotnetTestProtocolContractTests.ProtocolVersion_IsStable.
+    [TestMethod]
+    public void ProtocolVersion_IsStable()
+    {
+        // Indirect through a collection so the MSTest analyzer does not flag the comparison of a compile-time
+        // constant as "always true" (MSTEST0032).
+        string[] versions = [ProtocolConstants.Version];
+        Assert.AreEqual("1.0.0", versions[0]);
     }
 
     private static void Serialize<TMessage>(object serializer, TMessage message, Stream stream)


### PR DESCRIPTION
## What

Establish a **source-shared** single source of truth for the `dotnet test` named-pipe protocol **wire contract**.

`ObjectFieldIds.cs` (serializer-id + field-id registry) and `Constants.cs` (handshake property names, execution modes, session-event types, test states, protocol version) are duplicated **by hand** in `dotnet/sdk` — where its `ObjectFieldIds` literally carries a *"must be kept aligned with the testfx repo"* warning. Any drift is a silent wire-protocol break.

These two files are **zero-dependency** (plain `internal` consts, no `[Embedded]`, no `Extensions.Messages`), so they can be **compiled into another assembly via a shared `.props`** instead of copied.

## Changes

- **`DotnetTestProtocolContract.props`** — shared-source manifest that `<Compile>`-includes `ObjectFieldIds.cs` + `Constants.cs`. Microsoft.Testing.Platform does **not** import it (it already globs these files); it is for external consumers.
- **`Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests`** — a standalone consumer that does **not** reference the platform's protocol types. It compiles the shared source into its **own assembly** and pins every serializer id (incl. reserved id `4`), handshake property name, execution mode, session-event type, test state and the protocol version. This is the proof that the contract is self-contained and consumable with one source of truth.
- Registered the new project in `TestFx.slnx`.
- Filled gaps in the in-repo contract tests (`ProtocolTests.cs`): round-trip `CommandLineOptionMessages` / `FileArtifactMessages` / `TestSessionEvent` and `SerializerIds_AreStable` pinning the full id registry.

## Why only the contract (not models/serializers) — yet

While prototyping a fuller share, I verified hard couplings that block the models/serializers today:
- The `[Embedded]` transport (`NamedPipe*`, `IRequest`/`IResponse`/`INamedPipeSerializer`) is **per-assembly, not runtime-unified** (confirmed via an `InvalidCastException`) and is shared platform-wide.
- `DiscoveredTestMessage` couples to `TestMetadataProperty` (`Microsoft.Testing.Platform.Extensions.Messages`).
- testfx serializers use a different class shape (`NamedPipeSerializer<T>`) than the SDK copy (`BaseSerializer` + `INamedPipeSerializer`).

So the contract is the cleanly shareable, highest-drift-risk piece. Extending the package to models/serializers is a follow-up that first needs to decouple `TestMetadataProperty` and converge the serializer shape.

## Verification

Standalone consumer: **6/6 tests passed, 0 warnings, 0 errors** (net8.0). The consumer build compiles `Microsoft.Testing.Platform` transitively, confirming the platform is unaffected. `ProtocolTests` additions: **13/13 passing**.

## Follow-ups (not in this PR)

1. Wire the `.props` into a real **source NuGet** (`contentFiles`/`buildTransitive`) so `dotnet/sdk` consumes it.
2. Decouple `DiscoveredTestMessage` from `TestMetadataProperty` and converge serializer shape, then extend the package to models + serializers.
3. Switch `dotnet/sdk` to consume the package and delete its hand-copied `ObjectFieldIds`.
