### PR TITLE
docs: add missing 4.3.0/2.3.0 changelog entries for `#9182`, `#9192`, `#9195`, `#9212`

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -34,6 +34,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add --progress {auto|on|off} and deprecate --no-progress in MTP terminal reporter by @Evangelink in [#9145](https://github.com/microsoft/testfx/pull/9145)
 * Add silence-driven progress heartbeat for SimpleAnsi/NoAnsi output modes by @Evangelink in [#9147](https://github.com/microsoft/testfx/pull/9147)
 * Add Azure DevOps per-assembly log groups by @Evangelink in [#9177](https://github.com/microsoft/testfx/pull/9177)
+* Add Azure DevOps history-driven slow-test threshold enricher by @Evangelink in [#9182](https://github.com/microsoft/testfx/pull/9182)
 * Handshake from the test host orchestrator in the dotnet test pipe protocol, advertising the orchestration feature (e.g. retry) by @Copilot in [#9215](https://github.com/microsoft/testfx/pull/9215)
 
 ### Fixed
@@ -70,6 +71,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Flag bootstrap-only CLI options when set in testconfig.json by @Evangelink in [#9055](https://github.com/microsoft/testfx/pull/9055)
 * Fix report file-name collision between net8.0 and net8.0-windows builds by @Evangelink in [#9121](https://github.com/microsoft/testfx/pull/9121)
 * Harden report TFM resolution for custom/non-OS platforms (browserwasm) by @Evangelink in [#9137](https://github.com/microsoft/testfx/pull/9137)
+* Fix --list-tests json output under --server mode by streaming discovered tests to the SDK over the dotnet-test pipe by @Evangelink in [#9192](https://github.com/microsoft/testfx/pull/9192)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -45,6 +45,8 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Render BCL values with full precision in assertion failure messages by @Evangelink in [#8964](https://github.com/microsoft/testfx/pull/8964)
 * Apply DebuggerDisableUserUnhandledExceptionsAttribute to Assert.Throws helpers by @Evangelink in [#9041](https://github.com/microsoft/testfx/pull/9041)
 * Flag `Assert.AreEqual(x, x)` / `AreSame(x, x)` / `AreNotEqual(x, x)` / `AreNotSame(x, x)` by @Evangelink in [#9088](https://github.com/microsoft/testfx/pull/9088)
+* Remove redundant `actual type:` line from Assert.Throws\* failure message by @Evangelink in [#9195](https://github.com/microsoft/testfx/pull/9195)
+* Include full exception (stack trace + inner exceptions) in Assert.Throws\* failure messages by @Evangelink in [#9212](https://github.com/microsoft/testfx/pull/9212)
 
 ## <a name="4.2.3" />[4.2.3] - 2026-05-14
 


### PR DESCRIPTION
Add missing changelog entries for four PRs merged between the June 17 QA report and now (June 19).

**MSTest changelog (4.3.0 / Fixed):**
- [`#9195`](https://github.com/microsoft/testfx/pull/9195): Remove redundant `actual type:` line from Assert.Throws\* failure message
- [`#9212`](https://github.com/microsoft/testfx/pull/9212): Include full exception (stack trace + inner exceptions) in Assert.Throws\* failure messages

**Platform changelog (2.3.0 / Added & Fixed):**
- [`#9182`](https://github.com/microsoft/testfx/pull/9182): Add Azure DevOps history-driven slow-test threshold enricher
- [`#9192`](https://github.com/microsoft/testfx/pull/9192): Fix `--list-tests json` output under `--server` mode by streaming discovered tests to the SDK over the dotnet-test pipe




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/27811782274/agentic_workflow) workflow. · 747.9 AIC · ⌖ 23.9 AIC · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27811782274, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/27811782274 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->