### PR TITLE
[efficiency-improver] perf: single-pass aggregation in AppendTestRunSummary

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -42,10 +42,33 @@ internal sealed partial class TerminalTestReporter
 
         List<TestProgressState> assemblies = [.. _assemblies.Values.OrderBy(static a => a.Id)];
 
-        int totalTests = assemblies.Sum(static a => a.TotalTests);
-        int totalFailedTests = assemblies.Sum(static a => a.FailedTests);
-        int totalSkippedTests = assemblies.Sum(static a => a.SkippedTests);
-        int totalPassedTests = assemblies.Sum(static a => a.PassedTests);
+        // Single-pass aggregation: compute all summary counters in one foreach instead of
+        // 7 separate LINQ calls (Sum×5, Any×1, Count×1), saving 6 extra O(N) passes and
+        // 6 LINQ enumerator allocations per test run.
+        int totalTests = 0;
+        int totalFailedTests = 0;
+        int totalSkippedTests = 0;
+        int totalPassedTests = 0;
+        int totalRetried = 0;
+        bool anyAssemblyFailed = false;
+        int failedAssembliesWithoutFailedTests = 0;
+
+        foreach (TestProgressState assembly in assemblies)
+        {
+            totalTests += assembly.TotalTests;
+            totalFailedTests += assembly.FailedTests;
+            totalSkippedTests += assembly.SkippedTests;
+            totalPassedTests += assembly.PassedTests;
+            totalRetried += assembly.RetriedFailedTests;
+            if (!assembly.Success)
+            {
+                anyAssemblyFailed = true;
+                if (assembly.FailedTests == 0)
+                {
+                    failedAssembliesWithoutFailedTests++;
+                }
+            }
+        }
 
         // DESIGN: `allTestsWereSkipped` is intentionally treated as a failed run. Skipped tests don't count as
         // "ran", so an all-skipped (or zero-test) run is reported in red as "Zero tests ran". This is the strict
@@ -59,7 +82,7 @@ internal sealed partial class TerminalTestReporter
         // Orchestrator-only: an assembly whose process ended unsuccessfully (crash / non-zero exit) with no failed
         // tests is still a run failure. Gated on ShowAssembly (the orchestrator marker): the in-process host leaves
         // ShowAssembly off and never sets Success, so this stays false and its verdict/color are unchanged.
-        bool hasFailedAssemblies = _options.ShowAssembly && assemblies.Any(static a => !a.Success);
+        bool hasFailedAssemblies = _options.ShowAssembly && anyAssemblyFailed;
 
         bool runFailed = TestRunSummaryHelper.IsRunFailed(totalTests, totalFailedTests, totalSkippedTests, WasCancelled, _options.MinimumExpectedTests) || HasHandshakeFailure || hasFailedAssemblies;
         terminal.SetColor(runFailed ? TerminalColor.DarkRed : TerminalColor.DarkGreen);
@@ -99,12 +122,12 @@ internal sealed partial class TerminalTestReporter
         int failed = totalFailedTests;
         int passed = totalPassedTests;
         int skipped = totalSkippedTests;
-        int retried = assemblies.Sum(static a => a.RetriedFailedTests);
+        int retried = totalRetried;
 
         // Orchestrator-only: count assemblies that ended unsuccessfully without a failed test (crash / non-zero exit)
         // plus handshake failures. These are surfaced as an "error: N" line so they aren't hidden behind a zero
         // failed-test count. In-process leaves ShowAssembly off and never has handshake failures, so error is 0.
-        int error = (_options.ShowAssembly ? assemblies.Count(static a => !a.Success && a.FailedTests == 0) : 0) + HandshakeFailureCount;
+        int error = (_options.ShowAssembly ? failedAssembliesWithoutFailedTests : 0) + HandshakeFailureCount;
         TimeSpan runDuration = _testExecutionStartTime != null && _testExecutionEndTime != null ? (_testExecutionEndTime - _testExecutionStartTime).Value : TimeSpan.Zero;
 
         bool colorizeFailed = failed > 0;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -44,7 +44,7 @@ internal sealed partial class TerminalTestReporter
 
         // Single-pass aggregation: compute all summary counters in one foreach instead of
         // 7 separate LINQ calls (Sum×5, Any×1, Count×1), saving 6 extra O(N) passes and
