### PR TITLE
Share terminal handshake-failure surface + port SDK oracle test (1/n)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
@@ -43,6 +43,8 @@ internal static partial class TerminalResources
 
     internal static string @DurationLowercase => GetResourceString("DurationLowercase");
 
+    internal static string @ExitCode => GetResourceString("ExitCode");
+
     internal static string @Expected => GetResourceString("Expected");
 
     internal static string @Failed => GetResourceString("Failed");
@@ -50,6 +52,8 @@ internal static partial class TerminalResources
     internal static string @FailedLowercase => GetResourceString("FailedLowercase");
 
     internal static string @ForTest => GetResourceString("ForTest");
+
+    internal static string @HandshakeFailuresHeader => GetResourceString("HandshakeFailuresHeader");
 
     internal static string @InProcessArtifactsProduced => GetResourceString("InProcessArtifactsProduced");
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -280,4 +280,10 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
   <data name="SucceededLowercase" xml:space="preserve">
     <value>succeeded</value>
   </data>
+  <data name="HandshakeFailuresHeader" xml:space="preserve">
+    <value>Handshake failures:</value>
+  </data>
+  <data name="ExitCode" xml:space="preserve">
+    <value>Exit code</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Formatting.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Formatting.cs
@@ -124,26 +124,29 @@ internal sealed partial class TerminalTestReporter
     }
 
     private static void AppendAssemblyLinkTargetFrameworkAndArchitecture(ITerminal terminal, TestProgressState assemblyRun)
+        => AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyRun.Assembly, assemblyRun.TargetFramework, assemblyRun.Architecture);
+
+    private static void AppendAssemblyLinkTargetFrameworkAndArchitecture(ITerminal terminal, string assembly, string? targetFramework, string? architecture)
     {
-        terminal.AppendLink(assemblyRun.Assembly, lineNumber: null);
-        if (assemblyRun.TargetFramework == null && assemblyRun.Architecture == null)
+        terminal.AppendLink(assembly, lineNumber: null);
+        if (targetFramework == null && architecture == null)
         {
             return;
         }
 
         terminal.Append(" (");
-        if (assemblyRun.TargetFramework != null)
+        if (targetFramework != null)
         {
-            terminal.Append(assemblyRun.TargetFramework);
-            if (assemblyRun.Architecture != null)
+            terminal.Append(targetFramework);
+            if (architecture != null)
             {
                 terminal.Append('|');
             }
         }
 
-        if (assemblyRun.Architecture != null)
+        if (architecture != null)
         {
-            terminal.Append(assemblyRun.Architecture);
+            terminal.Append(architecture);
         }
 
         terminal.Append(')');

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs
@@ -12,18 +12,28 @@ internal sealed partial class TerminalTestReporter
     private readonly object _handshakeFailuresLock = new();
 #endif
     private readonly List<HandshakeFailureRecord> _handshakeFailures = [];
-    private int _handshakeFailuresCount;
 
     /// <summary>
-    /// Gets a value indicating whether any assembly failed to hand-shake (e.g. a child test host process
-    /// exited before it could start a session). Used by the <c>dotnet test</c> orchestrator to surface a
-    /// non-success exit even when no test result was ever reported.
+    /// Gets a value indicating whether any assembly failed to handshake (e.g. a child test host process exited
+    /// before it could start a session). Used by the <c>dotnet test</c> orchestrator to surface a non-success exit
+    /// even when no test result was ever reported.
     /// </summary>
-    public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
+    public bool HasHandshakeFailure
+    {
+        get
+        {
+            // Read the count under the same lock that guards every mutation of the list, so the flag and the list
+            // are always observed in a consistent state (see HandshakeFailure / the reset in TestExecutionCompleted).
+            lock (_handshakeFailuresLock)
+            {
+                return _handshakeFailures.Count > 0;
+            }
+        }
+    }
 
     /// <summary>
     /// Report that an assembly failed to produce a usable handshake. This is an orchestrator-only path (the
-    /// in-process host always hand-shakes); it records the failure so <see cref="HasHandshakeFailure"/> flips and
+    /// in-process host always handshakes); it records the failure so <see cref="HasHandshakeFailure"/> flips and
     /// the failure is re-printed in the end-of-run recap, and prints the immediate failure context.
     /// </summary>
     internal void HandshakeFailure(string assemblyPath, string? targetFramework, int exitCode, string outputData, string errorData, bool reportEvenWhenHelp = false)
@@ -37,7 +47,6 @@ internal sealed partial class TerminalTestReporter
             return;
         }
 
