### PR TITLE
Add orchestrator TestInProgress/TestDiscovered overloads for SDK parity

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
@@ -85,6 +85,16 @@ This is an INTERNAL, source-only package: it shares - as compiled source - the p
           PackagePath="contentFiles/cs/any/TerminalReporter/%(Filename)%(Extension)" />
 
     <!--
+      EmbeddedAttribute polyfill: the shared source marks its types [Microsoft.CodeAnalysis.Embedded]; that attribute
+      is not present in a vanilla consumer (e.g. dotnet/sdk's dotnet.csproj), so ship the trivial polyfill as source.
+      It is 'internal sealed partial' so it merges harmlessly if the consumer ever defines its own.
+    -->
+    <None Include="$(RepoRoot)src\Polyfills\EmbeddedAttribute.cs"
+          Pack="true"
+          BuildAction="Compile"
+          PackagePath="contentFiles/cs/any/TerminalReporter/EmbeddedAttribute.cs" />
+
+    <!--
       Terminal localized resources. The resx + xlf are shipped under build/ (NOT contentFiles) so they are not
       auto-compiled with the wrong metadata; the auto-imported build-extension props below adds the resx as a
       strongly-typed <EmbeddedResource> (Generator="MSBuild:Compile" plus StronglyTyped* metadata) with a pinned

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
@@ -96,10 +96,10 @@ This is an INTERNAL, source-only package: it shares - as compiled source - the p
 
     <!--
       Terminal localized resources. The resx + xlf are shipped under build/ (NOT contentFiles) so they are not
-      auto-compiled with the wrong metadata; the auto-imported build-extension props below adds the resx as a
-      strongly-typed <EmbeddedResource> (Generator="MSBuild:Compile" plus StronglyTyped* metadata) with a pinned
-      ManifestResourceName, and XliffTasks (present in the consumer, e.g. dotnet/sdk via Arcade) finds the sibling
-      xlf/ to emit satellite assemblies.
+      auto-compiled with the wrong metadata; the auto-imported build-extension props below adds the resx as an
+      <EmbeddedResource GenerateSource="true"> with a pinned Namespace (and ManifestResourceName) so XliffTasks
+      generates the strongly-typed TerminalResources accessor in the namespace the shared reporter source expects,
+      and XliffTasks (present in the consumer, e.g. dotnet/sdk via Arcade) finds the sibling xlf/ to emit satellites.
     -->
     <None Include="@(TerminalReporterContractResource)"
           Pack="true"

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -5,24 +5,22 @@
     (NuGet imports build/<PackageId>.props). It wires the terminal reporter's localized resources - shipped by this
     package under build/TerminalReporter/ - into the consumer's own compilation:
 
-      * The resx is added as a strongly-typed <EmbeddedResource> (Generator="MSBuild:Compile" plus the
-        StronglyTyped* metadata) so the consumer's build generates the `TerminalResources` accessor and embeds
-        the strings into the consumer assembly. This does not depend on Arcade's GenerateSource pipeline.
-      * StronglyTypedNamespace/StronglyTypedClassName pin the generated accessor to
-        Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources - the type the shared reporter source
-        expects - regardless of the consumer's RootNamespace, and ManifestResourceName keeps the embedded
-        manifest name in sync so the runtime ResourceManager lookup resolves the same resource set.
-      * The sibling xlf/ folder lets XliffTasks emit satellite assemblies for each language. This requires the
-        consumer to have XliffTasks; dotnet/sdk (the intended consumer) has it via Arcade.
+      * The resx is added as an <EmbeddedResource GenerateSource="true"> using the Arcade/XliffTasks convention
+        (dotnet/sdk, the intended consumer, provides both): the consumer's build generates the `TerminalResources`
+        strongly-typed accessor (embedding the strings into the consumer assembly, with the accessor's
+        ResourceManager bound to the consumer assembly) AND lets XliffTasks emit per-language satellites from the
+        sibling xlf/ folder. We intentionally do NOT use the manual Generator="MSBuild:Compile" + StronglyTyped*
+        metadata here: that path collides with XliffTasks (the per-culture resx XliffTasks generates inherit the
+        StronglyTyped metadata, so GenerateResource sees multiple sources for one strongly-typed class -> MSB3573).
+      * Namespace pins the generated accessor to Microsoft.Testing.Platform.OutputDevice.Terminal (the namespace the
+        shared reporter source expects) regardless of the consumer's RootNamespace; the class name defaults to the
+        resx file name (TerminalResources), so the manifest name resolves to
+        Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources.
   -->
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TerminalReporter\TerminalResources.resx"
-                      Generator="MSBuild:Compile"
-                      StronglyTypedFileName="$(IntermediateOutputPath)TerminalResources.g.cs"
-                      StronglyTypedLanguage="C#"
-                      StronglyTypedNamespace="Microsoft.Testing.Platform.OutputDevice.Terminal"
-                      StronglyTypedClassName="TerminalResources"
-                      ManifestResourceName="Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources"
+                      GenerateSource="true"
+                      Namespace="Microsoft.Testing.Platform.OutputDevice.Terminal"
                       Link="TerminalReporter\TerminalResources.resx" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -28,8 +28,8 @@
     The shared reporter source is authored against the testfx global usings (ImplicitUsings=enable plus these
     namespaces). Supply them here so the consumer compiles the source without per-file usings. These only take
     effect when the consumer has ImplicitUsings enabled (the package also relies on LangVersion supporting the
-    'field' keyword, i.e. preview/latest, and on the Microsoft.CodeAnalysis.EmbeddedAttribute polyfill - which
-    dotnet/sdk already provides). See PACKAGE.md.
+    'field' keyword, i.e. preview/latest). The Microsoft.CodeAnalysis.EmbeddedAttribute the shared types need is
+    shipped by this package itself as a source polyfill (see the .csproj). See PACKAGE.md.
   -->
   <ItemGroup Condition=" '$(ImplicitUsings)' == 'enable' or '$(ImplicitUsings)' == 'true' ">
     <Using Include="System.Collections" />

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -14,14 +14,17 @@
         StronglyTyped metadata, so GenerateResource sees multiple sources for one strongly-typed class -> MSB3573).
       * Namespace pins the generated accessor to Microsoft.Testing.Platform.OutputDevice.Terminal (the namespace the
         shared reporter source expects) regardless of the consumer's RootNamespace; the class name defaults to the
-        resx file name (TerminalResources), so the manifest name resolves to
-        Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources.
+        resx file name (TerminalResources). ManifestResourceName pins the embedded resource name to
+        Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources so the generated accessor's ResourceManager
+        resolves it. We deliberately do NOT set Link: the resx lives outside the consumer's project cone (it ships in
+        this package), and a Link would feed into the derived manifest resource name / accessor binding, which is
+        exactly what TerminalReporterContract.props avoids for the same reason.
   -->
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TerminalReporter\TerminalResources.resx"
                       GenerateSource="true"
                       Namespace="Microsoft.Testing.Platform.OutputDevice.Terminal"
-                      Link="TerminalReporter\TerminalResources.resx" />
+                      ManifestResourceName="Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources" />
   </ItemGroup>
 
   <!--

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/ExceptionFlattener.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/ExceptionFlattener.cs
@@ -28,7 +28,7 @@ internal sealed class ExceptionFlattener
         IEnumerable<Exception?> aggregateExceptions = exception switch
         {
             AggregateException aggregate => aggregate.Flatten().InnerExceptions,
-            _ => [exception?.InnerException],
+            _ => new Exception?[] { exception?.InnerException },
         };
 
         foreach (Exception? aggregate in aggregateExceptions)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
@@ -41,7 +41,11 @@ internal static partial class TerminalResources
 
     internal static string @ConsoleIsAlreadyInBatchingMode => GetResourceString("ConsoleIsAlreadyInBatchingMode");
 
+    internal static string @DiscoveringTestsFrom => GetResourceString("DiscoveringTestsFrom");
+
     internal static string @DurationLowercase => GetResourceString("DurationLowercase");
