### PR TITLE
Add source NuGet package for the dotnet test wire contract (follow-up to #9218)

### DIFF
--- a/TestFx.slnx
+++ b/TestFx.slnx
@@ -55,6 +55,7 @@
     <Project Path="src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Microsoft.Testing.Extensions.VSTestBridge.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Platform.AI/Microsoft.Testing.Platform.AI.csproj" />
+    <Project Path="src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Platform.MSBuild/Microsoft.Testing.Platform.MSBuild.csproj" />
     <Project Path="src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj" />
   </Folder>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Microsoft.Testing.Extensions.HangDump.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Microsoft.Testing.Extensions.HangDump.csproj
@@ -33,6 +33,7 @@ This package extends Microsoft Testing Platform to provide an implementation of 
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\NamedPipeSerializer.cs" Link="IPC\Serializers\NamedPipeSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\VoidResponseSerializer.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\ObjectFieldIds.cs" Link="IPC\ObjectFieldIds.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
 
     <!-- Embedded helpers from Microsoft.Testing.Platform -->

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj
@@ -14,6 +14,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\NamedPipeSerializer.cs" Link="IPC\Serializers\NamedPipeSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\VoidResponseSerializer.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\ObjectFieldIds.cs" Link="IPC\ObjectFieldIds.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
 
     <!-- Embedded helpers from Microsoft.Testing.Platform -->

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\NamedPipeSerializer.cs" Link="IPC\Serializers\NamedPipeSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\VoidResponseSerializer.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\ObjectFieldIds.cs" Link="IPC\ObjectFieldIds.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
 
     <!-- Embedded helpers from Microsoft.Testing.Platform -->

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\NamedPipeSerializer.cs" Link="IPC\Serializers\NamedPipeSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\VoidResponseSerializer.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\ObjectFieldIds.cs" Link="IPC\ObjectFieldIds.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
 
     <!-- Embedded helpers from Microsoft.Testing.Platform -->

--- a/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj
@@ -1,6 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--
+      netstandard2.0 is deliberate, NOT net8/9/10: this is a source-only package. The contract files are shipped as
+      contentFiles/cs/any and are compiled into the CONSUMER's compilation under the consumer's own TFM (e.g. net11
+      in dotnet/sdk), so this TargetFramework never reaches consumers. It only governs the throwaway lib build we use
+      as a "the shared source compiles standalone" guard - and netstandard2.0 makes that guard maximally portable
+      (and needs no runtime packs). Bump it only if a future addition (models/serializers) genuinely needs a newer
+      API; even then it would not change what consumers compile against.
+    -->
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!--

--- a/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!--
+      Source-only package: it ships the 'dotnet test' wire-contract source files (ObjectFieldIds.cs + Constants.cs)
+      as contentFiles so a consumer (the dotnet/sdk 'dotnet test' implementation) compiles them into its OWN
+      assembly. This keeps a single source of truth for the protocol ids/constants instead of hand-copying them.
+
+      The project still compiles the two files (into a lib that is intentionally NOT packed - IncludeBuildOutput is
+      false) so we get a build-time guarantee that the shared contract compiles standalone.
+    -->
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
+
+    <!--
+      Transport/source package: consumed cross-repo (dotnet/sdk) via dependency flow, not meant to be installed by
+      end users from nuget.org. Flip to 'true' (and remove DevelopmentDependency) if public publication is desired.
+    -->
+    <IsShipping>false</IsShipping>
+
+    <!-- NU5128: source-only package has no lib/ assembly, only contentFiles. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+
+    <PackageDescription>
+      <![CDATA[Microsoft Testing is a set of platform, framework and protocol intended to make it possible to run any test on any target or device.
+
+This package shares - as compiled source - the 'dotnet test' named-pipe wire contract (serializer/field ids and handshake/session/state constants) so that the protocol has a single source of truth across the microsoft/testfx and dotnet/sdk repositories. It is an implementation detail of 'dotnet test' integration and is not intended for direct end-user consumption.]]>
+    </PackageDescription>
+  </PropertyGroup>
+
+  <!--
+    Pulls in @(DotnetTestProtocolContractSource) (the canonical contract file list) and, by default, compiles those
+    files. The package layout below packs the SAME item as contentFiles, so the NuGet and the in-repo source-share
+    can never drift.
+  -->
+  <Import Project="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\DotnetTestProtocolContract.props" />
+
+  <ItemGroup>
+    <None Include="@(DotnetTestProtocolContractSource)"
+          Pack="true"
+          BuildAction="Compile"
+          PackagePath="contentFiles/cs/any/DotnetTestProtocol/%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/Microsoft.Testing.Platform.DotnetTestProtocol.csproj
@@ -4,10 +4,9 @@
     <!--
       netstandard2.0 is deliberate, NOT net8/9/10: this is a source-only package. The contract files are shipped as
       contentFiles/cs/any and are compiled into the CONSUMER's compilation under the consumer's own TFM (e.g. net11
-      in dotnet/sdk), so this TargetFramework never reaches consumers. It only governs the throwaway lib build we use
-      as a "the shared source compiles standalone" guard - and netstandard2.0 makes that guard maximally portable
-      (and needs no runtime packs). Bump it only if a future addition (models/serializers) genuinely needs a newer
-      API; even then it would not change what consumers compile against.
+      in dotnet/sdk), so this TargetFramework never reaches consumers. This project does not compile the contract
+      files itself (see DotnetTestProtocolContractCompile below), so the TFM only governs the empty placeholder
+      assembly; netstandard2.0 keeps it the lightest and needs no runtime packs.
     -->
     <TargetFramework>netstandard2.0</TargetFramework>
 
