### PR TITLE
[test-improver] test: add edge case tests for async-suffix suppressors and redundant display name analyzer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/RedundantTestMethodDisplayNameAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/RedundantTestMethodDisplayNameAnalyzerTests.cs
@@ -164,4 +164,40 @@ public sealed class RedundantTestMethodDisplayNameAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenCustomDerivedAttributeDisplayNameEqualsMethodName_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [[|CustomTestMethod(DisplayName = "MyTestMethod")|]]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [CustomTestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseAsyncSuffixTestFixtureMethodSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseAsyncSuffixTestFixtureMethodSuppressorTests.cs
@@ -189,6 +189,43 @@ public static class SomeClass
         }.RunAsync();
     }
 
+    [TestMethod]
+    public async Task AsyncMethodWithoutFixtureAttribute_DiagnosticIsNotSuppressed()
+    {
+        string code = """
+            using System.Threading.Tasks;
+
+            public class SomeClass
+            {
+                public async Task {|#0:SomeMethod|}() { }
+            }
+            """;
+
+        // Verify issue is reported without suppressor
+        await new VerifyCS.Test
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic(WarnForMissingAsyncSuffix.Rule)
+                    .WithLocation(0)
+                    .WithIsSuppressed(false),
+            },
+        }.RunAsync();
+
+        // Verify issue is still reported with suppressor (no fixture attribute → not suppressed)
+        await new TestWithSuppressor
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics =
+            {
+                VerifyCS.Diagnostic(WarnForMissingAsyncSuffix.Rule)
+                    .WithLocation(0)
+                    .WithIsSuppressed(false),
+            },
+        }.RunAsync();
+    }
+
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1038:Compiler extensions should be implemented in assemblies with compiler-provided references", Justification = "For suppression test only.")]
     [SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1036:Specify analyzer banned API enforcement setting", Justification = "For suppression test only.")]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseAsyncSuffixTestMethodSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseAsyncSuffixTestMethodSuppressorTests.cs
@@ -102,6 +102,71 @@ public sealed class UseAsyncSuffixTestMethodSuppressorTests
         }.RunAsync();
     }
 
+    [TestMethod]
+    public async Task AsyncMethodWithCustomDerivedTestMethodAttribute_DiagnosticIsSuppressed()
+    {
+        string code =
+            """
+
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class SomeClass
+            {
+                [CustomTestMethod]
+                public async Task {|#0:TestMethod|}() { }
+            }
+
+            """;
+
+        // Verify issue is reported without suppressor
+        await new VerifyCS.Test
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics = { VerifyCS.Diagnostic(WarnForMissingAsyncSuffix.Rule).WithLocation(0).WithIsSuppressed(false) },
+        }.RunAsync();
+
+        // Verify issue is suppressed — custom attributes deriving from TestMethodAttribute are also covered
+        await new TestWithSuppressor
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics = { VerifyCS.Diagnostic(WarnForMissingAsyncSuffix.Rule).WithLocation(0).WithIsSuppressed(true) },
+        }.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task AsyncMethodWithoutAnyTestAttribute_DiagnosticIsNotSuppressed()
+    {
+        string code =
+            """
+
+            using System.Threading.Tasks;
+
+            public class SomeClass
+            {
+                public async Task {|#0:MyMethod|}() { }
+            }
+
+            """;
+
+        // Verify issue is reported without suppressor
+        await new VerifyCS.Test
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics = { VerifyCS.Diagnostic(WarnForMissingAsyncSuffix.Rule).WithLocation(0).WithIsSuppressed(false) },
+        }.RunAsync();
+
+        // Verify issue is still reported with suppressor (no TestMethod attribute → not suppressed)
+        await new TestWithSuppressor
+        {
+            TestState = { Sources = { code } },
+            ExpectedDiagnostics = { VerifyCS.Diagnostic(WarnForMissingAsyncSuffix.Rule).WithLocation(0).WithIsSuppressed(false) },
+        }.RunAsync();
+    }
+
     [SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1038:Compiler extensions should be implemented in assemblies with compiler-provided references", Justification = "For suppression test only.")]
     [SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1036:Specify analyzer banned API enforcement setting", Justification = "For suppression test only.")]
     [DiagnosticAnalyzer(LanguageNames.CSharp)]


### PR DESCRIPTION
## Goal and Rationale

Three analyzer test files had untested boundary paths. This PR fills the most meaningful gaps:

| Analyzer | Missing scenario |
|---|---|
| `RedundantTestMethodDisplayNameAnalyzer` (MSTEST0071) | Custom attribute derived from `TestMethodAttribute` with `DisplayName = "MethodName"` → should report diagnostic (the `Inherits()` path was untested) |
| `UseAsyncSuffixTestMethodSuppressor` (MSTEST0027) | Custom attribute derived from `TestMethodAttribute` → should suppress; async method with *no* `TestMethod` attribute → should **not** suppress |
| `UseAsyncSuffixTestFixtureMethodSuppressor` (MSTEST0028) | Regular async method with no fixture attribute → should **not** suppress |

## Approach

Added one test to `RedundantTestMethodDisplayNameAnalyzerTests` and two to each of the two suppressor test files. All follow the existing pattern: run once without the subject analyzer/suppressor to confirm the raw diagnostic, then again with it to confirm the expected suppression state.

**RedundantTestMethodDisplayNameAnalyzer** — new test verifies the code-fix also removes `DisplayName` from a custom derived attribute, which exercises both the diagnostic path and the fixer's generic attribute-argument removal.

**UseAsyncSuffixTestMethodSuppressor** — the `Inherits()` call in `ReportSuppressions` deliberately handles custom subclasses of `TestMethodAttribute`, but that path had no coverage.

**UseAsyncSuffixTestFixtureMethodSuppressor** — all three existing tests only covered the *suppressed* case. The new test confirms a plain async method is left untouched.

## Coverage Impact

Exercises previously uncovered branches in:
- `RedundantTestMethodDisplayNameAnalyzer.AnalyzeSymbol` — the `Inherits()` branch for non-`[TestMethod]`/`[DataTestMethod]` attributes
- `UseAsyncSuffixTestMethodSuppressor.ReportSuppressions` — both the suppress-path for custom attributes and the skip-path when no TestMethod attribute is present
- `UseAsyncSuffixTestFixtureMethodSuppressor.ReportSuppressions` — the skip-path when no fixture attribute is present

## Test Status

Build: ✅ succeeded (0 warnings, 0 errors)

| File | Before | After |
|---|---|---|
| `RedundantTestMethodDisplayNameAnalyzerTests` | 6 | 7 |
| `UseAsyncSuffixTestMethodSuppressorTests` | 3 | 5 |
| `UseAsyncSuffixTestFixtureMethodSuppressorTests` | 3 | 4 |
| **Total** | **12** | **16** |

All 16 tests pass.

## Reproducibility

```bash
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "FullyQualifiedName~RedundantTestMethodDisplayNameAnalyzerTests|FullyQualifiedName~UseAsyncSuffixTestMethodSuppressorTests|FullyQualifiedName~UseAsyncSuffixTestFixtureMethodSuppressorTests"
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/27920707553/agentic_workflow) workflow. · 1.1K AIC · ⌖ 24 AIC · ⊞ 58K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27920707553, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/27920707553 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->