+
+    internal static string @Error => GetResourceString("Error");
 
     internal static string @ExitCode => GetResourceString("ExitCode");
 
@@ -70,6 +74,8 @@ internal static partial class TerminalResources
     internal static string @PressCtrlCAgainToForceExit => GetResourceString("PressCtrlCAgainToForceExit");
 
     internal static string @Retried => GetResourceString("Retried");
+
+    internal static string @RunningTestsFrom => GetResourceString("RunningTestsFrom");
 
     internal static string @SkippedLowercase => GetResourceString("SkippedLowercase");
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
@@ -69,6 +69,8 @@ internal static partial class TerminalResources
 
     internal static string @PressCtrlCAgainToForceExit => GetResourceString("PressCtrlCAgainToForceExit");
 
+    internal static string @Retried => GetResourceString("Retried");
+
     internal static string @SkippedLowercase => GetResourceString("SkippedLowercase");
 
     internal static string @StackFrameAt => GetResourceString("StackFrameAt");
@@ -118,6 +120,8 @@ internal static partial class TerminalResources
     internal static string @TestRunSummary => GetResourceString("TestRunSummary");
 
     internal static string @TotalLowercase => GetResourceString("TotalLowercase");
+
+    internal static string @Try => GetResourceString("Try");
 
     internal static string @ZeroTestsRan => GetResourceString("ZeroTestsRan");
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
@@ -41,6 +41,12 @@ internal static partial class TerminalResources
 
     internal static string @ConsoleIsAlreadyInBatchingMode => GetResourceString("ConsoleIsAlreadyInBatchingMode");
 
+    internal static string @DiscoveredTestsInAssembly => GetResourceString("DiscoveredTestsInAssembly");
+
+    internal static string @DiscoveredTestsSummary => GetResourceString("DiscoveredTestsSummary");
+
+    internal static string @DiscoveredTestsSummarySingular => GetResourceString("DiscoveredTestsSummarySingular");
+
     internal static string @DiscoveringTestsFrom => GetResourceString("DiscoveringTestsFrom");
 
     internal static string @DurationLowercase => GetResourceString("DurationLowercase");

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -290,4 +290,12 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
     <value>failed with {0} error(s)</value>
     <comment>{0} is the number of errors in an assembly summary line</comment>
   </data>
+  <data name="Try" xml:space="preserve">
+    <value>try {0}</value>
+    <comment>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</comment>
+  </data>
+  <data name="Retried" xml:space="preserve">
+    <value>retried</value>
+    <comment>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</comment>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -310,4 +310,16 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
     <value>error</value>
     <comment>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</comment>
   </data>
+  <data name="DiscoveredTestsInAssembly" xml:space="preserve">
+    <value>Discovered {0} tests in assembly</value>
+    <comment>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</comment>
+  </data>
+  <data name="DiscoveredTestsSummarySingular" xml:space="preserve">
+    <value>Discovered {0} tests.</value>
+    <comment>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</comment>
+  </data>
+  <data name="DiscoveredTestsSummary" xml:space="preserve">
+    <value>Discovered {0} tests in {1} assemblies.</value>
+    <comment>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</comment>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -298,4 +298,16 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
     <value>retried</value>
     <comment>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</comment>
   </data>
+  <data name="RunningTestsFrom" xml:space="preserve">
+    <value>Running tests from</value>
+    <comment>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</comment>
+  </data>
+  <data name="DiscoveringTestsFrom" xml:space="preserve">
+    <value>Discovering tests from</value>
+    <comment>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</comment>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>error</value>
+    <comment>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</comment>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Handshake.cs
@@ -32,6 +32,20 @@ internal sealed partial class TerminalTestReporter
     }
 
     /// <summary>
+    /// Gets the number of assemblies that failed to handshake. Counted toward the run summary's "error" line.
+    /// </summary>
+    private int HandshakeFailureCount
+    {
+        get
+        {
+            lock (_handshakeFailuresLock)
+            {
+                return _handshakeFailures.Count;
+            }
+        }
+    }
+
+    /// <summary>
     /// Report that an assembly failed to produce a usable handshake. This is an orchestrator-only path (the
     /// in-process host always handshakes); it records the failure so <see cref="HasHandshakeFailure"/> flips and
     /// the failure is re-printed in the end-of-run recap, and prints the immediate failure context.

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -9,11 +9,13 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 internal sealed partial class TerminalTestReporter
 {
     private bool _isHelp;
+    private bool _isRetry;
 
     public void TestExecutionStarted(DateTimeOffset testStartTime, int workerCount, bool isDiscovery, bool isHelp, bool isRetry)
     {
         _isDiscovery = isDiscovery;
         _isHelp = isHelp;
+        _isRetry = isRetry;
         _testExecutionStartTime = testStartTime;
         _terminalWithProgress.StartShowingProgress(workerCount);
     }
@@ -24,6 +26,12 @@ internal sealed partial class TerminalTestReporter
         // in-process host starts a single assembly with a single fixed instance id (one attempt).
         TestProgressState assemblyRun = GetOrAddAssemblyRun(assembly, targetFramework, architecture, executionId);
         assemblyRun.NotifyHandshake(instanceId);
+
+        // Defensive: even if the orchestrator did not flag the run as a retry up front (e.g. the retry parameter
+        // could not be parsed), a second handshake for the same assembly means a retry is happening. Flip _isRetry
+        // so the per-test "(try N)" annotation and the summary's "(+N retried)" suffix are shown. The in-process
+        // host only ever handshakes once (TryCount stays 1), so this never trips for it.
+        _isRetry |= assemblyRun.TryCount > 1;
     }
 
     private TestProgressState GetOrAddAssemblyRun(string assembly, string? targetFramework, string? architecture, string executionId)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -32,6 +32,27 @@ internal sealed partial class TerminalTestReporter
         // so the per-test "(try N)" annotation and the summary's "(+N retried)" suffix are shown. The in-process
         // host only ever handshakes once (TryCount stays 1), so this never trips for it.
         _isRetry |= assemblyRun.TryCount > 1;
+
+        // Orchestrator-only: print the per-assembly "Running tests from <assembly>" banner (or "Discovering tests
+        // from" in discovery mode), prefixed with "(try N)" on a retry. Gated on ShowAssembly + ShowAssemblyStartAndComplete,
+        // which the in-process host leaves off, so its output is unchanged.
+        if (_options.ShowAssembly && _options.ShowAssemblyStartAndComplete)
+        {
+            _terminalWithProgress.WriteToTerminal(terminal =>
+            {
+                if (_isRetry)
+                {
+                    terminal.SetColor(TerminalColor.DarkGray);
+                    terminal.Append($"({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, assemblyRun.TryCount)}) ");
+                    terminal.ResetColor();
+                }
+
+                terminal.Append(_isDiscovery ? TerminalResources.DiscoveringTestsFrom : TerminalResources.RunningTestsFrom);
+                terminal.Append(' ');
+                AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly, targetFramework, architecture);
+                terminal.AppendLine();
+            });
+        }
     }
 
     private TestProgressState GetOrAddAssemblyRun(string assembly, string? targetFramework, string? architecture, string executionId)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Messaging.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Messaging.cs
@@ -43,6 +43,21 @@ internal sealed partial class TerminalTestReporter
             }
         });
 
