### PR TITLE
Update bundled Playwright for .NET to 1.60.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.14</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <!-- Test Platform, .NET Test SDK and Object Model  -->
     <MicrosoftNETTestSdkVersion>18.4.0</MicrosoftNETTestSdkVersion>
-    <MicrosoftPlaywrightVersion>1.58.0</MicrosoftPlaywrightVersion>
+    <MicrosoftPlaywrightVersion>1.60.0</MicrosoftPlaywrightVersion>
     <MicrosoftTestingExtensionsFakesVersion>18.1.1</MicrosoftTestingExtensionsFakesVersion>
     <!-- Microsoft.Testing.Internal.Framework is an internal-only NuGet (consumed by tests that
          opt into UseInternalTestFramework via TestFramework.ForTestingMSTest); there is no public


### PR DESCRIPTION
Updates the bundled Playwright for .NET version in MSTest SDK from **1.58.0** to **1.60.0** (latest stable on NuGet).

When `<EnablePlaywright>` is set, the MSTest SDK brings in Playwright through the `MicrosoftPlaywrightVersion` property. This bumps it so users on the minimal SDK setup get recent Playwright features and fixes without an explicit override.

A companion PR will fix the underlying reason Dependabot wasn't proposing these bumps automatically.

Fixes #9362