### PR TITLE
Temporarily disable LocalizationTests/LocalizationFailingTests so loc can flow (#9295)

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
+// Temporarily disabled: OneLocBuild keeps reverting the TerminalResources.*.xlf targets to English,
+// which makes these tests fail on every loc check-in. Re-enable once proper translations flow. See https://github.com/microsoft/testfx/issues/9295.
+[Ignore("Disabled until OneLocBuild ships proper TerminalResources translations. See https://github.com/microsoft/testfx/issues/9295.")]
 [TestClass]
 public sealed class LocalizationFailingTests : AcceptanceTestBase<LocalizationFailingTests.TestAssetFixture>
 {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
+// Temporarily disabled: OneLocBuild keeps reverting the TerminalResources.*.xlf targets to English,
+// which makes these tests fail on every loc check-in. Re-enable once proper translations flow. See https://github.com/microsoft/testfx/issues/9295.
+[Ignore("Disabled until OneLocBuild ships proper TerminalResources translations. See https://github.com/microsoft/testfx/issues/9295.")]
 [TestClass]
 public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetFixture>
 {


### PR DESCRIPTION
Temporarily `[Ignore]` the `LocalizationTests` and `LocalizationFailingTests` acceptance tests.

## Why
The OneLocBuild auto check-in PRs (#9248, #9254, #9262, #9292, ...) repeatedly revert the `TerminalResources.*.xlf` `<target>` text back to English (`state="new"`), because `TerminalResources.resx` is a new loc file (strings extracted/moved out of `PlatformResources` in #9246, de-duped in #9260) that the downstream localization pipeline has not translated yet. With `LclSource: lclFilesInRepo` the loc handback is the source of truth, so each OneLocBuild run re-clobbers the manually-restored translations.

XliffTasks bakes that English `<target>` text into the fr/es satellite assemblies, so the product genuinely emits English under `DOTNET_CLI_UI_LANGUAGE=fr/es` — which correctly fails these tests and turns `main` red on every loc check-in (see restore PRs #9252, #9261, #9288).

## What
Disable both test classes so the OneLocBuild PRs can flow and the downstream pipeline can produce proper `TerminalResources` translations. This is a temporary measure tracked by #9295; re-enable both classes once correct localized xlf are checked in.

Closes nothing; tracked by #9295.