### PR TITLE
Share TestResultCapture core across report extensions (#9319)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -60,13 +60,10 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
-    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameHelper.cs" Link="Helpers\ReportFileNameHelper.cs" />
-    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\CapturedTestResultBase.cs" Link="Helpers\CapturedTestResultBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TargetFrameworkMonikerHelper.cs" Link="Helpers\TargetFrameworkMonikerHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
-    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TargetFrameworkMonikerHelper.cs" Link="Helpers\TargetFrameworkMonikerHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;
@@ -13,49 +13,41 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 // stdout/stderr/stack traces) in memory for the whole session.
 internal static class TestResultCapture
 {
-    internal const int MaxStandardStreamLength = TestResultCaptureHelper.MaxStandardStreamLength;
-    internal const int MaxStackTraceLength = TestResultCaptureHelper.MaxStackTraceLength;
-    internal const int MaxMessageLength = TestResultCaptureHelper.MaxMessageLength;
-    internal const int MaxIdentityFieldLength = TestResultCaptureHelper.MaxIdentityFieldLength;
-    internal const int MaxTraitFieldLength = TestResultCaptureHelper.MaxTraitFieldLength;
-
     public static CapturedTestResult? TryCapture(TestNode node)
     {
-        TestNodeStateProperty? state = node.Properties.SingleOrDefault<TestNodeStateProperty>();
-        if (state is null or DiscoveredTestNodeStateProperty or InProgressTestNodeStateProperty)
+        CapturedTestResultCoreData? coreData = TestResultCaptureHelper.TryCaptureCore(node, includeLocation: true);
+        if (!coreData.HasValue)
         {
             return null;
         }
 
-        CapturedTestResultProperties properties = TestResultCaptureHelper.ExtractProperties(node.Properties, includeLocation: true);
-        (string status, string? rawStatus) = ClassifyStatus(state);
-        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-        (string? ns, string? className, string? methodName) = GetClassAndMethodName(properties.Identifier);
-        CapturedExceptionDetails exceptionDetails = TestResultCaptureHelper.ExtractExceptionDetails(state);
+        CapturedTestResultCoreData core = coreData.GetValueOrDefault();
+        (string status, string? rawStatus) = ClassifyStatus(core.State);
+        (string? ns, string? className, string? methodName) = GetClassAndMethodName(core.Properties.Identifier);
 
         return new CapturedTestResult
         {
             // Identity fields are test-controlled and can be unbounded (e.g. very long
             // UIDs/display names from generated data), so we also cap them to keep the
             // session-wide result list and generated report within a predictable budget.
-            Uid = Truncate(node.Uid.Value, MaxIdentityFieldLength)!,
-            DisplayName = Truncate(node.DisplayName, MaxIdentityFieldLength)!,
+            Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             Status = status,
             RawStatus = rawStatus,
-            Duration = duration,
-            StartTime = properties.Timing?.GlobalTiming.StartTime,
-            EndTime = properties.Timing?.GlobalTiming.EndTime,
-            Namespace = Truncate(ns, MaxIdentityFieldLength),
-            ClassName = Truncate(className, MaxIdentityFieldLength),
-            MethodName = Truncate(methodName, MaxIdentityFieldLength),
-            ErrorMessage = Truncate(exceptionDetails.ErrorMessage, MaxMessageLength),
-            ExceptionType = exceptionDetails.ExceptionType,
-            StackTrace = Truncate(exceptionDetails.StackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(properties.StandardOutput?.StandardOutput, MaxStandardStreamLength),
-            StandardError = Truncate(properties.StandardError?.StandardError, MaxStandardStreamLength),
-            FilePath = Truncate(properties.Location?.FilePath, MaxIdentityFieldLength),
-            Line = properties.Location?.LineSpan.Start.Line,
-            Traits = properties.Traits,
+            Duration = core.Duration,
+            StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
+            EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
+            Namespace = TestResultCaptureHelper.Truncate(ns, TestResultCaptureHelper.MaxIdentityFieldLength),
+            ClassName = TestResultCaptureHelper.Truncate(className, TestResultCaptureHelper.MaxIdentityFieldLength),
+            MethodName = TestResultCaptureHelper.Truncate(methodName, TestResultCaptureHelper.MaxIdentityFieldLength),
+            ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength),
+            ExceptionType = core.ExceptionDetails.ExceptionType,
+            StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength),
+            StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength),
+            StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength),
+            FilePath = TestResultCaptureHelper.Truncate(core.Properties.Location?.FilePath, TestResultCaptureHelper.MaxIdentityFieldLength),
+            Line = core.Properties.Location?.LineSpan.Start.Line,
+            Traits = core.Properties.Traits,
         };
     }
 
