### PR TITLE
Fix dedup-analysis: use current GitHub Models inference endpoint

### DIFF
--- a/.github/scripts/analyze-duplicates.py
+++ b/.github/scripts/analyze-duplicates.py
@@ -77,7 +77,7 @@ def analyze_with_llm(findings_context: str, model: str) -> str:
     from openai import OpenAI
 
     client = OpenAI(
-        base_url="https://models.inference.ai.azure.com",
+        base_url="https://models.github.ai/inference",
         api_key=os.environ["GITHUB_TOKEN"],
     )
 


### PR DESCRIPTION
## Problem

The scheduled **Code Duplication Analysis** workflow (`dedup-analysis.yml`) has failed on **every run since it was added** (8+ consecutive weekly runs). Example: https://github.com/microsoft/testfx/actions/runs/27944924334

The `Analyze duplicates with GitHub Models` step crashes with:

```
openai.BadRequestError: Error code: 400 - {'error': {'code': 'unknown_model',
  'message': 'Unknown model: openai/gpt-4.1-mini'}}
```

## Root cause

`.github/scripts/analyze-duplicates.py` points the OpenAI client at the **legacy** GitHub Models endpoint `https://models.inference.ai.azure.com`. That endpoint does not recognize publisher-prefixed model IDs such as `openai/gpt-4.1-mini` (it expected bare names like `gpt-4o-mini`), so every request 400s.

## Fix

Switch the client `base_url` to the current GitHub Models inference endpoint `https://models.github.ai/inference`, which accepts the `openai/`-prefixed catalog IDs. The configured model (`openai/gpt-4.1-mini`) is valid there, so no model change is needed.

Verified against the live endpoint with the repo token:

```
POST https://models.github.ai/inference/chat/completions
{"model":"openai/gpt-4.1-mini", ...}  ->  200, message.content = "OK"
```

One-line change:

```diff
- base_url="https://models.inference.ai.azure.com",
+ base_url="https://models.github.ai/inference",
```