-        // 6 LINQ enumerator allocations per test run.
+        // 7 LINQ enumerator allocations per test run.
         int totalTests = 0;
         int totalFailedTests = 0;
         int totalSkippedTests = 0;


### PR DESCRIPTION
## Goal

Replace 7 separate LINQ calls over the `assemblies` list in `AppendTestRunSummary` with a single `foreach` that computes all counters in one pass.

## Focus Area

**Code-Level Efficiency** — eliminating redundant iteration and LINQ allocations in the end-of-run test summary renderer.

## Approach

**Before:** `AppendTestRunSummary` made 7 separate linear passes over the already-materialized `List<TestProgressState> assemblies`:

```csharp
int totalTests     = assemblies.Sum(a => a.TotalTests);       // pass 1
int totalFailed    = assemblies.Sum(a => a.FailedTests);      // pass 2
int totalSkipped   = assemblies.Sum(a => a.SkippedTests);     // pass 3
int totalPassed    = assemblies.Sum(a => a.PassedTests);      // pass 4
bool hasFailedAsm  = assemblies.Any(a => !a.Success);         // pass 5
int retried        = assemblies.Sum(a => a.RetriedFailed);    // pass 6
int errorCount     = assemblies.Count(a => !a.Success && a.FailedTests == 0); // pass 7
```

Each LINQ method allocates its own enumerator struct on the heap and traverses the list independently.

**After:** One `foreach` loop computes all 7 values in a single pass:

```csharp
foreach (TestProgressState a in assemblies)
{
    totalTests        += a.TotalTests;
    totalFailedTests  += a.FailedTests;
    totalSkippedTests += a.SkippedTests;
    totalPassedTests  += a.PassedTests;
    totalRetried      += a.RetriedFailedTests;
    if (!a.Success) { anyAssemblyFailed = true; if (a.FailedTests == 0) failedAssembliesWithoutFailedTests++; }
}
```

## Energy Efficiency Evidence

| Metric | Before | After |
|--------|--------|-------|
| Passes over `assemblies` per summary render | 7 | 1 |
| LINQ enumerator allocations | 7 | 0 |

**Proxy metric used:** Managed allocation count + iteration count at end-of-run summary render.

**Absolute magnitude:** Low — `assemblies.Count` is typically 1–4 (one per test binary). The per-run savings are small, but this is the right pattern and eliminates unnecessary allocation churn.

**Reasoning linking proxy to energy reduction:** Each LINQ call allocates a `List<T>.Enumerator` on the heap; with 7 calls × potentially millions of test runs across the ecosystem, those short-lived allocations contribute to GC pressure. Eliminating them reduces CPU time spent on garbage collection.

## Green Software Foundation Context

🌱 **Hardware Efficiency** — reducing per-call managed allocations makes better use of the underlying hardware by lowering GC overhead on the finalization thread and reducing cache churn from short-lived heap objects.

## Trade-offs

- **Readability:** The single loop is slightly more verbose but arguably more cohesive — all related counters are visibly computed together in one place rather than scattered across 7 one-liners. The comment above the loop explains the rationale.
- **Correctness:** The original `assemblies.Any(!Success)` had LINQ short-circuit semantics; the new loop always sets the flag but the `hasFailedAssemblies = _options.ShowAssembly && anyAssemblyFailed` assignment retains the conditional short-circuit for the final assignment. Net behaviour is identical.

## Reproducibility

No benchmark numbers to reproduce — this is a code pattern improvement. The proxy metric (7 LINQ calls → 1 foreach) is self-evident from reading the diff.

## Test Status

CI will confirm build + unit tests. The change is a pure internal refactor with no API or output changes.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/27987826912/agentic_workflow) workflow. · 2.4K AIC · ⌖ 38.3 AIC · ⊞ 58.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27987826912, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/27987826912 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->