@@ -16,17 +15,24 @@
       as contentFiles so a consumer (the dotnet/sdk 'dotnet test' implementation) compiles them into its OWN
       assembly. This keeps a single source of truth for the protocol ids/constants instead of hand-copying them.
 
-      The project still compiles the two files (into a lib that is intentionally NOT packed - IncludeBuildOutput is
-      false) so we get a build-time guarantee that the shared contract compiles standalone.
+      DotnetTestProtocolContractCompile=false makes the imported .props skip its <Compile> items: this project only
+      *packs* the files, it does not compile them. The guarantee that the shared contract compiles standalone is
+      provided by the dedicated consumer test project
+      (test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests), not by this package build.
     -->
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DotnetTestProtocolContractCompile>false</DotnetTestProtocolContractCompile>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+
+    <!-- Build-only / source contribution: it must not flow as a transitive runtime dependency to consumers. -->
     <DevelopmentDependency>true</DevelopmentDependency>
 
     <!--
-      Transport/source package: consumed cross-repo (dotnet/sdk) via dependency flow, not meant to be installed by
-      end users from nuget.org. Flip to 'true' (and remove DevelopmentDependency) if public publication is desired.
+      IsShipping=false keeps this package OUT of nuget.org and in the internal (NonShipping) feed used for cross-repo
+      dependency flow (dotnet/sdk). NOTE: the exact internal-feed shipping mechanism still needs confirmation with
+      the Arcade team (see PR discussion).
     -->
     <IsShipping>false</IsShipping>
 
@@ -41,9 +47,9 @@ This package shares - as compiled source - the 'dotnet test' named-pipe wire con
   </PropertyGroup>
 
   <!--
-    Pulls in @(DotnetTestProtocolContractSource) (the canonical contract file list) and, by default, compiles those
-    files. The package layout below packs the SAME item as contentFiles, so the NuGet and the in-repo source-share
-    can never drift.
+    Pulls in @(DotnetTestProtocolContractSource) - the canonical contract file list. We set
+    DotnetTestProtocolContractCompile=false above, so the .props does NOT add <Compile> items here; this project only
+    packs that same item as contentFiles, so the NuGet and the in-repo source-share can never drift.
   -->
   <Import Project="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\DotnetTestProtocolContract.props" />
 

