### PR TITLE
[code-simplifier] Move ResolveProvidedFileName to ReportEngineBase and inline HTML ClassifyOutcome wrapper

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileNaming.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileNaming.cs
@@ -16,13 +16,6 @@ internal sealed partial class CtrfReportEngine
         return ReplaceInvalidFileNameChars(raw);
     }
 
-    private string ResolveJsonFileName(string template)
-    {
-        string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
-    }
-
     // CTRF `osPlatform` is the short Node-style platform identifier (e.g. "win32",
     // "linux", "darwin"). The full descriptive OS string belongs in `osVersion`.
     private static string GetCtrfOsPlatform()

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
@@ -53,7 +53,7 @@ internal sealed partial class CtrfReportEngine : ReportEngineBase
             out string[]? providedFileName);
 
         string fileName = fileNameExplicitlyProvided
-            ? ResolveJsonFileName(GetProvidedFileName(providedFileName))
+            ? ResolveProvidedFileName(GetProvidedFileName(providedFileName))
             : BuildDefaultFileName(finishTime);
 
         string outputDirectory = _configuration.GetTestResultDirectory();

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -54,7 +54,7 @@ internal sealed class HtmlReportEngine : ReportEngineBase
             out string[]? providedFileName);
 
         string fileName = fileNameExplicitlyProvided
-            ? ResolveHtmlFileName(GetProvidedFileName(providedFileName))
+            ? ResolveProvidedFileName(GetProvidedFileName(providedFileName))
             : BuildDefaultFileName("html");
 
         string outputDirectory = _configuration.GetTestResultDirectory();
@@ -104,13 +104,6 @@ internal sealed class HtmlReportEngine : ReportEngineBase
 #else
         await stream.Stream.WriteAsync(bytes, 0, bytes.Length, _cancellationToken).ConfigureAwait(false);
 #endif
-    }
-
-    private string ResolveHtmlFileName(string template)
-    {
-        string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
     }
 
 #pragma warning disable IDE0051 // Accessed by unit tests through reflection.

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -26,7 +26,9 @@ internal static class TestResultCapture
             // session-wide result list and generated HTML within a predictable budget.
             Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
-            Outcome = ClassifyOutcome(core.State),
+            // HTML does not special-case cancellation — it falls through to the shared
+            // helper which maps it to "failed", unlike JUnit which maps it to "cancelled".
+            Outcome = TestResultCaptureHelper.ClassifyOutcome(core.State),
             Duration = core.Duration,
             StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
             EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
@@ -40,10 +42,4 @@ internal static class TestResultCapture
             Traits = core.Properties.Traits,
         };
     }
-
-    private static string ClassifyOutcome(TestNodeStateProperty state)
-        // Cancellation is intentionally handled in report-specific wrappers. HTML has
-        // historically let cancellation fall through to the failed outcome category, so
-        // this wrapper simply delegates to the shared helper with no special-casing.
-        => TestResultCaptureHelper.ClassifyOutcome(state);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
@@ -63,7 +63,7 @@ internal sealed class JUnitReportEngine : ReportEngineBase
             out string[]? providedFileName);
 
         string fileName = fileNameExplicitlyProvided
-            ? ResolveXmlFileName(GetProvidedFileName(providedFileName))
+            ? ResolveProvidedFileName(GetProvidedFileName(providedFileName))
             : BuildDefaultFileName("xml");
 
         string outputDirectory = _configuration.GetTestResultDirectory();
@@ -109,13 +109,6 @@ internal sealed class JUnitReportEngine : ReportEngineBase
             willOverwrite
                 ? string.Format(CultureInfo.InvariantCulture, ExtensionResources.JUnitReportFileExistsAndWillBeOverwritten, finalPath)
                 : null);
-    }
-
-    private string ResolveXmlFileName(string template)
-    {
-        string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
     }
 
 #pragma warning disable IDE0051 // Accessed by unit tests through reflection.

--- a/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
@@ -58,6 +58,13 @@ internal abstract class ReportEngineBase
             ? providedFileName[0]
             : throw ApplicationStateGuard.Unreachable();
 
+    protected string ResolveProvidedFileName(string template)
+    {
+        string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
+        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
+    }
+
     protected string BuildDefaultFileName(string extension)
     {
         // Deterministic <asm>_<tfm>_<arch>.<extension> shape — discoverable across


### PR DESCRIPTION
## Code Simplification - 2026-06-22

This PR simplifies recently modified code from PR #9330 to improve clarity, consistency, and maintainability while preserving all functionality.

### Files Simplified

- `src/Platform/SharedExtensionHelpers/ReportEngineBase.cs` — adds `ResolveProvidedFileName` to the shared base class
- `src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs` — removes duplicate `ResolveHtmlFileName` method
- `src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs` — removes duplicate `ResolveXmlFileName` method
- `src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileNaming.cs` — removes duplicate `ResolveJsonFileName` method
- `src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs` — updates call site
- `src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs` — inlines trivial `ClassifyOutcome` forwarding wrapper

### Improvements Made

1. **Eliminated Duplicated Logic**
   - `ResolveHtmlFileName`, `ResolveXmlFileName`, and `ResolveJsonFileName` were three private methods with identical bodies across the three report engines. They are replaced by a single `protected string ResolveProvidedFileName(string template)` on `ReportEngineBase`, completing the base class's file-naming support alongside the existing `GetProvidedFileName` and `BuildDefaultFileName` methods.

2. **Removed Unnecessary Indirection**
   - `HtmlReport.TestResultCapture` had a one-liner private `ClassifyOutcome` method that only forwarded to `TestResultCaptureHelper.ClassifyOutcome`. The call site comment now documents the intentional non-special-casing of cancellation (consistent with the JUnit wrapper which _does_ special-case it).

### Changes Based On

Recent changes from:
- #9330 — Share TestResultCapture core across report extensions

### Testing

- ✅ All 547 tests pass (11 skipped on non-Windows), 0 failures — `Microsoft.Testing.Extensions.UnitTests` on net9.0
- ✅ All three affected projects build cleanly on `netstandard2.0`
- ✅ No functional changes — behavior is identical

### Review Focus

Please verify:
- Functionality is preserved across CTRF, HTML, and JUnit report engines
- The `ResolveProvidedFileName` contract matches the removed per-engine methods exactly
- The inlined `ClassifyOutcome` comment preserves the design intent


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/27962311795/agentic_workflow) workflow. · 2.5K AIC · ⌖ 25.1 AIC · ⊞ 44.7K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-23T15:29:50.542Z --> on Jun 23, 2026, 3:29 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27962311795, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/27962311795 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->