### PR TITLE
Add missing changelog entries for MSTEST0071 and AzureDevOps summary fix

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -72,6 +72,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Fix report file-name collision between net8.0 and net8.0-windows builds by @Evangelink in [#9121](https://github.com/microsoft/testfx/pull/9121)
 * Harden report TFM resolution for custom/non-OS platforms (browserwasm) by @Evangelink in [#9137](https://github.com/microsoft/testfx/pull/9137)
 * Fix --list-tests json output under --server mode by streaming discovered tests to the SDK over the dotnet-test pipe by @Evangelink in [#9192](https://github.com/microsoft/testfx/pull/9192)
+* Make AzureDevOps summary report file name unique per assembly by @Evangelink in [#9264](https://github.com/microsoft/testfx/pull/9264)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -34,6 +34,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add Assert.AddValueFormatter for customizing assertion failure rendering by @Evangelink in [#9148](https://github.com/microsoft/testfx/pull/9148)
 * Add Span\<T> and Memory\<T> overloads to Assert.HasCount and extend MSTEST0037 coverage by @Evangelink in [#9176](https://github.com/microsoft/testfx/pull/9176)
 * Add [ArchitectureConditionAttribute] to gate tests by process architecture by @Evangelink in [#9233](https://github.com/microsoft/testfx/pull/9233)
+* Add MSTEST0071 analyzer and code fix for redundant test method display name by @Evangelink in [#9272](https://github.com/microsoft/testfx/pull/9272)
 
 ### Fixed
 


### PR DESCRIPTION
Two user-facing changelog entries were missed when the PRs were merged:

- **`docs/Changelog.md`**: Add entry for MSTEST0071 analyzer and code fix for redundant test method display name ([`#9272`](https://github.com/microsoft/testfx/pull/9272)) in the 4.3.0 UNRELEASED `Added` section.
- **`docs/Changelog-Platform.md`**: Add entry for making AzureDevOps summary report file name unique per assembly ([`#9264`](https://github.com/microsoft/testfx/pull/9264)) in the 2.3.0 UNRELEASED `Fixed` section.

Found during adhoc QA pass (2026-06-21).




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/27896983867/agentic_workflow) workflow. · 886.4 AIC · ⌖ 23.7 AIC · ⊞ 51.2K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27896983867, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/27896983867 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->