--- a/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/PACKAGE.md
@@ -1,0 +1,31 @@
+# Microsoft.Testing.Platform.DotnetTestProtocol
+
+This package shares — **as compiled source** — the `dotnet test` named-pipe **wire contract** used between a
+[Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) test host and the
+`dotnet test` command line.
+
+It exists so the protocol's serializer/field ids and handshake/session/state constants have a **single source of
+truth** across the [microsoft/testfx](https://github.com/microsoft/testfx) and
+[dotnet/sdk](https://github.com/dotnet/sdk) repositories, instead of being hand-copied (where any drift is a silent
+wire-protocol break).
+
+> This package is an implementation detail of `dotnet test` integration. It is **not** intended for direct
+> end-user consumption.
+
+## What's inside
+
+The package ships two zero-dependency source files as `contentFiles` (compiled into the consuming assembly):
+
+- `ObjectFieldIds.cs` — serializer ids and per-message field ids.
+- `Constants.cs` — handshake property names, execution modes, session-event types, test states and the protocol
+  version.
+
+Because they are delivered as `contentFiles/cs/any` with `BuildAction=Compile`, the consumer compiles them into its
+**own** assembly, so the `internal` types are visible without any `InternalsVisibleTo` plumbing.
+
+## Scope
+
+Only the wire **contract** (ids + constants) is shared here. The message **models** and **serializers** are not
+included yet because they still depend on `TestMetadataProperty`
+(`Microsoft.Testing.Platform.Extensions.Messages`) and use a different class shape than the SDK's copy; sharing them
+requires decoupling/unifying first.

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestProtocolContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestProtocolContract.props
@@ -25,18 +25,18 @@
       it (it compiles these files via its default source globbing); importing it there would double-include them.
 
         The single canonical list of contract files lives in the @(DotnetTestProtocolContractSource) item below.
-        - Source consumers (e.g. the standalone contract test project) get them as <Compile> items (the default).
-        - The Microsoft.Testing.Platform.DotnetTestProtocol package project sets
-          DotnetTestProtocolContractCompile=false and instead packs @(DotnetTestProtocolContractSource) as
-          contentFiles, so the NuGet and the source-share never drift.
+      - Source consumers (e.g. the standalone contract test project) get them as <Compile> items (the default).
+      - The Microsoft.Testing.Platform.DotnetTestProtocol package project sets
+        DotnetTestProtocolContractCompile=false and instead packs @(DotnetTestProtocolContractSource) as
+        contentFiles, so the NuGet and the source-share never drift.
   -->
   <ItemGroup>
-      <DotnetTestProtocolContractSource Include="$(MSBuildThisFileDirectory)IPC\ObjectFieldIds.cs" />
-      <DotnetTestProtocolContractSource Include="$(MSBuildThisFileDirectory)IPC\Constants.cs" />
+    <DotnetTestProtocolContractSource Include="$(MSBuildThisFileDirectory)IPC\ObjectFieldIds.cs" />
+    <DotnetTestProtocolContractSource Include="$(MSBuildThisFileDirectory)IPC\Constants.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(DotnetTestProtocolContractCompile)' != 'false' ">
-      <Compile Include="@(DotnetTestProtocolContractSource)" Link="DotnetTestProtocol\%(Filename)%(Extension)" />
+    <Compile Include="@(DotnetTestProtocolContractSource)" Link="DotnetTestProtocol\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestProtocolContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestProtocolContract.props
@@ -23,10 +23,20 @@
     USAGE
       Import this file from any project that needs the contract. Microsoft.Testing.Platform itself does NOT import
       it (it compiles these files via its default source globbing); importing it there would double-include them.
+
+        The single canonical list of contract files lives in the @(DotnetTestProtocolContractSource) item below.
+        - Source consumers (e.g. the standalone contract test project) get them as <Compile> items (the default).
+        - The Microsoft.Testing.Platform.DotnetTestProtocol package project sets
+          DotnetTestProtocolContractCompile=false and instead packs @(DotnetTestProtocolContractSource) as
+          contentFiles, so the NuGet and the source-share never drift.
   -->
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)IPC\ObjectFieldIds.cs" Link="DotnetTestProtocol\ObjectFieldIds.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)IPC\Constants.cs" Link="DotnetTestProtocol\Constants.cs" />
+      <DotnetTestProtocolContractSource Include="$(MSBuildThisFileDirectory)IPC\ObjectFieldIds.cs" />
+      <DotnetTestProtocolContractSource Include="$(MSBuildThisFileDirectory)IPC\Constants.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(DotnetTestProtocolContractCompile)' != 'false' ">
+      <Compile Include="@(DotnetTestProtocolContractSource)" Link="DotnetTestProtocol\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.Testing.Platform.IPC;
 
+[Embedded]
 internal static class TestStates
 {
     internal const byte Discovered = 0;
@@ -15,12 +18,14 @@ internal static class TestStates
     internal const byte InProgress = 7;
 }
 
+[Embedded]
 internal static class SessionEventTypes
 {
     internal const byte TestSessionStart = 0;
     internal const byte TestSessionEnd = 1;
 }
 
+[Embedded]
 internal static class HandshakeMessagePropertyNames
 {
     internal const byte PID = 0;
@@ -47,6 +52,7 @@ internal static class HandshakeMessagePropertyNames
     internal const byte OrchestratorFeature = 11;
 }
 
+[Embedded]
 internal static class HandshakeMessageHostTypes
 {
     // A regular (console or server) test host that actually runs tests.
@@ -63,6 +69,7 @@ internal static class HandshakeMessageHostTypes
     internal const string TestHostOrchestrator = "TestHostOrchestrator";
 }
 
