### PR TITLE
Fix MSBuild file quality findings from #9227

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -52,17 +52,25 @@
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Name)"  Condition=" '$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Name)' != '' "/>
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Parent.Name)"  Condition=" '$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Parent.Name)' != '' "/>
     </ItemGroup>
-  </Target>
 
-  <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
-  <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild" Condition=" '$(EnableMSTestV2CopyResources)' == 'true' " DependsOnTargets="GetMSTestV2CultureHierarchy">
-
-    <!-- Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item. -->
+    <!--
+      Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item.
+      This is populated here (rather than inside CopyMSTestV2Resources) so the item group is available when the
+      Inputs/Outputs of CopyMSTestV2Resources are evaluated for incremental build.
+    -->
     <ItemGroup>
       <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
         <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
       </MSTestV2Files>
     </ItemGroup>
+  </Target>
+
+  <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
+  <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild"
+          Condition=" '$(EnableMSTestV2CopyResources)' == 'true' "
+          DependsOnTargets="GetMSTestV2CultureHierarchy"
+          Inputs="@(MSTestV2Files)"
+          Outputs="@(MSTestV2Files->'$(TargetDir)%(UICulture)\%(FileName)%(Extension)')">
 
     <ItemGroup>
       <!-- Add the localization file as content so it gets copied from nuget to bin folder. -->

--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/uwp/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/uwp/MSTest.TestAdapter.targets
@@ -28,17 +28,25 @@
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Name)"  Condition=" '$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Name)' != '' "/>
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Parent.Name)"  Condition=" '$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Parent.Parent.Name)' != '' "/>
     </ItemGroup>
-  </Target>
 
-  <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
-  <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild" Condition=" '$(EnableMSTestV2CopyResources)' == 'true' " DependsOnTargets="GetMSTestV2CultureHierarchy">
-
-    <!-- Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item. -->
+    <!--
+      Expand the UICulture hierarchy to items, such as cs-CZ, cs, and attach the culture metadata to the item.
+      This is populated here (rather than inside CopyMSTestV2Resources) so the item group is available when the
+      Inputs/Outputs of CopyMSTestV2Resources are evaluated for incremental build.
+    -->
     <ItemGroup>
       <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
         <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
       </MSTestV2Files>
     </ItemGroup>
+  </Target>
+
+  <!-- Copy resources over to $(TargetDir) if this is a localized build. -->
+  <Target Name="CopyMSTestV2Resources" BeforeTargets="PrepareForBuild"
+          Condition=" '$(EnableMSTestV2CopyResources)' == 'true' "
+          DependsOnTargets="GetMSTestV2CultureHierarchy"
+          Inputs="@(MSTestV2Files)"
+          Outputs="@(MSTestV2Files->'$(TargetDir)%(UICulture)\%(FileName)%(Extension)')">
 
     <ItemGroup>
       <!-- Add the localization file as content so it gets copied from nuget to bin folder. -->

--- a/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/ClassicEngine.targets
@@ -60,7 +60,7 @@
 
     <!-- Fakes -->
     <EnableMicrosoftTestingExtensionsFakes Condition=" '$(EnableMicrosoftTestingExtensionsFakes)' != 'false' and '$(TestingExtensionsProfile)' == 'AllMicrosoft' " >true</EnableMicrosoftTestingExtensionsFakes>
-    <MicrosoftTestingExtensionsFakesVersion Condition=" '$(MicrosoftTestingExtensionsFakesVersion)' == '' " >$(MicrosoftTestingExtensionsFakesVersion)</MicrosoftTestingExtensionsFakesVersion>
+    <!-- MicrosoftTestingExtensionsFakesVersion is always injected by the generated Sdk.props (from Sdk.props.template). -->
   </PropertyGroup>
 
   <!-- Core -->

--- a/src/Package/MSTest.Sdk/Sdk/Runner/Common.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/Common.targets
@@ -28,7 +28,7 @@
     <!-- MS Code Coverage -->
     <EnableMicrosoftTestingExtensionsCodeCoverage Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' != 'false' and '$(TestingExtensionsProfile)' == 'Default' " >true</EnableMicrosoftTestingExtensionsCodeCoverage>
     <EnableMicrosoftTestingExtensionsCodeCoverage Condition=" '$(EnableMicrosoftTestingExtensionsCodeCoverage)' != 'false' and '$(TestingExtensionsProfile)' == 'AllMicrosoft' " >true</EnableMicrosoftTestingExtensionsCodeCoverage>
-    <MicrosoftTestingExtensionsCodeCoverageVersion Condition=" '$(MicrosoftTestingExtensionsCodeCoverageVersion)' == '' " >$(MicrosoftTestingExtensionsCodeCoverageVersion)</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <!-- MicrosoftTestingExtensionsCodeCoverageVersion is always injected by the generated Sdk.props (from Sdk.props.template). -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #9227 — addresses all 3 warnings from the MSBuild File Quality Report.

### 🟡 A-3 — Incremental build for `CopyMSTestV2Resources`
Files: `buildTransitive/common/MSTest.TestAdapter.targets`, `buildTransitive/uwp/MSTest.TestAdapter.targets`

Added `Inputs`/`Outputs` so the target is skipped when localization resources are already up to date.

**Correction to the issue's suggested fix:** the report's snippet kept `MSTestV2Files` populated *inside* the target body, but `Inputs`/`Outputs` are evaluated **before** the body runs (after `DependsOnTargets`), so the item group would have been empty and incremental skipping would misbehave. This PR moves the `MSTestV2Files` ItemGroup into the `GetMSTestV2CultureHierarchy` dependency target so the items exist when `Inputs`/`Outputs` are evaluated.

### 🟡 B-1 — Self-assignment no-op version guards
- `Runner/ClassicEngine.targets` — removed the `MicrosoftTestingExtensionsFakesVersion` guard that assigned the property to itself.
- `Runner/Common.targets` — removed the identical `MicrosoftTestingExtensionsCodeCoverageVersion` no-op.

Both versions are always injected by the generated `Sdk.props` (placeholders in `Sdk.props.template`), so the guards were unreachable dead code; each is replaced with an explanatory comment.

All four edited `.targets` files validated as well-formed XML.