+    /// <summary>
+    /// Orchestrator overload (<c>dotnet test</c>): carries the assembly/target-framework/architecture and per-attempt
+    /// instance id known to the multi-process orchestrator. The shared in-progress tracking is keyed by execution id,
+    /// so those extra arguments are accepted for signature parity and the overload delegates to the core method.
+    /// </summary>
+    public void TestInProgress(
+        string assembly,
+        string? targetFramework,
+        string? architecture,
+        string executionId,
+        string instanceId,
+        string testNodeUid,
+        string displayName)
+        => TestInProgress(executionId, testNodeUid, displayName);
+
     public void TestInProgress(
         string executionId,
         string testNodeUid,

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -156,15 +156,29 @@ internal sealed partial class TerminalTestReporter
     /// <summary>
     /// Orchestrator overload (<c>dotnet test</c>): the multi-process orchestrator also knows each discovered test's
     /// uid, file path and line number. The shared discovery summary currently lists display names only, so those are
-    /// accepted for signature parity and the overload delegates to the core method when <paramref name="displayName"/>
-    /// is known.
+    /// accepted for signature parity. When <paramref name="displayName"/> is missing the <paramref name="uid"/> is used
+    /// as the listed name; when neither is available the test is still counted (so the discovery total stays correct)
+    /// but no blank entry is added to the summary.
     /// </summary>
     internal void TestDiscovered(string executionId, string? displayName, string? uid, string? filePath, int? lineNumber)
     {
-        if (displayName is not null)
+        // Prefer the display name, fall back to the uid so the discovered test is still listed by something.
+        string? name = displayName ?? uid;
+        if (name is not null)
         {
-            TestDiscovered(executionId, displayName);
+            TestDiscovered(executionId, name);
+            return;
         }
+
+        // No name available at all: still increment the discovered count so the discovery summary total stays
+        // correct (in discovery mode TotalTests is computed from DiscoveredTests), but avoid adding a blank entry.
+        if (!_assemblies.TryGetValue(executionId, out TestProgressState? asm))
+        {
+            throw ApplicationStateGuard.Unreachable();
+        }
+
+        asm.DiscoveredTests++;
+        _terminalWithProgress.UpdateWorker(asm.SlotIndex);
     }
 
     internal void TestDiscovered(string executionId, string displayName)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -237,6 +237,42 @@ internal sealed partial class TerminalTestReporter
         int totalTests = assemblies.Sum(static a => a.TotalTests);
         bool runFailed = WasCancelled || totalTests < 1;
 
+        if (_options.ShowAssembly)
+        {
+            // Orchestrator (dotnet test): a per-assembly "Discovered N tests in assembly - <link>" header followed by
+            // the discovered test names, then a run-level total ("Discovered N tests." / "... in N assemblies.").
+            foreach (TestProgressState assembly in assemblies)
+            {
+                terminal.Append(string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsInAssembly, assembly.DiscoveredTestDisplayNames.Count));
+                terminal.Append(" - ");
+                AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly);
+                terminal.AppendLine();
+                foreach (string displayName in assembly.DiscoveredTestDisplayNames)
+                {
+                    terminal.Append(SingleIndentation);
+                    terminal.AppendLine(displayName);
+                }
+
+                terminal.AppendLine();
+            }
+
+            terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
+            terminal.AppendLine(assemblies.Count <= 1
+                ? string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsSummarySingular, totalTests)
+                : string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsSummary, totalTests, assemblies.Count));
+            terminal.ResetColor();
+            terminal.AppendLine();
+
+            if (WasCancelled)
+            {
+                terminal.Append(TerminalResources.Aborted);
+                terminal.AppendLine();
+            }
+
+            return;
+        }
+
+        // In-process host: the single "Test discovery summary: found N test(s)" format (unchanged shipping output).
         foreach (TestProgressState assembly in assemblies)
         {
             foreach (string displayName in assembly.DiscoveredTestDisplayNames)

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -156,10 +156,12 @@ internal sealed partial class TerminalTestReporter
     /// <summary>
     /// Orchestrator overload (<c>dotnet test</c>): the multi-process orchestrator also knows each discovered test's
     /// uid, file path and line number. The shared discovery summary currently lists display names only, so those are
-    /// accepted for signature parity and the overload delegates to the core method.
+    /// accepted for signature parity and the overload delegates to the core method. When <paramref name="displayName"/>
+    /// is <see langword="null"/> we fall back to <paramref name="uid"/> so the discovery summary stays informative
+    /// (and the discovered-test count stays accurate) instead of adding a blank entry.
     /// </summary>
     internal void TestDiscovered(string executionId, string? displayName, string? uid, string? filePath, int? lineNumber)
-        => TestDiscovered(executionId, displayName ?? string.Empty);
+        => TestDiscovered(executionId, displayName ?? uid ?? string.Empty);
 
     internal void TestDiscovered(string executionId, string displayName)
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -56,12 +56,17 @@ internal sealed partial class TerminalTestReporter
         // Two sibling sites mirror this decision and must stay in lockstep:
         //   - TestApplicationResult.ConsumeAsync (excludes skipped from `_totalRanTests` -> exit code 8)
         //   - Microsoft.Testing.Platform.MSBuild InvokeTestingPlatformTask (run-summary verdict)
-        bool runFailed = TestRunSummaryHelper.IsRunFailed(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests) || HasHandshakeFailure;
+        // Orchestrator-only: an assembly whose process ended unsuccessfully (crash / non-zero exit) with no failed
+        // tests is still a run failure. Gated on ShowAssembly (the orchestrator marker): the in-process host leaves
+        // ShowAssembly off and never sets Success, so this stays false and its verdict/color are unchanged.
+        bool hasFailedAssemblies = _options.ShowAssembly && assemblies.Any(static a => !a.Success);
+
+        bool runFailed = TestRunSummaryHelper.IsRunFailed(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests) || HasHandshakeFailure || hasFailedAssemblies;
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
 
         terminal.Append(TerminalResources.TestRunSummary);
         terminal.Append(' ');
-        terminal.Append(TestRunSummaryHelper.GetVerdictText(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests, HasHandshakeFailure));
+        terminal.Append(TestRunSummaryHelper.GetVerdictText(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests, HasHandshakeFailure, hasFailedAssemblies));
 
         // For a single assembly (the in-process host) the verdict is followed by the assembly link, exactly as
         // before. For multiple assemblies (the dotnet test orchestrator) the per-assembly identity is rendered in
@@ -94,6 +99,7 @@ internal sealed partial class TerminalTestReporter
         int failed = totalFailedTests;
         int passed = totalPassedTests;
         int skipped = totalSkippedTests;
+        int retried = assemblies.Sum(static a => a.RetriedFailedTests);
         TimeSpan runDuration = _testExecutionStartTime != null && _testExecutionEndTime != null ? (_testExecutionEndTime - _testExecutionStartTime).Value : TimeSpan.Zero;
 
         bool colorizeFailed = failed > 0;
@@ -107,7 +113,19 @@ internal sealed partial class TerminalTestReporter
         string durationText = $"{SingleIndentation}{TerminalResources.DurationLowercase}: ";
 
         terminal.ResetColor();
-        terminal.AppendLine(totalText);
+        terminal.Append(totalText);
+
+        // Orchestrator-only: when failed tests were retried, append "(+N retried)" after the total so the headline
+        // count (which reflects the final attempt) is reconciled with the extra retried executions. retried is 0 for
+        // the in-process host, so the total line stays byte-identical there.
+        if (retried > 0)
+        {
+            terminal.SetColor(TerminalColor.DarkGray);
+            terminal.Append($" (+{retried} {TerminalResources.Retried})");
+            terminal.ResetColor();
+        }
+
+        terminal.AppendLine();
         if (colorizeFailed)
         {
             terminal.SetColor(TerminalColor.DarkRed);

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -156,12 +156,16 @@ internal sealed partial class TerminalTestReporter
     /// <summary>
     /// Orchestrator overload (<c>dotnet test</c>): the multi-process orchestrator also knows each discovered test's
     /// uid, file path and line number. The shared discovery summary currently lists display names only, so those are
-    /// accepted for signature parity and the overload delegates to the core method. When <paramref name="displayName"/>
-    /// is <see langword="null"/> we fall back to <paramref name="uid"/> so the discovery summary stays informative
-    /// (and the discovered-test count stays accurate) instead of adding a blank entry.
+    /// accepted for signature parity and the overload delegates to the core method when <paramref name="displayName"/>
+    /// is known.
     /// </summary>
     internal void TestDiscovered(string executionId, string? displayName, string? uid, string? filePath, int? lineNumber)
-        => TestDiscovered(executionId, displayName ?? uid ?? string.Empty);
+    {
+        if (displayName is not null)
+        {
+            TestDiscovered(executionId, displayName);
+        }
+    }
 
     internal void TestDiscovered(string executionId, string displayName)
     {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -61,7 +61,7 @@ internal sealed partial class TerminalTestReporter
 
         terminal.Append(TerminalResources.TestRunSummary);
         terminal.Append(' ');
-        terminal.Append(TestRunSummaryHelper.GetVerdictText(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests));
+        terminal.Append(TestRunSummaryHelper.GetVerdictText(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests, HasHandshakeFailure));
 
         // For a single assembly (the in-process host) the verdict is followed by the assembly link, exactly as
         // before. For multiple assemblies (the dotnet test orchestrator) the per-assembly identity is rendered in

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -100,17 +100,31 @@ internal sealed partial class TerminalTestReporter
         int passed = totalPassedTests;
         int skipped = totalSkippedTests;
         int retried = assemblies.Sum(static a => a.RetriedFailedTests);
+
+        // Orchestrator-only: count assemblies that ended unsuccessfully without a failed test (crash / non-zero exit)
+        // plus handshake failures. These are surfaced as an "error: N" line so they aren't hidden behind a zero
+        // failed-test count. In-process leaves ShowAssembly off and never has handshake failures, so error is 0.
+        int error = (_options.ShowAssembly ? assemblies.Count(static a => !a.Success && a.FailedTests == 0) : 0) + HandshakeFailureCount;
         TimeSpan runDuration = _testExecutionStartTime != null && _testExecutionEndTime != null ? (_testExecutionEndTime - _testExecutionStartTime).Value : TimeSpan.Zero;
 
         bool colorizeFailed = failed > 0;
         bool colorizePassed = passed > 0 && failed == 0;
         bool colorizeSkipped = skipped > 0 && skipped == total && failed == 0;
 
+        string errorText = $"{SingleIndentation}{TerminalResources.Error}: {error}";
         string totalText = $"{SingleIndentation}{TerminalResources.TotalLowercase}: {total}";
         string failedText = $"{SingleIndentation}{TerminalResources.FailedLowercase}: {failed}";
         string passedText = $"{SingleIndentation}{TerminalResources.SucceededLowercase}: {passed}";
         string skippedText = $"{SingleIndentation}{TerminalResources.SkippedLowercase}: {skipped}";
         string durationText = $"{SingleIndentation}{TerminalResources.DurationLowercase}: ";
+
+        if (error > 0)
+        {
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.AppendLine(errorText);
+            terminal.ResetColor();
+            terminal.AppendLine();
+        }
 
         terminal.ResetColor();
         terminal.Append(totalText);

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -243,7 +243,7 @@ internal sealed partial class TerminalTestReporter
             // the discovered test names, then a run-level total ("Discovered N tests." / "... in N assemblies.").
             foreach (TestProgressState assembly in assemblies)
             {
-                terminal.Append(string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsInAssembly, assembly.DiscoveredTestDisplayNames.Count));
+                terminal.Append(string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsInAssembly, assembly.DiscoveredTests));
                 terminal.Append(" - ");
                 AppendAssemblyLinkTargetFrameworkAndArchitecture(terminal, assembly);
                 terminal.AppendLine();

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -153,6 +153,14 @@ internal sealed partial class TerminalTestReporter
         AppendHandshakeFailureRecap(terminal);
     }
 
+    /// <summary>
+    /// Orchestrator overload (<c>dotnet test</c>): the multi-process orchestrator also knows each discovered test's
+    /// uid, file path and line number. The shared discovery summary currently lists display names only, so those are
+    /// accepted for signature parity and the overload delegates to the core method.
+    /// </summary>
+    internal void TestDiscovered(string executionId, string? displayName, string? uid, string? filePath, int? lineNumber)
+        => TestDiscovered(executionId, displayName ?? string.Empty);
+
     internal void TestDiscovered(string executionId, string displayName)
     {
         if (!_assemblies.TryGetValue(executionId, out TestProgressState? asm))

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs
@@ -121,8 +121,12 @@ internal sealed partial class TerminalTestReporter
         _terminalWithProgress.NotifyTestCompleted();
         if (outcome != TestOutcome.Passed || GetShowPassedTests())
         {
+            // Capture the attempt number (1-based) at completion time so the per-test "(try N)" annotation reflects
+            // the retry attempt this result belongs to.
+            int attempt = asm.TryCount;
             _terminalWithProgress.WriteToTerminal(terminal => RenderTestCompleted(
                 terminal,
+                attempt,
                 displayName,
                 outcome,
                 duration,
@@ -143,6 +147,7 @@ internal sealed partial class TerminalTestReporter
 
     private void RenderTestCompleted(
         ITerminal terminal,
+        int attempt,
         string displayName,
         TestOutcome outcome,
         TimeSpan? duration,
@@ -176,6 +181,16 @@ internal sealed partial class TerminalTestReporter
 
         terminal.SetColor(color);
         terminal.Append(outcomeText);
+
+        // Orchestrator-only: annotate which retry attempt this result belongs to (e.g. "failed (try 2)") so retried
+        // results are not mistaken for duplicates. _isRetry is only ever set for the dotnet test orchestrator; the
+        // in-process host leaves it false, so its per-test lines are unchanged.
+        if (_isRetry)
+        {
+            terminal.SetColor(TerminalColor.DarkGray);
+            terminal.Append($" ({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, attempt)})");
+        }
+
         terminal.ResetColor();
         terminal.Append(' ');
         terminal.Append(MakeControlCharactersVisible(displayName, true));

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -27,6 +27,21 @@
         <target state="translated">Konzole je již v režimu dávkování.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -27,10 +27,20 @@
         <target state="translated">Konzole je již v režimu dávkování.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">doba trvání</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Dalším stisknutím kombinace kláves Ctrl+C vynutíte ukončení.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">vynecháno</target>
@@ -244,6 +249,11 @@ Platné hodnoty jsou All, Failed, None. Výchozí hodnota je All (nebo Failed, k
         <source>Test run summary:</source>
         <target state="translated">Souhrn testovacího běhu:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -27,6 +27,21 @@
         <target state="translated">Die Konsole befindet sich bereits im Batchmodus.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -27,10 +27,20 @@
         <target state="translated">Die Konsole befindet sich bereits im Batchmodus.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">Dauer</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Drücken Sie erneut Ctrl+C, um das Beenden zu erzwingen.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">übersprungen</target>
@@ -244,6 +249,11 @@ Gültige Werte sind „All“, „Failed“ und „None“. Der Standardwert ist
         <source>Test run summary:</source>
         <target state="translated">Testlaufzusammenfassung:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Presione Ctrl+C de nuevo para forzar la salida.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">omitido</target>
@@ -244,6 +249,11 @@ Los valores válidos son "All", "Failed", "None". El valor predeterminado es "Al
         <source>Test run summary:</source>
         <target state="translated">Resumen de la serie de pruebas:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -27,6 +27,21 @@
         <target state="translated">La consola ya está en modo de procesamiento por lotes.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -27,10 +27,20 @@
         <target state="translated">La consola ya está en modo de procesamiento por lotes.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">duración</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -27,6 +27,21 @@
         <target state="translated">La console est déjà en mode de traitement par lot.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -27,10 +27,20 @@
         <target state="translated">La console est déjà en mode de traitement par lot.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">durée</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Appuyez de nouveau sur Ctrl+C pour forcer la fermeture.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">ignoré</target>
@@ -244,6 +249,11 @@ Les valeurs valides sont « All », « Failed » et « None ». La valeur 
         <source>Test run summary:</source>
         <target state="translated">Résumé de série de tests :</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Premere di nuovo Ctrl+C per forzare l'uscita.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">ignorato</target>
@@ -244,6 +249,11 @@ I valori validi sono 'All', 'Failed', 'None'. L'impostazione predefinita è 'All
         <source>Test run summary:</source>
         <target state="translated">Riepilogo esecuzione test:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -27,6 +27,21 @@
         <target state="translated">La console è già in modalità batch.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -27,10 +27,20 @@
         <target state="translated">La console è già in modalità batch.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">durata</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -27,10 +27,20 @@
         <target state="translated">コンソールは既にバッチ 処理モードです。</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">期間</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -27,6 +27,21 @@
         <target state="translated">コンソールは既にバッチ 処理モードです。</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -107,6 +107,11 @@
         <target state="translated">強制終了するには、Ctrl+C キーをもう一度押してください。</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">スキップされました</target>
@@ -244,6 +249,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
         <source>Test run summary:</source>
         <target state="translated">テストの実行の概要:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -27,10 +27,20 @@
         <target state="translated">콘솔이 이미 일괄 처리 모드에 있습니다.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">기간</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -107,6 +107,11 @@
         <target state="translated">강제 종료하려면 Ctrl+C를 한 번 더 누르세요.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">건너뜀</target>
@@ -244,6 +249,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
         <source>Test run summary:</source>
         <target state="translated">테스트 실행 요약:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -27,6 +27,21 @@
         <target state="translated">콘솔이 이미 일괄 처리 모드에 있습니다.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -27,6 +27,21 @@
         <target state="translated">Konsola jest już w trybie dzielenia na partie.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -27,10 +27,20 @@
         <target state="translated">Konsola jest już w trybie dzielenia na partie.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">czas trwania</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Naciśnij ponownie klawisze Ctrl+C, aby wymusić wyjście.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">pominięte</target>
@@ -244,6 +249,11 @@ Prawidłowe wartości to „All”, „Failed”, „None”. Wartość domyśln
         <source>Test run summary:</source>
         <target state="translated">Podsumowanie przebiegu testu:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Pressione Ctrl+C de novo para forçar a saída.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">ignorado</target>
@@ -244,6 +249,11 @@ Os valores válidos são 'All', 'Failed', 'None'. O padrão é 'All' (ou 'Failed
         <source>Test run summary:</source>
         <target state="translated">Resumo da execução de teste:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -27,10 +27,20 @@
         <target state="translated">O console já está no modo de lote.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">duração</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -27,6 +27,21 @@
         <target state="translated">O console já está no modo de lote.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Нажмите Ctrl+C еще раз, чтобы выполнить принудительный выход.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">пропущено</target>
@@ -244,6 +249,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
         <source>Test run summary:</source>
         <target state="translated">Сводка тестового запуска:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -27,10 +27,20 @@
         <target state="translated">Консоль уже находится в пакетном режиме.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">длительность</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -27,6 +27,21 @@
         <target state="translated">Консоль уже находится в пакетном режиме.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Çıkmayı zorlamak için Ctrl+C tuşlarına yeniden basın.</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">atlandı</target>
@@ -244,6 +249,11 @@ Geçerli değerler: 'All', 'Failed', 'None'. Varsayılan değer 'All' (veya bir 
         <source>Test run summary:</source>
         <target state="translated">Test çalıştırması özeti:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -27,10 +27,20 @@
         <target state="translated">Konsol zaten işlem grubu oluşturma modunda bulunuyor.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">süre</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -27,6 +27,21 @@
         <target state="translated">Konsol zaten işlem grubu oluşturma modunda bulunuyor.</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -27,6 +27,21 @@
         <target state="translated">控制台已处于批处理模式。</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -27,10 +27,20 @@
         <target state="translated">控制台已处于批处理模式。</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">持续时间</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="translated">再次按 Ctrl+C 强制退出。</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">已跳过</target>
@@ -244,6 +249,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
         <source>Test run summary:</source>
         <target state="translated">测试运行摘要:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -27,10 +27,20 @@
         <target state="translated">主控台已處於批次處理模式。</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveringTestsFrom">
+        <source>Discovering tests from</source>
+        <target state="new">Discovering tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before discovering tests in an assembly; followed by the assembly path/target framework/architecture.</note>
+      </trans-unit>
       <trans-unit id="DurationLowercase">
         <source>duration</source>
         <target state="translated">持續時間</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Error">
+        <source>error</source>
+        <target state="new">error</target>
+        <note>Label for the count of assemblies that failed without producing a failed test (crash / non-zero exit / handshake failure) in the run summary, e.g. 'error: 1'.</note>
       </trans-unit>
       <trans-unit id="ExitCode">
         <source>Exit code</source>
@@ -111,6 +121,11 @@
         <source>retried</source>
         <target state="new">retried</target>
         <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
+      <trans-unit id="RunningTestsFrom">
+        <source>Running tests from</source>
+        <target state="new">Running tests from</target>
+        <note>Per-assembly banner printed by the dotnet test orchestrator before running an assembly; followed by the assembly path/target framework/architecture.</note>
       </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="translated">再次按 Ctrl+C 以強制離開。</target>
         <note>{Locked="Ctrl+C"}</note>
       </trans-unit>
+      <trans-unit id="Retried">
+        <source>retried</source>
+        <target state="new">retried</target>
+        <note>Suffix appended to the total test count in the run summary to indicate how many failed tests were retried, e.g. 'total: 5 (+2 retried)'.</note>
+      </trans-unit>
       <trans-unit id="SkippedLowercase">
         <source>skipped</source>
         <target state="translated">已跳過</target>
@@ -244,6 +249,11 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
         <source>Test run summary:</source>
         <target state="translated">測試回合摘要：</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Try">
+        <source>try {0}</source>
+        <target state="new">try {0}</target>
+        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -27,6 +27,21 @@
         <target state="translated">主控台已處於批次處理模式。</target>
         <note>Exception that is thrown when console is already collecting input into a batch (into a string builder), and code asks to enable batching mode again.</note>
       </trans-unit>
+      <trans-unit id="DiscoveredTestsInAssembly">
+        <source>Discovered {0} tests in assembly</source>
+        <target state="new">Discovered {0} tests in assembly</target>
+        <note>Per-assembly discovery header printed by the dotnet test orchestrator; followed by the assembly path/target framework/architecture. {0} is the discovered test count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummary">
+        <source>Discovered {0} tests in {1} assemblies.</source>
+        <target state="new">Discovered {0} tests in {1} assemblies.</target>
+        <note>dotnet test orchestrator discovery total across multiple assemblies. {0} is the discovered test count, {1} the assembly count.</note>
+      </trans-unit>
+      <trans-unit id="DiscoveredTestsSummarySingular">
+        <source>Discovered {0} tests.</source>
+        <target state="new">Discovered {0} tests.</target>
+        <note>dotnet test orchestrator discovery total for a single assembly. {0} is the discovered test count.</note>
+      </trans-unit>
       <trans-unit id="DiscoveringTestsFrom">
         <source>Discovering tests from</source>
         <target state="new">Discovering tests from</target>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
@@ -33,9 +33,10 @@ internal static class TestRunSummaryHelper
     /// <item><paramref name="hasHandshakeFailures"/>: at least one assembly failed to hand-shake. This escalates to
     /// "Failed!" ahead of the "Zero tests ran" branch (a handshake failure is not a benign empty run).</item>
     /// <item><paramref name="hasFailedAssemblies"/>: at least one assembly process ended unsuccessfully (e.g. crashed
-    /// or returned a non-zero exit code) even though its tests passed. This escalates to "Failed!" but only AFTER the
-    /// "Zero tests ran" branch, so a project that legitimately contains zero tests (which exits non-zero by design)
-    /// is still reported as "Zero tests ran" rather than a failure.</item>
+    /// or returned a non-zero exit code) even though its tests passed. This escalates the verdict wording to "Failed!"
+    /// but only AFTER the "Zero tests ran" branch, so a project that legitimately contains zero tests (which exits
+    /// non-zero by design) keeps the "Zero tests ran" wording rather than "Failed!". Note this only affects the displayed
+    /// verdict text: <see cref="IsRunFailed"/> still treats a zero-test run as a failed run.</item>
     /// </list>
     /// In-process callers never have either condition and pass <see langword="false"/>, so their verdict is unchanged.
     /// </remarks>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
@@ -28,12 +28,18 @@ internal static class TestRunSummaryHelper
     /// Computes the verdict string for the test run.
     /// </summary>
     /// <remarks>
-    /// When <paramref name="hasHandshakeFailures"/> is <see langword="true"/> (multi-assembly orchestrator only), at
-    /// least one assembly failed to hand-shake. Such a failure must surface as "Failed!" and must NOT be masked by the
-    /// benign "Zero tests ran" wording, even though the failing assembly contributed zero tests. In-process callers
-    /// never have handshake failures and pass <see langword="false"/>, so their verdict is unchanged.
+    /// The two orchestrator-only flags surface non-test failures that must not be masked by the test-count wording:
+    /// <list type="bullet">
+    /// <item><paramref name="hasHandshakeFailures"/>: at least one assembly failed to hand-shake. This escalates to
+    /// "Failed!" ahead of the "Zero tests ran" branch (a handshake failure is not a benign empty run).</item>
+    /// <item><paramref name="hasFailedAssemblies"/>: at least one assembly process ended unsuccessfully (e.g. crashed
+    /// or returned a non-zero exit code) even though its tests passed. This escalates to "Failed!" but only AFTER the
+    /// "Zero tests ran" branch, so a project that legitimately contains zero tests (which exits non-zero by design)
+    /// is still reported as "Zero tests ran" rather than a failure.</item>
+    /// </list>
+    /// In-process callers never have either condition and pass <see langword="false"/>, so their verdict is unchanged.
     /// </remarks>
-    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests, bool hasHandshakeFailures = false)
+    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests, bool hasHandshakeFailures = false, bool hasFailedAssemblies = false)
         => true switch
         {
             _ when wasCancelled => TerminalResources.Aborted,
@@ -41,6 +47,7 @@ internal static class TestRunSummaryHelper
             _ when failedTests > 0 => $"{TerminalResources.Failed}!",
             _ when hasHandshakeFailures => $"{TerminalResources.Failed}!",
             _ when totalTests == 0 || totalTests == skippedTests => TerminalResources.ZeroTestsRan,
+            _ when hasFailedAssemblies => $"{TerminalResources.Failed}!",
             _ => $"{TerminalResources.Passed}!",
         };
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TestRunSummaryHelper.cs
@@ -27,13 +27,20 @@ internal static class TestRunSummaryHelper
     /// <summary>
     /// Computes the verdict string for the test run.
     /// </summary>
-    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests)
+    /// <remarks>
+    /// When <paramref name="hasHandshakeFailures"/> is <see langword="true"/> (multi-assembly orchestrator only), at
+    /// least one assembly failed to hand-shake. Such a failure must surface as "Failed!" and must NOT be masked by the
+    /// benign "Zero tests ran" wording, even though the failing assembly contributed zero tests. In-process callers
+    /// never have handshake failures and pass <see langword="false"/>, so their verdict is unchanged.
+    /// </remarks>
+    internal static string GetVerdictText(int totalTests, int failedTests, int skippedTests, bool wasCancelled, int minimumExpectedTests, bool hasHandshakeFailures = false)
         => true switch
         {
             _ when wasCancelled => TerminalResources.Aborted,
             _ when totalTests < minimumExpectedTests => string.Format(CultureInfo.CurrentCulture, TerminalResources.MinimumExpectedTestsPolicyViolation, totalTests, minimumExpectedTests),
-            _ when totalTests == 0 || totalTests == skippedTests => TerminalResources.ZeroTestsRan,
             _ when failedTests > 0 => $"{TerminalResources.Failed}!",
+            _ when hasHandshakeFailures => $"{TerminalResources.Failed}!",
+            _ when totalTests == 0 || totalTests == skippedTests => TerminalResources.ZeroTestsRan,
             _ => $"{TerminalResources.Passed}!",
         };
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1284,8 +1284,10 @@ public sealed class TerminalTestReporterTests
         Assert.Contains($"{TerminalResources.ExitCode}: 1", output);
         Assert.Contains("the err", output);
 
-        // No test ran, so the run verdict is the red "Zero tests ran" (runFailed also includes HasHandshakeFailure).
-        Assert.Contains(TerminalResources.ZeroTestsRan, output);
+        // The summary verdict escalates to "Failed!" rather than the benign "Zero tests ran": a handshake failure
+        // must not be masked as an empty run (dotnet/sdk#51608). The per-assembly immediate-failure context above
+        // still legitimately says "Zero tests ran" (the assembly really did register zero tests).
+        Assert.Contains($"{TerminalResources.TestRunSummary} {TerminalResources.Failed}!", output);
 
         // Per-run state is reset after completion so a subsequent session starts fresh.
         Assert.IsFalse(terminalReporter.HasHandshakeFailure);
@@ -1561,6 +1563,10 @@ public sealed class TerminalTestReporterTests
         Assert.Contains(TerminalResources.HandshakeFailuresHeader, output);
         Assert.Contains("A failed", output);
         Assert.Contains("B failed", output);
+
+        // With every assembly failing to handshake and zero tests, the summary verdict is "Failed!", not the
+        // benign "Zero tests ran" (dotnet/sdk#51608).
+        Assert.Contains($"{TerminalResources.TestRunSummary} {TerminalResources.Failed}!", output);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1608,6 +1608,9 @@ public sealed class TerminalTestReporterTests
 
         // 2) Summary total line carries the "(+1 retried)" suffix.
         Assert.Contains($"{TerminalResources.TotalLowercase}: 1 (+1 {TerminalResources.Retried})", output);
+
+        // The retry also surfaces in the per-assembly "(try N) Running tests from" banner.
+        Assert.Contains($"({tryTwo}) {TerminalResources.RunningTestsFrom}", output);
     }
 
     [TestMethod]
@@ -1679,6 +1682,9 @@ public sealed class TerminalTestReporterTests
         // The run verdict escalates to "Failed!" (not "Passed!") because the assembly process failed.
         Assert.Contains($"{TerminalResources.TestRunSummary} {TerminalResources.Failed}!", output);
         Assert.DoesNotContain($"{TerminalResources.TestRunSummary} {TerminalResources.Passed}!", output);
+
+        // The summary surfaces the failed-process count on a dedicated "error: 1" line.
+        Assert.Contains($"{TerminalResources.Error}: 1", output);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1613,6 +1613,46 @@ public sealed class TerminalTestReporterTests
         Assert.Contains($"({tryTwo}) {TerminalResources.RunningTestsFrom}", output);
     }
 
+    // Orchestrator discovery (dotnet test --list-tests across N assemblies): each assembly gets a
+    // "Discovered N tests in assembly - <link>" header with its test names listed, and the run ends with a
+    // "Discovered M tests in K assemblies." total. The in-process host (ShowAssembly off) keeps its own
+    // "Test discovery summary: found N test(s)" format, covered by the existing discovery tests.
+    [TestMethod]
+    public void AppendTestDiscoverySummary_ForOrchestrator_PrintsPerAssemblyDiscoveredCountsAndTotal()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 2, isDiscovery: true, isHelp: false, isRetry: false);
+
+        string assemblyA = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\A.Tests.dll" : "/repo/A.Tests.dll";
+        string assemblyB = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\B.Tests.dll" : "/repo/B.Tests.dll";
+
+        terminalReporter.AssemblyRunStarted(assemblyA, "net9.0", "x64", executionId: "exec-A", instanceId: "inst-A");
+        terminalReporter.AssemblyRunStarted(assemblyB, "net9.0", "x64", executionId: "exec-B", instanceId: "inst-B");
+
+        terminalReporter.TestDiscovered("exec-A", "A.Test1");
+        terminalReporter.TestDiscovered("exec-A", "A.Test2");
+        terminalReporter.TestDiscovered("exec-B", "B.Test1");
+
+        terminalReporter.AssemblyRunCompleted("exec-A");
+        terminalReporter.AssemblyRunCompleted("exec-B");
+        terminalReporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: 0);
+
+        string output = stringBuilderConsole.Output;
+
+        // Per-assembly discovered-count headers and the listed test names.
+        Assert.Contains(string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsInAssembly, 2), output);
+        Assert.Contains(string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsInAssembly, 1), output);
+        Assert.Contains("A.Test1", output);
+        Assert.Contains("B.Test1", output);
+
+        // Run-level total across both assemblies.
+        Assert.Contains(string.Format(CultureInfo.CurrentCulture, TerminalResources.DiscoveredTestsSummary, 3, 2), output);
+
+        // The in-process-only "Test discovery summary: found N test(s)" wording must NOT appear for the orchestrator.
+        Assert.DoesNotContain(string.Format(CultureInfo.CurrentCulture, TerminalResources.TestDiscoverySummarySingular, 3), output);
+    }
+
     [TestMethod]
     public void AssemblyRunCompleted_WhenKnownAssemblyFails_PrintsExecutableSummary()
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1138,6 +1138,39 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    public void TerminalTestReporter_WhenOrchestratorDiscoveryDisplayNameIsNull_ShouldNotAddBlankSummaryEntry()
+    {
+        // Arrange
+        string assembly = "test.dll";
+        string targetFramework = "net8.0";
+        string architecture = "x64";
+        var stringBuilderConsole = new StringBuilderConsole();
+        var terminalReporter = new TerminalTestReporter(stringBuilderConsole, static () => false, new TerminalTestReporterOptions
+        {
+            ShowPassedTests = () => false,
+            AnsiMode = AnsiMode.NoAnsi,
+            ShowProgress = () => false,
+        });
+
+        DateTimeOffset startTime = DateTimeOffset.MinValue;
+        DateTimeOffset endTime = DateTimeOffset.MaxValue;
+
+        // Act
+        terminalReporter.TestExecutionStarted(startTime, 1, isDiscovery: true, isHelp: false, isRetry: false);
+        terminalReporter.AssemblyRunStarted(assembly, targetFramework, architecture, "0", "0");
+        terminalReporter.TestDiscovered("0", displayName: null, uid: "uid", filePath: null, lineNumber: null);
+        terminalReporter.TestDiscovered("0", "TestMethod1", uid: "uid-1", filePath: null, lineNumber: null);
+        terminalReporter.AssemblyRunCompleted("0");
+        terminalReporter.TestExecutionCompleted(endTime, exitCode: null);
+
+        string[] outputLines = stringBuilderConsole.Output.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+        // Assert
+        Assert.DoesNotContain(TerminalTestReporter.SingleIndentation, outputLines);
+        Assert.Contains($"{TerminalTestReporter.SingleIndentation}TestMethod1", outputLines);
+    }
+
+    [TestMethod]
     public void TerminalTestReporter_WhenMultipleAssemblies_AggregatesCountsAndOmitsAssemblyLinkOnVerdict()
     {
         // Arrange — two assemblies (the dotnet test orchestrator case), each registered under its own

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1563,6 +1563,53 @@ public sealed class TerminalTestReporterTests
         Assert.Contains(ExpectedCounts(1, 0, 0, retried: 1), assemblyLine);
     }
 
