### PR TITLE
[test-improver] test: add edge case tests for UnusedParameterSuppressor (MSTEST0047)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UnusedParameterSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UnusedParameterSuppressorTests.cs
@@ -250,6 +250,96 @@ public sealed class UnusedParameterSuppressorTests
         }.RunAsync();
     }
 
+    [TestMethod]
+    public async Task TestMethodWithUnusedTestContext_DiagnosticIsNotSuppressed()
+    {
+        // [TestMethod] is not in the suppressor's fixture-attribute list, so even a TestContext
+        // parameter should not be suppressed.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SomeClass
+            {
+                [TestMethod]
+                public void TestMethod(TestContext {|#0:context|})
+                {
+                }
+            }
+            """;
+
+        // Verify issue is reported without suppressor
+        await new VerifyCS.Test
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic(WarnForUnusedParameters.Rule)
+                    .WithLocation(0)
+                    .WithArguments("context")
+                    .WithIsSuppressed(false),
+            },
+        }.RunAsync();
+
+        // Verify issue is still reported with suppressor (not suppressed)
+        await new TestWithSuppressor
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic(WarnForUnusedParameters.Rule)
+                    .WithLocation(0)
+                    .WithArguments("context")
+                    .WithIsSuppressed(false),
+            },
+        }.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task AssemblyInitializeWithUnusedNonTestContextParameter_DiagnosticIsNotSuppressed()
+    {
+        // The suppressor only suppresses TestContext parameters; a non-TestContext parameter in a
+        // fixture method (e.g. [AssemblyInitialize]) should not be suppressed.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SomeClass
+            {
+                [AssemblyInitialize]
+                public static void Initialize(string {|#0:message|})
+                {
+                }
+            }
+            """;
+
+        // Verify issue is reported without suppressor
+        await new VerifyCS.Test
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic(WarnForUnusedParameters.Rule)
+                    .WithLocation(0)
+                    .WithArguments("message")
+                    .WithIsSuppressed(false),
+            },
+        }.RunAsync();
+
+        // Verify issue is still reported with suppressor (not suppressed)
+        await new TestWithSuppressor
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic(WarnForUnusedParameters.Rule)
+                    .WithLocation(0)
+                    .WithArguments("message")
+                    .WithIsSuppressed(false),
+            },
+        }.RunAsync();
+    }
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1038:Compiler extensions should be implemented in assemblies with compiler-provided references", Justification = "For suppression test only.")]
     [SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1036:Specify analyzer banned API enforcement setting", Justification = "For suppression test only.")]


### PR DESCRIPTION
## Goal and Rationale

`UnusedParameterSuppressor` (MSTEST0047) suppresses IDE0060 ("Remove unused parameter") when **both** of these hold:
1. The parameter type is `TestContext`
2. The containing method has `[AssemblyInitialize]`, `[ClassInitialize]`, `[GlobalTestInitialize]`, or `[GlobalTestCleanup]`

The existing tests verified the positive cases (suppressed) and two negative cases (regular method / non-TestContext in TestMethod). However, the exact boundary conditions — one condition true but not the other — were untested.

## Approach

Added two new test methods to `UnusedParameterSuppressorTests.cs`:

| Test | Scenario | Expected |
|------|----------|----------|
| `TestMethodWithUnusedTestContext_DiagnosticIsNotSuppressed` | `[TestMethod]` with unused `TestContext` parameter | **Not suppressed** — `[TestMethod]` is not in the fixture-attribute list |
| `AssemblyInitializeWithUnusedNonTestContextParameter_DiagnosticIsNotSuppressed` | `[AssemblyInitialize]` with unused `string` parameter | **Not suppressed** — only `TestContext` parameters are eligible |

Each test runs twice: once without the suppressor (to confirm the diagnostic fires), and once with the suppressor (to confirm it is *not* suppressed).

## Coverage Impact

These tests target the two independent guard conditions in `UnusedParameterSuppressor.ReportSuppressions`, ensuring the parameter-type check and the attribute check are each independently exercised with a failing case.

## Trade-offs

Minimal — tests follow the existing pattern in the file and add no complexity.

## Reproducibility

```bash
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "FullyQualifiedName~UnusedParameterSuppressorTests"
```

## Test Status

Build: ✅ succeeded (0 warnings, 0 errors)
`MSTest.Analyzers.UnitTests` (UnusedParameterSuppressorTests): ✅ 8 passed, 0 failed (was 6)




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27886942305/agentic_workflow) workflow. · 1.7K AIC · ⌖ 23.7 AIC · ⊞ 58K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27886942305, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27886942305 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->