### PR TITLE
docs: add missing changelog entry for ArchitectureConditionAttribute (`#9233`)

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -33,6 +33,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add MSTEST0070 analyzer validating \[MemberCondition] member references by @Evangelink in [#9076](https://github.com/microsoft/testfx/pull/9076)
 * Add Assert.AddValueFormatter for customizing assertion failure rendering by @Evangelink in [#9148](https://github.com/microsoft/testfx/pull/9148)
 * Add Span\<T> and Memory\<T> overloads to Assert.HasCount and extend MSTEST0037 coverage by @Evangelink in [#9176](https://github.com/microsoft/testfx/pull/9176)
+* Add [ArchitectureConditionAttribute] to gate tests by process architecture by @Evangelink in [#9233](https://github.com/microsoft/testfx/pull/9233)
 
 ### Fixed
 


### PR DESCRIPTION
PR `#9233` (Add `ArchitectureConditionAttribute` to gate tests by process architecture) was merged on 2026-06-19 but its changelog entry was not added to the 4.3.0 UNRELEASED section.

This adds the missing line to `docs/Changelog.md`.

Found during routine QA scan.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/27863626076/agentic_workflow) workflow. · 724.7 AIC · ⌖ 64.2 AIC · ⊞ 51.1K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27863626076, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/27863626076 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->