### PR TITLE
[perf-improver] perf: replace per-test Queue/Stack copies with List-based index iteration in TestMethodInfo lifecycle

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.cs
@@ -241,12 +241,14 @@ internal sealed partial class TestClassInfo
     internal ExecutionContext? ExecutionContext { get; set; }
 
     /// <summary>
-    /// Gets a queue of test initialize methods to call for this type.
+    /// Gets a list of base-class test initialize methods, ordered nearest-derived first (i.e. direct parent at index 0,
+    /// grandparent at index 1, …). Callers that need grandparent-first execution iterate in reverse.
     /// </summary>
-    public Queue<MethodInfo> BaseTestInitializeMethodsQueue { get; } = new();
+    public List<MethodInfo> BaseTestInitializeMethodsQueue { get; } = [];
 
     /// <summary>
-    /// Gets a queue of test cleanup methods to call for this type.
+    /// Gets a list of base-class test cleanup methods, ordered nearest-derived first (i.e. direct parent at index 0,
+    /// grandparent at index 1, …). Callers that need parent-first execution iterate forward.
     /// </summary>
-    public Queue<MethodInfo> BaseTestCleanupMethodsQueue { get; } = new();
+    public List<MethodInfo> BaseTestCleanupMethodsQueue { get; } = [];
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Lifecycle.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Lifecycle.cs
@@ -59,11 +59,17 @@ internal partial class TestMethodInfo
                 testCleanupException = testCleanupMethod is not null
                     ? await InvokeCleanupMethodAsync(testCleanupMethod, _classInstance, timeoutTokenSource).ConfigureAwait(false)
                     : null;
-                var baseTestCleanupQueue = new Queue<MethodInfo>(Parent.BaseTestCleanupMethodsQueue);
-                while (baseTestCleanupQueue.Count > 0 && testCleanupException is null)
+                if (testCleanupException is null)
                 {
-                    testCleanupMethod = baseTestCleanupQueue.Dequeue();
-                    testCleanupException = await InvokeCleanupMethodAsync(testCleanupMethod, _classInstance, timeoutTokenSource).ConfigureAwait(false);
+                    foreach (MethodInfo baseCleanupMethod in Parent.BaseTestCleanupMethodsQueue)
+                    {
+                        testCleanupMethod = baseCleanupMethod;
+                        testCleanupException = await InvokeCleanupMethodAsync(baseCleanupMethod, _classInstance, timeoutTokenSource).ConfigureAwait(false);
+                        if (testCleanupException is not null)
+                        {
+                            break;
+                        }
+                    }
                 }
             }
             finally
@@ -180,10 +186,10 @@ internal partial class TestMethodInfo
         {
             // TestInitialize methods for base classes are called in reverse order of discovery
             // Grandparent -> Parent -> Child TestClass
-            var baseTestInitializeStack = new Stack<MethodInfo>(Parent.BaseTestInitializeMethodsQueue);
-            while (baseTestInitializeStack.Count > 0)
+            List<MethodInfo> baseTestInitializeList = Parent.BaseTestInitializeMethodsQueue;
+            for (int i = baseTestInitializeList.Count - 1; i >= 0; i--)
             {
-                testInitializeMethod = baseTestInitializeStack.Pop();
+                testInitializeMethod = baseTestInitializeList[i];
                 testInitializeException = testInitializeMethod is not null
                     ? await InvokeInitializeMethodAsync(testInitializeMethod, classInstance, timeoutTokenSource).ConfigureAwait(false)
                     : null;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ClassInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ClassInfo.cs
@@ -322,7 +322,7 @@ internal sealed partial class TypeCache
             {
                 if (instanceMethods is not null && !instanceMethods.Contains(methodInfo.Name))
                 {
-                    classInfo.BaseTestInitializeMethodsQueue.Enqueue(methodInfo);
+                    classInfo.BaseTestInitializeMethodsQueue.Add(methodInfo);
                 }
             }
         }
@@ -342,7 +342,7 @@ internal sealed partial class TypeCache
             {
                 if (instanceMethods is not null && !instanceMethods.Contains(methodInfo.Name))
                 {
-                    classInfo.BaseTestCleanupMethodsQueue.Enqueue(methodInfo);
+                    classInfo.BaseTestCleanupMethodsQueue.Add(methodInfo);
                 }
             }
         }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -814,8 +814,8 @@ public class TestMethodInfoTests : TestContainer
         DummyTestClass.DummyAsyncTestMethodBody = () => Task.Run(() => callOrder.Add("baseAsyncTestInitializeCalled1"));
         DummyTestClass.TestInitializeMethodBody = classInstance => callOrder.Add("classTestInitializeCalled");
         _testClassInfo.TestInitializeMethod = typeof(DummyTestClass).GetMethod("DummyTestInitializeMethod")!;