+[Embedded]
 internal static class HandshakeMessageExecutionModes
 {
     // Standard test run.
@@ -75,6 +82,7 @@ internal static class HandshakeMessageExecutionModes
     internal const string Discover = "discover";
 }
 
+[Embedded]
 internal static class ProtocolConstants
 {
     internal const string Version = "1.0.0";

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
@@ -1,27 +1,33 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.Testing.Platform.IPC;
 
 // WARNING: Please note this file needs to be kept aligned with the one in the dotnet sdk.
 // The protocol follows the concept of optional properties.
 // The id is used to identify the property in the stream and it will be skipped if it's not recognized.
 // We can add new properties with new ids, but we CANNOT change the existing ids (to support backwards compatibility).
+[Embedded]
 internal static class VoidResponseFieldsId
 {
     public const int MessagesSerializerId = 0;
 }
 
+[Embedded]
 internal static class TestHostCompletedRequestFieldsId
 {
     public const int MessagesSerializerId = 1;
 }
 
+[Embedded]
 internal static class TestHostProcessPIDRequestFieldsId
 {
     public const int MessagesSerializerId = 2;
 }
 
+[Embedded]
 internal static class CommandLineOptionMessagesFieldsId
 {
     public const int MessagesSerializerId = 3;
@@ -30,6 +36,7 @@ internal static class CommandLineOptionMessagesFieldsId
     public const ushort CommandLineOptionMessageList = 2;
 }
 
+[Embedded]
 internal static class CommandLineOptionMessageFieldsId
 {
     public const ushort Name = 1;
@@ -39,6 +46,7 @@ internal static class CommandLineOptionMessageFieldsId
     // Reserved: field ID 5 was ObsolescenceMessage, removed as unused.
 }
 
+[Embedded]
 internal static class DiscoveredTestMessagesFieldsId
 {
     public const int MessagesSerializerId = 5;
@@ -48,6 +56,7 @@ internal static class DiscoveredTestMessagesFieldsId
     public const ushort DiscoveredTestMessageList = 3;
 }
 
+[Embedded]
 internal static class DiscoveredTestMessageFieldsId
 {
     public const ushort Uid = 1;
@@ -61,12 +70,14 @@ internal static class DiscoveredTestMessageFieldsId
     public const ushort ParameterTypeFullNames = 9;
 }
 
+[Embedded]
 internal static class TraitMessageFieldsId
 {
     public const ushort Key = 1;
     public const ushort Value = 2;
 }
 
+[Embedded]
 internal static class TestResultMessagesFieldsId
 {
     public const int MessagesSerializerId = 6;
@@ -77,6 +88,7 @@ internal static class TestResultMessagesFieldsId
     public const ushort FailedTestMessageList = 4;
 }
 
+[Embedded]
 internal static class SuccessfulTestResultMessageFieldsId
 {
     public const ushort Uid = 1;
@@ -89,6 +101,7 @@ internal static class SuccessfulTestResultMessageFieldsId
     public const ushort SessionUid = 8;
 }
 
+[Embedded]
 internal static class FailedTestResultMessageFieldsId
 {
     public const ushort Uid = 1;
@@ -102,6 +115,7 @@ internal static class FailedTestResultMessageFieldsId
     public const ushort SessionUid = 9;
 }
 
+[Embedded]
 internal static class ExceptionMessageFieldsId
 {
     public const ushort ErrorMessage = 1;
@@ -109,6 +123,7 @@ internal static class ExceptionMessageFieldsId
     public const ushort StackTrace = 3;
 }
 
+[Embedded]
 internal static class FileArtifactMessagesFieldsId
 {
     public const int MessagesSerializerId = 7;
@@ -118,6 +133,7 @@ internal static class FileArtifactMessagesFieldsId
     public const ushort FileArtifactMessageList = 3;
 }
 
+[Embedded]
 internal static class FileArtifactMessageFieldsId
 {
     public const ushort FullPath = 1;
@@ -128,6 +144,7 @@ internal static class FileArtifactMessageFieldsId
     public const ushort SessionUid = 6;
 }
 
+[Embedded]
 internal static class TestSessionEventFieldsId
 {
     public const int MessagesSerializerId = 8;
@@ -137,11 +154,13 @@ internal static class TestSessionEventFieldsId
     public const ushort ExecutionId = 3;
 }
 
+[Embedded]
 internal static class HandshakeMessageFieldsId
 {
     public const int MessagesSerializerId = 9;
 }
 
+[Embedded]
 internal static class TestInProgressMessagesFieldsId
 {
     public const int MessagesSerializerId = 10;
@@ -151,6 +170,7 @@ internal static class TestInProgressMessagesFieldsId
     public const ushort TestInProgressMessageList = 3;
 }
 
+[Embedded]
 internal static class TestInProgressMessageFieldsId
 {
     public const ushort Uid = 1;

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj
@@ -12,6 +12,16 @@
   </ItemGroup>
 
   <!--
+    [Embedded] on the shared contract types resolves to Microsoft.CodeAnalysis.EmbeddedAttribute (not a framework
+    type). This independent consumer must provide it - the platform/extensions get it from src/Polyfills, and
+    dotnet/sdk already defines it for its copied IPC transport. We include only the polyfill (not via a package
+    reference) to mirror how an external consumer would supply the attribute.
+  -->
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)src\Polyfills\EmbeddedAttribute.cs" Link="Polyfills\EmbeddedAttribute.cs" />
+  </ItemGroup>
+
+  <!--
     This project intentionally does NOT reference Microsoft.Testing.Platform's protocol types directly. It compiles
     the shared 'dotnet test' wire-contract source (ObjectFieldIds + Constants) into its own assembly via the shared
     .props, proving that the contract can live in testfx and be consumed by an independent assembly (e.g. dotnet/sdk)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj
@@ -23,6 +23,8 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\NamedPipeSerializer.cs" Link="IPC\Serializers\NamedPipeSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Serializers\VoidResponseSerializer.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\IPC\Models\VoidResponse.cs" Link="IPC\Serializers\VoidResponseSerializer.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\ObjectFieldIds.cs" Link="IPC\ObjectFieldIds.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\IPC\Constants.cs" Link="IPC\Constants.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
 
     <!-- Embedded helpers from Microsoft.Testing.Platform -->


### PR DESCRIPTION
## What

Follow-up #1 to #9218 (which established the shared `dotnet test` wire-contract **source** via `DotnetTestProtocolContract.props`).

This wires that source-share into a real **source-only NuGet package**, `Microsoft.Testing.Platform.DotnetTestProtocol`, so `dotnet/sdk`'s `dotnet test` implementation can **compile** `ObjectFieldIds.cs` + `Constants.cs` from a single source of truth instead of hand-copying them (where any drift is a silent wire-protocol break).

## Changes

- **New package project** `src/Platform/Microsoft.Testing.Platform.DotnetTestProtocol/`:
  - Ships the two zero-dependency contract files as `contentFiles/cs/any/...` with `BuildAction=Compile`, so the consumer compiles them into its **own** assembly (the `internal` types are then visible with no `InternalsVisibleTo`).
  - `IncludeBuildOutput=false` ⇒ pure source package, no `lib/`.
  - `PACKAGE.md` documents scope and that it is a `dotnet test` implementation detail, not for direct end-user use.
- **Refactor `DotnetTestProtocolContract.props`** to declare the canonical file list **once** as `@(DotnetTestProtocolContractSource)`. Both the source-share `<Compile>` (used by the standalone contract test project) and the package's `contentFiles` derive from that item, so the NuGet and the in-repo source can never drift.
- **Registered** the project in `TestFx.slnx`.

## Verification

- `build.cmd -pack` produces `Microsoft.Testing.Platform.DotnetTestProtocol.2.3.0-dev.nupkg` (0 warnings, 0 errors). The `.nuspec` carries both files under `<contentFiles ... buildAction="Compile" />`.
- An **external consumer** project (no reference to `Microsoft.Testing.Platform`) restores the produced package and compiles, accessing `Microsoft.Testing.Platform.IPC.CommandLineOptionMessagesFieldsId` and `TestStates` from the shared source — **0 warnings, 0 errors**.
- The existing standalone contract test project (`Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests`) still builds across `net8.0` / `net9.0` / `net462` after the `.props` refactor.

## Open question for reviewers

The package is currently `IsShipping=false` — i.e. a **transport/source** package flowed cross-repo via dependency flow, **not** published to nuget.org. This seemed the idiomatic choice for an internal-only source contract consumed solely by `dotnet/sdk`. If you'd rather publish it publicly, it's a one-line flip (`IsShipping=true` + drop `DevelopmentDependency`). Happy to change.

## Follow-ups (still open from #9218)

2. Decouple `DiscoveredTestMessage` from `TestMetadataProperty` and converge the serializer shape, then extend this package to the message **models + serializers**.
3. Switch `dotnet/sdk` to consume this package and delete its hand-copied `ObjectFieldIds`.
