### PR TITLE
[docs] Update glossary - weekly full scan

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -27,17 +27,9 @@ An MTP struct (`ArgumentArity.cs`) that defines the minimum and maximum number o
 
 A shared static helper compiled into MTP extensions via file linking (no NuGet service registration or InternalsVisibleTo required) that provides template-based naming for test artifact files (dump files, report files, etc.). Templates are strings containing `{placeholder}` tokens (case-sensitive, lowercase): `{pname}` (process name), `{pid}` (process ID), `{asm}` (entry-assembly name), `{tfm}` (target framework moniker, best-effort runtime detection), `{arch}` (process architecture), and `{time}` (high-precision UTC timestamp). Custom per-call overrides can replace default placeholder values via a `Dictionary<string, string>`. Used directly by the [HangDump](#hangdump) and [CrashDump](#crashdump) extensions, and indirectly by the report extensions ([HtmlReport](#htmlreport), [JUnitReport](#junitreport), and [TrxReport](#trxreport)) via the shared `ReportFileNameHelper`. The legacy `%p` pattern is not handled here; it is substituted by the [HangDump](#hangdump) extension as a separate post-processing step for backward compatibility. The [CrashDump](#crashdump) consumer passes the .NET runtime's `%e` and `%p` placeholders as the `processName` and `processId` arguments so `{pname}` and `{pid}` resolve to `%e` and `%p` respectively — those are then expanded by the runtime's `createdump` at crash-write time (the testhost PID is not yet known when the environment variables are configured).
 
-### AzureDevOpsReport
-
-An MTP extension (`Microsoft.Testing.Extensions.AzureDevOpsReport`) that formats and reports test results to Azure DevOps pipelines. It generates pipeline-compatible output including TFM and test name details for richer CI reporting.
-
-### AzureFoundry
-
-An MTP extension (`Microsoft.Testing.Extensions.AzureFoundry`) that integrates [Azure AI Foundry](https://azure.microsoft.com/products/ai-foundry) (Azure OpenAI) with Microsoft.Testing.Platform as an [IChatClientProvider](#ichatclientprovider) implementation. It reads Azure OpenAI connection settings from environment variables and supplies AI chat-client capabilities to any testing extension that consumes the [Microsoft.Testing.Platform.AI](#microsofttestingplatformai) abstractions. This is the reference implementation of the `Microsoft.Testing.Platform.AI` abstractions.
-
 ### AssemblyFixtureProviderAttribute
 
-An MSTest assembly-level attribute (`[AssemblyFixtureProvider(typeof(T))]`) in `Microsoft.VisualStudio.TestTools.UnitTesting` that enables cross-assembly assembly fixtures. When applied to a library assembly, it causes any `[AssemblyInitialize]` and `[AssemblyCleanup]` methods on the specified `FixtureType` to be discovered and executed once per consuming test assembly that loads the library at runtime. This allows shared test infrastructure (e.g., database setup, container lifecycle) to be co-located in a test-helper library rather than repeated across every test project. Local `[AssemblyInitialize]`/`[AssemblyCleanup]` declarations always take precedence over provider-contributed ones; the attribute may be applied multiple times on the same assembly to expose multiple fixture types; and it can also be applied on the consuming test assembly to opt into fixtures from a third-party library. Introduced in [PR #8677](https://github.com/microsoft/testfx/pull/8677).
+An MSTest assembly-level attribute (`[assembly: AssemblyFixtureProvider(typeof(T))]`) in `Microsoft.VisualStudio.TestTools.UnitTesting` that enables cross-assembly assembly fixtures. When applied to a library assembly, it causes any `[AssemblyInitialize]` and `[AssemblyCleanup]` methods on the specified `FixtureType` to be discovered and executed once per consuming test assembly that loads the library at runtime. This allows shared test infrastructure (e.g., database setup, container lifecycle) to be co-located in a test-helper library rather than repeated across every test project. Local `[AssemblyInitialize]`/`[AssemblyCleanup]` declarations always take precedence over provider-contributed ones; the attribute may be applied multiple times on the same assembly to expose multiple fixture types; and it can also be applied on the consuming test assembly to opt into fixtures from a third-party library. Introduced in [PR #8677](https://github.com/microsoft/testfx/pull/8677).
 
 ### Assert.Scope (soft assertions)
 
@@ -49,10 +41,18 @@ using (Assert.Scope())
     Assert.AreEqual(1, actual.X);  // collected, execution continues
     Assert.AreEqual(2, actual.Y);  // collected, execution continues
 }
-// Dispose() throws a single AssertFailedException containing both failures
+// Dispose() throws a single AssertFailedException containing all failures
 ```
 
-See [RFC 011](docs/RFCs/011-Soft-Assertions-Nullability-Design.md) for the nullability-annotation design decisions.
+See `docs/RFCs/011-Soft-Assertions-Nullability-Design.md` for the nullability-annotation design decisions.
+
+### AzureDevOpsReport
+
+An MTP extension (`Microsoft.Testing.Extensions.AzureDevOpsReport`) that formats and reports test results to Azure DevOps pipelines. It generates pipeline-compatible output including TFM and test name details for richer CI reporting.
+
+### AzureFoundry
+
+An MTP extension (`Microsoft.Testing.Extensions.AzureFoundry`) that integrates [Azure AI Foundry](https://azure.microsoft.com/products/ai-foundry) (Azure OpenAI) with Microsoft.Testing.Platform as an [IChatClientProvider](#ichatclientprovider) implementation. It reads Azure OpenAI connection settings from environment variables and supplies AI chat-client capabilities to any testing extension that consumes the [Microsoft.Testing.Platform.AI](#microsofttestingplatformai) abstractions. This is the reference implementation of the `Microsoft.Testing.Platform.AI` abstractions.
 
 ## C
 
@@ -208,7 +208,7 @@ A NuGet package (`Microsoft.Testing.Platform.AI`) that provides AI extensibility
 
 ### Microsoft.Testing.Extensions.Logging
 
-An experimental MTP extension (`Microsoft.Testing.Extensions.Logging`, `[TPEXP]`) that bridges Microsoft Testing Platform diagnostic logs to any `Microsoft.Extensions.Logging` provider (e.g., Console, Serilog, Application Insights, OpenTelemetry exporters). Register via `AddMicrosoftExtensionsLogging()` on `ITestApplicationBuilder`, passing either an existing `ILoggerFactory` or a configuration delegate for the logging builder. The minimum log level is bounded by the platform's effective diagnostic level; per-category filters in the `ILoggingBuilder` can narrow but not widen it. MTP core (`Microsoft.Testing.Platform`) does not depend on `Microsoft.Extensions.Logging`; this package provides an additive opt-in bridge only. Currently **experimental** — API surface may change without notice. See [RFC 013](docs/RFCs/013-Microsoft-Extensions-Bridges.md) for the design.
+An experimental MTP extension (`Microsoft.Testing.Extensions.Logging`, `[TPEXP]`) that bridges Microsoft Testing Platform diagnostic logs to any `Microsoft.Extensions.Logging` provider (e.g., Console, Serilog, Application Insights, OpenTelemetry exporters). Register via `AddMicrosoftExtensionsLogging()` on `ITestApplicationBuilder`, passing either an existing `ILoggerFactory` or a configuration delegate for the logging builder. The minimum log level is bounded by the platform's effective diagnostic level; per-category filters in the `ILoggingBuilder` can narrow but not widen it. MTP core (`Microsoft.Testing.Platform`) does not depend on `Microsoft.Extensions.Logging`; this package provides an additive opt-in bridge only. Currently **experimental** — API surface may change without notice. See `docs/RFCs/013-Microsoft-Extensions-Bridges.md` for the design.
 
 ## N
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -35,6 +35,25 @@ An MTP extension (`Microsoft.Testing.Extensions.AzureDevOpsReport`) that formats
 
 An MTP extension (`Microsoft.Testing.Extensions.AzureFoundry`) that integrates [Azure AI Foundry](https://azure.microsoft.com/products/ai-foundry) (Azure OpenAI) with Microsoft.Testing.Platform as an [IChatClientProvider](#ichatclientprovider) implementation. It reads Azure OpenAI connection settings from environment variables and supplies AI chat-client capabilities to any testing extension that consumes the [Microsoft.Testing.Platform.AI](#microsofttestingplatformai) abstractions. This is the reference implementation of the `Microsoft.Testing.Platform.AI` abstractions.
 
+### AssemblyFixtureProviderAttribute
+
+An MSTest assembly-level attribute (`[AssemblyFixtureProvider(typeof(T))]`) in `Microsoft.VisualStudio.TestTools.UnitTesting` that enables cross-assembly assembly fixtures. When applied to a library assembly, it causes any `[AssemblyInitialize]` and `[AssemblyCleanup]` methods on the specified `FixtureType` to be discovered and executed once per consuming test assembly that loads the library at runtime. This allows shared test infrastructure (e.g., database setup, container lifecycle) to be co-located in a test-helper library rather than repeated across every test project. Local `[AssemblyInitialize]`/`[AssemblyCleanup]` declarations always take precedence over provider-contributed ones; the attribute may be applied multiple times on the same assembly to expose multiple fixture types; and it can also be applied on the consuming test assembly to opt into fixtures from a third-party library. Introduced in [PR #8677](https://github.com/microsoft/testfx/pull/8677).
+
+### Assert.Scope (soft assertions)
+
+An experimental MSTest feature (`[MSTESTEXP]`) that defers assertion failures instead of throwing immediately. Calling `Assert.Scope()` returns an `IDisposable` scope; while the scope is active, assertion failures are collected rather than thrown. When the scope is disposed, all collected failures are reported together as a single `AssertFailedException`. Nesting scopes is not allowed. `Assert.Fail()` and `Assert.Inconclusive()` still throw immediately inside a scope; all other assertions participate in soft collection. Use this to check multiple conditions in one test pass without stopping on the first failure:
+
+```csharp
+using (Assert.Scope())
+{
+    Assert.AreEqual(1, actual.X);  // collected, execution continues
+    Assert.AreEqual(2, actual.Y);  // collected, execution continues
+}
+// Dispose() throws a single AssertFailedException containing both failures
+```
+
+See [RFC 011](docs/RFCs/011-Soft-Assertions-Nullability-Design.md) for the nullability-annotation design decisions.
+
 ## C
 
 ### CIConditionAttribute
@@ -171,6 +190,10 @@ A meta-package that bundles `MSTest.TestFramework`, `MSTest.TestAdapter`, and `M
 
 A Roslyn C# source-generator package (`MSTest.SourceGeneration`) that enables MSTest test projects to be published with Native AOT (`PublishAot=true`) or trimming (`PublishTrimmed=true`) without IL2026/IL3050 warnings or `MissingMethodException` failures at runtime. At compile time the generator scans all `[TestClass]`-decorated types and emits a `[ModuleInitializer]`-decorated registration method containing `[DynamicDependency]` hints and a pre-resolved `MethodInfo` dictionary, replacing the per-startup `Assembly.GetTypes()` and `Type.GetMethods()` reflection scans. Adoption requires only a `<PackageReference>` to `MSTest.SourceGeneration`; existing test code needs no changes. Several shapes are outside the generator's current scope (generic test classes, inherited `[TestClass]`, `file`-local types, etc.) — see `docs/source-generator/design.md` for the full scope and known limitations.
 
+### MSTestParallelizeScope / MSTestParallelizeWorkers
+
+MSBuild properties that let users opt in to MSTest assembly-level parallelization without authoring a C# source file. Setting `<MSTestParallelizeScope>` emits `[assembly: Parallelize(Scope = ExecutionScope.X)]`; setting `<MSTestParallelizeWorkers>` emits `[assembly: Parallelize(Workers = N)]`; both together emit `[assembly: Parallelize(Scope = …, Workers = …)]`. Setting scope to `None` emits `[assembly: DoNotParallelize]` instead. Both properties require `GenerateAssemblyInfo` to be `true` and act via the standard `AssemblyAttribute` MSBuild item. Introduced in [PR #8233](https://github.com/microsoft/testfx/pull/8233).
+
 ### MTP
 
 See **Microsoft.Testing.Platform**.
@@ -182,6 +205,10 @@ A lightweight, extensible test platform for .NET that serves as a modern alterna
 ### Microsoft.Testing.Platform.AI
 
 A NuGet package (`Microsoft.Testing.Platform.AI`) that provides AI extensibility abstractions for Microsoft.Testing.Platform. It defines the [IChatClientProvider](#ichatclientprovider) interface and leverages [Microsoft.Extensions.AI](https://www.nuget.org/packages/Microsoft.Extensions.AI) types so that test frameworks and extensions can consume Large Language Model (LLM) capabilities — flaky test analysis, crash dump analysis, test failure root-cause analysis, and more — without implementing provider-specific logic. This package ships the **abstractions only**; an AI provider implementation such as [Microsoft.Testing.Extensions.AzureFoundry](#azurefoundry) must also be registered to supply actual AI capabilities. See `docs/microsoft.testing.platform/001-AI-Extensibility.md` for the design RFC.
+
+### Microsoft.Testing.Extensions.Logging
+
+An experimental MTP extension (`Microsoft.Testing.Extensions.Logging`, `[TPEXP]`) that bridges Microsoft Testing Platform diagnostic logs to any `Microsoft.Extensions.Logging` provider (e.g., Console, Serilog, Application Insights, OpenTelemetry exporters). Register via `AddMicrosoftExtensionsLogging()` on `ITestApplicationBuilder`, passing either an existing `ILoggerFactory` or a configuration delegate for the logging builder. The minimum log level is bounded by the platform's effective diagnostic level; per-category filters in the `ILoggingBuilder` can narrow but not widen it. MTP core (`Microsoft.Testing.Platform`) does not depend on `Microsoft.Extensions.Logging`; this package provides an additive opt-in bridge only. Currently **experimental** — API surface may change without notice. See [RFC 013](docs/RFCs/013-Microsoft-Extensions-Bridges.md) for the design.
 
 ## N
 
@@ -234,6 +261,12 @@ An MTP extension (`Microsoft.Testing.Extensions.Retry`) that automatically re-ru
 ### RFC
 
 Request for Comments document in the `docs/RFCs/` folder. RFCs describe design decisions, proposed features, and implementation details for MSTest and MTP.
+
+## S
+
+### SequenceOrder
+
+A public enum in `Microsoft.VisualStudio.TestTools.UnitTesting` that controls whether elements must appear in the same position when comparing sequences with `Assert.AreSequenceEqual` and `Assert.AreNotSequenceEqual`. Values: `InOrder` (0, default) — elements must appear in the same order in both sequences (LINQ `SequenceEqual` semantics); `InAnyOrder` (1) — elements may appear in any order, but each element must appear the same number of times in both sequences (multiset equality). Introduced in [PR #8334](https://github.com/microsoft/testfx/pull/8334).
 
 ## T
 


### PR DESCRIPTION
### Glossary Updates

**Scan Type**: Full scan (weekly — Monday June 23, 2026)

**Terms Added**:

- **AssemblyFixtureProviderAttribute**: New MSTest assembly-level attribute (PR #8677) enabling cross-assembly `[AssemblyInitialize]`/`[AssemblyCleanup]` fixtures; not previously documented in the glossary.
- **Assert.Scope (soft assertions)**: New experimental feature (`[MSTESTEXP]`) that defers and collects assertion failures instead of throwing immediately (RFC 011); significant new concept worthy of a standalone entry.
- **MSTestParallelizeScope / MSTestParallelizeWorkers**: New MSBuild properties (PR #8233) for opting into assembly-level parallelization without C# source; user-facing configuration with no prior glossary coverage.
- **Microsoft.Testing.Extensions.Logging**: New experimental MTP extension (`[TPEXP]`) bridging MTP diagnostic logs to `Microsoft.Extensions.Logging` providers (RFC 013); new package added to platform extensions.
- **SequenceOrder**: New public enum (PR #8334) controlling order semantics for `Assert.AreSequenceEqual`/`Assert.AreNotSequenceEqual`; required to understand the new sequence assertions correctly. Added a new **## S** section.

**Changes Analyzed**:
- Reviewed 1 commit from the past 7 days (`8886048` — dependency mirror from dotnet-maestro[bot])
- Audited `PublicAPI.Unshipped.txt` files across all projects to identify new public API surface
- Reviewed `docs/Changelog.md` (v4.3.0 unreleased section) for feature context
- Reviewed RFC 011, RFC 013, and MSBuild `.targets` files for accurate definitions

**Related Changes**:
- `8886048`: `[main] Update dependencies from microsoft/testfx (#9357)` — full repo mirror commit introducing all current source
- PR #8677: Add `[AssemblyFixtureProvider]` for cross-assembly assembly fixtures
- PR #8334: Add `Assert.AreSequenceEqual`/`AreNotSequenceEqual` with `SequenceOrder` option
- PR #8233: Add `MSTestParallelizeScope`/`Workers` MSBuild properties
- RFC 011: Soft Assertions and Nullability Annotation Design (`Assert.Scope`)
- RFC 013: `Microsoft.Extensions.*` Bridges (`Microsoft.Testing.Extensions.Logging`)

**Not added** (rationale):
- `Assert.AddValueFormatter` — utility/hook method, not a distinct concept
- MSTEST0064–MSTEST0071 analyzer rules — no existing precedent for per-rule analyzer entries in the glossary




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Glossary Maintainer](https://github.com/microsoft/testfx/actions/runs/28005175980/agentic_workflow) workflow. · 1K AIC · ⌖ 60.5 AIC · ⊞ 43.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+glossary-maintainer%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/glossary-maintainer.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-25T05:59:58.698Z --> on Jun 25, 2026, 5:59 AM UTC

<!-- gh-aw-agentic-workflow: Glossary Maintainer, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28005175980, workflow_id: glossary-maintainer, run: https://github.com/microsoft/testfx/actions/runs/28005175980 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: glossary-maintainer -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/glossary-maintainer -->