-        Interlocked.Increment(ref _handshakeFailuresCount);
         lock (_handshakeFailuresLock)
         {
             _handshakeFailures.Add(new HandshakeFailureRecord(assemblyPath, targetFramework, exitCode, outputData, errorData));
@@ -46,8 +55,15 @@ internal sealed partial class TerminalTestReporter
         _terminalWithProgress.WriteToTerminal(terminal =>
         {
             terminal.ResetColor();
-            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyPath, targetFramework, architecture: null);
-            terminal.Append(' ');
+
+            // assemblyPath can be empty on the defensive "unknown execution id" path, where AppendLink would emit
+            // nothing; skip the link (and its trailing space) so we don't render a blank, unactionable prefix.
+            if (!RoslynString.IsNullOrEmpty(assemblyPath))
+            {
+                AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyPath, targetFramework, architecture: null);
+                terminal.Append(' ');
+            }
+
             terminal.SetColor(TerminalColor.DarkRed);
             terminal.Append(TerminalResources.ZeroTestsRan);
             terminal.ResetColor();

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+[UnsupportedOSPlatform("browser")]
+internal sealed partial class TerminalTestReporter
+{
+#if NET9_0_OR_GREATER
+    private readonly Lock _handshakeFailuresLock = new();
+#else
+    private readonly object _handshakeFailuresLock = new();
+#endif
+    private readonly List<HandshakeFailureRecord> _handshakeFailures = [];
+    private int _handshakeFailuresCount;
+
+    /// <summary>
+    /// Gets a value indicating whether any assembly failed to hand-shake (e.g. a child test host process
+    /// exited before it could start a session). Used by the <c>dotnet test</c> orchestrator to surface a
+    /// non-success exit even when no test result was ever reported.
+    /// </summary>
+    public bool HasHandshakeFailure => _handshakeFailuresCount > 0;
+
+    /// <summary>
+    /// Report that an assembly failed to produce a usable handshake. This is an orchestrator-only path (the
+    /// in-process host always hand-shakes); it records the failure so <see cref="HasHandshakeFailure"/> flips and
+    /// the failure is re-printed in the end-of-run recap, and prints the immediate failure context.
+    /// </summary>
+    internal void HandshakeFailure(string assemblyPath, string? targetFramework, int exitCode, string outputData, string errorData, bool reportEvenWhenHelp = false)
+    {
+        if (_isHelp && !reportEvenWhenHelp)
+        {
+            // Backward-compat workaround: older Microsoft.Testing.Platform versions don't perform a handshake on the
+            // --help path (the host just prints help and exits). In that case the orchestrator routes here with the
+            // "process exited without a usable handshake" payload, which is expected and should not be reported as a
+            // failure. Explicit protocol-level rejections pass reportEvenWhenHelp=true and are still surfaced.
+            return;
+        }
+
+        Interlocked.Increment(ref _handshakeFailuresCount);
+        lock (_handshakeFailuresLock)
+        {
+            _handshakeFailures.Add(new HandshakeFailureRecord(assemblyPath, targetFramework, exitCode, outputData, errorData));
+        }
+
+        _terminalWithProgress.WriteToTerminal(terminal =>
+        {
+            terminal.ResetColor();
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assemblyPath, targetFramework, architecture: null);
+            terminal.Append(' ');
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.Append(TerminalResources.ZeroTestsRan);
+            terminal.ResetColor();
+            terminal.AppendLine();
+            AppendExecutableSummary(terminal, exitCode, outputData, errorData);
+        });
+    }
+
+    /// <summary>
+    /// Re-print handshake failures captured during the run so that — even when there is a lot of diagnostic output
+    /// before the summary — the user sees the actionable failure context (assembly, exit code, stdout, stderr) at
+    /// the end of the run rather than having to scroll back.
+    /// </summary>
+    private void AppendHandshakeFailureRecap(ITerminal terminal)
+    {
+        HandshakeFailureRecord[] failures;
+        lock (_handshakeFailuresLock)
+        {
+            if (_handshakeFailures.Count == 0)
+            {
+                return;
+            }
+
+            failures = _handshakeFailures.ToArray();
+        }
+
+        terminal.AppendLine();
+        terminal.SetColor(TerminalColor.DarkRed);
+        terminal.AppendLine(TerminalResources.HandshakeFailuresHeader);
+        terminal.ResetColor();
+
+        foreach (HandshakeFailureRecord failure in failures)
+        {
+            terminal.Append(SingleIndentation);
+            AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, failure.AssemblyPath, failure.TargetFramework, architecture: null);
+            terminal.AppendLine();
+            AppendExecutableSummary(terminal, failure.ExitCode, failure.OutputData, failure.ErrorData);
+        }
+    }
+
+    private static void AppendExecutableSummary(ITerminal terminal, int? exitCode, string? outputData, string? errorData)
+    {
+        terminal.Append(TerminalResources.ExitCode);
+        terminal.Append(": ");
+        terminal.AppendLine(exitCode?.ToString(CultureInfo.CurrentCulture) ?? "<null>");
+        AppendOutputWhenPresent(TerminalResources.StandardOutput, outputData);
+        AppendOutputWhenPresent(TerminalResources.StandardError, errorData);
+
+        void AppendOutputWhenPresent(string description, string? output)
+        {
+            if (!RoslynString.IsNullOrWhiteSpace(output))
+            {
+                AppendIndentedLine(terminal, $"{description}: {output}", SingleIndentation);
+            }
+        }
+    }
+
+    private readonly record struct HandshakeFailureRecord(
+        string AssemblyPath,
+        string? TargetFramework,
+        int ExitCode,
+        string OutputData,
+        string ErrorData);
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -61,6 +61,33 @@ internal sealed partial class TerminalTestReporter
         _terminalWithProgress.RemoveWorker(assemblyRun.SlotIndex);
     }
 
