### PR TITLE
Add terminal reporter (source + resx/xlf) to the Internal.DotnetTest source package

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
@@ -86,9 +86,10 @@ This is an INTERNAL, source-only package: it shares - as compiled source - the p
 
     <!--
       Terminal localized resources. The resx + xlf are shipped under build/ (NOT contentFiles) so they are not
-      auto-compiled with the wrong metadata; the auto-imported build-extension props below adds the resx as an
-      <EmbeddedResource GenerateSource="true"> with a pinned ManifestResourceName, and XliffTasks (present in the
-      consumer, e.g. dotnet/sdk via Arcade) finds the sibling xlf/ to emit satellite assemblies.
+      auto-compiled with the wrong metadata; the auto-imported build-extension props below adds the resx as a
+      strongly-typed <EmbeddedResource> (Generator="MSBuild:Compile" plus StronglyTyped* metadata) with a pinned
+      ManifestResourceName, and XliffTasks (present in the consumer, e.g. dotnet/sdk via Arcade) finds the sibling
+      xlf/ to emit satellite assemblies.
     -->
     <None Include="@(TerminalReporterContractResource)"
           Pack="true"
@@ -97,7 +98,7 @@ This is an INTERNAL, source-only package: it shares - as compiled source - the p
           Pack="true"
           PackagePath="build/TerminalReporter/xlf/%(Filename)%(Extension)" />
 
-    <!-- Auto-imported build extension that wires the resx (GenerateSource + satellites) into the consumer. -->
+    <!-- Auto-imported build extension that wires the resx (strongly-typed accessor + satellites) into the consumer. -->
     <None Include="build\Microsoft.Testing.Platform.Internal.DotnetTest.props"
           Pack="true"
           PackagePath="build/Microsoft.Testing.Platform.Internal.DotnetTest.props" />

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
@@ -15,10 +15,15 @@
       shared source files as contentFiles/cs/any so a consumer (the dotnet/sdk 'dotnet test' implementation)
       compiles them into its OWN assembly, keeping a single source of truth instead of hand-copying.
 
-      It currently hosts the named-pipe wire contract (ObjectFieldIds.cs + Constants.cs) and is intended to grow to
-      host the other source shared with dotnet/sdk (e.g. the terminal reporter). The name is deliberately generic
-      and carries 'Internal' so it is clearly NOT a public API / client library (see also issue #5667, closed
-      pending a real use case for a public MTP client).
+      Internal, source-only package for the 'dotnet test' <-> Microsoft.Testing.Platform integration. It ships
+      shared source files as contentFiles/cs/any so a consumer (the dotnet/sdk 'dotnet test' implementation)
+      compiles them into its OWN assembly, keeping a single source of truth instead of hand-copying.
+
+      It hosts (a) the named-pipe wire contract (ObjectFieldIds.cs + Constants.cs) and (b) the terminal reporter
+      (reporter + rendering + state + the small platform abstractions it needs) together with its localized
+      resources (TerminalResources.resx + xlf, wired up by the build-extension props this package ships - see
+      build/). The name is deliberately generic and carries 'Internal' so it is clearly NOT a public API / client
+      library (see also issue #5667, closed pending a real use case for a public MTP client).
 
       *ContractCompile=false makes the imported .props skip its <Compile> items: this project only *packs* the files,
       it does not compile them. The guarantee that each shared contract compiles standalone is provided by its
@@ -29,6 +34,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <DotnetTestProtocolContractCompile>false</DotnetTestProtocolContractCompile>
+    <TerminalReporterContractCompile>false</TerminalReporterContractCompile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 
     <!-- Build-only / source contribution: it must not flow as a transitive runtime dependency to consumers. -->
@@ -58,11 +64,43 @@ This is an INTERNAL, source-only package: it shares - as compiled source - the p
   -->
   <Import Project="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\ServerMode\DotnetTest\DotnetTestProtocolContract.props" />
 
+  <!--
+    Pulls in @(TerminalReporterContractSource) (the reporter source + abstractions) and
+    @(TerminalReporterContractResource) (TerminalResources.resx). TerminalReporterContractCompile=false above stops
+    the .props from <Compile>-ing them here; this project only packs them.
+  -->
+  <Import Project="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\Terminal\TerminalReporterContract.props" />
+
   <ItemGroup>
+    <!-- (a) wire contract source -->
     <None Include="@(DotnetTestProtocolContractSource)"
           Pack="true"
           BuildAction="Compile"
           PackagePath="contentFiles/cs/any/DotnetTestProtocol/%(Filename)%(Extension)" />
+
+    <!-- (b) terminal reporter source (reporter + rendering + state + abstractions), compiled by the consumer -->
+    <None Include="@(TerminalReporterContractSource)"
+          Pack="true"
+          BuildAction="Compile"
+          PackagePath="contentFiles/cs/any/TerminalReporter/%(Filename)%(Extension)" />
+
+    <!--
+      Terminal localized resources. The resx + xlf are shipped under build/ (NOT contentFiles) so they are not
+      auto-compiled with the wrong metadata; the auto-imported build-extension props below adds the resx as an
+      <EmbeddedResource GenerateSource="true"> with a pinned ManifestResourceName, and XliffTasks (present in the
+      consumer, e.g. dotnet/sdk via Arcade) finds the sibling xlf/ to emit satellite assemblies.
+    -->
+    <None Include="@(TerminalReporterContractResource)"
+          Pack="true"
+          PackagePath="build/TerminalReporter/%(Filename)%(Extension)" />
+    <None Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\Terminal\xlf\*.xlf"
+          Pack="true"
+          PackagePath="build/TerminalReporter/xlf/%(Filename)%(Extension)" />
+
+    <!-- Auto-imported build extension that wires the resx (GenerateSource + satellites) into the consumer. -->
+    <None Include="build\Microsoft.Testing.Platform.Internal.DotnetTest.props"
+          Pack="true"
+          PackagePath="build/Microsoft.Testing.Platform.Internal.DotnetTest.props" />
   </ItemGroup>
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/PACKAGE.md
@@ -14,20 +14,35 @@ break).
 
 ## What's inside
 
