### PR TITLE
Add package README for MSTest.SourceGeneration

### DIFF
--- a/src/Analyzers/MSTest.SourceGeneration/PACKAGE.md
+++ b/src/Analyzers/MSTest.SourceGeneration/PACKAGE.md
@@ -1,0 +1,7 @@
+# MSTest.SourceGeneration
+
+MSTest is Microsoft supported Test Framework.
+
+This package provides the C# source generators that emit reflection metadata so that MSTest test assemblies can run trim-safe and NativeAOT-compatible.
+
+For access to the testing framework, install the MSTest.TestFramework package.


### PR DESCRIPTION
The `MSTest.SourceGeneration` package was missing a README (NuGet warns about this per https://aka.ms/nuget/authoring-best-practices/readme).

This adds a `PACKAGE.md` in the project directory, which `Directory.Build.targets` automatically picks up as `PackageReadmeFile` and packs into the `.nupkg` — the same convention used by every other packable project in the repo (e.g. `MSTest.Analyzers.Package`).

Verified with `dotnet pack`: the generated `.nupkg` now contains `PACKAGE.md` and its nuspec includes `<readme>PACKAGE.md</readme>`.