### PR TITLE
Fix flaky DrainDataAsync_Loop_ShouldFail (unblocks PR #9355 CI)

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -34,7 +34,15 @@ public sealed class AsynchronousMessageBusTests
         await Assert.ThrowsAsync<InvalidOperationException>(proxy.DrainDataAsync);
     }
 
+    // This test relies on the background consumer tasks (started via ITask.Run) ping-ponging
+    // messages between the two consumers so the drain keeps observing newly received payloads and
+    // ultimately surfaces the publisher/consumer loop. On .NET Framework, under the assembly's
+    // method-level parallelism (many concurrent test methods competing for the slowly-growing
+    // ThreadPool), those background tasks can be starved long enough that the drain finishes its
+    // attempts without seeing the loop, making the test intermittently fail (see #6892). Running it
+    // non-parallel removes that contention and keeps the loop detection deterministic.
     [TestMethod]
+    [DoNotParallelize]
     public async Task DrainDataAsync_Loop_ShouldFail()
     {
         using MessageBusProxy proxy = new();


### PR DESCRIPTION
## Problem

The CI build for #9355 failed on the **Build Windows Debug** leg, but the failure is unrelated to that PR's changes (its analyzer tests all pass). The failing test is:

```
failed DrainDataAsync_Loop_ShouldFail (179ms)
  Assertion failed. Expected exception of exact type InvalidOperationException but no exception was thrown.
  from Microsoft.Testing.Platform.UnitTests.exe (net48|x64)
```

This is a known, intermittently-flaky test (historically tracked by #6892) and only fails on **net462** under heavy CI load.

## Root cause

`DrainDataAsync_Loop_ShouldFail` sets up two consumers that produce messages each other reacts to, creating a publisher/consumer loop. Detection relies on the background consumer tasks (started via `ITask.Run`) ping-ponging messages so that `AsynchronousMessageBus.DrainDataAsync` keeps observing newly received payloads across its drain rounds and ultimately throws.

On .NET Framework, under the assembly's method-level parallelism (32 workers competing for the slowly-growing ThreadPool), those background tasks can be starved long enough that the drain completes its attempts without observing the loop — so no exception is thrown and the assertion fails. The drain/marker logic itself is deterministic; the flakiness comes purely from ThreadPool contention with the other concurrently-running test methods.

## Fix

Mark the single test `[DoNotParallelize]` (the same pattern already used by `TerminalOutputDeviceTests`) so it runs without competing for threads, keeping loop detection deterministic. This is a test-only change with no production impact.

Verified locally on net462/net8.0/net9.0: the project builds clean and all 5 `AsynchronousMessageBusTests` pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>