-The package ships shared source files as `contentFiles/cs/any` with `BuildAction=Compile`, so the consumer compiles
-them into its **own** assembly and the `internal` types are visible without any `InternalsVisibleTo` plumbing.
+The package ships shared source as `contentFiles/cs/any` with `BuildAction=Compile`, so the consumer compiles it
+into its **own** assembly and the `internal` types are visible without any `InternalsVisibleTo` plumbing:
 
-Today it ships the `dotnet test` named-pipe **wire contract**:
+- **Wire contract** (`contentFiles/cs/any/DotnetTestProtocol/`): `ObjectFieldIds.cs` (serializer/field ids) and
+  `Constants.cs` (handshake property names, execution modes, session-event types, test states, protocol version).
+- **Terminal reporter** (`contentFiles/cs/any/TerminalReporter/`): the reporter + rendering + state types and the
+  small platform abstractions they need (`IConsole`/`IStopwatch`/`IColor`/`System*`, `RoslynString`,
+  `ApplicationStateGuard`, `StackTraceHelper`, `TargetFrameworkParser`, `TestRunSummaryHelper`).
+- **Terminal localized resources** (`build/TerminalReporter/`): `TerminalResources.resx` + `xlf/`, wired into the
+  consumer by the auto-imported `build/Microsoft.Testing.Platform.Internal.DotnetTest.props` (it generates the
+  strongly-typed `TerminalResources` accessor in the expected namespace and, where XliffTasks is present, emits
+  satellite assemblies for each language).
 
-- `ObjectFieldIds.cs` — serializer ids and per-message field ids.
-- `Constants.cs` — handshake property names, execution modes, session-event types, test states and the protocol
-  version.
+## Consuming it (plug-in requirements)
 
-It is designed to grow to host the other source shared with `dotnet test` (e.g. the terminal reporter).
+Reference the package and the source compiles into your assembly. For the terminal reporter source the consumer
+must have:
+
+- **`ImplicitUsings` enabled** — the build props supplies the extra global usings the shared source relies on
+  (`System.Text`, `System.Runtime.CompilerServices`, `System.Runtime.Versioning`, …) when implicit usings are on.
+- **A `LangVersion` that supports the `field` keyword** (preview/latest).
+- **The `Microsoft.CodeAnalysis.EmbeddedAttribute` polyfill** — dotnet/sdk already defines it (for its copied IPC
+  transport); other consumers must supply a tiny internal copy.
+- **XliffTasks** (only for localized satellites) — dotnet/sdk has it via Arcade.
+
+The wire-contract source is zero-dependency and needs none of the above.
 
 ## Scope
 
-Only the wire **contract** (ids + constants) is shared today. The message **models** and **serializers** are not
-included yet because they still depend on `TestMetadataProperty`
+The message **models** and **serializers** are not shared yet because they still depend on `TestMetadataProperty`
 (`Microsoft.Testing.Platform.Extensions.Messages`) and use a different class shape than the SDK's copy; sharing them
 requires decoupling/unifying first.

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -5,11 +5,13 @@
     (NuGet imports build/<PackageId>.props). It wires the terminal reporter's localized resources - shipped by this
     package under build/TerminalReporter/ - into the consumer's own compilation:
 