@@ -88,7 +80,4 @@ internal static class TestResultCapture
         string? ns = RoslynString.IsNullOrEmpty(identifier.Namespace) ? null : identifier.Namespace;
         return (ns, identifier.TypeName, identifier.MethodName);
     }
-
-    internal static string? Truncate(string? value, int maxLength)
-        => TestResultCaptureHelper.Truncate(value, maxLength);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -55,7 +55,7 @@ internal sealed class HtmlReportEngine : ReportEngineBase
 
         string fileName = fileNameExplicitlyProvided
             ? ResolveHtmlFileName(GetProvidedFileName(providedFileName))
-            : BuildDefaultFileName();
+            : BuildDefaultFileName("html");
 
         string outputDirectory = _configuration.GetTestResultDirectory();
         // Path.Combine short-circuits when the second argument is rooted, so an absolute
@@ -106,19 +106,6 @@ internal sealed class HtmlReportEngine : ReportEngineBase
 #endif
     }
 
-    private string BuildDefaultFileName()
-    {
-        // Deterministic <asm>_<tfm>_<arch>.html shape — discoverable across reruns and
-        // multi-target/multi-arch matrices. A second run into the same TestResults folder
-        // overwrites the previous file (with a warning), matching the behavior of an
-        // explicitly-provided file name.
-        string moduleName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string targetFrameworkMoniker = TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
-        string architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        string raw = $"{moduleName}_{targetFrameworkMoniker}_{architecture}.html";
-        return ReplaceInvalidFileNameChars(raw);
-    }
-
     private string ResolveHtmlFileName(string template)
     {
         string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
@@ -126,8 +113,10 @@ internal sealed class HtmlReportEngine : ReportEngineBase
         return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
     }
 
+#pragma warning disable IDE0051 // Accessed by unit tests through reflection.
     private static string ReplaceInvalidFileNameChars(string fileName)
         => ReportFileNameSanitizer.ReplaceInvalidFileNameChars(fileName);
+#pragma warning restore IDE0051
 
     private static string LoadTemplate()
     {

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Extensions.Messages;
@@ -10,45 +10,34 @@ namespace Microsoft.Testing.Extensions.HtmlReport;
 // stdout/stderr/stack traces) in memory for the whole session.
 internal static class TestResultCapture
 {
-    internal const int MaxStandardStreamLength = TestResultCaptureHelper.MaxStandardStreamLength;
-    internal const int MaxStackTraceLength = TestResultCaptureHelper.MaxStackTraceLength;
-    internal const int MaxMessageLength = TestResultCaptureHelper.MaxMessageLength;
-    internal const int MaxIdentityFieldLength = TestResultCaptureHelper.MaxIdentityFieldLength;
-    internal const int MaxTraitFieldLength = TestResultCaptureHelper.MaxTraitFieldLength;
-
     public static CapturedTestResult? TryCapture(TestNode node)
     {
-        TestNodeStateProperty? state = node.Properties.SingleOrDefault<TestNodeStateProperty>();
-        if (state is null or DiscoveredTestNodeStateProperty or InProgressTestNodeStateProperty)
+        CapturedTestResultCoreData? coreData = TestResultCaptureHelper.TryCaptureCore(node);
+        if (!coreData.HasValue)
         {
             return null;
         }
 
-        CapturedTestResultProperties properties = TestResultCaptureHelper.ExtractProperties(node.Properties);
-        string outcome = ClassifyOutcome(state);
-        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-        (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(properties.Identifier);
-        CapturedExceptionDetails exceptionDetails = TestResultCaptureHelper.ExtractExceptionDetails(state);
-
+        CapturedTestResultCoreData core = coreData.GetValueOrDefault();
         return new CapturedTestResult
         {
             // Identity fields are test-controlled and can be unbounded (e.g. very long
             // UIDs/display names from generated data), so we also cap them to keep the
             // session-wide result list and generated HTML within a predictable budget.
-            Uid = Truncate(node.Uid.Value, MaxIdentityFieldLength)!,
-            DisplayName = Truncate(node.DisplayName, MaxIdentityFieldLength)!,
-            Outcome = outcome,
-            Duration = duration,
-            StartTime = properties.Timing?.GlobalTiming.StartTime,
-            EndTime = properties.Timing?.GlobalTiming.EndTime,
-            ClassName = Truncate(className, MaxIdentityFieldLength),
-            MethodName = Truncate(methodName, MaxIdentityFieldLength),
-            ErrorMessage = Truncate(exceptionDetails.ErrorMessage, MaxMessageLength),
-            ExceptionType = exceptionDetails.ExceptionType,
-            StackTrace = Truncate(exceptionDetails.StackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(properties.StandardOutput?.StandardOutput, MaxStandardStreamLength),
-            StandardError = Truncate(properties.StandardError?.StandardError, MaxStandardStreamLength),
-            Traits = properties.Traits,
+            Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            Outcome = ClassifyOutcome(core.State),
+            Duration = core.Duration,
+            StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
+            EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
+            ClassName = TestResultCaptureHelper.Truncate(core.ClassName, TestResultCaptureHelper.MaxIdentityFieldLength),
+            MethodName = TestResultCaptureHelper.Truncate(core.MethodName, TestResultCaptureHelper.MaxIdentityFieldLength),
+            ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength),
+            ExceptionType = core.ExceptionDetails.ExceptionType,
+            StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength),
+            StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength),
+            StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength),
+            Traits = core.Properties.Traits,
         };
     }
 
