### PR TITLE
[code-simplifier] Use range operators instead of Substring in Assert.ThrowsException.Core.cs

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs
@@ -188,7 +188,7 @@ public sealed partial class Assert
             string clrTypeName = actualType.ToString();
             if (actualExceptionText.StartsWith(clrTypeName, StringComparison.Ordinal))
             {
-                actualExceptionText = GetDisplayTypeName(actualType, includeNamespace: true) + actualExceptionText.Substring(clrTypeName.Length);
+                actualExceptionText = GetDisplayTypeName(actualType, includeNamespace: true) + actualExceptionText[clrTypeName.Length..];
             }
 
             EvidenceBlock evidence = EvidenceBlock.Create()
@@ -217,7 +217,7 @@ public sealed partial class Assert
         int tick = name.IndexOf('`');
         if (tick >= 0)
         {
-            name = name.Substring(0, tick);
+            name = name[..tick];
         }
 
         if (includeNamespace && !string.IsNullOrEmpty(type.Namespace))


### PR DESCRIPTION
## Code Simplification – 2026-06-17

This PR simplifies two `.Substring()` calls introduced in #9212 by replacing them with C# range-operator equivalents, as required by the project's editorconfig (`csharp_style_prefer_range_operator = true:warning`, IDE0057).

### Files Simplified

- `src/TestFramework/TestFramework/Assertions/Assert.ThrowsException.Core.cs` – replaced two `.Substring()` calls with range operators

### Improvements Made

| Before | After |
|---|---|
| `actualExceptionText.Substring(clrTypeName.Length)` | `actualExceptionText[clrTypeName.Length..]` |
| `name.Substring(0, tick)` | `name[..tick]` |

Range operators (`[n..]` / `[..n]`) are already the established pattern across the codebase (e.g. `MSTestAdapter.PlatformServices`) and are preferred by the project's editorconfig rules. The changes are purely syntactic – no behavioral difference.

### Changes Based On

Recent changes from:
- #9212 – Include full exception (stack trace + inner exceptions) in Assert.Throws* failure messages

### Testing

- ✅ No functional changes – behavior is identical (range-operator slicing is equivalent to `Substring`)
- ✅ Change is purely syntactic and consistent with existing codebase patterns

### Review Focus

Please verify that the range-operator expressions read clearly and that no behavioral change was accidentally introduced.


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27695685680/agentic_workflow) workflow. · 1K AIC · ⌖ 47 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-18T14:41:25.980Z --> on Jun 18, 2026, 2:41 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27695685680, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27695685680 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->