-      * The resx is added as an <EmbeddedResource GenerateSource="true"> so the consumer's build generates the
-        strongly-typed `TerminalResources` accessor and embeds the strings into the consumer assembly.
-      * ManifestResourceName is pinned so the generated accessor lands in
-        Microsoft.Testing.Platform.OutputDevice.Terminal - the namespace the shared reporter source expects -
-        regardless of the consumer's RootNamespace.
+      * The resx is added as a strongly-typed <EmbeddedResource> (Generator="MSBuild:Compile" plus the
+        StronglyTyped* metadata) so the consumer's build generates the `TerminalResources` accessor and embeds
+        the strings into the consumer assembly. This does not depend on Arcade's GenerateSource pipeline.
+      * StronglyTypedNamespace/StronglyTypedClassName pin the generated accessor to
+        Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources - the type the shared reporter source
+        expects - regardless of the consumer's RootNamespace, and ManifestResourceName keeps the embedded
+        manifest name in sync so the runtime ResourceManager lookup resolves the same resource set.
       * The sibling xlf/ folder lets XliffTasks emit satellite assemblies for each language. This requires the
         consumer to have XliffTasks; dotnet/sdk (the intended consumer) has it via Arcade.
   -->

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -1,0 +1,48 @@
+<Project>
+
+  <!--
+    Auto-imported by NuGet for any project that references Microsoft.Testing.Platform.Internal.DotnetTest
+    (NuGet imports build/<PackageId>.props). It wires the terminal reporter's localized resources - shipped by this
+    package under build/TerminalReporter/ - into the consumer's own compilation:
+
+      * The resx is added as an <EmbeddedResource GenerateSource="true"> so the consumer's build generates the
+        strongly-typed `TerminalResources` accessor and embeds the strings into the consumer assembly.
+      * ManifestResourceName is pinned so the generated accessor lands in
+        Microsoft.Testing.Platform.OutputDevice.Terminal - the namespace the shared reporter source expects -
+        regardless of the consumer's RootNamespace.
+      * The sibling xlf/ folder lets XliffTasks emit satellite assemblies for each language. This requires the
+        consumer to have XliffTasks; dotnet/sdk (the intended consumer) has it via Arcade.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)TerminalReporter\TerminalResources.resx"
+                      Generator="MSBuild:Compile"
+                      StronglyTypedFileName="$(IntermediateOutputPath)TerminalResources.g.cs"
+                      StronglyTypedLanguage="C#"
+                      StronglyTypedNamespace="Microsoft.Testing.Platform.OutputDevice.Terminal"
+                      StronglyTypedClassName="TerminalResources"
+                      ManifestResourceName="Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources"
+                      Link="TerminalReporter\TerminalResources.resx" />
+  </ItemGroup>
+
+  <!--
+    The shared reporter source is authored against the testfx global usings (ImplicitUsings=enable plus these
+    namespaces). Supply them here so the consumer compiles the source without per-file usings. These only take
+    effect when the consumer has ImplicitUsings enabled (the package also relies on LangVersion supporting the
+    'field' keyword, i.e. preview/latest, and on the Microsoft.CodeAnalysis.EmbeddedAttribute polyfill - which
+    dotnet/sdk already provides). See PACKAGE.md.
+  -->
+  <ItemGroup Condition=" '$(ImplicitUsings)' == 'enable' or '$(ImplicitUsings)' == 'true' ">
+    <Using Include="System.Collections" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Diagnostics" />
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+    <Using Include="System.Globalization" />
+    <Using Include="System.Reflection" />
+    <Using Include="System.Runtime.CompilerServices" />
+    <Using Include="System.Runtime.InteropServices" />
+    <Using Include="System.Runtime.Versioning" />
+    <Using Include="System.Text" />
+    <Using Include="System.Text.RegularExpressions" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What

Makes `Microsoft.Testing.Platform.Internal.DotnetTest` the **one package with everything the SDK needs**: it now ships the terminal reporter source + its localized resources alongside the existing `dotnet test` wire contract. The SDK can replace its hand-forked terminal reporter with a single `PackageReference`.

## Changes

- Imports `TerminalReporterContract.props` and packs `@(TerminalReporterContractSource)` (reporter + rendering + state + the small platform abstractions) as `contentFiles/cs/any/TerminalReporter/`.
- Ships `TerminalResources.resx` + `xlf/` under `build/`, plus an auto-imported **build-extension props** (`build/<pkgid>.props`) that:
  - adds the resx as a **strongly-typed resource pinned** to `Microsoft.Testing.Platform.OutputDevice.Terminal`, so the generated `TerminalResources` accessor matches the reporter source regardless of the consumer's `RootNamespace`; XliffTasks (dotnet/sdk has it via Arcade) emits satellites from the sibling `xlf/`;
  - supplies the **global usings** the shared source relies on (when the consumer has `ImplicitUsings` enabled).
- `PACKAGE.md` documents the contents and the plug-in requirements.

No consumer-facing knobs — reference the package and the source compiles in.

## Verification

Built and **ran** an external, **out-of-repo, non-Arcade** consumer whose entire project is a single `PackageReference`: it compiles the protocol + terminal source and prints `TerminalResources.Passed` (from the embedded resx), `TerminalColor.Black`, and the protocol `TestStates.Passed` — proving the package delivers a self-contained, working reporter. (Localized **satellites** require XliffTasks in the consumer; dotnet/sdk has it — the resx/xlf→satellite path was validated separately under Arcade.)

## Follow-ups

- Plug the package into **dotnet/sdk**'s `dotnet test`, delete its forked terminal reporter, and confirm satellites generate there.
- Unify the reporter to render **1..N assemblies**.
- De-dup the terminal-exclusive keys still duplicated in `PlatformResources.resx`.