+    /// <summary>
+    /// Orchestrator overload: completes an assembly run with the child process exit code and captured output. When
+    /// the <paramref name="executionId"/> was never registered (the process exited before a usable handshake), the
+    /// completion is surfaced as a <see cref="HandshakeFailure(string, string?, int, string, string, bool)"/> rather
+    /// than throwing. On a non-zero exit code the executable summary (exit code + stdout/stderr) is printed.
+    /// </summary>
+    internal void AssemblyRunCompleted(string executionId, int exitCode, string? outputData, string? errorData)
+    {
+        if (!_assemblies.TryGetValue(executionId, out TestProgressState? assemblyRun))
+        {
+            HandshakeFailure(assemblyPath: string.Empty, targetFramework: null, exitCode, outputData ?? string.Empty, errorData ?? string.Empty);
+            return;
+        }
+
+        assemblyRun.Success = exitCode == 0 && assemblyRun.FailedTests == 0;
+        assemblyRun.Stopwatch.Stop();
+        _terminalWithProgress.RemoveWorker(assemblyRun.SlotIndex);
+
+        if (exitCode == 0)
+        {
+            // Report nothing on success; we don't want to report on test-discovery etc.
+            return;
+        }
+
+        _terminalWithProgress.WriteToTerminal(terminal => AppendExecutableSummary(terminal, exitCode, outputData, errorData));
+    }
+
     public void TestExecutionCompleted(DateTimeOffset endTime, int? exitCode)
     {
         _testExecutionEndTime = endTime;
@@ -73,11 +100,17 @@ internal sealed partial class TerminalTestReporter
 
         // This is relevant for HotReload scenarios. We want the next test sessions to start fresh, so we reset all
         // per-run state here (after the summary above has consumed it): the per-assembly runs, the collected
-        // artifacts, and the cancellation flag. Otherwise a later session would re-print the previous session's
-        // artifacts or stay stuck in the aborted state.
+        // artifacts, the handshake failures, and the cancellation flag. Otherwise a later session would re-print the
+        // previous session's artifacts/handshake failures or stay stuck in the aborted state.
         _assemblies.Clear();
         _artifacts.Clear();
         WasCancelled = false;
+        lock (_handshakeFailuresLock)
+        {
+            _handshakeFailures.Clear();
+        }
+
+        _handshakeFailuresCount = 0;
 
         _testExecutionStartTime = null;
         _testExecutionEndTime = null;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -110,8 +110,6 @@ internal sealed partial class TerminalTestReporter
             _handshakeFailures.Clear();
         }
 