@@ -57,7 +46,4 @@ internal static class TestResultCapture
         // historically let cancellation fall through to the failed outcome category, so
         // this wrapper simply delegates to the shared helper with no special-casing.
         => TestResultCaptureHelper.ClassifyOutcome(state);
-
-    internal static string? Truncate(string? value, int maxLength)
-        => TestResultCaptureHelper.Truncate(value, maxLength);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
@@ -64,7 +64,7 @@ internal sealed class JUnitReportEngine : ReportEngineBase
 
         string fileName = fileNameExplicitlyProvided
             ? ResolveXmlFileName(GetProvidedFileName(providedFileName))
-            : BuildDefaultFileName();
+            : BuildDefaultFileName("xml");
 
         string outputDirectory = _configuration.GetTestResultDirectory();
         // Path.Combine short-circuits when the second argument is rooted, so an absolute
@@ -111,19 +111,6 @@ internal sealed class JUnitReportEngine : ReportEngineBase
                 : null);
     }
 
-    private string BuildDefaultFileName()
-    {
-        // Deterministic <asm>_<tfm>_<arch>.xml shape — discoverable across reruns and
-        // multi-target/multi-arch matrices. A second run into the same TestResults folder
-        // overwrites the previous file (with a warning), matching the behavior of an
-        // explicitly-provided file name.
-        string moduleName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string targetFrameworkMoniker = TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
-        string architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        string raw = $"{moduleName}_{targetFrameworkMoniker}_{architecture}.xml";
-        return ReplaceInvalidFileNameChars(raw);
-    }
-
     private string ResolveXmlFileName(string template)
     {
         string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
@@ -131,6 +118,8 @@ internal sealed class JUnitReportEngine : ReportEngineBase
         return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
     }
 
+#pragma warning disable IDE0051 // Accessed by unit tests through reflection.
     private static string ReplaceInvalidFileNameChars(string fileName)
         => ReportFileNameSanitizer.ReplaceInvalidFileNameChars(fileName);
