### PR TITLE
[code-simplifier] Extract duplicated localization assert helpers into AcceptanceAssert

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
@@ -133,6 +133,34 @@ internal static class AcceptanceAssert
     public static void AssertOutputDoesNotContain(this TestHostResult testHostResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.IsFalse(testHostResult.StandardOutput.Contains(value, StringComparison.Ordinal), GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
+    /// <summary>
+    /// Asserts that the test host output contains the given value after Unicode normalization (FormC) and
+    /// non-breaking space (U+00A0) replacement. Use this instead of <see cref="AssertOutputContains"/> when
+    /// comparing localized strings that may use different normalization forms or typographic spacing conventions.
+    /// </summary>
+    public static void AssertOutputContainsNormalized(this TestHostResult testHostResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+    {
+        string normalizedOutput = NormalizeForLocalization(testHostResult.StandardOutput);
+        string normalizedValue = NormalizeForLocalization(value);
+        Assert.IsTrue(
+            normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
+            $"Output does not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
+    }
+
+    /// <summary>
+    /// Asserts that the test host output does not contain the given value after Unicode normalization (FormC) and
+    /// non-breaking space (U+00A0) replacement. Use this instead of <see cref="AssertOutputDoesNotContain"/> when
+    /// comparing localized strings that may use different normalization forms or typographic spacing conventions.
+    /// </summary>
+    public static void AssertOutputDoesNotContainNormalized(this TestHostResult testHostResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+    {
+        string normalizedOutput = NormalizeForLocalization(testHostResult.StandardOutput);
+        string normalizedValue = NormalizeForLocalization(value);
+        Assert.IsFalse(
+            normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
+            $"Output should not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
+    }
+
     public static void AssertStandardErrorContains(this TestHostResult testHostResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
        => Assert.Contains(value, testHostResult.StandardError, StringComparison.Ordinal, GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
@@ -165,4 +193,9 @@ internal static class AcceptanceAssert
 
     private static string GenerateFailedAssertionMessage(DotnetMuxerResult dotnetMuxerResult, string? callerMemberName, string? callerFilePath, int callerLineNumber, [CallerMemberName] string? assertCallerMemberName = null)
         => $"Expression '{assertCallerMemberName}' failed for member '{callerMemberName}' at line {callerLineNumber} of file '{callerFilePath}'. Output of the dotnet muxer is:{Environment.NewLine}{dotnetMuxerResult}";
+
+    // Localized resource strings may use different Unicode normalization forms (NFC vs NFD) than C# string literals.
+    // French locale also uses non-breaking space (U+00A0) before colons per typographic convention.
+    private static string NormalizeForLocalization(string text)
+        => text.Normalize(NormalizationForm.FormC).Replace('\u00A0', ' ');
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
@@ -144,7 +144,7 @@ internal static class AcceptanceAssert
         string normalizedValue = NormalizeForLocalization(value);
         Assert.IsTrue(
             normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
-            $"Output does not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
+            GenerateFailedAssertionMessage(testHostResult, callerMemberName, callerFilePath, callerLineNumber));
     }
 
     /// <summary>
@@ -158,7 +158,7 @@ internal static class AcceptanceAssert
         string normalizedValue = NormalizeForLocalization(value);
         Assert.IsFalse(
             normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
-            $"Output should not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
+            GenerateFailedAssertionMessage(testHostResult, callerMemberName, callerFilePath, callerLineNumber));
     }
 
     public static void AssertStandardErrorContains(this TestHostResult testHostResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
-
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
 // Temporarily disabled: OneLocBuild keeps reverting the TerminalResources.*.xlf targets to English,
@@ -12,23 +10,6 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public sealed class LocalizationFailingTests : AcceptanceTestBase<LocalizationFailingTests.TestAssetFixture>
 {
     private const string AssetName = "LocalizationTestsFailing";
-
-    // Localized resource strings may use different Unicode normalization forms (NFC vs NFD)
-    // than C# string literals. Normalizing both sides to FormC avoids false mismatches
-    // with the ordinal comparison used by AssertOutputContains.
-    // French locale also uses non-breaking space (U+00A0) before colons per typographic convention,
-    // so we normalize NBSP to regular space for comparison.
-    private static string NormalizeForComparison(string text)
-        => text.Normalize(NormalizationForm.FormC).Replace('\u00A0', ' ');
-
-    private static void AssertOutputContainsNormalized(TestHostResult testHostResult, string value)
-    {
-        string normalizedOutput = NormalizeForComparison(testHostResult.StandardOutput);
-        string normalizedValue = NormalizeForComparison(value);
-        Assert.IsTrue(
-            normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
-            $"Output does not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
-    }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
@@ -42,8 +23,8 @@ public sealed class LocalizationFailingTests : AcceptanceTestBase<LocalizationFa
         testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
 
         // Verify failure summary is in French ("Résumé de série de tests : Échec!")
-        AssertOutputContainsNormalized(testHostResult, "Résumé de série de tests : Échec!");
-        AssertOutputContainsNormalized(testHostResult, "échec: 1");
+        testHostResult.AssertOutputContainsNormalized("Résumé de série de tests : Échec!");
+        testHostResult.AssertOutputContainsNormalized("échec: 1");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
-
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
 // Temporarily disabled: OneLocBuild keeps reverting the TerminalResources.*.xlf targets to English,
@@ -12,32 +10,6 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetFixture>
 {
     private const string AssetName = "LocalizationTests";
-
-    // Localized resource strings may use different Unicode normalization forms (NFC vs NFD)
-    // than C# string literals. Normalizing both sides to FormC avoids false mismatches
-    // with the ordinal comparison used by AssertOutputContains.
-    // French locale also uses non-breaking space (U+00A0) before colons per typographic convention,
-    // so we normalize NBSP to regular space for comparison.
-    private static string NormalizeForComparison(string text)
-        => text.Normalize(NormalizationForm.FormC).Replace('\u00A0', ' ');
-
-    private static void AssertOutputContainsNormalized(TestHostResult testHostResult, string value)
-    {
-        string normalizedOutput = NormalizeForComparison(testHostResult.StandardOutput);
-        string normalizedValue = NormalizeForComparison(value);
-        Assert.IsTrue(
-            normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
-            $"Output does not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
-    }
-
-    private static void AssertOutputDoesNotContainNormalized(TestHostResult testHostResult, string value)
-    {
-        string normalizedOutput = NormalizeForComparison(testHostResult.StandardOutput);
-        string normalizedValue = NormalizeForComparison(value);
-        Assert.IsFalse(
-            normalizedOutput.Contains(normalizedValue, StringComparison.Ordinal),
-            $"Output should not contain '{value}'.{Environment.NewLine}Output:{Environment.NewLine}{testHostResult.StandardOutput}");
-    }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
@@ -51,17 +23,17 @@ public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetF
         testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // Verify the summary line is in French ("Résumé de série de tests : Réussite!")
-        AssertOutputContainsNormalized(testHostResult, "Résumé de série de tests : Réussite!");
+        testHostResult.AssertOutputContainsNormalized("Résumé de série de tests : Réussite!");
 
         // Verify the count labels are in French
-        AssertOutputContainsNormalized(testHostResult, "total: 2");
-        AssertOutputContainsNormalized(testHostResult, "échec: 0");
-        AssertOutputContainsNormalized(testHostResult, "opération réussie: 2");
-        AssertOutputContainsNormalized(testHostResult, "ignoré: 0");
+        testHostResult.AssertOutputContainsNormalized("total: 2");
+        testHostResult.AssertOutputContainsNormalized("échec: 0");
+        testHostResult.AssertOutputContainsNormalized("opération réussie: 2");
+        testHostResult.AssertOutputContainsNormalized("ignoré: 0");
 
         // Verify English strings are NOT in the output
-        AssertOutputDoesNotContainNormalized(testHostResult, "Test run summary:");
-        AssertOutputDoesNotContainNormalized(testHostResult, "succeeded:");
+        testHostResult.AssertOutputDoesNotContainNormalized("Test run summary:");
+        testHostResult.AssertOutputDoesNotContainNormalized("succeeded:");
     }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -105,8 +77,8 @@ public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetF
         testHostResult.AssertExitCodeIs(ExitCode.Success);
 
         // French should win because TESTINGPLATFORM_UI_LANGUAGE has higher precedence
-        AssertOutputContainsNormalized(testHostResult, "Résumé de série de tests : Réussite!");
-        AssertOutputDoesNotContainNormalized(testHostResult, "Resumen de la serie de pruebas:");
+        testHostResult.AssertOutputContainsNormalized("Résumé de série de tests : Réussite!");
+        testHostResult.AssertOutputDoesNotContainNormalized("Resumen de la serie de pruebas:");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()


### PR DESCRIPTION
## Code Simplification — 2026-06-20

This PR simplifies recently modified code to improve clarity, consistency, and maintainability while preserving all functionality.

### Files Simplified

- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs` — Added two public extension methods `AssertOutputContainsNormalized` / `AssertOutputDoesNotContainNormalized` and a private `NormalizeForLocalization` helper
- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs` — Removed duplicated private helpers; updated call sites to use extension method syntax
- `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs` — Removed duplicated private helpers; updated call sites to use extension method syntax

### Improvements Made

1. **Eliminated Code Duplication**
   - Both `LocalizationTests` and `LocalizationFailingTests` contained identical private static helpers: `NormalizeForComparison`, `AssertOutputContainsNormalized`, and (in `LocalizationTests`) `AssertOutputDoesNotContainNormalized`
   - These 3 helpers (28 lines) are now consolidated into `AcceptanceAssert` as reusable extension methods

2. **Applied Project Conventions**
   - The new extension methods follow the exact signature pattern of all other helpers in `AcceptanceAssert` (including `[CallerMemberName]`, `[CallerFilePath]`, `[CallerLineNumber]` optional parameters for diagnostic messages)
   - Call sites now use fluent extension method syntax consistent with the rest of the test suite: `testHostResult.AssertOutputContainsNormalized("...")` instead of `AssertOutputContainsNormalized(testHostResult, "...")`

3. **Removed Redundant `using` Directive**
   - Both files had `using System.Text;` which is already covered by the project-level global using in `Directory.Build.props`

### Changes Based On

Recent changes from:
- #9296 — Temporarily disable LocalizationTests/LocalizationFailingTests so loc can flow (#9295)
- #9293 — Fix IDE0008 errors in TerminalTestReporterTests

### Testing

- ✅ No functional changes — behavior is identical
- ✅ Build compilation verified via manual review against the established `AcceptanceAssert` patterns
- i️ Integration tests are currently `[Ignore]`d (per #9295) so they do not run until OneLocBuild ships proper translations

### Review Focus

Please verify:
- Functionality is preserved — the `NormalizeForLocalization` logic is byte-for-byte identical to the original `NormalizeForComparison` in both files
- The extension method signatures follow the established `AcceptanceAssert` pattern
- No unintended side effects from the consolidation


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27872890227/agentic_workflow) workflow. · 2.1K AIC · ⌖ 25.8 AIC · ⊞ 44.7K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-21T13:57:06.547Z --> on Jun 21, 2026, 1:57 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27872890227, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27872890227 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->