-        _handshakeFailuresCount = 0;
-
         _testExecutionStartTime = null;
         _testExecutionEndTime = null;
     }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -56,7 +56,7 @@ internal sealed partial class TerminalTestReporter
         // Two sibling sites mirror this decision and must stay in lockstep:
         //   - TestApplicationResult.ConsumeAsync (excludes skipped from `_totalRanTests` -> exit code 8)
         //   - Microsoft.Testing.Platform.MSBuild InvokeTestingPlatformTask (run-summary verdict)
-        bool runFailed = TestRunSummaryHelper.IsRunFailed(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests);
+        bool runFailed = TestRunSummaryHelper.IsRunFailed(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests) || HasHandshakeFailure;
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
 
         terminal.Append(TerminalResources.TestRunSummary);
@@ -133,6 +133,10 @@ internal sealed partial class TerminalTestReporter
         terminal.Append(durationText);
         AppendLongDuration(terminal, runDuration, wrapInParentheses: false, colorize: false);
         terminal.AppendLine();
+
+        // Re-print any handshake failures (orchestrator-only) at the very end so they aren't lost above the summary.
+        // No-op for the in-process host, which never reports handshake failures.
+        AppendHandshakeFailureRecap(terminal);
     }
 
     internal void TestDiscovered(string executionId, string displayName)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.cs
@@ -78,6 +78,15 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private int _counter;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="TerminalTestReporter"/> class for orchestrator callers that
+    /// drive cancellation out-of-band (via <see cref="StartCancelling"/>) rather than through a cancellation token.
+    /// </summary>
+    public TerminalTestReporter(IConsole console, TerminalTestReporterOptions options)
+        : this(console, static () => false, options)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="TerminalTestReporter"/> class with custom terminal and manual refresh for testing.
     /// </summary>
     public TerminalTestReporter(

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
@@ -52,4 +52,7 @@ internal sealed class TestProgressState
     public List<string> DiscoveredTestDisplayNames { get; internal set; } = [];
 
     public bool IsDiscovery { get; }
+
+    /// <summary>Gets or sets a value indicating whether the assembly run completed successfully (set by the orchestrator on completion).</summary>
+    public bool Success { get; internal set; }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Přerušeno</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">doba trvání</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Očekáváno</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Pro testování</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Abgebrochen</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">Dauer</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Erwartet</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Für Test</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Anulado</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">duración</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Se esperaba</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Para prueba</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Abandonné</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">durée</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Attendu</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Pour le test</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Operazione interrotta</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">durata</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Previsto</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Per test</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">中止されました</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">期間</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">予想</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">テスト用</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">중단됨</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">기간</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">필요</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">테스트용</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Przerwano</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">czas trwania</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Oczekiwane</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Na potrzeby testu</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Anulado</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">duração</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Esperado</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Para teste</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Прервано</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">длительность</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Ожидалось</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Для тестирования</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">Durduruldu</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">süre</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Beklenen</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">Test için</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">已中止</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">持续时间</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">预期</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">用于测试</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../TerminalResources.resx">
     <body>
-            <trans-unit id="Aborted">
+      <trans-unit id="Aborted">
         <source>Aborted</source>
         <target state="translated">已中止</target>
         <note />
@@ -32,6 +32,11 @@
         <target state="translated">持續時間</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCode">
+        <source>Exit code</source>
+        <target state="new">Exit code</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">預期</target>
@@ -51,6 +56,11 @@
         <source>For test</source>
         <target state="translated">用於測試</target>
         <note>is followed by test name</note>
+      </trans-unit>
+      <trans-unit id="HandshakeFailuresHeader">
+        <source>Handshake failures:</source>
+        <target state="new">Handshake failures:</target>
+        <note />
       </trans-unit>
       <trans-unit id="InProcessArtifactsProduced">
         <source>In process file artifacts produced:</source>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1223,6 +1223,41 @@ public sealed class TerminalTestReporterTests
         Assert.Contains("stderr", output);
     }
 