+#pragma warning restore IDE0051
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Testing.Extensions.JUnitReport;
 internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGenerator, CapturedTestResult>
 {
     // Parent chain for ALL TestNodeUpdateMessages (including Discovered / InProgress).
-    // Keyed by the TestNodeUid value after truncation to TestResultCapture.MaxIdentityFieldLength
+    // Keyed by the TestNodeUid value after truncation to TestResultCaptureHelper.MaxIdentityFieldLength
     // so it matches the capped RawUid / ParentRawUid keys used everywhere else in capture
     // (see TestResultCapture.GetParentChainEntry / TryCapture). The engine uses this to
     // reconstruct the testpath of every test case in the report.
@@ -79,7 +79,7 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
         // truncate it to a fixed identity budget before using it as a dictionary
         // key. Capture-side `RawUid`/`ParentRawUid` values are truncated to the
         // same budget so cross-lookups remain consistent.
-        string rawUid = TestResultCapture.Truncate(update.TestNode.Uid.Value, TestResultCapture.MaxIdentityFieldLength)!;
+        string rawUid = TestResultCaptureHelper.Truncate(update.TestNode.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!;
         _parentChain[rawUid] = TestResultCapture.GetParentChainEntry(update);
 
         base.OnTestNodeUpdate(update);

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/TestResultCapture.cs
@@ -10,12 +10,6 @@ namespace Microsoft.Testing.Extensions.JUnitReport;
 // stdout/stderr/stack traces) in memory for the whole session.
 internal static class TestResultCapture
 {
-    internal const int MaxStandardStreamLength = TestResultCaptureHelper.MaxStandardStreamLength;
-    internal const int MaxStackTraceLength = TestResultCaptureHelper.MaxStackTraceLength;
-    internal const int MaxMessageLength = TestResultCaptureHelper.MaxMessageLength;
-    internal const int MaxIdentityFieldLength = TestResultCaptureHelper.MaxIdentityFieldLength;
-    internal const int MaxTraitFieldLength = TestResultCaptureHelper.MaxTraitFieldLength;
-
     // The display name of a test node is also captured for non-terminal (Discovered /
     // InProgress) messages so that the engine can reconstruct the parent chain for
     // every terminal test. This DTO is intentionally tiny because every node in the
@@ -26,27 +20,22 @@ internal static class TestResultCapture
         => new(
             // Display names are test-controlled and may be very long, so cap them to
             // bound the size of the parent-chain dictionary and the generated XML.
-            Truncate(update.TestNode.DisplayName, MaxIdentityFieldLength)!,
+            TestResultCaptureHelper.Truncate(update.TestNode.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             // The parent UID is also test-controlled. Cap it to the same identity
             // budget used everywhere else; lookups against `_parentChain` (also
             // keyed by a truncated UID) stay consistent.
-            Truncate(update.ParentTestNodeUid?.Value, MaxIdentityFieldLength));
+            TestResultCaptureHelper.Truncate(update.ParentTestNodeUid?.Value, TestResultCaptureHelper.MaxIdentityFieldLength));
 
     public static CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
     {
         TestNode node = update.TestNode;
-        TestNodeStateProperty? state = node.Properties.SingleOrDefault<TestNodeStateProperty>();
-        if (state is null or DiscoveredTestNodeStateProperty or InProgressTestNodeStateProperty)
+        CapturedTestResultCoreData? coreData = TestResultCaptureHelper.TryCaptureCore(node);
+        if (!coreData.HasValue)
         {
             return null;
         }
 
-        CapturedTestResultProperties properties = TestResultCaptureHelper.ExtractProperties(node.Properties);
-        string outcome = ClassifyOutcome(state);
-        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
-        (string? className, string? methodName) = TestResultCaptureHelper.GetClassAndMethodName(properties.Identifier);
-        CapturedExceptionDetails exceptionDetails = TestResultCaptureHelper.ExtractExceptionDetails(state);
-
+        CapturedTestResultCoreData core = coreData.GetValueOrDefault();
         return new CapturedTestResult
         {
             // Identity fields are test-controlled and can be unbounded (e.g. very long
@@ -55,22 +44,22 @@ internal static class TestResultCapture
             // RawUid and ParentRawUid are used as keys/edges in the parent-chain
             // dictionary, so they must be capped with the same budget on both sides
             // to keep lookups consistent.
-            Uid = Truncate(node.Uid.Value, MaxIdentityFieldLength)!,
-            RawUid = Truncate(node.Uid.Value, MaxIdentityFieldLength)!,
-            ParentRawUid = Truncate(update.ParentTestNodeUid?.Value, MaxIdentityFieldLength),
-            DisplayName = Truncate(node.DisplayName, MaxIdentityFieldLength)!,
-            Outcome = outcome,
-            Duration = duration,
-            StartTime = properties.Timing?.GlobalTiming.StartTime,
-            EndTime = properties.Timing?.GlobalTiming.EndTime,
-            ClassName = Truncate(className, MaxIdentityFieldLength),
-            MethodName = Truncate(methodName, MaxIdentityFieldLength),
-            ErrorMessage = Truncate(exceptionDetails.ErrorMessage, MaxMessageLength),
-            ExceptionType = exceptionDetails.ExceptionType,
-            StackTrace = Truncate(exceptionDetails.StackTrace, MaxStackTraceLength),
-            StandardOutput = Truncate(properties.StandardOutput?.StandardOutput, MaxStandardStreamLength),
-            StandardError = Truncate(properties.StandardError?.StandardError, MaxStandardStreamLength),
-            Traits = properties.Traits,
+            Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            RawUid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            ParentRawUid = TestResultCaptureHelper.Truncate(update.ParentTestNodeUid?.Value, TestResultCaptureHelper.MaxIdentityFieldLength),
+            DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            Outcome = ClassifyOutcome(core.State),
+            Duration = core.Duration,
+            StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
+            EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
+            ClassName = TestResultCaptureHelper.Truncate(core.ClassName, TestResultCaptureHelper.MaxIdentityFieldLength),
+            MethodName = TestResultCaptureHelper.Truncate(core.MethodName, TestResultCaptureHelper.MaxIdentityFieldLength),
+            ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength),
+            ExceptionType = core.ExceptionDetails.ExceptionType,
+            StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength),
+            StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength),
+            StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength),
+            Traits = core.Properties.Traits,
         };
     }
 
