### PR TITLE
[perf-improver] Extend performance runner timing scenarios to Linux/macOS and add ClassLevel variant

### DIFF
--- a/test/Performance/MSTest.Performance.Runner/Program.cs
+++ b/test/Performance/MSTest.Performance.Runner/Program.cs
@@ -47,7 +47,8 @@ internal class EntryPoint
             .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
             .NextStep(() => new CleanupDisposable()));
 
-        pipelineRunner.AddPipeline("Default", "Scenario1_DotnetTrace", [OSPlatform.Windows], parametersBag =>
+        // dotnet-trace is a cross-platform CLI tool; no Windows-only restriction needed.
+        pipelineRunner.AddPipeline("Default", "Scenario1_DotnetTrace", [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX], parametersBag =>
         Pipeline
             .FirstStep(() => new Scenario1(numberOfClass: 100, methodsPerClass: 100, tfm: "net9.0", executionScope: ExecutionScope.MethodLevel), parametersBag)
             .NextStep(() => new DotnetMuxer(BuildConfiguration.Debug))
@@ -79,11 +80,24 @@ internal class EntryPoint
             .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
             .NextStep(() => new CleanupDisposable()));
 
-        pipelineRunner.AddPipeline("Default", "Scenario1_PlainProcess", [OSPlatform.Windows], parametersBag =>
+        // PlainProcess records wall-clock time, CPU time, and processor count via the standard
+        // Process API — all cross-platform. Register it for all major OS platforms so contributors
+        // on Linux and macOS can capture baseline timing data without needing Windows tools.
+        pipelineRunner.AddPipeline("Default", "Scenario1_PlainProcess", [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX], parametersBag =>
         Pipeline
             .FirstStep(() => new Scenario1(numberOfClass: 100, methodsPerClass: 100, tfm: "net9.0", executionScope: ExecutionScope.MethodLevel), parametersBag)
             .NextStep(() => new DotnetMuxer(BuildConfiguration.Debug))
             .NextStep(() => new PlainProcess("Scenario1_PlainProcess.zip"))
+            .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
+            .NextStep(() => new CleanupDisposable()));
+
+        // Class-level variant: tests run in parallel at the class level rather than per-method.
+        // Useful for comparing parallelism-strategy overhead vs. MethodLevel on the same hardware.
+        pipelineRunner.AddPipeline("Default", "Scenario1_ClassLevel_PlainProcess", [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX], parametersBag =>
+        Pipeline
+            .FirstStep(() => new Scenario1(numberOfClass: 100, methodsPerClass: 100, tfm: "net9.0", executionScope: ExecutionScope.ClassLevel), parametersBag)
+            .NextStep(() => new DotnetMuxer(BuildConfiguration.Debug))
+            .NextStep(() => new PlainProcess("Scenario1_ClassLevel_PlainProcess.zip"))
             .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
             .NextStep(() => new CleanupDisposable()));
 


### PR DESCRIPTION
## Goal and Rationale

`MSTest.Performance.Runner` is the repo's performance profiling harness. It currently registers all its timing pipelines as **Windows-only**, even though two of them — `Scenario1_PlainProcess` and `Scenario1_DotnetTrace` — use only cross-platform APIs:

- `PlainProcess` measures wall-clock elapsed time, CPU time, and processor count via the standard `System.Diagnostics.Process` API, which works on Linux and macOS.
- `dotnet-trace` is a cross-platform CLI tool distributed via NuGet.

The Windows-only registration means contributors on Linux/macOS (and CI infrastructure) cannot run these scenarios at all, even though they would work correctly.

A second gap: no scenario measures **ClassLevel parallelism**. Only `MethodLevel` is covered. This makes it impossible to compare the two parallelism strategies using the existing tooling.

## Approach

1. **Remove the Windows restriction** from `Scenario1_PlainProcess` and `Scenario1_DotnetTrace` by adding `OSPlatform.Linux` and `OSPlatform.OSX` to each pipeline registration.

2. **Add `Scenario1_ClassLevel_PlainProcess`** — an identical timing pipeline that runs the 100×100 synthetic test suite with `ExecutionScope.ClassLevel`. Registered for all three OS platforms.

The Windows-only profiling pipelines (PerfView, VSDiagnostics, ConcurrencyVisualizer) are left unchanged.

## Files Changed

| File | Change |
|---|---|
| `test/Performance/MSTest.Performance.Runner/Program.cs` | Add Linux/macOS to DotnetTrace and PlainProcess platform arrays; add ClassLevel timing pipeline |

## Performance Evidence

These are **infrastructure** changes — they do not affect test execution or production code. No before/after measurements apply; the benefit is enabling cross-platform timing measurements that previously could not run at all.

With these changes, a contributor on Linux can run:

```bash
./build.sh -pack  # required to produce the MSTest NuGet packages
.dotnet/dotnet run --project test/Performance/MSTest.Performance.Runner \
  -- execute --pipelineNameFilter "*PlainProcess*"
```

And compare `Scenario1_PlainProcess` (MethodLevel) vs `Scenario1_ClassLevel_PlainProcess` (ClassLevel) results side-by-side in the generated `Results/` folder.

## Trade-offs

- No risk to production code; this is a tool project.
- The `Result.json` format (ElapsedTime, TotalProcessorTime, ProcessorCount, TotalAvailableMemoryBytes) is platform-independent.

## Test Status

Build: ✅ succeeded (0 warnings, 0 errors — full `./build.sh -c Debug`)
`MSTest.Performance.Runner`: ✅ compiles successfully targeting `net11.0`




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27907017916/agentic_workflow) workflow. · 1.3K AIC · ⌖ 25.8 AIC · ⊞ 57.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27907017916, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27907017916 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->