### PR TITLE
[test-improver] test: add enum, struct, and nullable value type edge cases for AvoidAssertAreSameWithValueTypesAnalyzer (MSTEST0038)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
@@ -256,4 +256,134 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenValueTypeIsEnum_Diagnostic()
+    {
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    [|Assert.AreSame(DayOfWeek.Monday, DayOfWeek.Tuesday)|];
+                    [|Assert.AreNotSame(DayOfWeek.Monday, DayOfWeek.Tuesday)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreEqual(DayOfWeek.Monday, DayOfWeek.Tuesday);
+                    Assert.AreNotEqual(DayOfWeek.Monday, DayOfWeek.Tuesday);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenValueTypeIsCustomStruct_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var a = new MyPoint(1, 2);
+                    var b = new MyPoint(3, 4);
+                    [|Assert.AreSame(a, b)|];
+                    [|Assert.AreNotSame(a, b)|];
+                }
+            }
+
+            public readonly struct MyPoint(int x, int y)
+            {
+                public int X { get; } = x;
+                public int Y { get; } = y;
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var a = new MyPoint(1, 2);
+                    var b = new MyPoint(3, 4);
+                    Assert.AreEqual(a, b);
+                    Assert.AreNotEqual(a, b);
+                }
+            }
+
+            public readonly struct MyPoint(int x, int y)
+            {
+                public int X { get; } = x;
+                public int Y { get; } = y;
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenValueTypeIsNullableInt_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int? a = 1;
+                    int? b = 2;
+                    [|Assert.AreSame(a, b)|];
+                    [|Assert.AreNotSame(a, b)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int? a = 1;
+                    int? b = 2;
+                    Assert.AreEqual(a, b);
+                    Assert.AreNotEqual(a, b);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`AvoidAssertAreSameWithValueTypesAnalyzer` (MSTEST0038) previously had only 4 tests, all using integer literals (`0`) as the representative value type. The analyzer's logic checks `IsValueType` which applies to any value type — enum, struct, and `Nullable<T>` — but none of these were exercised.

Added 3 targeted edge-case tests covering previously untested value type categories:

| New test | Value type kind | Why it matters |
|---|---|---|
| `WhenValueTypeIsEnum_Diagnostic` | Enum (`DayOfWeek`) | Enums are value types; devs often don't realize `AreSame` boxes them and always fails |
| `WhenValueTypeIsCustomStruct_Diagnostic` | User-defined `readonly struct` | Each `new MyPoint()` produces a separately boxed heap object; `AreSame` is always false at runtime |
| `WhenValueTypeIsNullableInt_Diagnostic` | `Nullable<T>` (`int?`) | `Nullable<T>` is itself a value type; `int?` variables boxed for `AreSame` are never reference-identical |

## Approach

Each test verifies both `AreSame` → `AreEqual` and `AreNotSame` → `AreNotEqual` for the given type, using the existing `VerifyCodeFixAsync` pattern.

## Trade-offs

- Tests are self-contained and small; no new dependencies.
- All 3 cases map to distinct, user-facing scenarios that the diagnostic is designed to catch.

## Reproducibility

```bash
DOTNET_INSTALL_DIR=/usr/share/dotnet ./build.sh --restore
.dotnet/dotnet run --project test/UnitTests/MSTest.Analyzers.UnitTests -f net8.0 --no-build -c Debug -- --filter "ClassName~AvoidAssertAreSameWithValueTypesAnalyzerTests"
```

## Test Status

✅ 7 tests passed (4 existing + 3 new), 0 failed.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27852600615/agentic_workflow) workflow. · 1.5K AIC · ⌖ 23.3 AIC · ⊞ 58K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27852600615, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27852600615 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->