@@ -89,7 +78,4 @@ internal static class TestResultCapture
 
         return TestResultCaptureHelper.ClassifyOutcome(state);
     }
-
-    internal static string? Truncate(string? value, int maxLength)
-        => TestResultCaptureHelper.Truncate(value, maxLength);
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -292,7 +292,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
   </data>
   <data name="Try" xml:space="preserve">
     <value>try {0}</value>
-    <comment>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</comment>
+    <comment>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</comment>
   </data>
   <data name="Retried" xml:space="preserve">
     <value>retried</value>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -283,7 +283,7 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       <trans-unit id="Try">
         <source>try {0}</source>
         <target state="new">try {0}</target>
-        <note>number or tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
+        <note>number of tries of the current test assembly when test assembly is being retried. {0} is number that starts at 1</note>
       </trans-unit>
       <trans-unit id="ZeroTestsRan">
         <source>Zero tests ran</source>

--- a/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
@@ -57,4 +57,17 @@ internal abstract class ReportEngineBase
         => providedFileName is { Length: > 0 }
             ? providedFileName[0]
             : throw ApplicationStateGuard.Unreachable();
+
+    protected string BuildDefaultFileName(string extension)
+    {
+        // Deterministic <asm>_<tfm>_<arch>.<extension> shape — discoverable across
+        // reruns and multi-target/multi-arch matrices. A second run into the same
+        // TestResults folder overwrites the previous file (with a warning), matching
+        // the behavior of an explicitly-provided file name.
+        string moduleName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
+        string targetFrameworkMoniker = TargetFrameworkMonikerHelper.GetTargetFrameworkMoniker();
+        string architecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        string raw = $"{moduleName}_{targetFrameworkMoniker}_{architecture}.{extension}";
+        return ReportFileNameSanitizer.ReplaceInvalidFileNameChars(raw);
+    }
 }

--- a/src/Platform/SharedExtensionHelpers/TestResultCaptureHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/TestResultCaptureHelper.cs
@@ -16,6 +16,22 @@ internal static class TestResultCaptureHelper
     internal const int MaxIdentityFieldLength = 4 * 1024;
     internal const int MaxTraitFieldLength = 1024;
 
