### PR TITLE
fix: Remove unused import of functools.cmp_to_key

### DIFF
--- a/eng/common/cross/install-debs.py
+++ b/eng/common/cross/install-debs.py
@@ -15,7 +15,7 @@ import tempfile
 import zstandard
 
 from collections import deque
-from functools import cmp_to_key
+
 
 async def download_file(session, url, dest_path, max_retries=3, retry_delay=2, timeout=60, checksum=None):
     """Asynchronous file download with retries."""


### PR DESCRIPTION
### 问题背景
This PR addresses a lint warning in the Python script `eng/common/cross/install-debs.py` where the import `from functools import cmp_to_key` was imported but never used. Unused imports can clutter code, increase maintenance overhead, and trigger linting errors, affecting code quality and readability.

### 修改内容
- **修改了什么**: Removed the unused import statement `from functools import cmp_to_key` from the file `eng/common/cross/install-debs.py`.
- **为什么这样改**: This import was not referenced anywhere in the script, making it redundant. Removing it cleans up the code, adheres to linting best practices, and ensures that only necessary dependencies are included, reducing potential confusion for developers.
- **提升**: Improves code readability and maintainability by eliminating dead code. This change aligns with Python's PEP 8 guidelines and enhances overall code quality without affecting functionality.

### 验证方式
- **现有测试**: Verified that all existing tests pass after the change, as this modification does not alter the script's behavior or functionality.
- **手动验证**: Ran the script manually to confirm it still operates correctly for installing deb packages, with no errors introduced.
- **Lint检查**: Performed linting to ensure no new warnings are generated, confirming the fix resolves the original issue.

### 其他信息
- **Breaking Changes**: None. This change is purely cosmetic and does not affect the public API or external behavior.
- **文档更新**: No documentation updates required, as this is a minor code cleanup.
- **已知限制**: No known limitations; the script remains fully functional as before.