### PR TITLE
Fix double registration in MSTest.AotReflection.SourceGeneration PoC and make it packable (non-shipping)

### DIFF
--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
@@ -48,7 +48,7 @@ This package is experimental and non-shipping; do not take a dependency on it in
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Package the generator in the analyzer directory of the nuget package -->
+    <!-- Package the generator in the analyzer directory of the NuGet package -->
     <None Include="$(OutputPath)\netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 

--- a/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
+++ b/src/Analyzers/MSTest.AotReflection.SourceGeneration/MSTest.AotReflection.SourceGeneration.csproj
@@ -8,20 +8,22 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <RootNamespace>MSTest.AotReflection.SourceGeneration</RootNamespace>
-    <IsPackable>false</IsPackable>
-    <!-- PoC project — not shipped, not signed. -->
+    <!-- PoC project — packable for local experimentation but not shipped, not signed. -->
+    <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
+  <!-- NuGet properties -->
   <PropertyGroup>
-    <Description>
-      PoC source generator that emits the metadata MSTest's IReflectionOperations would normally
-      produce via runtime reflection (attributes, declared members, instance factories, method
-      invokers). The eventual goal is to wire this output into the MSTest adapter so it can run
-      tests under NativeAOT without performing any runtime reflection. Tracked by
-      https://github.com/microsoft/testfx/issues/1837.
-    </Description>
+    <PackageDescription>
+      <![CDATA[PoC source generator that emits the metadata MSTest's IReflectionOperations would normally
+produce via runtime reflection (attributes, declared members, instance factories, method invokers).
+The eventual goal is to wire this output into the MSTest adapter so it can run tests under NativeAOT
+without performing any runtime reflection. Tracked by https://github.com/microsoft/testfx/issues/1837.
+
+This package is experimental and non-shipping; do not take a dependency on it in production code.]]>
+    </PackageDescription>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,15 +45,11 @@
     <Compile Include="..\Shared\SymbolAccessibilityHelper.cs" Link="Shared\SymbolAccessibilityHelper.cs" />
     <Compile Include="..\MSTest.SourceGeneration\Helpers\Constants.cs" Link="Helpers\Constants.cs" />
     <Compile Include="..\MSTest.SourceGeneration\Helpers\IndentedStringBuilder.cs" Link="Helpers\IndentedStringBuilder.cs" />
+  </ItemGroup>
 
-    <!-- Share the shipping generator's proven runtime-wiring source (ModuleInitializer + Register +
-         DynamicDependency rooting) so a project that references ONLY this AOT package is fully
-         functional today, on top of the reflection-free registry this generator also emits. This is
-         intentionally shared source (not a fork) so the wiring cannot drift from MSTest.SourceGeneration
-         until the reflection-free execution path is wired up and the two generators are consolidated. -->
-    <Compile Include="..\MSTest.SourceGeneration\Generators\ReflectionMetadataGenerator.cs" Link="Generators\ReflectionMetadataGenerator.cs" />
-    <Compile Include="..\MSTest.SourceGeneration\Emitters\ReflectionMetadataEmitter.cs" Link="Emitters\ReflectionMetadataEmitter.cs" />
-    <Compile Include="..\MSTest.SourceGeneration\Models\TestAssemblyMetadata.cs" Link="Models\TestAssemblyMetadata.cs" />
+  <ItemGroup>
+    <!-- Package the generator in the analyzer directory of the nuget package -->
+    <None Include="$(OutputPath)\netstandard2.0\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What

Two fixes to the experimental `MSTest.AotReflection.SourceGeneration` PoC:

1. **Fix double test registration.** The PoC `.csproj` `<Compile Include>`-ed `MSTest.SourceGeneration`'s `ReflectionMetadataGenerator.cs` — which is itself decorated with `[Generator]`. As a result, the PoC analyzer assembly ran **two** source generators, and each emitted a `[ModuleInitializer]` that called `ReflectionMetadataHook.Register(...)` for the same assembly:
   - `MSTestSourceGeneratedReflectionMetadata` (shipping generator, 3-arg `Register`)
   - `MSTestAotSourceGeneratedReflectionMetadata` (PoC generator, 5-arg `Register`)

   `CompositeSourceGeneratedReflectionDataProvider` appends both providers with no de-duplication, so every test class was discovered twice. A trivial 2-test project reported **4** passing tests.

   The PoC's own `RuntimeRegistrationEmitter` already emits a complete and strictly richer registration (5-arg overload carrying materialized type/assembly attributes) plus `[DynamicDependency]` rooting, so the shared shipping generator was redundant. The three shared `Compile` includes (`ReflectionMetadataGenerator.cs`, `ReflectionMetadataEmitter.cs`, `TestAssemblyMetadata.cs`) — none of which were referenced by any PoC source — are removed. Only one `[ModuleInitializer]` is emitted now.

2. **Make the project packable as a non-shipping package** (`IsPackable=true`, `IsShipping=false`) so it can be consumed locally for experimentation. The generator dll is packed under `analyzers/dotnet/cs`. The package lands in `artifacts/packages/<config>/NonShipping` and is not published.

## Verification

- `MSTest.AotReflection.SourceGeneration.UnitTests`: **66/66** pass.
- Stood up a minimal consuming project that references the generator as an analyzer:
  - **Before:** a 2-test project reported `total: 4` (each test discovered twice).
  - **After:** reports `total: 2`, and only the PoC's generated files are emitted (the duplicate `Sample.MSTestReflectionMetadata.g.cs` from the shipping generator is gone).
- `dotnet pack` produces `MSTest.AotReflection.SourceGeneration.<ver>.nupkg` in `NonShipping`, with the analyzer dll at `analyzers/dotnet/cs/`.

## Notes

This remains a PoC tracked by #1837. The reflection-free registry it emits is still not consumed by the adapter (runtime discovery continues to go through `ReflectionMetadataHook` + `[DynamicDependency]`), which is out of scope for this change.