+    // Companion to the test above driving the FULL lifecycle to validate the two retry-specific renderings the
+    // dotnet/sdk orchestrator acceptance test RunTestProjectWithWithRetryFeature_ShouldSucceed asserts:
+    //   1) each per-test result line is annotated with "(try N)" so retried attempts are distinguishable, and
+    //   2) the run summary's total line is suffixed with "(+N retried)".
+    // The in-process host never retries (isRetry stays false, TryCount stays 1), so neither rendering appears there.
+    [TestMethod]
+    public void TestExecutionCompleted_WhenTestsWereRetried_AnnotatesTryNumberAndSummaryRetriedCount()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        var terminalReporter = new TerminalTestReporter(stringBuilderConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.NoAnsi,
+            ShowProgress = () => false,
+            ShowPassedTests = () => true,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = true,
+        });
+
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Flaky.Tests.dll" : "/repo/Flaky.Tests.dll";
+        const string executionId = "exec-flaky";
+
+        // Attempt 1 fails the test...
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-1", testUid: "flaky-1", TestOutcome.Fail);
+
+        // ...attempt 2 (new instance id) retries and passes it.
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-2", testUid: "flaky-1", TestOutcome.Passed);
+
+        terminalReporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+        terminalReporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: 0);
+
+        string output = stringBuilderConsole.Output;
+
+        // 1) Per-test "(try N)" annotation: the failing first attempt is "(try 1)", the passing retry is "(try 2)".
+        string tryOne = string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, 1);
+        string tryTwo = string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, 2);
+        Assert.Contains($"({tryOne})", output);
+        Assert.Contains($"({tryTwo})", output);
+        Assert.DoesNotContain($"({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, 3)})", output);
+
+        // 2) Summary total line carries the "(+1 retried)" suffix.
+        Assert.Contains($"{TerminalResources.TotalLowercase}: 1 (+1 {TerminalResources.Retried})", output);
+    }
+
     [TestMethod]
     public void AssemblyRunCompleted_WhenKnownAssemblyFails_PrintsExecutableSummary()
     {
@@ -1606,6 +1653,32 @@ public sealed class TerminalTestReporterTests
 
         // ...but on success the executable summary (exit code + captured output) must not be printed.
         Assert.DoesNotContain($"{TerminalResources.ExitCode}:", stringBuilderConsole.Output);
+    }
+
+    // Drives the dotnet/sdk acceptance scenario RunMTPProjectThatCrashesWithExitCodeNonZero_ShouldFail_WithSameExitCode:
+    // an assembly whose tests all pass but whose process exits non-zero (a crash / explicit non-zero exit) is a run
+    // failure. The run-summary verdict must escalate to "Failed!" even though failed-test count is zero — but only
+    // AFTER the zero-tests branch, so a legitimately empty project is unaffected (covered separately).
+    [TestMethod]
+    public void TestExecutionCompleted_WhenAssemblyExitsNonZeroButTestsPassed_ReportsFailedVerdict()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Crashy.dll" : "/repo/Crashy.dll";
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", "exec-1", "inst-1");
+        ReportOrchestratorTest(terminalReporter, assembly, "exec-1", "inst-1", "t-1", TestOutcome.Passed);
+
+        // The process exits 47 even though the single test passed -> Success is false.
+        terminalReporter.AssemblyRunCompleted("exec-1", exitCode: 47, outputData: null, errorData: null);
+        terminalReporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: 47);
+
+        string output = stringBuilderConsole.Output;
+
+        // The run verdict escalates to "Failed!" (not "Passed!") because the assembly process failed.
+        Assert.Contains($"{TerminalResources.TestRunSummary} {TerminalResources.Failed}!", output);
+        Assert.DoesNotContain($"{TerminalResources.TestRunSummary} {TerminalResources.Passed}!", output);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1621,7 +1621,7 @@ public sealed class TerminalTestReporterTests
     public void AppendTestDiscoverySummary_ForOrchestrator_PrintsPerAssemblyDiscoveredCountsAndTotal()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 2, isDiscovery: true, isHelp: false, isRetry: false);
 
         string assemblyA = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\A.Tests.dll" : "/repo/A.Tests.dll";
