### PR TITLE
Fix IDE0008 errors in TerminalTestReporterTests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1465,7 +1465,7 @@ public sealed class TerminalTestReporterTests
     public void AssemblyRunCompleted_WhenKnownAssemblyFails_PrintsExecutableSummary()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Failing.dll" : "/repo/Failing.dll";
@@ -1489,7 +1489,7 @@ public sealed class TerminalTestReporterTests
         // Keep the default ShowAssemblyStartAndComplete: true so the reporter DOES print the per-assembly summary
         // line. Otherwise a zero-exit run writes nothing at all and the DoesNotContain assertion below passes
         // vacuously instead of verifying that the executable-summary block is specifically suppressed on success.
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Passing.dll" : "/repo/Passing.dll";
@@ -1510,7 +1510,7 @@ public sealed class TerminalTestReporterTests
     public void TestExecutionCompleted_WhenHandshakeFailures_PrintsRecapAndFailsRun()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole, showAssemblyStartAndComplete: false);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole, showAssemblyStartAndComplete: false);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 2, isDiscovery: false, isHelp: false, isRetry: false);
 
         // Two assemblies fail to handshake (their execution ids were never registered). The assembly paths are not
@@ -1534,7 +1534,7 @@ public sealed class TerminalTestReporterTests
     public void AssemblyRunStarted_AfterRetry_RendersLatestAttemptCounts()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Flaky.dll" : "/repo/Flaky.dll";


### PR DESCRIPTION
Four `var terminalReporter = CreateOrchestratorReporter(...)` declarations in `TerminalTestReporterTests.cs` triggered IDE0008 (use explicit type instead of `var`) because the type is not apparent from the factory-method call (`csharp_style_var_elsewhere = false`). This broke the build across net9.0, net8.0 and net462.

Replaced `var` with the explicit `TerminalTestReporter` type at all four call sites (lines 1468, 1492, 1513, 1537).