+    // Companion to the test above covering the full lifecycle: after a handshake failure, TestExecutionCompleted must
+    // re-print the failure recap in the summary and (via runFailed |= HasHandshakeFailure) mark the run as failed even
+    // though no test ever ran.
+    [TestMethod]
+    public void AssemblyRunCompleted_WhenExecutionIdUnknown_SummaryReprintsRecapAndReportsFailure()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        var terminalReporter = new TerminalTestReporter(stringBuilderConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.NoAnsi,
+            ShowProgress = () => false,
+        });
+
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+        terminalReporter.AssemblyRunCompleted("never-registered", exitCode: 1, outputData: "the out", errorData: "the err");
+
+        // The flag is observable before the run completes (the orchestrator reads it to force a non-zero exit).
+        Assert.IsTrue(terminalReporter.HasHandshakeFailure);
+
+        terminalReporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: null);
+
+        string output = stringBuilderConsole.Output;
+
+        // The end-of-run recap header is re-printed in the summary with the captured failure context.
+        Assert.Contains(TerminalResources.HandshakeFailuresHeader, output);
+        Assert.Contains($"{TerminalResources.ExitCode}: 1", output);
+        Assert.Contains("the err", output);
+
+        // No test ran, so the run verdict is the red "Zero tests ran" (runFailed also includes HasHandshakeFailure).
+        Assert.Contains(TerminalResources.ZeroTestsRan, output);
+
+        // Per-run state is reset after completion so a subsequent session starts fresh.
+        Assert.IsFalse(terminalReporter.HasHandshakeFailure);
+    }
+
     [TestMethod]
     public void TerminalTestReporter_WhenReusedAcrossSessions_DoesNotLeakArtifactsOrCancelledState()
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1195,6 +1195,34 @@ public sealed class TerminalTestReporterTests
         Assert.DoesNotContain(secondAssembly, output);
     }
 
