### PR TITLE
[efficiency-improver] perf: single-pass GroupBy partition in TestExecutionManager parallelization

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -148,10 +148,21 @@ internal partial class TestExecutionManager
 
             // Create test sets for execution, we can execute them in parallel based on parallel settings
             // Parallel and not parallel sets.
-            IEnumerable<IGrouping<bool, TestCase>> testSets = testsToRun.GroupBy(t => t.GetPropertyValue(EngineConstants.DoNotParallelizeProperty, false));
-
-            IGrouping<bool, TestCase>? parallelizableTestSet = testSets.FirstOrDefault(g => !g.Key);
-            IGrouping<bool, TestCase>? nonParallelizableTestSet = testSets.FirstOrDefault(g => g.Key);
+            // Single-pass partition: enumerate testsToRun once via GroupBy (lazy GroupBy evaluated twice
+            // — once per FirstOrDefault — caused 2 full passes over testsToRun).
+            IEnumerable<TestCase>? parallelizableTestSet = null;
+            IEnumerable<TestCase>? nonParallelizableTestSet = null;
+            foreach (IGrouping<bool, TestCase> group in testsToRun.GroupBy(t => t.GetPropertyValue(EngineConstants.DoNotParallelizeProperty, false)))
+            {
+                if (group.Key)
+                {
+                    nonParallelizableTestSet = group;
+                }
+                else
+                {
+                    parallelizableTestSet = group;
+                }
+            }
 
             if (parallelizableTestSet != null)
             {


### PR DESCRIPTION
## Goal and Rationale

In `TestExecutionManager.Parallelization.cs`, the test set partition for parallel/non-parallel tests used a lazy `GroupBy` query that was evaluated **twice** — once per `FirstOrDefault` call — causing two full O(n) passes over `testsToRun`.

For a test suite with *n* tests in a parallelized run, this means:
- **Before**: `n` calls to `GetPropertyValue(DoNotParallelizeProperty, ...)` — twice — plus two internal LINQ `Lookup<bool, TestCase>` allocations
- **After**: `n` calls once, one `Lookup` allocation

## Focus Area

**Code-Level Efficiency** — redundant computation (lazy LINQ query re-evaluated on each `FirstOrDefault`)

## Approach

Replace the two-`FirstOrDefault` pattern:
```csharp
// Before: lazy GroupBy evaluated twice (2 full passes over testsToRun)
IEnumerable<IGrouping<bool, TestCase>> testSets = testsToRun.GroupBy(...);
IGrouping<bool, TestCase>? parallelizableTestSet    = testSets.FirstOrDefault(g => !g.Key);
IGrouping<bool, TestCase>? nonParallelizableTestSet = testSets.FirstOrDefault(g =>  g.Key);
```

...with a single foreach that reads the materialised groups (at most 2) from one GroupBy evaluation:
```csharp
// After: single pass — GroupBy evaluates testsToRun once, foreach iterates ≤2 groups
IEnumerable<TestCase>? parallelizableTestSet    = null;
IEnumerable<TestCase>? nonParallelizableTestSet = null;
foreach (IGrouping<bool, TestCase> group in testsToRun.GroupBy(...))
{
    if (group.Key) nonParallelizableTestSet = group;
    else           parallelizableTestSet    = group;
}
```

The `IGrouping<bool, TestCase>` assigned variables are already materialized by LINQ's GroupBy, so all downstream uses (`.Select()`, `.GroupBy()` for class-level chunking, `ExecuteTestsWithTestRunnerAsync`) continue to work identically.

## Energy Efficiency Evidence

**Proxy metric**: CPU cycles / instruction count (maps to energy via fewer memory reads and fewer allocator pressure events).

| Scenario | `testsToRun` iterations | `Lookup` allocs |
|---|---|---|
| Before (2× `FirstOrDefault`) | 2n | 2 |
| After (single `foreach`) | n | 1 |

For a suite of 1 000 tests with parallelization enabled: saves ~1 000 calls to `TestCase.GetPropertyValue()` and one internal `Lookup<bool, TestCase>` allocation per test assembly processed. For suites with many test assemblies or large test counts, the saving scales linearly.

*Note: this code path runs only when `DisableParallelization == false && CanParallelizeAssembly && parallelWorkers > 0`, so sequential runs are unaffected.*

## Green Software Foundation Context

- **Hardware Efficiency**: reduces unnecessary CPU work (redundant iteration and memory allocation) making the same task consume fewer resources.
- **Energy Proportionality**: computational cost now scales with n once rather than twice, making resource usage more proportional to actual work.

## Trade-offs

None: the refactor is semantically equivalent. The `foreach` reads `GroupBy` groups (at most 2 for a boolean key), and the variable types widen from `IGrouping<bool, TestCase>?` to `IEnumerable<TestCase>?` — all downstream consumers only use the `IEnumerable<TestCase>` interface.

## Reproducibility

```bash
# Baseline: count calls under debugger or add tracing to GetPropertyValue — two bursts of n calls
# After: single burst of n calls
./build.sh -test
```

## Test Status

Build: ✅ 0 errors, 0 warnings  
Unit tests (MTP-based): ✅ all passed (`Microsoft.Testing.Extensions.UnitTests`, `Microsoft.Testing.Extensions.VSTestBridge.UnitTests`, `Microsoft.Testing.Platform.MSBuild.UnitTests`, `Microsoft.Testing.Platform.UnitTests`, `MSTest.Analyzers.UnitTests`)




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27850344728/agentic_workflow) workflow. · 3.3K AIC · ⌖ 53.7 AIC · ⊞ 58.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27850344728, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27850344728 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->