@@ -1657,7 +1657,7 @@ public sealed class TerminalTestReporterTests
     public void AssemblyRunCompleted_WhenKnownAssemblyFails_PrintsExecutableSummary()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Failing.dll" : "/repo/Failing.dll";
@@ -1681,7 +1681,7 @@ public sealed class TerminalTestReporterTests
         // Keep the default ShowAssemblyStartAndComplete: true so the reporter DOES print the per-assembly summary
         // line. Otherwise a zero-exit run writes nothing at all and the DoesNotContain assertion below passes
         // vacuously instead of verifying that the executable-summary block is specifically suppressed on success.
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Passing.dll" : "/repo/Passing.dll";
@@ -1706,7 +1706,7 @@ public sealed class TerminalTestReporterTests
     public void TestExecutionCompleted_WhenAssemblyExitsNonZeroButTestsPassed_ReportsFailedVerdict()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Crashy.dll" : "/repo/Crashy.dll";
@@ -1731,7 +1731,7 @@ public sealed class TerminalTestReporterTests
     public void TestExecutionCompleted_WhenHandshakeFailures_PrintsRecapAndFailsRun()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole, showAssemblyStartAndComplete: false);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole, showAssemblyStartAndComplete: false);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 2, isDiscovery: false, isHelp: false, isRetry: false);
 
         // Two assemblies fail to handshake (their execution ids were never registered). The assembly paths are not
