### PR TITLE
[efficiency-improver] perf: avoid GroupBy lazy evaluation for empty-check in AppendTestRunSummary

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -11,7 +11,7 @@ internal sealed partial class TerminalTestReporter
     private void AppendTestRunSummary(ITerminal terminal)
     {
         IEnumerable<IGrouping<bool, TestRunArtifact>> artifactGroups = _artifacts.GroupBy(a => a.OutOfProcess);
-        if (artifactGroups.Any())
+        if (_artifacts.Count > 0)
         {
             // Add extra empty line when we will be writing any artifacts, to split it from previous output.
             terminal.AppendLine();


### PR DESCRIPTION
## Goal and Rationale

Replace `artifactGroups.Any()` with `_artifacts.Count > 0` in `TerminalTestReporter.Summary.cs`.

**Focus area:** Code-Level Efficiency

The original code:
```csharp
IEnumerable<IGrouping<bool, TestRunArtifact>> artifactGroups = _artifacts.GroupBy(a => a.OutOfProcess);
if (artifactGroups.Any())   // ← triggers first GroupBy traversal
{
    terminal.AppendLine();
}

foreach (IGrouping<bool, TestRunArtifact> artifactGroup in artifactGroups)  // ← triggers second GroupBy traversal
```

`GroupBy` is lazy. Calling `Any()` on the resulting `IEnumerable<IGrouping<...>>` iterates `_artifacts` once to find the first element. The `foreach` below then re-evaluates the `GroupBy` from scratch, iterating `_artifacts` a second time. In total: **two full passes** over `_artifacts` plus **two GroupBy enumerator allocations** for every call to `AppendTestRunSummary`.

## Approach

`_artifacts` is declared as `List<TestRunArtifact>` (line 41 of `TerminalTestReporter.cs`). `List<T>.Count` is an O(1) property read with no allocation. Replacing `artifactGroups.Any()` with `_artifacts.Count > 0`:

- Eliminates the first GroupBy traversal entirely
- Eliminates the first GroupBy enumerator allocation
- Leaves the `foreach` as the sole consumer of `artifactGroups` (one pass, unchanged)

The semantics are equivalent: if `_artifacts` is empty, `GroupBy` produces no groups; if non-empty, it always produces at least one group.

## Energy Efficiency Evidence

**Proxy metric:** Memory allocation count + iteration count (proxy for CPU energy draw)

| Condition | Before | After |
|-----------|--------|-------|
| Empty `_artifacts` | `GroupBy()` iter alloc + `Any()` call | O(1) `Count` read, zero alloc |
| Non-empty `_artifacts` (n artifacts) | 2 × full pass over n elements + 2 GroupBy enumerator allocs | 1 × full pass over n elements + 1 GroupBy enumerator alloc |

This is an end-of-run path called once per test run. The absolute savings are modest, but the pattern is a clean correctness improvement (avoids a common lazy-LINQ double-evaluation pitfall). The same idiom (`_artifacts.Count == 0`) is already used at line 140 of `TerminalTestReporter.cs`.

**GSF principle — Hardware Efficiency:** reducing unnecessary object allocations and loop iterations makes the same hardware do less work per functional unit (test run).

## Trade-offs

None. The change reduces computational work, makes the code slightly clearer (intent: "do we have any artifacts?"), and is consistent with the existing `_artifacts.Count == 0` guard in the same file.

## Reproducibility

No benchmarks needed for this path — the improvement is analytically demonstrable from the lazy-LINQ semantics. For profiling: run a test suite that produces artifacts and use dotnet-trace/PerfView to count allocations in `AppendTestRunSummary`.

## Test Status

The change is a one-line expression substitution with no logic change. CI will run the full test suite.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27885165137/agentic_workflow) workflow. · 2K AIC · ⌖ 35.1 AIC · ⊞ 58.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27885165137, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27885165137 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->