+    internal static CapturedTestResultCoreData? TryCaptureCore(TestNode node, bool includeLocation = false)
+    {
+        TestNodeStateProperty? state = node.Properties.SingleOrDefault<TestNodeStateProperty>();
+        if (state is null or DiscoveredTestNodeStateProperty or InProgressTestNodeStateProperty)
+        {
+            return null;
+        }
+
+        CapturedTestResultProperties properties = ExtractProperties(node.Properties, includeLocation);
+        TimeSpan duration = properties.Timing?.GlobalTiming.Duration ?? TimeSpan.Zero;
+        (string? className, string? methodName) = GetClassAndMethodName(properties.Identifier);
+        CapturedExceptionDetails exceptionDetails = ExtractExceptionDetails(state);
+
+        return new CapturedTestResultCoreData(state, properties, duration, className, methodName, exceptionDetails);
+    }
+
     internal static CapturedTestResultProperties ExtractProperties(PropertyBag propertyBag, bool includeLocation = false)
     {
         TimingProperty? timing = null;
@@ -140,3 +156,11 @@ internal readonly record struct CapturedExceptionDetails(
     string? ErrorMessage,
     string? StackTrace,
     string? ExceptionType);
+
+internal readonly record struct CapturedTestResultCoreData(
+    TestNodeStateProperty State,
+    CapturedTestResultProperties Properties,
+    TimeSpan Duration,
+    string? ClassName,
+    string? MethodName,
+    CapturedExceptionDetails ExceptionDetails);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
 using System.Text.Json;
 
 using Microsoft.Testing.Extensions.CtrfReport;
@@ -18,7 +19,14 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public class CtrfReportEngineTests
 {
-    private const int MaxStandardStreamLength = 32 * 1024;
+    private static readonly Type CaptureHelperType = typeof(CtrfReportEngine).Assembly
+        .GetType("Microsoft.Testing.Extensions.TestResultCaptureHelper", throwOnError: true)!;
+
+    // Bound to the production constant (resolved via reflection from the CtrfReport assembly, since the
+    // linked TestResultCaptureHelper type is ambiguous across extension assemblies) so the test stays
+    // aligned with the shared truncation behavior.
+    private static readonly int MaxStandardStreamLength =
+        (int)CaptureHelperType.GetField(nameof(MaxStandardStreamLength), BindingFlags.NonPublic | BindingFlags.Static)!.GetRawConstantValue()!;
 
     private readonly Mock<IEnvironment> _environmentMock = new();
     private readonly Mock<ICommandLineOptions> _commandLineOptionsMock = new();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public class CtrfReportEngineTests
 {
+    private const int MaxStandardStreamLength = 32 * 1024;
+
     private readonly Mock<IEnvironment> _environmentMock = new();
     private readonly Mock<ICommandLineOptions> _commandLineOptionsMock = new();
     private readonly Mock<IConfiguration> _configurationMock = new();
@@ -117,7 +119,7 @@ public class CtrfReportEngineTests
     [TestMethod]
     public void TestResultCapture_Truncates_OverLength_StandardOutput_AtBoundary()
     {
-        string huge = new('a', TestResultCapture.MaxStandardStreamLength + 7);
+        string huge = new('a', MaxStandardStreamLength + 7);
 
         var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
         bag.Add(new StandardOutputProperty(huge));
@@ -127,9 +129,9 @@ public class CtrfReportEngineTests
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.StandardOutput);
-        Assert.StartsWith(new string('a', TestResultCapture.MaxStandardStreamLength), result.StandardOutput!);
+        Assert.StartsWith(new string('a', MaxStandardStreamLength), result.StandardOutput!);
         Assert.Contains("[truncated, original length:", result.StandardOutput);
-        Assert.Contains((TestResultCapture.MaxStandardStreamLength + 7).ToString(CultureInfo.InvariantCulture), result.StandardOutput);
+        Assert.Contains((MaxStandardStreamLength + 7).ToString(CultureInfo.InvariantCulture), result.StandardOutput);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public class HtmlReportEngineTests
 {
+    private const int MaxStandardStreamLength = 32 * 1024;
+    private const int MaxIdentityFieldLength = 4 * 1024;
+    private const int MaxTraitFieldLength = 1024;
+
     private readonly Mock<IEnvironment> _environmentMock = new();
     private readonly Mock<ICommandLineOptions> _commandLineOptionsMock = new();
     private readonly Mock<IConfiguration> _configurationMock = new();
@@ -110,7 +114,7 @@ public class HtmlReportEngineTests
     [TestMethod]
     public void TestResultCapture_Truncates_OverLength_StandardOutput_AtBoundary()
     {
-        string huge = new('a', TestResultCapture.MaxStandardStreamLength + 7);
+        string huge = new('a', MaxStandardStreamLength + 7);
 
         var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
         bag.Add(new StandardOutputProperty(huge));
@@ -120,15 +124,15 @@ public class HtmlReportEngineTests
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.StandardOutput);
-        Assert.StartsWith(new string('a', TestResultCapture.MaxStandardStreamLength), result.StandardOutput!);
+        Assert.StartsWith(new string('a', MaxStandardStreamLength), result.StandardOutput!);
         Assert.Contains("[truncated, original length:", result.StandardOutput);
-        Assert.Contains((TestResultCapture.MaxStandardStreamLength + 7).ToString(CultureInfo.InvariantCulture), result.StandardOutput);
+        Assert.Contains((MaxStandardStreamLength + 7).ToString(CultureInfo.InvariantCulture), result.StandardOutput);
     }
 
     [TestMethod]
     public void TestResultCapture_Does_Not_Truncate_When_Exactly_At_MaxLength()
     {
-        string atMax = new('a', TestResultCapture.MaxStandardStreamLength);
+        string atMax = new('a', MaxStandardStreamLength);
 
         var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
         bag.Add(new StandardOutputProperty(atMax));
@@ -144,7 +148,7 @@ public class HtmlReportEngineTests
     {
         // Build a string whose (maxLength-1)-th char is the high surrogate of a pair.
         // After truncation the high surrogate must be dropped so the result is valid UTF-16.
-        string prefix = new('a', TestResultCapture.MaxStandardStreamLength - 1);
+        string prefix = new('a', MaxStandardStreamLength - 1);
         const string surrogatePair = "\uD83D\uDE00"; // 😀 — high surrogate at index maxLength-1
         string input = prefix + surrogatePair + new string('z', 10);
 
@@ -170,7 +174,7 @@ public class HtmlReportEngineTests
 
         // Confirm we backed off exactly one char over the high surrogate.
         Assert.AreEqual(
-            TestResultCapture.MaxStandardStreamLength - 1,
+            MaxStandardStreamLength - 1,
             newlineIdx,
             "Prefix should be maxLength-1 chars (backed off over the high surrogate).");
     }
@@ -574,7 +578,7 @@ public class HtmlReportEngineTests
     [TestMethod]
     public void TestResultCapture_TruncatesIdentityFields_AtBoundary()
     {
-        string huge = new('a', TestResultCapture.MaxIdentityFieldLength + 7);
+        string huge = new('a', MaxIdentityFieldLength + 7);
 
         var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
         bag.Add(new TestMethodIdentifierProperty("asm", "n", "t", huge, 0, [], "void"));
@@ -592,8 +596,8 @@ public class HtmlReportEngineTests
     [TestMethod]
     public void TestResultCapture_TruncatesTraitKeysAndValues_AtBoundary()
     {
-        string hugeKey = new('k', TestResultCapture.MaxTraitFieldLength + 3);
-        string hugeValue = new('v', TestResultCapture.MaxTraitFieldLength + 5);
+        string hugeKey = new('k', MaxTraitFieldLength + 3);
+        string hugeValue = new('v', MaxTraitFieldLength + 5);
 
         var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
         bag.Add(new TestMetadataProperty(hugeKey, hugeValue));

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
+
 using Microsoft.Testing.Extensions.HtmlReport;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
@@ -16,9 +18,18 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public class HtmlReportEngineTests
 {
-    private const int MaxStandardStreamLength = 32 * 1024;
-    private const int MaxIdentityFieldLength = 4 * 1024;
-    private const int MaxTraitFieldLength = 1024;
+    private static readonly Type CaptureHelperType = typeof(HtmlReportEngine).Assembly
+        .GetType("Microsoft.Testing.Extensions.TestResultCaptureHelper", throwOnError: true)!;
+
+    // Bound to the production constants (resolved via reflection from the HtmlReport assembly, since the
+    // linked TestResultCaptureHelper type is ambiguous across extension assemblies) so the tests stay
+    // aligned if the shared truncation limits change.
+    private static readonly int MaxStandardStreamLength = GetCaptureHelperConstant(nameof(MaxStandardStreamLength));
+    private static readonly int MaxIdentityFieldLength = GetCaptureHelperConstant(nameof(MaxIdentityFieldLength));
+    private static readonly int MaxTraitFieldLength = GetCaptureHelperConstant(nameof(MaxTraitFieldLength));
+
+    private static int GetCaptureHelperConstant(string name)
+        => (int)CaptureHelperType.GetField(name, BindingFlags.NonPublic | BindingFlags.Static)!.GetRawConstantValue()!;
 
     private readonly Mock<IEnvironment> _environmentMock = new();
     private readonly Mock<ICommandLineOptions> _commandLineOptionsMock = new();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TestResultCaptureHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TestResultCaptureHelperTests.cs
@@ -41,7 +41,7 @@ public sealed class TestResultCaptureHelperTests
     private static (string? ClassName, string? MethodName) InvokeGetClassAndMethodName(TestMethodIdentifierProperty? identifier)
         => ((string?, string?))GetClassAndMethodNameMethod.Invoke(null, [identifier])!;
 
-    // TryCaptureCore returns a nullable internal record struct (TryCaptureResult?); reflection
+    // TryCaptureCore returns a nullable internal record struct (CapturedTestResultCoreData?); reflection
     // boxes a present value to the struct instance and a missing value to null. Fields are read
     // back through the boxed instance's properties so the test stays decoupled from the type.
     private static object? InvokeTryCaptureCore(TestNode node, bool includeLocation = false)

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TestResultCaptureHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TestResultCaptureHelperTests.cs
@@ -28,6 +28,10 @@ public sealed class TestResultCaptureHelperTests
         HelperType.GetMethod("GetClassAndMethodName", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("Could not resolve TestResultCaptureHelper.GetClassAndMethodName.");
 
+    private static readonly MethodInfo TryCaptureCoreMethod =
+        HelperType.GetMethod("TryCaptureCore", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Could not resolve TestResultCaptureHelper.TryCaptureCore.");
+
     private static string? InvokeTruncate(string? value, int maxLength)
         => (string?)TruncateMethod.Invoke(null, [value, maxLength]);
 
@@ -36,6 +40,15 @@ public sealed class TestResultCaptureHelperTests
 
     private static (string? ClassName, string? MethodName) InvokeGetClassAndMethodName(TestMethodIdentifierProperty? identifier)
         => ((string?, string?))GetClassAndMethodNameMethod.Invoke(null, [identifier])!;
+
+    // TryCaptureCore returns a nullable internal record struct (TryCaptureResult?); reflection
+    // boxes a present value to the struct instance and a missing value to null. Fields are read
+    // back through the boxed instance's properties so the test stays decoupled from the type.
+    private static object? InvokeTryCaptureCore(TestNode node, bool includeLocation = false)
+        => TryCaptureCoreMethod.Invoke(null, [node, includeLocation]);
+
+    private static object? GetMember(object instance, string propertyName)
+        => instance.GetType().GetProperty(propertyName)!.GetValue(instance);
 
     [TestMethod]
     public void Truncate_NullValue_ReturnsNull()
@@ -132,5 +145,97 @@ public sealed class TestResultCaptureHelperTests
         (string? className, string? methodName) = InvokeGetClassAndMethodName(identifier);
         Assert.AreEqual("MyType", className);
         Assert.AreEqual("MyMethod", methodName);
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_NoState_ReturnsNull()
+    {
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = new() };
+        Assert.IsNull(InvokeTryCaptureCore(node));
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_DiscoveredState_ReturnsNull()
+    {
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) };
+        Assert.IsNull(InvokeTryCaptureCore(node));
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_InProgressState_ReturnsNull()
+    {
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = new(InProgressTestNodeStateProperty.CachedInstance) };
+        Assert.IsNull(InvokeTryCaptureCore(node));
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_TerminalState_ReturnsCoreData()
+    {
+        var identifier = new TestMethodIdentifierProperty(
+            assemblyFullName: "MyAsm",
+            @namespace: "My.Ns",
+            typeName: "MyType",
+            methodName: "MyMethod",
+            methodArity: 0,
+            parameterTypeFullNames: [],
+            returnTypeFullName: "System.Void");
+        var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
+        bag.Add(identifier);
+        TestNode node = new() { Uid = "the-uid", DisplayName = "The display name", Properties = bag };
+
+        object? result = InvokeTryCaptureCore(node);
+
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOfType<PassedTestNodeStateProperty>(GetMember(result, "State"));
+        Assert.AreEqual(TimeSpan.Zero, GetMember(result, "Duration"));
+        Assert.AreEqual("My.Ns.MyType", GetMember(result, "ClassName"));
+        Assert.AreEqual("MyMethod", GetMember(result, "MethodName"));
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_FailedStateWithException_PopulatesExceptionDetails()
+    {
+        var exception = new InvalidOperationException("boom");
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = new(new FailedTestNodeStateProperty(exception)) };
+
+        object? result = InvokeTryCaptureCore(node);
+
+        Assert.IsNotNull(result);
+        object? exceptionDetails = GetMember(result, "ExceptionDetails");
+        Assert.IsNotNull(exceptionDetails);
+        Assert.AreEqual("boom", GetMember(exceptionDetails, "ErrorMessage"));
+        Assert.AreEqual(typeof(InvalidOperationException).FullName, GetMember(exceptionDetails, "ExceptionType"));
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_IncludeLocationTrue_PopulatesLocation()
+    {
+        var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
+        bag.Add(new TestFileLocationProperty("Some.cs", new LinePositionSpan(new LinePosition(1, 0), new LinePosition(2, 0))));
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = bag };
+
+        object? result = InvokeTryCaptureCore(node, includeLocation: true);
+
+        Assert.IsNotNull(result);
+        object? properties = GetMember(result, "Properties");
+        Assert.IsNotNull(properties);
+        object? location = GetMember(properties, "Location");
+        Assert.IsNotNull(location);
+        Assert.AreEqual("Some.cs", GetMember(location, "FilePath"));
+    }
+
+    [TestMethod]
+    public void TryCaptureCore_IncludeLocationFalse_DoesNotPopulateLocation()
+    {
+        var bag = new PropertyBag(PassedTestNodeStateProperty.CachedInstance);
+        bag.Add(new TestFileLocationProperty("Some.cs", new LinePositionSpan(new LinePosition(1, 0), new LinePosition(2, 0))));
+        TestNode node = new() { Uid = "id", DisplayName = "T", Properties = bag };
+
+        object? result = InvokeTryCaptureCore(node, includeLocation: false);
+
+        Assert.IsNotNull(result);
+        object? properties = GetMember(result, "Properties");
+        Assert.IsNotNull(properties);
+        Assert.IsNull(GetMember(properties, "Location"));
     }
 }


### PR DESCRIPTION
Fixes #9319.

- Adds shared TestResultCaptureHelper.TryCaptureCore returning validated core capture data while preserving report-specific projections.
- Keeps HTML/JUnit outcome handling, JUnit RawUid/ParentRawUid/parent-chain data, and CTRF includeLocation=true fields (Namespace/FilePath/Line, Status/RawStatus).
- Removes per-report TestResultCapture truncate/limit forwarders in favor of TestResultCaptureHelper usage.
- Unifies HTML/JUnit default file-name generation through ReportEngineBase.BuildDefaultFileName(extension).