### PR TITLE
[perf-improver] perf: avoid redundant `TestNodeUid` allocation in `PopulateTestNodeStatistics`

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PerRequestServerDataConsumerService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/PerRequestServerDataConsumerService.cs
@@ -210,7 +210,7 @@ internal sealed class PerRequestServerDataConsumer(IServiceProvider serviceProvi
             return;
         }
 
-        TestNodeUid testNodeUid = new(message.TestNode.Uid.Value);
+        TestNodeUid testNodeUid = message.TestNode.Uid;
 
         switch (state)
         {


### PR DESCRIPTION
## Goal and Rationale

In server mode (VS / VS Code Test Explorer), `PopulateTestNodeStatistics` is called **twice per test**: once when the test transitions to `InProgress` and once when it reaches its final state (`Passed`, `Failed`, etc.).

Each call was constructing a new `TestNodeUid` wrapper:

```csharp
// Before
TestNodeUid testNodeUid = new(message.TestNode.Uid.Value);
```

This unnecessarily:
1. Reads the `.Value` string property from the already-existing `TestNodeUid`
2. Allocates a new `TestNodeUid` reference-type object wrapping that same string

`message.TestNode.Uid` **is** the `TestNodeUid` we want — no wrapping needed.

## Approach

Single-line fix: use the existing `TestNodeUid` instance directly.

```csharp
// After
TestNodeUid testNodeUid = message.TestNode.Uid;
```

The `ConcurrentDictionary<TestNodeUid, ...>` keys use value equality (`TestNodeUid.Equals` compares `.Value` strings), so the semantics are identical with the original instance.

## Performance Evidence

**Methodology**: static analysis / allocation counting.

| Scenario | Allocations removed per test |
|---|---|
| Server mode (VS/VS Code), 1 000 tests | ~2 000 `TestNodeUid` objects (~48 KB on 64-bit) |
| Server mode, 10 000 tests | ~20 000 objects (~480 KB) |

These are Gen0 short-lived allocations. Removing them reduces GC collection frequency proportionally — particularly noticeable in large test suites run under VS Test Explorer where the interactive latency budget is tight.

## Trade-offs

None. This is a pure reduction: the existing instance has the same identity for all dictionary operations (`Equals` is value-based on the `Value` string).

## Reproducibility

To verify via profiler:
```
dotnet run --project test/... -- --server dotnettestcli
```
Profile `PerRequestServerDataConsumer.PopulateTestNodeStatistics` allocations before/after.

## Test Status

Change is a single-line type-safe assignment (`TestNode.Uid` is declared `TestNodeUid`). CI will confirm build and tests pass.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/27963241204/agentic_workflow) workflow. · 3.7K AIC · ⌖ 24.7 AIC · ⊞ 57.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27963241204, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/27963241204 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->