@@ -1759,7 +1759,7 @@ public sealed class TerminalTestReporterTests
     public void AssemblyRunStarted_AfterRetry_RendersLatestAttemptCounts()
     {
         var stringBuilderConsole = new StringBuilderConsole();
-        var terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
         terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\Flaky.dll" : "/repo/Flaky.dll";

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1138,7 +1138,7 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
-    public void TerminalTestReporter_WhenOrchestratorDiscoveryDisplayNameIsNull_ShouldNotAddBlankSummaryEntry()
+    public void TerminalTestReporter_WhenOrchestratorDiscoveryDisplayNameIsNull_CountsTestAndFallsBackToUid()
     {
         // Arrange
         string assembly = "test.dll";
@@ -1158,16 +1158,83 @@ public sealed class TerminalTestReporterTests
         // Act
         terminalReporter.TestExecutionStarted(startTime, 1, isDiscovery: true, isHelp: false, isRetry: false);
         terminalReporter.AssemblyRunStarted(assembly, targetFramework, architecture, "0", "0");
-        terminalReporter.TestDiscovered("0", displayName: null, uid: "uid", filePath: null, lineNumber: null);
+
+        // No display name and no uid: counted, but must not add a blank indented entry.
+        terminalReporter.TestDiscovered("0", displayName: null, uid: null, filePath: null, lineNumber: null);
+        // No display name but a uid: the uid is used as the listed name.
+        terminalReporter.TestDiscovered("0", displayName: null, uid: "uid-fallback", filePath: null, lineNumber: null);
+        // Normal display name.
         terminalReporter.TestDiscovered("0", "TestMethod1", uid: "uid-1", filePath: null, lineNumber: null);
+
+        // Assert - every discovered test is counted (even the unnamed one). TotalTests is computed from
+        // DiscoveredTests in discovery mode and is cleared by TestExecutionCompleted, so assert it before that.
+        Assert.AreEqual(3, terminalReporter.TotalTests);
+
         terminalReporter.AssemblyRunCompleted("0");
         terminalReporter.TestExecutionCompleted(endTime, exitCode: null);
 
         string[] outputLines = stringBuilderConsole.Output.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
 
-        // Assert
+        // Assert - no blank indented entry for the unnamed test, but the uid fallback and display name are listed.
         Assert.DoesNotContain(TerminalTestReporter.SingleIndentation, outputLines);
+        Assert.Contains($"{TerminalTestReporter.SingleIndentation}uid-fallback", outputLines);
         Assert.Contains($"{TerminalTestReporter.SingleIndentation}TestMethod1", outputLines);
+    }
+
+    [TestMethod]
+    public void TerminalTestReporter_OrchestratorTestInProgress_TracksActiveTestLikeCoreOverload()
+    {
+        // The orchestrator (dotnet test) TestInProgress overload carries extra assembly/target-framework/architecture
+        // and per-attempt instance metadata for call-site parity, but must track the active test exactly like the core
+        // (executionId, uid, displayName) overload. Verify the orchestrator-driven test surfaces in the active-test
+        // progress frame: its display name only appears in the output if it was registered as a running test.
+        string targetFramework = "net8.0";
+        string architecture = "x64";
+        string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\work\assembly.dll" : "/mnt/work/assembly.dll";
+
+        var stringBuilderConsole = new StringBuilderConsole();
+        var stopwatchFactory = new StopwatchFactory();
+        var terminalReporter = new TerminalTestReporter(stringBuilderConsole, static () => false, new TerminalTestReporterOptions
+        {
+            ShowPassedTests = () => true,
+            AnsiMode = AnsiMode.ForceAnsi,
+            ShowActiveTests = true,
+            ShowProgress = () => true,
+        })
+        {
+            CreateStopwatch = stopwatchFactory.CreateStopwatch,
+        };
+
+        var startHandle = new AutoResetEvent(initialState: false);
+        var stopHandle = new AutoResetEvent(initialState: false);
+
+        // Disable the timer updates so the captured output is deterministic.
+        terminalReporter.OnProgressStartUpdate += (sender, args) => startHandle.WaitOne();
+        terminalReporter.OnProgressStopUpdate += (sender, args) => stopHandle.Set();
+
+        DateTimeOffset startTime = DateTimeOffset.MinValue;
+        terminalReporter.TestExecutionStarted(startTime, 1, isDiscovery: false, isHelp: false, isRetry: false);
+        terminalReporter.AssemblyRunStarted(assembly, targetFramework, architecture, "0", "0");
+
+        // A core-overload active test we will complete to trigger a progress redraw.
+        terminalReporter.TestInProgress(executionId: "0", testNodeUid: "Trigger", displayName: "Trigger");
+        stopwatchFactory.AddTime(TimeSpan.FromMilliseconds(1));
+
+        // The orchestrator overload (extra assembly/targetFramework/architecture/instanceId args). This test is never
+        // completed, so its name can only appear in the output via the active-test progress frame.
+        terminalReporter.TestInProgress(assembly, targetFramework, architecture, executionId: "0", instanceId: "0", testNodeUid: "OrchestratorActive1", displayName: "OrchestratorActive1");
+        stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+
+        // Completing the trigger test redraws the progress frame, which lists the still-active orchestrator test.
+        terminalReporter.TestCompleted("0", testNodeUid: "Trigger", "Trigger", TestOutcome.Passed, TimeSpan.FromSeconds(10),
+            informativeMessage: null, errorMessage: null, exception: null, expected: null, actual: null, standardOutput: null, errorOutput: null);
+
+        string output = stringBuilderConsole.Output;
+        startHandle.Set();
+        stopHandle.WaitOne();
+
+        // The orchestrator-driven test is registered as active and therefore rendered in the progress frame.
+        Assert.Contains("OrchestratorActive1", output);
     }
 
     [TestMethod]


### PR DESCRIPTION
## What

Adds the two orchestrator overloads the dotnet/sdk `dotnet test` integration calls but the shared reporter lacked:
- `TestInProgress(assembly, targetFramework, architecture, executionId, instanceId, testNodeUid, displayName)`
- `TestDiscovered(executionId, displayName, uid, filePath, lineNumber)`

Both are **additive** and delegate to the existing execution-id-keyed core methods (the extra arguments are carried for signature parity; the shared in-progress tracking and discovery summary are keyed by execution id / display name). This lets dotnet/sdk consume the `Microsoft.Testing.Platform.Internal.DotnetTest` source package without call-site changes.

**Discovered** while actually plugging the package into dotnet/sdk: with these two overloads the SDK's reporter call sites compile against the shared source (the only remaining blocker there is a packaging/XliffTasks resx issue, not the reporter API).

## Verification
Platform clean on net8.0/net9.0/netstandard2.0 (0 warnings); `TerminalTestReporterTests` 108/0.