+    // Ported from the dotnet/sdk TerminalTestReporterTests (regression for dotnet/sdk#51608) to validate the
+    // orchestrator handshake-failure surface of the shared reporter: if a child test host process exits before a
+    // session was ever started (so the execution id is never registered), the orchestrator overload of
+    // AssemblyRunCompleted must not throw — it must surface the exit as a handshake failure and render the
+    // actionable context (exit code + captured stdout/stderr) instead.
+    [TestMethod]
+    public void AssemblyRunCompleted_WhenExecutionIdUnknown_DoesNotThrowAndReportsHandshakeFailure()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        var terminalReporter = new TerminalTestReporter(stringBuilderConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = () => false,
+        });
+
+        // Must not throw even though "never-registered" was never passed to AssemblyRunStarted.
+        terminalReporter.AssemblyRunCompleted(executionId: "never-registered", exitCode: 1, outputData: "stdout", errorData: "stderr");
+
+        Assert.IsTrue(terminalReporter.HasHandshakeFailure);
+
+        // Validate the rendered UI state: the immediate failure context is printed.
+        string output = stringBuilderConsole.Output;
+        Assert.Contains(TerminalResources.ZeroTestsRan, output);
+        Assert.Contains($"{TerminalResources.ExitCode}: 1", output);
+        Assert.Contains("stdout", output);
+        Assert.Contains("stderr", output);
+    }
+
     [TestMethod]
     public void TerminalTestReporter_WhenReusedAcrossSessions_DoesNotLeakArtifactsOrCancelledState()
     {


### PR DESCRIPTION
## What

First slice of unifying the shared Microsoft.Testing.Platform terminal reporter with the `dotnet/sdk` `dotnet test` orchestrator fork — driven and validated by **porting the SDK's own reporter test as the expected-UI oracle**, per the idea of bringing the SDK's UI-state assertions into testfx so the superset can be built test-first.

Follows the terminal-sharing effort (#9246 → #9256). The SDK calls orchestrator-only methods the shared reporter lacked; this adds the first, cleanly-additive group.

## Added (all additive — the in-process host never reports handshake failures, so its output stays byte-identical)

- `HandshakeFailure(assemblyPath, tfm, exitCode, output, error, reportEvenWhenHelp)` + `HasHandshakeFailure` + an end-of-run `AppendHandshakeFailureRecap` (no-op when there are none).
- Rich `AssemblyRunCompleted(executionId, exitCode, outputData, errorData)` overload that surfaces an **unknown execution id as a handshake failure** (instead of throwing `KeyNotFoundException`) and prints the executable summary (exit code + stdout/stderr) on a non-zero exit.
- `TerminalTestReporter(IConsole, options)` ctor overload for orchestrator callers that drive cancellation out-of-band via `StartCancelling`.
- `TestProgressState.Success`; a string-based `AppendAssemblyLinkTargetFrameworkAndArchitecture` overload; `AppendExecutableSummary`.
- New `TerminalResources` keys `HandshakeFailuresHeader` / `ExitCode` (resx + 13 xlf regenerated via `UpdateXlf`; hand-maintained `!IS_CORE_MTP` accessors updated).

## Oracle test ported

`AssemblyRunCompleted_WhenExecutionIdUnknown_DoesNotThrowAndReportsHandshakeFailure` — ported from the SDK's `TerminalTestReporterTests` (regression for [dotnet/sdk#51608](https://github.com/dotnet/sdk/issues/51608)), translated to MSTest + the testfx `StringBuilderConsole` harness. It asserts both `HasHandshakeFailure` **and** the rendered failure UI (`Zero tests ran`, `Exit code: 1`, the captured `stdout`/`stderr`).

## Scope

This is **1/n**. The remaining SDK orchestrator surface — per-assembly counts in the summary (`ShowAssembly`), the instanceId-based **retry** counting model, and the unified `TestCompleted`/`TestInProgress`/`TestDiscovered` signatures — lands in follow-ups, each validated by porting the matching SDK test (`AssemblyRunCompleted_WithShowAssemblyStartAndComplete_PrintsPerAssemblyCounts`, `TestExecutionCompleted_WithMultipleAssemblies_...`, `AssemblyRunCompleted_WhenTestsWereRetried_ShowsRetriedCount`).

## Verification

- Platform builds clean on **net8.0 / net9.0 / netstandard2.0** (0 warnings incl. IDE/SA).
- Full `Microsoft.Testing.Platform.UnitTests` suite green: **1199 total, 0 failed** (the ~89 byte-exact in-process tests confirm unchanged in-process UI).
- Standalone `TerminalReporterContract` consumer still compiles in isolation.