-        _testClassInfo.BaseTestInitializeMethodsQueue.Enqueue(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
-        _testClassInfo.BaseTestInitializeMethodsQueue.Enqueue(typeof(DummyTestClass).GetMethod("DummyAsyncTestMethod")!);
+        _testClassInfo.BaseTestInitializeMethodsQueue.Add(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
+        _testClassInfo.BaseTestInitializeMethodsQueue.Add(typeof(DummyTestClass).GetMethod("DummyAsyncTestMethod")!);
 
         TestResult result = await _testMethodInfo.InvokeAsync(null);
 
@@ -840,7 +840,7 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task TestMethodInfoInvokeShouldNotThrowIfTestInitializeForBaseClassIsNull()
     {
-        _testClassInfo.BaseTestInitializeMethodsQueue.Enqueue(null!);
+        _testClassInfo.BaseTestInitializeMethodsQueue.Add(null!);
 
         TestResult result = await _testMethodInfo.InvokeAsync(null);
 
@@ -1119,8 +1119,8 @@ public class TestMethodInfoTests : TestContainer
         DummyTestClassBase.BaseTestClassMethodBody = classInstance => callOrder.Add("baseTestCleanupCalled" + callOrder.Count);
         DummyTestClass.TestCleanupMethodBody = classInstance => callOrder.Add("classTestCleanupCalled");
         _testClassInfo.TestCleanupMethod = typeof(DummyTestClass).GetMethod("DummyTestCleanupMethod")!;
-        _testClassInfo.BaseTestCleanupMethodsQueue.Enqueue(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
-        _testClassInfo.BaseTestCleanupMethodsQueue.Enqueue(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
+        _testClassInfo.BaseTestCleanupMethodsQueue.Add(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
+        _testClassInfo.BaseTestCleanupMethodsQueue.Add(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
 
         TestResult result = await _testMethodInfo.InvokeAsync(null);
 
@@ -1140,8 +1140,8 @@ public class TestMethodInfoTests : TestContainer
         DummyTestClassBase.BaseTestClassMethodBody = classInstance => callOrder.Add("baseTestCleanupCalled" + callOrder.Count);
         DummyTestClass.TestCleanupMethodBody = classInstance => callOrder.Add("classTestCleanupCalled");
         _testClassInfo.TestCleanupMethod = typeof(DummyTestClass).GetMethod("DummyTestCleanupMethod")!;
-        _testClassInfo.BaseTestCleanupMethodsQueue.Enqueue(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
-        _testClassInfo.BaseTestCleanupMethodsQueue.Enqueue(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
+        _testClassInfo.BaseTestCleanupMethodsQueue.Add(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
+        _testClassInfo.BaseTestCleanupMethodsQueue.Add(typeof(DummyTestClassBase).GetMethod("DummyBaseTestClassMethod")!);
 
         await _testMethodInfo.InvokeAsync(null);
         TestResult result = await _testMethodInfo.InvokeAsync(null);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
@@ -661,7 +661,7 @@ public class TypeCacheTests : TestContainer
         _typeCache.GetTestMethodInfo(testMethod);
 
         _typeCache.ClassInfoCache.Should().HaveCount(1);
-        baseType.GetMethod("TestInit").Should().BeSameAs(_typeCache.ClassInfoCache.First()!.BaseTestInitializeMethodsQueue.Peek());
+        baseType.GetMethod("TestInit").Should().BeSameAs(_typeCache.ClassInfoCache.First()!.BaseTestInitializeMethodsQueue[0]);
     }
 
     public void GetTestMethodInfoShouldCacheTestCleanupAttributeDefinedInBaseClass()
@@ -679,7 +679,7 @@ public class TypeCacheTests : TestContainer
         _typeCache.GetTestMethodInfo(testMethod);
 
         _typeCache.ClassInfoCache.Should().HaveCount(1);
-        baseType.GetMethod("TestCleanup").Should().BeSameAs(_typeCache.ClassInfoCache.First()!.BaseTestCleanupMethodsQueue.Peek());
+        baseType.GetMethod("TestCleanup").Should().BeSameAs(_typeCache.ClassInfoCache.First()!.BaseTestCleanupMethodsQueue[0]);
     }
 
     public void GetTestMethodInfoShouldCacheClassInfoInstanceAndReuseFromCache()


### PR DESCRIPTION
## Goal and Rationale

Every test that has any base class hierarchy was allocating two short-lived collection copies on the hot per-test path:

- `new Queue<MethodInfo>(Parent.BaseTestCleanupMethodsQueue)` in `RunTestCleanupMethodAsync`
- `new Stack<MethodInfo>(Parent.BaseTestInitializeMethodsQueue)` in `RunTestInitializeMethodAsync`

These copies exist only to iterate the base-class TestInitialize/TestCleanup methods in the correct order (grandparent-first for init, parent-first for cleanup). The underlying collections are never mutated during the test run — the copies are unnecessary.

## Approach

Change the backing type of `BaseTestInitializeMethodsQueue` and `BaseTestCleanupMethodsQueue` on the `internal sealed partial class TestClassInfo` from `Queue<MethodInfo>` to `List<MethodInfo>`. Population in `TypeCache.ClassInfo.cs` changes from `.Enqueue()` to `.Add()` (same insertion order: direct parent first, grandparent second, ...).

The iteration in `TestMethodInfo.Lifecycle.cs` is then rewritten to be allocation-free:

| Path | Before | After |
|---|---|---|
| **Cleanup** | `new Queue<MethodInfo>(queue)` → dequeue loop | `foreach` over list (forward = parent-first ✓) |
| **Initialize** | `new Stack<MethodInfo>(queue)` → pop loop | backward `for` by index (grandparent-first ✓) |

## Performance Evidence

**Methodology**: Per-invocation allocation savings are small but multiply across every test in every run with any base-class TestInitialize/TestCleanup. For a test class with one base:

| Allocation | Before | After |
|---|---|---|
| `Queue<MethodInfo>` copy (cleanup) | 1 per test invocation | 0 |
| `Stack<MethodInfo>` copy (init) | 1 per test invocation | 0 |
| Internal `MethodInfo[]` backing arrays | 2 per test invocation | 0 |

In a solution with thousands of tests inheriting from a common base class, this eliminates thousands of ephemeral Gen0 objects per test run, reducing GC pressure on the adapter thread.

No micro-benchmark exists for this specific path in the repo; the improvement is structural (eliminate unnecessary copies).

## Trade-offs

- `BaseTestInitializeMethodsQueue` and `BaseTestCleanupMethodsQueue` property names no longer accurately describe the backing type (they say "Queue" but now hold a `List`). Both properties are on an `internal sealed` class so there is no public API surface affected. The XML docs have been updated.
- `List<T>` has O(1) indexed access and O(n) forward/backward iteration — same as `Queue<T>` for this use case. No performance regression.

## Reproducibility

```sh
# Run the directly-affected unit tests
.dotnet/dotnet run --project test/UnitTests/MSTestAdapter.PlatformServices.UnitTests -f net9.0 \
  --no-build -p:TargetFrameworks=net9.0 -- --treenode-filter "*/*/TestMethodInfoTests/*"
# 89/89 pass

.dotnet/dotnet run --project test/UnitTests/MSTestAdapter.PlatformServices.UnitTests -f net9.0 \
  --no-build -p:TargetFrameworks=net9.0 -- --treenode-filter "*/*/TypeCacheTests/*"
# 50/50 pass
```

## Test Status

✅ Full build: `./build.sh` — **Build succeeded, 0 warnings, 0 errors**

✅ All MTP/adapter unit tests pass (827/851 succeeded — 24 pre-existing failures in unrelated deployment-path tests, confirmed identical before and after this change)

✅ `TestMethodInfoTests`: 89/89 pass

✅ `TypeCacheTests`: 50/50 pass




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27831457042/agentic_workflow) workflow. · 3.8K AIC · ⌖ 26.2 AIC · ⊞ 57.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27831457042, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27831457042 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->