### PR TITLE
[test-improver] test: add edge case tests for TestContextShouldBeValidAnalyzer (MSTEST0005)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
@@ -544,37 +544,23 @@ public sealed class TestContextShouldBeValidAnalyzerTests
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
 
+    [DataRow("private")]
+    [DataRow("protected")]
+    [DataRow("internal")]
     [TestMethod]
-    public async Task WhenTestContextPropertyHasPrivateSetter_NoDiagnostic()
+    public async Task WhenTestContextPropertyHasNonPublicSetter_NoDiagnostic(string setterAccessibility)
     {
-        // A public TestContext property named exactly "TestContext" with a private setter
-        // satisfies IsTestContextPropertyAutomaticallyAssigned (SetMethod is not null), so
-        // the runtime can still inject the value and no diagnostic should be reported.
-        string code = """
+        // A public TestContext property named exactly "TestContext" with a non-public setter
+        // satisfies IsTestContextPropertyAutomaticallyAssigned (SetMethod is not null, regardless
+        // of the setter's accessibility), so the runtime can still inject the value via reflection
+        // and no diagnostic should be reported.
+        string code = $$"""
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
             [TestClass]
             public class MyTestClass
             {
-                public TestContext TestContext { get; private set; }
-            }
-            """;
-
-        await VerifyCS.VerifyCodeFixAsync(code, code);
-    }
-
-    [TestMethod]
-    public async Task WhenTestContextPropertyHasProtectedSetter_NoDiagnostic()
-    {
-        // Same as the private-setter case: a protected setter still satisfies the
-        // SetMethod-is-not-null check in IsTestContextPropertyAutomaticallyAssigned.
-        string code = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                public TestContext TestContext { get; protected set; }
+                public TestContext TestContext { get; {{setterAccessibility}} set; }
             }
             """;
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextShouldBeValidAnalyzerTests.cs
@@ -543,4 +543,98 @@ public sealed class TestContextShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenTestContextPropertyHasPrivateSetter_NoDiagnostic()
+    {
+        // A public TestContext property named exactly "TestContext" with a private setter
+        // satisfies IsTestContextPropertyAutomaticallyAssigned (SetMethod is not null), so
+        // the runtime can still inject the value and no diagnostic should be reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; private set; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestContextPropertyHasProtectedSetter_NoDiagnostic()
+    {
+        // Same as the private-setter case: a protected setter still satisfies the
+        // SetMethod-is-not-null check in IsTestContextPropertyAutomaticallyAssigned.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; protected set; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenInvalidTestContextPropertyIsOnNonTestClass_NoDiagnostic()
+    {
+        // The analyzer only validates TestContext properties inside [TestClass]-attributed types.
+        // A class without [TestClass] must never be flagged, even if its TestContext property
+        // layout would be invalid inside a test class.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                public TestContext TestContext { get; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestContextAssignedOnlyInMultiParamConstructor_Diagnostic()
+    {
+        // TryGetTestContextParameterIfValidConstructor requires the constructor to have
+        // exactly ONE parameter of type TestContext. A constructor with extra parameters
+        // is not recognised, so the assignment is invisible to the analyzer and the
+        // property (which lacks an auto-setter) must be reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public MyTestClass(TestContext testContext, string name)
+                {
+                    TestContext = testContext;
+                }
+
+                public TestContext [|TestContext|] { get; }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public MyTestClass(TestContext testContext, string name)
+                {
+                    TestContext = testContext;
+                }
+
+                public TestContext TestContext { get; set; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`TestContextShouldBeValidAnalyzer` (MSTEST0005) has non-trivial logic across several paths — `IsTestContextPropertyAutomaticallyAssigned`, `TryGetTestContextParameterIfValidConstructor`, and the early-return for non-test-class types — that had no dedicated test coverage.

## Approach

Added 4 targeted edge-case tests covering previously untested code paths:

| New test | Code path exercised |
|---|---|
| `WhenTestContextPropertyHasPrivateSetter_NoDiagnostic` | `IsTestContextPropertyAutomaticallyAssigned` → `SetMethod is not null` with a private setter |
| `WhenTestContextPropertyHasProtectedSetter_NoDiagnostic` | Same check with a protected setter |
| `WhenInvalidTestContextPropertyIsOnNonTestClass_NoDiagnostic` | Early return: class without `[TestClass]` attribute is skipped entirely |
| `WhenTestContextAssignedOnlyInMultiParamConstructor_Diagnostic` | `TryGetTestContextParameterIfValidConstructor` only accepts single-parameter constructors; a two-parameter constructor is not recognised, so the readonly property is correctly reported |

## Trade-offs

- Tests are self-contained; no new dependencies or infrastructure.
- All 4 cases map to distinct, understandable behaviors that developers could reasonably encounter.

## Reproducibility

```bash
DOTNET_INSTALL_DIR=/usr/share/dotnet ./build.sh --restore
.dotnet/dotnet run --project test/UnitTests/MSTest.Analyzers.UnitTests -f net8.0 --no-build -c Debug -- --filter "ClassName~TestContextShouldBeValidAnalyzerTests"
```

## Test Status

✅ 71 tests passed (67 existing + 4 new), 0 failed.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27726042801/agentic_workflow) workflow. · 1.1K AIC · ⌖ 40.3 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27726042801, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27726042801 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->